### PR TITLE
fix: fixing the way we import View primitive in some primitives

### DIFF
--- a/packages/react/src/primitives/Badge/Badge.tsx
+++ b/packages/react/src/primitives/Badge/Badge.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentClassNames } from '../shared/constants';
 import classNames from 'classnames';
 import { BadgeProps } from '../types';
-import { View } from '@aws-amplify/ui-react';
+import { View } from '../View';
 
 export const Badge: React.FC<BadgeProps> = ({
   className,

--- a/packages/react/src/primitives/Card/Card.tsx
+++ b/packages/react/src/primitives/Card/Card.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 import { ComponentClassNames } from '../shared/constants';
 import { CardProps } from '../types/card';
-import { View } from '@aws-amplify/ui-react';
+import { View } from '../View';
 
 export const Card: React.FC<CardProps> = ({ className, children, ...rest }) => {
   return (

--- a/packages/react/src/primitives/Heading/Heading.tsx
+++ b/packages/react/src/primitives/Heading/Heading.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentClassNames } from '../shared/constants';
 import classNames from 'classnames';
 import { HeadingProps } from '../types';
-import { View } from '@aws-amplify/ui-react';
+import { View } from '../View';
 
 interface HeadingLevels {
   [key: number]: keyof JSX.IntrinsicElements;

--- a/packages/react/src/primitives/Text/Text.tsx
+++ b/packages/react/src/primitives/Text/Text.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 import { ComponentClassNames } from '../shared/constants';
 import { TextProps } from '../types/text';
-import { View } from '@aws-amplify/ui-react';
+import { View } from '../View';
 
 export const Text: React.FC<TextProps> = (props) => {
   const {


### PR DESCRIPTION
*Issue #, if available:*

Some unit tests will emit wired console errors from `@aws-amplify/auth/lib/Auth.js` that are not related to the component itself, though the tests passed.
```
  ● Console

    console.error
Error: ERROR] 58:***2.73*** AuthError - 
                  Error: Amplify has not been configured correctly. 
                  The configuration object is missing required auth properties.
                  This error is typically caused by one of the following scenarios:
      
                  ***. Did you run `amplify push` after adding auth via `amplify add auth`?
                      See https://aws-amplify.github.io/docs/js/authentication#amplify-project-setup for more information
      
                  2. This could also be caused by multiple conflicting versions of amplify packages, see (https://docs.amplify.aws/lib/troubleshooting/upgrading/q/platform/js) for help upgrading Amplify packages.

      at ConsoleLogger.Object.<anonymous>.ConsoleLogger._log (../../node_modules/@aws-amplify/core/src/Logger/ConsoleLogger.ts:***5:4)
      at ConsoleLogger.Object.<anonymous>.ConsoleLogger.error (../../node_modules/@aws-amplify/core/src/Logger/ConsoleLogger.ts:***74:***2)
      at NoUserPoolError.AuthError [as constructor] (../../node_modules/@aws-amplify/auth/src/Errors.ts:34:***0)
      at new NoUserPoolError (../../node_modules/@aws-amplify/auth/src/Errors.ts:40:3)
      at AuthClass.Object.<anonymous>.AuthClass.rejectNoUserPool (../../node_modules/@aws-amplify/auth/src/Auth.ts:2208:25)
      at AuthClass.Object.<anonymous>.AuthClass.currentUserPoolUser (../../node_modules/@aws-amplify/auth/src/Auth.ts:***207:***6)
      at AuthClass.<anonymous> (../../node_modules/@aws-amplify/auth/src/Auth.ts:***373:23)
      at step (../../node_modules/@aws-amplify/auth/lib/Auth.js:56:23)
```

*Description of changes:*

This happened in the primitives where we import the `<View>`  from node module `@aws-amplify/ui-react`  instead of straight from within the package `../View`. The console errors disappeared after I made the change correspondingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
