### PR TITLE
build(vue): declaration file type conflict

### DIFF
--- a/packages/core/src/types/authMachine.ts
+++ b/packages/core/src/types/authMachine.ts
@@ -33,7 +33,6 @@ export interface SignUpContext {
   login_mechanisms?: string[];
   intent?: string;
   authAttributes?: Record<string, any>;
-  challengeName?: string;
 }
 
 export interface ResetPasswordContext {
@@ -44,13 +43,11 @@ export interface ResetPasswordContext {
   intent?: string;
   user?: CognitoUserAmplify;
   authAttributes?: Record<string, any>;
-  challengeName?: string;
 }
 
 export interface SignOutContext {
   user?: CognitoUserAmplify;
   authAttributes?: Record<string, any>;
-  challengeName?: string;
 }
 
 // actors that have forms. Has `formValues, remoteErrror, and validationError in common.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Following up https://github.com/aws-amplify/amplify-ui/pull/310#discussion_r698049403. Opened this pr for mainly ci checks and keeping track of progress.

Error we get is: 
```
[rpt2] /home/runner/work/amplify-ui/amplify-ui/packages/vue/src/components/confirm-sign-in.vue?vue&type=script&lang.ts(37,52): semantic error TS2339: Property 'challengeName' does not exist on type 'AuthActorContext'.
```

although we assert `ActorContext` to be `SignInContext` here:https://github.com/aws-amplify/amplify-ui/blob/64ef5f95e3d125b82ec8970f78b5b12f8b6213cf/packages/vue/src/components/confirm-sign-in.vue#L93-L95



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
