### PR TITLE
Add instructions for sign in screen workaround when pulling

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -13,7 +13,7 @@ Within [/environments](/environments), there are pre-built backend environments 
 
 This will create a `src/aws-exports.js` for use in your testing.
 
-_Note: If you are taken to a sign in screen when pulling an environment with `amplify pull`, you can workaround this by first visiting the Amplify Admin UI for that environment ([example](https://us-east-1.admin.amplifyapp.com/admin/dbffpda9986dp/staging/home))and then attempting to pull it again._
+_Note: If you are taken to a sign in screen when pulling an environment with `amplify pull`, you can workaround this by first visiting the Amplify Admin UI for that environment ([example](https://us-east-1.admin.amplifyapp.com/admin/dbffpda9986dp/staging/home)) and then attempting to pull it again._
 
 ## Creating a Backend Environment
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Sometimes, when pulling an example environment using `amplify pull`, you're directed to a sign in screen and the pulling won't progress. A workaround to this issue is visiting that environment's Amplify Admin UI in from Isengard then attempting to pull the environment again with `amplify pull`. This PR just adds that note to `README.md` in the `environments/` directory.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
