### PR TITLE
chore: prevent commit to main

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,7 @@
 branch="$(git branch --show-current)"
 
 if [ "$branch" = "main" ]; then
-  echo "Direct commits to main branch is not allowed."
+  echo "Direct commits to main branch are not allowed."
   exit 1
 fi
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,8 @@
 #!/bin/sh
-branch="$(git rev-parse --abbrev-ref HEAD)"
+branch="$(git branch --show-current)"
 
 if [ "$branch" = "main" ]; then
-  echo "You can't commit directly to main branch"
+  echo "Direct commits to main branch is not allowed."
   exit 1
 fi
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,11 @@
 #!/bin/sh
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "main" ]; then
+  echo "You can't commit directly to main branch"
+  exit 1
+fi
+
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*  This additional shell commands prevent committing to main by mistake. If you need to bypass this hook for whatever reason, then you can do so via git commit --no-verify.

![Screen Shot 2021-08-24 at 3 04 49 PM](https://user-images.githubusercontent.com/43682783/130696383-3c18c072-7d7c-453d-bf32-2f6e10ea3068.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
