### PR TITLE
Adding banner to the docs

### DIFF
--- a/docs/src/components/Layout/Banner.tsx
+++ b/docs/src/components/Layout/Banner.tsx
@@ -1,0 +1,10 @@
+import * as react from 'react';
+
+export const Banner = () => (
+  <div className="developer-preview-banner">
+    ⚠️ These docs are a developer preview for the upcoming major version of the
+    Amplify UI packages <em>only</em>. They are very much a work-in-progress. If
+    you stumbled on here by accident and want to find the current stable docs
+    head to <a href="https://docs.amplify.aws/ui">docs.amplify.aws/ui</a>
+  </div>
+);

--- a/docs/src/components/Layout/index.tsx
+++ b/docs/src/components/Layout/index.tsx
@@ -39,6 +39,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import * as React from 'react';
 import { PlatformSelect } from './PlatformSelect';
+import { Banner } from './Banner';
 
 export default function Layout({
   children,
@@ -146,6 +147,7 @@ export default function Layout({
           />
         </Head>
       )}
+      <Banner />
       <UniversalNav
         heading="Amplify Docs"
         brandIcon="/assets/logo-light.svg"

--- a/docs/src/styles/styles.css
+++ b/docs/src/styles/styles.css
@@ -39,3 +39,11 @@ a > h3::before {
   content: '#';
   @apply absolute -ml-5 text-amazon;
 }
+
+.developer-preview-banner {
+  padding: 2rem;
+  background-color: var(--color-ink-hv);
+  color: white;
+  font-size: 1.5rem;
+  line-height: 1.5;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adding a banner to the ui docs site to let users know this is a developer preview and to head to the production docs site for everything else. Suggestions on styling/content/etc. encouraged!

<img width="1439" alt="CleanShot 2021-08-05 at 09 41 14@2x" src="https://user-images.githubusercontent.com/321279/128388312-7827c8bc-577e-471b-bd09-19e6b02b87e0.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
