### PR TITLE
chore(wip): setting up icon build

### DIFF
--- a/packages/react/src/primitives/Icon/index.ts
+++ b/packages/react/src/primitives/Icon/index.ts
@@ -1,1 +1,2 @@
 export * from './Icon';
+export * from '@aws-amplify/ui-theme-base/dist/react';

--- a/packages/theme-base/package.json
+++ b/packages/theme-base/package.json
@@ -9,11 +9,15 @@
   ],
   "scripts": {
     "build": "yarn run build:sd; yarn run build:css",
+    "build:icons": "node scripts/generateIcons.js",
     "build:sd": "style-dictionary build --config ./sd.config.js",
     "build:css": "globcat src/css/theme.css dist/variables.css src/css/**/*.css --output dist/theme.css",
     "clean": "rimraf dist"
   },
   "devDependencies": {
+    "change-case": "^4.1.2",
+    "fs-extra": "^10.0.0",
+    "glob": "^7.1.7",
     "globcat": "^1.3.4",
     "rimraf": "^3.0.2",
     "style-dictionary": "^3.0.1"

--- a/packages/theme-base/scripts/generateIcons.js
+++ b/packages/theme-base/scripts/generateIcons.js
@@ -1,0 +1,40 @@
+const glob = require('glob');
+const fs = require('fs-extra');
+const {pascalCase} = require('change-case');
+
+const dirPath = `dist/react/`;
+fs.removeSync(dirPath); // we could also do this in an npm script with rimraf
+
+const iconNames = [];
+
+// we should probably use path.resolve and __dirname here I think
+// in case we run the npm from the root or this package
+glob("../../material-design-icons/src/**/materialicons/*.svg", function (er, files) {
+  
+  files.forEach(filePath => {
+    const iconName = `Icon${pascalCase(filePath.split('/')[5])}`;
+    const source = fs.readFileSync(filePath, {encoding:'utf8'});
+    const outputPath = `${dirPath}${iconName}.jsx`;
+
+    // apparently there are some duplicates?
+    if (iconNames.indexOf(iconName) >= 0) {
+      return;
+    }
+    
+    const reactCode = `import React from 'react';
+export const ${iconName} = () => {
+  return (
+    ${source.replace('<path d="M0 0h24v24H0V0z" fill="none"/>','')}
+  )
+};`
+    fs.ensureDirSync(dirPath);
+    fs.writeFileSync(outputPath, reactCode);
+    iconNames.push(iconName);
+  });
+  
+  const reactCode = iconNames.map(iconName => {
+    return `export * from './${iconName}'`;
+  }).join(`\n`);
+  
+  fs.writeFileSync(`${dirPath}index.js`, reactCode);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5581,6 +5581,11 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
+async-limiter@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
 async@0.9.x:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
@@ -10098,7 +10103,7 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.6, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.6, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -18272,11 +18277,6 @@ trim@0.0.1:
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
   integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
 
-trim@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
-  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
-
 trough@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
@@ -19607,10 +19607,22 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^6.2.1, ws@^7.3.1, ws@^7.4.5, ws@^7.4.6, ws@~7.4.2:
+ws@^6.2.1:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
+  integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^7.3.1, ws@^7.4.5:
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.2.tgz#09cc8fea3bec1bc5ed44ef51b42f945be36900f6"
   integrity sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==
+
+ws@~7.4.2:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* I moved the icon generation to the 'theme-base' package because we will probably want to do similar things to generate icons for Angular, Vue, and other platforms eventually. The icon build script generates 1 jsx file per icon that looks like this:

```js
import React from 'react';
export const Icon1k = () => {
  return (
    <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-8.5 12H9v-4.5H7.5V9h3v6zm7 0h-1.75L14 12.75V15h-1.5V9H14v2.25L15.75 9h1.75l-2.25 3 2.25 3z"/></svg>
  )
};
```

I think we might need to edit the output a bit and remove the width and height attributes on the svg element so that it can be sized properly and we might want to add a className on there somewhere, but it is a start. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
