### PR TITLE
feat: adding ui for confirm sign in page

### DIFF
--- a/examples/next/pages/components/authenticator/sign-in/auth-with-sms-mfa.tsx
+++ b/examples/next/pages/components/authenticator/sign-in/auth-with-sms-mfa.tsx
@@ -1,9 +1,14 @@
-import { Authenticator } from "aws-amplify-react";
+import { Authenticator } from "@aws-amplify/ui-react";
 import { Amplify } from "aws-amplify";
 
 import awsExports from "@environments/auth-with-phone-and-sms-mfa/src/aws-exports";
 
-Amplify.configure(awsExports);
+Amplify.configure({
+  ...awsExports,
+  auth: {
+    login_mechanisms: ['phone_number'],
+  },
+});
 
 export default function AuthenticatorWithSmsMfa() {
   return <Authenticator />;

--- a/packages/core/src/authMachine.ts
+++ b/packages/core/src/authMachine.ts
@@ -65,6 +65,7 @@ export const authMachine = Machine<AuthContext, AuthEvent>(
               onDone: [
                 {
                   cond: "shouldConfirmSignIn",
+                  actions: "setUser",
                   target: "#auth.confirmSignIn",
                 },
                 {
@@ -333,7 +334,8 @@ export const authMachine = Machine<AuthContext, AuthEvent>(
         return Auth.signIn(username, password);
       },
       async confirmSignIn(context, event) {
-        const { user, confirmation_code: code } = event.data;
+        const { user } = context;
+        const { confirmation_code: code } = event.data;
 
         return Auth.confirmSignIn(user, code);
       },

--- a/packages/e2e/cypress/integration/components/authenticator/sign-in-sms-mfa/sign-in-sms-mfa.steps.ts
+++ b/packages/e2e/cypress/integration/components/authenticator/sign-in-sms-mfa/sign-in-sms-mfa.steps.ts
@@ -2,23 +2,23 @@ import { And, Given, Then, When } from "cypress-cucumber-preprocessor/steps";
 
 Given("I'm running the example {string}", (url: string) => {
   cy.visit(url);
-  cy.get("[data-test=sign-in-header-section]").should("be.visible");
+  cy.get("[data-amplify-authenticator-signin]").should("be.visible");
 });
 
 When("I type a valid phone number {string}", (phoneNumber: string) => {
-  cy.get("[data-test=username-input]").type(Cypress.env(phoneNumber));
+  cy.get("[data-amplify-usernamealias]").type(Cypress.env(phoneNumber));
 });
 
 When("I type an invalid username {string}", (phoneNumber: string) => {
-  cy.get("[data-test=username-input]").type(Cypress.env(phoneNumber));
+  cy.get("[data-amplify-usernamealias]").type(Cypress.env(phoneNumber));
 });
 
 And("I type an invalid password {string}", (password: string) => {
-  cy.get("[data-test=sign-in-password-input]").type(Cypress.env(password));
+  cy.get("[data-amplify-password]").type(Cypress.env(password));
 });
 
 And("I type a valid password {string}", (password: string) => {
-  cy.get("[data-test=sign-in-password-input]").type(Cypress.env(password));
+  cy.get("[data-amplify-password]").type(Cypress.env(password));
 });
 
 And("I click the {string} button", (name: string) => {
@@ -26,9 +26,10 @@ And("I click the {string} button", (name: string) => {
 });
 
 Then("I will be redirected to the confirm sms mfa page", () => {
-  cy.get("[data-test=confirm-sign-in-header-section]").should("be.visible");
+  cy.get("[data-amplify-authenticator-confirmsignin]").should("be.visible");
 });
 
+// TODO - this test is failing in the new Authenticator until we add in the error handling in the component
 Then("I see {string}", (message: string) => {
   const [messageString, username] = message.split(" ");
   cy.get("body").contains([messageString, Cypress.env(username)].join(" "));

--- a/packages/react/src/components/Authenticator/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn.tsx
@@ -1,10 +1,54 @@
-import React from 'react';
+import { useAmplify, useAuth } from "@aws-amplify/ui-react";
+
+import {
+  ConfirmationCodeInput,
+  ConfirmSignInFooter,
+  ConfirmSignInFooterProps,
+} from "./shared";
 
 /**
  * placeholder component
  */
 export const ConfirmSignIn = (): JSX.Element => {
+  const amplifyNamespace = "Authenticator.ConfirmSignIn";
+  const {
+    components: { Fieldset, Form, Heading, Label },
+  } = useAmplify(amplifyNamespace);
+
+  const [state, send] = useAuth();
+  const isPending = state.matches("confirmSignIn.pending");
+
+  const footerProps: ConfirmSignInFooterProps = {
+    amplifyNamespace,
+    isPending,
+    send,
+  };
+
   return (
-    <h1>Hello world - time to confirm your sign in!</h1>
+    <Form
+      data-amplify-authenticator-confirmsignin=""
+      method="post"
+      onSubmit={event => {
+        event.preventDefault();
+
+        const formData = new FormData(event.target);
+
+        send({
+          type: "SUBMIT",
+          // @ts-ignore Property 'fromEntries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.ts(2550)
+          data: Object.fromEntries(formData),
+        });
+      }}
+    >
+      <Heading level={1}>Confirm SMS Code</Heading>
+
+      <Fieldset disabled={isPending}>
+        <Label data-amplify-confirmationcode>
+          <ConfirmationCodeInput amplifyNamespace={amplifyNamespace} />
+        </Label>
+      </Fieldset>
+
+      <ConfirmSignInFooter {...footerProps} />
+    </Form>
   );
-}
+};

--- a/packages/react/src/components/Authenticator/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp.tsx
@@ -1,24 +1,33 @@
 import { useAmplify, useAuth } from "@aws-amplify/ui-react";
+
+import {
+  ConfirmationCodeInput,
+  ConfirmationCodeInputProps,
+  ConfirmSignInFooter,
+  ConfirmSignInFooterProps,
+} from "./shared";
 import { UserNameAlias } from "./UserNameAlias";
 
 export function ConfirmSignUp() {
+  const amplifyNamespace = "Authenticator.ConfirmSignUp";
   const {
-    components: {
-      Box,
-      Button,
-      Fieldset,
-      Footer,
-      Form,
-      Heading,
-      Input,
-      Label,
-      Spacer,
-      Text,
-    },
-  } = useAmplify("Authenticator.ConfirmSignUp");
+    components: { Box, Button, Fieldset, Form, Heading, Label, Text },
+  } = useAmplify(amplifyNamespace);
 
   const [state, send] = useAuth();
   const isPending = state.matches("confirmSignUp.pending");
+
+  const footerProps: ConfirmSignInFooterProps = {
+    amplifyNamespace,
+    isPending,
+    send,
+  };
+
+  const confirmationCodeInputProps: ConfirmationCodeInputProps = {
+    amplifyNamespace,
+    label: "Confirmation Code",
+    placeholder: "Enter your code",
+  };
 
   return (
     // TODO Automatically add these namespaces again from `useAmplify`
@@ -43,14 +52,7 @@ export function ConfirmSignUp() {
         <UserNameAlias data-amplify-usernamealias />
 
         <Label data-amplify-confirmationcode>
-          <Text>Confirmation Code</Text>
-          <Input
-            autoComplete="one-time-code"
-            name="confirmation_code"
-            placeholder="Enter your code"
-            required
-            type="text"
-          />
+          <ConfirmationCodeInput {...confirmationCodeInputProps} />
           <Box>
             <Text>Lost your code?</Text>{" "}
             <Button type="button">Reset Code</Button>
@@ -58,15 +60,7 @@ export function ConfirmSignUp() {
         </Label>
       </Fieldset>
 
-      <Footer>
-        <Button onClick={() => send({ type: "SIGN_IN" })} type="button">
-          Back to Sign In
-        </Button>
-        <Spacer />
-        <Button isDisabled={isPending} type="submit">
-          {isPending ? <>Confirming&hellip;</> : <>Confirm</>}
-        </Button>
-      </Footer>
+      <ConfirmSignInFooter {...footerProps} />
     </Form>
   );
 }

--- a/packages/react/src/components/Authenticator/shared/ConfirmSignInFooter.tsx
+++ b/packages/react/src/components/Authenticator/shared/ConfirmSignInFooter.tsx
@@ -1,0 +1,29 @@
+import { useAmplify } from "@aws-amplify/ui-react";
+
+export interface ConfirmSignInFooterProps {
+  amplifyNamespace: string;
+  isPending: boolean;
+  send({ type: string }): void;
+}
+
+export const ConfirmSignInFooter = (
+  props: ConfirmSignInFooterProps
+): JSX.Element => {
+  const { amplifyNamespace, isPending, send } = props;
+
+  const {
+    components: { Button, Footer, Spacer },
+  } = useAmplify(amplifyNamespace);
+
+  return (
+    <Footer>
+      <Button onClick={() => send({ type: "SIGN_IN" })} type="button">
+        Back to Sign In
+      </Button>
+      <Spacer />
+      <Button isDisabled={isPending} type="submit">
+        {isPending ? <>Confirming&hellip;</> : <>Confirm</>}
+      </Button>
+    </Footer>
+  );
+};

--- a/packages/react/src/components/Authenticator/shared/ConfirmationCodeInput.tsx
+++ b/packages/react/src/components/Authenticator/shared/ConfirmationCodeInput.tsx
@@ -1,0 +1,35 @@
+import { useAmplify } from "@aws-amplify/ui-react";
+
+export interface ConfirmationCodeInputProps {
+  amplifyNamespace: string;
+  label?: string;
+  placeholder?: string;
+  required?: boolean;
+}
+
+export const ConfirmationCodeInput = (
+  props: ConfirmationCodeInputProps
+): JSX.Element => {
+  const {
+    amplifyNamespace,
+    label = "Code *",
+    placeholder = "Code",
+    required = true,
+  } = props;
+  const {
+    components: { Input, Text },
+  } = useAmplify(amplifyNamespace);
+
+  return (
+    <>
+      <Text>{label}</Text>
+      <Input
+        autoComplete="one-time-code"
+        name="confirmation_code"
+        placeholder={placeholder}
+        required={required}
+        type="text"
+      />
+    </>
+  );
+};

--- a/packages/react/src/components/Authenticator/shared/index.ts
+++ b/packages/react/src/components/Authenticator/shared/index.ts
@@ -1,0 +1,2 @@
+export * from "./ConfirmationCodeInput";
+export * from "./ConfirmSignInFooter";


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

Adding UI for the confirm sign in page. API calls all work and submit successfully. Auth machine integration is solid and transitions function as expected. Split off a couple pieces of component code into their own component files since they are being used in both the `ConfirmSignUp` and `ConfirmSignIn` pages. Updated cypress test file for the new authenticator ui. The last test in the file is failing (invalid input should show a "User not found" message) because that has not been added to the new ui yet. The rest of the tests pass as expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
