### PR TITLE
fix(core): set unverified attribute when verification is prompted

### DIFF
--- a/packages/core/src/machines/actors/auth/signIn.ts
+++ b/packages/core/src/machines/actors/auth/signIn.ts
@@ -87,6 +87,7 @@ export const signInActor = createMachine<SignInContext, AuthEvent>(
                 {
                   cond: 'shouldRequestVerification',
                   target: '#signInActor.verifyUser',
+                  actions: 'setUnverifiedAttributes',
                 },
                 {
                   target: 'resolved',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This calls `setUnverifiedAttributes` action when verification is triggered in state machine.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
