### PR TITLE
Fix vue-example workspace name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "angular-docs": "yarn workspace angular-docs",
     "docs": "yarn workspace docs",
     "next-example": "yarn workspace next-example",
-    "vue-example": "yarn workspace vue-exmaple",
+    "vue-example": "yarn workspace vue-example",
     "e2e": "yarn workspace e2e",
     "build:icons": "yarn react build:icons",
     "build:angular": "yarn angular build",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixing a typo with the `vue-example` workspace name in our `package.json`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
