### PR TITLE
Explicitly exclude aws-amplify modules

### DIFF
--- a/packages/core/tsup.config.cjs
+++ b/packages/core/tsup.config.cjs
@@ -5,6 +5,6 @@ module.exports = {
   dts: true,
   entryPoints: ['src/index.ts'],
   format: ['cjs', 'esm'],
-  sourcemap: 'both',
+  sourcemap: 'external',
   splitting: false,
 };

--- a/packages/react/tsup.config.cjs
+++ b/packages/react/tsup.config.cjs
@@ -7,6 +7,6 @@ module.exports = {
   // `aws-amplify` is external, but sub-dependencies weren't automatically externalized ("require" statements were included)
   external: ['`aws-amplify', /^@aws-amplify\//],
   format: ['cjs', 'esm'],
-  sourcemap: 'both',
+  sourcemap: 'external',
   splitting: false,
 };

--- a/packages/react/tsup.config.cjs
+++ b/packages/react/tsup.config.cjs
@@ -4,6 +4,8 @@
 module.exports = {
   dts: true,
   entryPoints: ['src/index.tsx'],
+  // `aws-amplify` is external, but sub-dependencies weren't automatically externalized ("require" statements were included)
+  external: ['`aws-amplify', /^@aws-amplify\//],
   format: ['cjs', 'esm'],
   sourcemap: 'both',
   splitting: false,


### PR DESCRIPTION
Fixes <img width="974" alt="Screen Shot 2021-08-20 at 5 24 01 PM" src="https://user-images.githubusercontent.com/15182/130464680-e3620b92-15f3-4743-9397-6076ee628b2e.png">


*Description of changes:*

- [x] Explicitly prevent `aws-amplify` and `@aws-amplify/*` from being bundled
- [x] Only generate `.map` files for sourcemaps


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
