### PR TITLE
fix vscode settings and change theme scripts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "editor.insertSpaces": false,
+  "editor.insertSpaces": true,
   "files.insertFinalNewline": true,
   "prettier.requireConfig": true,
   "typescript.tsdk": "node_modules/typescript/lib",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "install": "yarn run build:theme-base",
+    "install": "yarn run theme-base build:all",
     "postinstall": "patch-package",
     "build": "yarn workspaces run build",
     "angular": "yarn workspace @aws-amplify/ui-angular",

--- a/packages/theme-base/package.json
+++ b/packages/theme-base/package.json
@@ -8,7 +8,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn run build:sd; yarn run build:css; yarn run build:icons",
+    "build": "yarn run build:sd; yarn run build:css",
+    "build:all": "yarn run build; yarn run build:icons",
     "build:icons": "yarn run clean:icons && node scripts/generateIcons.js",
     "build:sd": "style-dictionary build --config ./sd.config.js",
     "build:css": "globcat src/css/theme.css dist/variables.css src/css/**/*.css --output dist/theme.css",


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* 
* Changing editor.insertSpaces to true
* Adding a `build:all` script in theme-base which builds the icons and removing icon building from `build` so we can speed up the turn around time for building the theme considering we don't need to re-build the icons every time. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
