### PR TITLE
Fix phone parsing error in sign up

### DIFF
--- a/packages/core/src/authMachine.ts
+++ b/packages/core/src/authMachine.ts
@@ -1,12 +1,7 @@
 import { get } from "lodash";
 import { Auth, Amplify } from "aws-amplify";
 import { Machine, assign } from "xstate";
-import {
-  AuthChallengeNames,
-  AuthContext,
-  AuthEvent,
-  AuthFormData,
-} from "./types";
+import { AuthChallengeNames, AuthContext, AuthEvent } from "./types";
 import { passwordMatches, runValidators } from "./validators";
 
 export const authMachine = Machine<AuthContext, AuthEvent>(


### PR DESCRIPTION
*Issue #, if available:* [82](https://github.com/aws-amplify/amplify-ui/issues/82)

*Description of changes:* As part of [PR 63](https://github.com/aws-amplify/amplify-ui/pull/63), a bug was introduced in the `signUp` service of the Auth Machine where a `primaryAlias` of `phone_number` would not be parsed correctly. This PR parses the `phone_number` from the `formValues` submitted by an end user during sign up before breaking out the `primaryAlias` used for signing up.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
