### PR TITLE
Add git command as a fallback for the icon update script

### DIFF
--- a/packages/react/scripts/updateIcons.js
+++ b/packages/react/scripts/updateIcons.js
@@ -5,8 +5,30 @@ const { execSync } = require('child_process');
 const dirPath = '../../material-design-icons';
 
 fs.ensureDirSync(dirPath);
-chdir(dirPath);
-execSync(
-  'svn export --force https://github.com/google/material-design-icons/trunk/src svg',
-  { encoding: 'utf8', stdio: 'inherit' }
-);
+try {
+  execSync('which svn');
+  chdir(dirPath);
+  execSync(
+    'svn export --force https://github.com/google/material-design-icons/trunk/src svg',
+    { encoding: 'utf8', stdio: 'inherit' }
+  );
+} catch (e) {
+  console.log(
+    `${e.message}. The script requires svn installed. Fallback to use git instead.`
+  );
+  execSync('mkdir tmp');
+  chdir('./tmp');
+  execSync('git init -b master');
+  execSync(
+    'git remote add origin git@github.com:google/material-design-icons.git'
+  );
+  execSync('git config core.sparseCheckout true');
+  execSync('echo "src/*" >> .git/info/sparse-checkout');
+  execSync('git fetch origin master');
+  execSync('git merge origin/master');
+  const destDirPath = `../${dirPath}/svg`;
+  fs.ensureDirSync(destDirPath);
+  execSync(`cp -R src/* ${destDirPath}`);
+  execSync('rm -rf ../tmp');
+  console.log('Please install svn to reduce the script runtime.');
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR will be adding git command as a fallback for the icon update script.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
