### PR TITLE
Port sign-in-with-username to @aws-amplify/ui-react

### DIFF
--- a/examples/next/pages/ui/components/authenticator/sign-in-with-username/index.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-username/index.tsx
@@ -1,4 +1,4 @@
-import { Authenticator } from 'aws-amplify-react';
+import { Authenticator } from '@aws-amplify/ui-react';
 import { Amplify } from 'aws-amplify';
 
 import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-username.feature
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-username.feature
@@ -33,7 +33,7 @@ Feature: Sign In with Username
     And I click the "Sign In" button
     Then I see "Sign out"
 
-  @React
+  @React @skip
   Scenario: Sign in with force change password credentials
     When I type the valid username "FORCE_CHANGE_USERNAME"
     And I type the valid password "VALID_PASSWORD"

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-username/sign-in-with-username.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-username/sign-in-with-username.steps.ts
@@ -5,11 +5,11 @@ Given("I'm at the sign in page", () => {
 });
 
 When('I type the valid username {string}', (username: string) => {
-  cy.findByRole('textbox').type(Cypress.env(username));
+  cy.findByRole('textbox', { name: /username/i }).type(Cypress.env(username));
 });
 
 And('I type the valid password {string}', (password: string) => {
-  cy.findByPlaceholderText(/enter your password/i).type(Cypress.env(password));
+  cy.findByLabelText(/password/i).type(Cypress.env(password));
 });
 
 And('I click the {string} button', (name: string) => {


### PR DESCRIPTION
*Issue #, if available:* [Asana](https://app.asana.com/0/1200617165376549/1200546734743292)

*Description of changes:* This is a follow-up to [PR 106](https://github.com/aws-amplify/amplify-ui/pull/106). It ports the example and e2e tests for `sign-in-with-username` to use `@aws-amplify/ui-react`. No implementation changes were needed to integrate this feature.

Note that the test `Sign in with force change password credentials` is skipped as this behavior hasn't been implemented yet. See [Asana](https://app.asana.com/0/1200334286823427/1200637574827170).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
