### PR TITLE
Separate id and testid, update View types

### DIFF
--- a/packages/react/src/primitives/Badge/__tests__/Badge.test.tsx
+++ b/packages/react/src/primitives/Badge/__tests__/Badge.test.tsx
@@ -27,7 +27,7 @@ describe('Badge: ', () => {
 
   it('can render any arbitrary data-* attribute', async () => {
     render(
-      <Badge data-demo="true" id="dataTest">
+      <Badge data-demo="true" testId="dataTest">
         {badgeText}
       </Badge>
     );

--- a/packages/react/src/primitives/Card/__test__/Card.test.tsx
+++ b/packages/react/src/primitives/Card/__test__/Card.test.tsx
@@ -1,27 +1,27 @@
-import { Card } from "../Card";
-import { render, screen } from "@testing-library/react";
-import "@testing-library/jest-dom";
-import "@testing-library/jest-dom/extend-expect";
-import { ComponentClassNames } from "../../shared";
+import { Card } from '../Card';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/extend-expect';
+import { ComponentClassNames } from '../../shared';
 
-describe("Card component", () => {
-  it("can render custom classnames", async () => {
-    render(<Card className="custom-classname" id="cardId"></Card>);
+describe('Card component', () => {
+  it('can render custom classnames', async () => {
+    render(<Card className="custom-classname" testId="cardId"></Card>);
 
-    const card = await screen.findByTestId("cardId");
-    expect(card.className).toContain("custom-classname");
+    const card = await screen.findByTestId('cardId');
+    expect(card.className).toContain('custom-classname');
     expect(card.className).toContain(ComponentClassNames.Card);
   });
 
-  it("can render any arbitrary data-* attribute", async () => {
-    render(<Card data-demo="true" id="cardId"></Card>);
-    const card = await screen.findByTestId("cardId");
-    expect(card.dataset["demo"]).toBe("true");
+  it('can render any arbitrary data-* attribute', async () => {
+    render(<Card data-demo="true" testId="cardId"></Card>);
+    const card = await screen.findByTestId('cardId');
+    expect(card.dataset['demo']).toBe('true');
   });
 
-  it("can render <section> tag", async () => {
-    render(<Card as="section" id="cardId"></Card>);
-    const card = await screen.findByTestId("cardId");
-    expect(card.nodeName).toBe("SECTION");
+  it('can render <section> tag', async () => {
+    render(<Card as="section" testId="cardId"></Card>);
+    const card = await screen.findByTestId('cardId');
+    expect(card.nodeName).toBe('SECTION');
   });
 });

--- a/packages/react/src/primitives/Collection/__tests__/Collection.test.tsx
+++ b/packages/react/src/primitives/Collection/__tests__/Collection.test.tsx
@@ -27,7 +27,7 @@ describe('Collection component', () => {
 
   it('should render Flex when rendering list collection', async () => {
     render(
-      <Collection id={testList} type="list" items={emojis}>
+      <Collection testId={testList} type="list" items={emojis}>
         {(item, index) => (
           <div key={index} aria-label={item.title}>
             {item.emoji}
@@ -48,7 +48,7 @@ describe('Collection component', () => {
     render(
       <Collection
         className="custom-collection"
-        id={testList}
+        testId={testList}
         type="list"
         items={emojis}
       >
@@ -68,7 +68,7 @@ describe('Collection component', () => {
       <Collection
         className="custom-collection"
         data-demo={true}
-        id={testList}
+        testId={testList}
         type="list"
         items={emojis}
       >

--- a/packages/react/src/primitives/Flex/__tests__/Flex.test.tsx
+++ b/packages/react/src/primitives/Flex/__tests__/Flex.test.tsx
@@ -59,7 +59,7 @@ describe('Flex: ', () => {
 
   it('can render any arbitrary data-* attribute', async () => {
     render(
-      <Flex data-demo="true" id="dataTest">
+      <Flex data-demo="true" testId="dataTest">
         {flexText}
       </Flex>
     );

--- a/packages/react/src/primitives/Icon/__tests__/Icon.test.tsx
+++ b/packages/react/src/primitives/Icon/__tests__/Icon.test.tsx
@@ -1,41 +1,48 @@
-import { render, screen } from "@testing-library/react";
-import "@testing-library/jest-dom";
-import "@testing-library/jest-dom/extend-expect";
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/extend-expect';
 
-import { Icon } from "../Icon";
-import { ComponentClassNames } from "../../shared";
+import { Icon } from '../Icon';
+import { ComponentClassNames } from '../../shared';
 
-describe("Icon component", () => {
-  const iconTestId = "iconSearch";
-  const pathData = `M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 
-  3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 
+describe('Icon component', () => {
+  const iconTestId = 'iconSearch';
+  const pathData = `M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91
+  3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49
   19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z`;
 
-  it("should render <svg> with default attributes", async () => {
-    render(<Icon id={iconTestId} pathData={pathData} ariaLabel="Search" />);
+  it('should render <svg> with default attributes', async () => {
+    render(
+      <Icon
+        id={iconTestId}
+        testId={iconTestId}
+        pathData={pathData}
+        ariaLabel="Search"
+      />
+    );
 
     const icon = await screen.findByTestId(iconTestId);
     expect(icon.id).toBe(iconTestId);
-    expect(icon.nodeName).toBe("svg");
-    expect(icon.dataset["size"]).toBe("medium");
-    expect(icon.getAttribute("viewBox")).toBe("0 0 24 24");
+    expect(icon.nodeName).toBe('svg');
+    expect(icon.dataset['size']).toBe('medium');
+    expect(icon.getAttribute('viewBox')).toBe('0 0 24 24');
     expect(icon.classList[0]).toContain(ComponentClassNames.Icon);
   });
 
-  it("should render <path> with provided path data", async () => {
-    render(<Icon id={iconTestId} pathData={pathData} ariaLabel="Search" />);
+  it('should render <path> with provided path data', async () => {
+    render(<Icon testId={iconTestId} pathData={pathData} ariaLabel="Search" />);
 
     const icon = await screen.findByTestId(iconTestId);
     expect(icon.childNodes.length).toBe(1);
     const path = icon.childNodes[0] as SVGElement;
-    expect(path.getAttribute("d")).toBe(pathData);
-    expect(path.getAttribute("fill")).toBe("currentColor");
+    expect(path.getAttribute('d')).toBe(pathData);
+    expect(path.getAttribute('fill')).toBe('currentColor');
   });
 
-  it("should render a classname for Icon", async () => {
+  it('should render a classname for Icon', async () => {
     render(
       <Icon
-        id={iconTestId}
+        testId={iconTestId}
         pathData={pathData}
         className="my-icon-component"
         ariaLabel="Search"
@@ -45,13 +52,13 @@ describe("Icon component", () => {
     const icon = await screen.findByTestId(iconTestId);
     expect(icon.classList.length).toBe(2);
     expect(icon.classList[0]).toContain(ComponentClassNames.Icon);
-    expect(icon.classList[1]).toContain("my-icon-component");
+    expect(icon.classList[1]).toContain('my-icon-component');
   });
 
-  it("can set data-size attribute", async () => {
+  it('can set data-size attribute', async () => {
     render(
       <Icon
-        id={iconTestId}
+        testId={iconTestId}
         pathData={pathData}
         size="small"
         ariaLabel="Search"
@@ -59,13 +66,13 @@ describe("Icon component", () => {
     );
 
     const icon = await screen.findByTestId(iconTestId);
-    expect(icon.dataset["size"]).toBe("small");
+    expect(icon.dataset['size']).toBe('small');
   });
 
-  it("can set viewBox attribute", async () => {
+  it('can set viewBox attribute', async () => {
     render(
       <Icon
-        id={iconTestId}
+        testId={iconTestId}
         pathData={pathData}
         viewBox={{ minX: 0, minY: 0, width: 100, height: 100 }}
         ariaLabel="Search"
@@ -73,6 +80,6 @@ describe("Icon component", () => {
     );
 
     const icon = await screen.findByTestId(iconTestId);
-    expect(icon.getAttribute("viewBox")).toBe("0 0 100 100");
+    expect(icon.getAttribute('viewBox')).toBe('0 0 100 100');
   });
 });

--- a/packages/react/src/primitives/Image/__tests__/Image.test.tsx
+++ b/packages/react/src/primitives/Image/__tests__/Image.test.tsx
@@ -27,7 +27,7 @@ describe('Image: ', () => {
     const htmlWidth = 480;
     render(
       <Image
-        id="dataTest"
+        testId="dataTest"
         alt={altText}
         src={src}
         srcSet={srcSet}
@@ -79,7 +79,7 @@ describe('Image: ', () => {
   });
 
   it('can render any arbitrary data-* attribute', async () => {
-    render(<Image data-cat="true" id="dataTest" alt={altText} src={src} />);
+    render(<Image data-cat="true" testId="dataTest" alt={altText} src={src} />);
     const image = await screen.findByTestId('dataTest');
     expect(image.dataset['cat']).toBe('true');
   });
@@ -94,7 +94,7 @@ describe('Image: ', () => {
         opacity="0.5"
         objectFit="cover"
         objectPosition="top left"
-        id="stylingTest"
+        testId="stylingTest"
       />
     );
 

--- a/packages/react/src/primitives/View/View.tsx
+++ b/packages/react/src/primitives/View/View.tsx
@@ -9,6 +9,7 @@ export const View: React.FC<ViewProps> = (props) => {
     children,
     role,
     id,
+    testId,
     ariaLabel,
     isDisabled,
     htmlWidth,
@@ -22,7 +23,7 @@ export const View: React.FC<ViewProps> = (props) => {
     <ViewTag
       aria-label={ariaLabel}
       className={className}
-      data-testid={id}
+      data-testid={testId}
       disabled={isDisabled}
       height={htmlHeight}
       id={id}

--- a/packages/react/src/primitives/View/__tests__/View.test.tsx
+++ b/packages/react/src/primitives/View/__tests__/View.test.tsx
@@ -9,9 +9,17 @@ describe('View: ', () => {
   const viewText = 'Hello from inside a view';
 
   it('renders correct defaults', async () => {
-    render(<View>{viewText}</View>);
+    const viewId = 'viewId';
+    const viewTestId = 'viewTestId';
+    render(
+      <View id={viewId} testId={viewTestId}>
+        {viewText}
+      </View>
+    );
 
     const view = await screen.findByText(viewText);
+    expect(view.id).toBe(viewId);
+    expect(view.dataset['testid']).toBe(viewTestId);
     expect(view.innerHTML).toBe(viewText);
     expect(view.nodeName).toBe('DIV');
   });
@@ -24,7 +32,7 @@ describe('View: ', () => {
 
   it('can render a <p> HTML element', async () => {
     render(
-      <View as="p" id="pTagTest">
+      <View as="p" testId="pTagTest">
         {viewText}
       </View>
     );
@@ -34,7 +42,7 @@ describe('View: ', () => {
 
   it('can render any arbitrary data-* attribute', async () => {
     render(
-      <View as="p" data-demo="true" id="dataTest">
+      <View as="p" data-demo="true" testId="dataTest">
         {viewText}
       </View>
     );
@@ -72,7 +80,7 @@ describe('View: ', () => {
 
   it('can apply styling via props', async () => {
     render(
-      <View width="100%" opacity="0.5" borderRadius="6px" id="stylingTest">
+      <View width="100%" opacity="0.5" borderRadius="6px" testId="stylingTest">
         {viewText}
       </View>
     );

--- a/packages/react/src/primitives/types/base.ts
+++ b/packages/react/src/primitives/types/base.ts
@@ -2,12 +2,20 @@ import React from 'react';
 
 // Base component definition
 export interface BaseComponentProps {
+  /**
+   * Unique identifier
+   */
   id?: string;
 
   /**
    * Additional CSS class name for component
    */
   className?: string;
+
+  /**
+   * Used to provide a `data-testid` attribute for testing purposes
+   */
+  testId?: string;
 
   /**
    * Any arbitrary props will be passed to the underlying element.

--- a/packages/react/src/primitives/types/view.ts
+++ b/packages/react/src/primitives/types/view.ts
@@ -1,7 +1,7 @@
 import { AriaProps, BaseComponentProps } from './base';
 import { BaseStyleProps } from './style';
 import { Property } from 'csstype';
-
+import { AriaRole } from 'react';
 export type ViewAsHTMLElementTypes = keyof JSX.IntrinsicElements;
 
 export interface ViewProps
@@ -10,7 +10,7 @@ export interface ViewProps
     AriaProps {
   as?: ViewAsHTMLElementTypes;
 
-  role?: string;
+  role?: AriaRole;
 
   isDisabled?: boolean;
 


### PR DESCRIPTION
*Description of changes:*
This PR adds a `testId` prop, mapping it separately from `id` to the `data-testid` attribute (which is needed for testing in react testing library).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
