### PR TITLE
fix typescript union type error message

### DIFF
--- a/packages/react/src/primitives/shared/utils.ts
+++ b/packages/react/src/primitives/shared/utils.ts
@@ -16,7 +16,7 @@ export const convertStylePropsToStyleObj = (props: AllStyleProps) => {
       (typeof stylePropValue !== 'string' || strHasLength(stylePropValue))
     ) {
       const reactStyleProp = ComponentPropsToStylePropsMap[stylePropKey];
-      style[reactStyleProp] = stylePropValue;
+      style = {...style, [reactStyleProp]: stylePropValue };
     }
   });
   return style;


### PR DESCRIPTION
*Description of changes:*
Fixes TS build error:
```
error TS2590: Expression produces a union type that is too complex to represent.
```
I believe this error was caused by the way Typescript compares types when doing assignment (creating a overly complex union type). By building a new object with `style` spread into it and the new key:value pair, I think we prevent the union type from getting too large.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
