### PR TITLE
Vue: Not confirmed email/phone won't allow you to continue on Confirm Sign Up page 

### DIFF
--- a/packages/vue/src/components/confirm-sign-up.vue
+++ b/packages/vue/src/components/confirm-sign-up.vue
@@ -108,7 +108,10 @@ export default defineComponent({
       value: { context },
     } = state;
 
-    const [primaryAlias] = useAliases(context?.config?.login_mechanisms);
+    let [primaryAlias] = useAliases(context?.config?.login_mechanisms);
+    if (!context?.formValues?.confirm_password) {
+      primaryAlias = 'username';
+    }
 
     //computed properties
 


### PR DESCRIPTION
*Issue #, if available:*

Steps To Reproduce:
1. Create a new account with email
2. Don't confirm the email address on the `Confirm Sign Up Page` (Refresh Page)
3. Log back in with the new email user
4. The `Confirm Sign Up` page appears, but the username box is empty and won't allow you to enter anything

*Description of changes:*

I noticed this bug, and i realized that my logic to pass the data from the formValues was incorrect for Phone or Email. This PR fixes that. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
