### PR TITLE
Add post-merge githook to run yarn install

### DIFF
--- a/.husky/common.sh
+++ b/.husky/common.sh
@@ -1,0 +1,10 @@
+# This fixes an issue running Yarn on Windows
+# @see https://typicode.github.io/husky/#/?id=yarn-on-windows
+command_exists () {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Workaround for Windows 10, Git Bash and Yarn
+if command_exists winpty && test -t 1; then
+  exec < /dev/tty
+fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+. "$(dirname "$0")/common.sh"
+
+yarn install


### PR DESCRIPTION
*Description of changes:*
This adds a [post-merge](https://git-scm.com/docs/githooks#_post_merge) git hook which runs `yarn install`.

*Tested by pulling a remote commit:*
```
➜  amplify-ui git:(postMergeHook) git pull upstream postMergeHook 
From github.com:aws-amplify/amplify-ui
 * branch              postMergeHook -> FETCH_HEAD
Updating f47705fd..6cd1bf9d
Fast-forward
 CONTRIBUTING.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
yarn install v1.22.10
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
