### PR TITLE
feat: show error message on mfa code screen

### DIFF
--- a/packages/core/src/authMachine.ts
+++ b/packages/core/src/authMachine.ts
@@ -156,6 +156,7 @@ export const authMachine = Machine<AuthContext, AuthEvent>(
             },
           },
           submit: {
+            entry: 'clearError',
             invoke: {
               src: 'confirmSignIn',
               onDone: {

--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -25,7 +25,7 @@ export const ConfirmSignIn = (): JSX.Element => {
     send,
   };
 
-  const { challengeName } = state.context;
+  const { challengeName, remoteError } = state.context;
   let mfaType: string = 'SMS';
   if (challengeName === AuthChallengeNames.SOFTWARE_TOKEN_MFA) {
     mfaType = 'TOTP';
@@ -53,7 +53,10 @@ export const ConfirmSignIn = (): JSX.Element => {
 
       <Fieldset disabled={isPending}>
         <Label data-amplify-confirmationcode>
-          <ConfirmationCodeInput amplifyNamespace={amplifyNamespace} />
+          <ConfirmationCodeInput
+            amplifyNamespace={amplifyNamespace}
+            errorText={remoteError}
+          />
         </Label>
       </Fieldset>
 

--- a/packages/react/src/components/Authenticator/shared/ConfirmationCodeInput.tsx
+++ b/packages/react/src/components/Authenticator/shared/ConfirmationCodeInput.tsx
@@ -2,6 +2,7 @@ import { useAmplify } from '@aws-amplify/ui-react';
 
 export interface ConfirmationCodeInputProps {
   amplifyNamespace: string;
+  errorText?: string;
   label?: string;
   placeholder?: string;
   required?: boolean;
@@ -12,6 +13,7 @@ export const ConfirmationCodeInput = (
 ): JSX.Element => {
   const {
     amplifyNamespace,
+    errorText,
     label = 'Code *',
     placeholder = 'Code',
     required = true,
@@ -19,6 +21,12 @@ export const ConfirmationCodeInput = (
   const {
     components: { Input, Text },
   } = useAmplify(amplifyNamespace);
+
+  const errorTextComponent = errorText ? (
+    <Text data-amplify-confirmation-code-error-text variant="error">
+      {errorText}
+    </Text>
+  ) : null;
 
   return (
     <>
@@ -30,6 +38,7 @@ export const ConfirmationCodeInput = (
         required={required}
         type="text"
       />
+      {errorTextComponent}
     </>
   );
 };


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

Show the error message when Cognito returns an error upon MFA confirmation code submission. The error message shown for now is just what Cognito returns. We can always update this with customer error messages of our own later on.

<img width="482" alt="Screen Shot 2021-07-22 at 11 40 56 AM" src="https://user-images.githubusercontent.com/17255334/126691851-39f7b4fc-1723-4fc7-90d5-a0a0c8012daa.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
