### PR TITLE
VisuallyHidden Primitive

### DIFF
--- a/docs/src/pages/ui/primitives/visuallyHidden/index.page.mdx
+++ b/docs/src/pages/ui/primitives/visuallyHidden/index.page.mdx
@@ -1,0 +1,7 @@
+---
+title: VisuallyHidden
+---
+
+import { Fragment } from '@/components/Fragment';
+
+<Fragment>{({ platform }) => import(`./${platform}.mdx`)}</Fragment>

--- a/docs/src/pages/ui/primitives/visuallyHidden/react.mdx
+++ b/docs/src/pages/ui/primitives/visuallyHidden/react.mdx
@@ -1,0 +1,25 @@
+import { Button, IconDone, VisuallyHidden } from '@aws-amplify/ui-react';
+import { Example } from '@/components/Example';
+
+`VisuallyHidden` is a common techinique used in web accessibility to hide content from the visual client, but keep it readable for screen readers.
+
+## Usage
+
+Import the `VisuallyHidden` primitive and styles.
+
+```jsx
+import { Button, IconDone, VisuallyHidden } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+<Button variation="primary">
+  <VisuallyHidden>Donemark</VisuallyHidden>
+  <IconDone size="large" />
+</Button>;
+```
+
+<Example>
+  <Button variation="primary">
+    <VisuallyHidden>Donemark</VisuallyHidden>
+    <IconDone size="large" />
+  </Button>
+</Example>

--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -1857,6 +1857,7 @@ Array [
   "Spacer",
   "Text",
   "View",
+  "VisuallyHidden",
   "Wrapper",
   "components",
   "convertStylePropsToStyleObj",

--- a/packages/react/src/primitives/Pagination/PaginationItem.tsx
+++ b/packages/react/src/primitives/Pagination/PaginationItem.tsx
@@ -2,9 +2,9 @@ import React, { useCallback } from 'react';
 
 import { Button } from '../Button';
 import { Flex } from '../Flex';
-import { Text } from '../Text';
-import { View } from '../View';
 import { IconChevronLeft, IconChevronRight } from '../Icon';
+import { View } from '../View';
+import { VisuallyHidden } from '../VisuallyHidden';
 import { PaginationItemProps } from '../types/pagination';
 
 export const PaginationItem: React.FC<PaginationItemProps> = (props) => {
@@ -30,9 +30,7 @@ export const PaginationItem: React.FC<PaginationItemProps> = (props) => {
                * Use markup to indicate the current item of a menu, such as the current page on a website, to improve orientation in the menu.
                * @link https://www.w3.org/WAI/tutorials/menus/structure/#indicate-the-current-item
                */}
-              <Text as="span" className="visuallyhidden">
-                Current Page:
-              </Text>
+              <VisuallyHidden>Current Page:</VisuallyHidden>
               {page}
             </Flex>
           ) : (

--- a/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
@@ -205,7 +205,7 @@ describe('Pagination component test suite', () => {
       expect(pageItem.nodeName).toBe('SPAN');
       expect(pageItem).toHaveClass('current');
       const invisibleLabel = await screen.findByText('Current Page:');
-      expect(invisibleLabel).toHaveClass('visuallyhidden');
+      expect(invisibleLabel).toHaveClass(ComponentClassNames.VisuallyHidden);
 
       userEvent.click(pageItem);
       expect(mockOnClick).not.toHaveBeenCalled();

--- a/packages/react/src/primitives/Rating/Rating.tsx
+++ b/packages/react/src/primitives/Rating/Rating.tsx
@@ -5,8 +5,8 @@ import { RatingProps } from '../types';
 import { RatingIcon } from './RatingIcon';
 import { RatingMixedIcon } from './RatingMixedIcon';
 import { Flex } from '../Flex';
-import { Text } from '../Text';
 import { IconStar } from '../Icon';
+import { VisuallyHidden } from '../VisuallyHidden';
 import { isIconFilled, isIconEmpty, isIconMixed } from './utils';
 
 const RATING_DEFAULT_MAX_VALUE = 5;
@@ -63,9 +63,9 @@ export const Rating: React.FC<RatingProps> = (props) => {
       {...rest}
     >
       {items}
-      <Text className="sr-only">
+      <VisuallyHidden>
         {value} out of {maxValue} rating
-      </Text>
+      </VisuallyHidden>
     </Flex>
   );
 };

--- a/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 
 import { View } from '../View';
@@ -6,10 +7,15 @@ import { VisuallyHiddenProps } from '../types/visuallyHidden';
 
 export const VisuallyHidden: React.FC<VisuallyHiddenProps> = ({
   children,
+  className,
   ...rest
 }) => {
   return (
-    <View as="span" className={ComponentClassNames.VisuallyHidden} {...rest}>
+    <View
+      as="span"
+      className={classNames(ComponentClassNames.VisuallyHidden, className)}
+      {...rest}
+    >
       {children}
     </View>
   );

--- a/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { View } from '../View';
+import { ComponentClassNames } from '../shared/constants';
+import { VisuallyHiddenProps } from '../types/visuallyHidden';
+
+export const VisuallyHidden: React.FC<VisuallyHiddenProps> = ({
+  children,
+  ...rest
+}) => {
+  return (
+    <View as="span" className={ComponentClassNames.VisuallyHidden} {...rest}>
+      {children}
+    </View>
+  );
+};

--- a/packages/react/src/primitives/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
+++ b/packages/react/src/primitives/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+
+import { VisuallyHidden } from '../VisuallyHidden';
+import { ComponentClassNames } from '../../shared/constants';
+
+describe('VisuallyHidden test suite', () => {
+  it('should render classname correctly', async () => {
+    const hiddenContent = 'A hidden text';
+    render(<VisuallyHidden>{hiddenContent}</VisuallyHidden>);
+
+    const visuallyHidden = await screen.findByText(hiddenContent);
+    expect(visuallyHidden).toHaveClass(ComponentClassNames.VisuallyHidden);
+  });
+});

--- a/packages/react/src/primitives/VisuallyHidden/index.ts
+++ b/packages/react/src/primitives/VisuallyHidden/index.ts
@@ -1,0 +1,1 @@
+export * from './VisuallyHidden';

--- a/packages/react/src/primitives/index.tsx
+++ b/packages/react/src/primitives/index.tsx
@@ -13,6 +13,7 @@ export * from './Placeholder';
 export * from './Rating';
 export * from './Text';
 export * from './View';
+export * from './VisuallyHidden';
 
 export * from './shared';
 export * from './types';

--- a/packages/react/src/primitives/shared/constants.ts
+++ b/packages/react/src/primitives/shared/constants.ts
@@ -14,4 +14,5 @@ export enum ComponentClassNames {
   Rating = 'amplify-rating',
   Text = 'amplify-text',
   View = 'amplify-view',
+  VisuallyHidden = 'amplify-visually-hidden',
 }

--- a/packages/react/src/primitives/types/visuallyHidden.ts
+++ b/packages/react/src/primitives/types/visuallyHidden.ts
@@ -1,0 +1,3 @@
+import { BaseComponentProps } from './base';
+
+export interface VisuallyHiddenProps extends BaseComponentProps {}

--- a/packages/ui/src/theme/css/component/pagination.scss
+++ b/packages/ui/src/theme/css/component/pagination.scss
@@ -26,11 +26,6 @@
     );
   }
 
-  .visuallyhidden {
-    position: absolute;
-    visibility: hidden;
-  }
-
   .ellipsis {
     padding-left: var(--amplify-components-pagination-ellipsis-padding-left);
     padding-right: var(--amplify-components-pagination-ellipsis-padding-right);

--- a/packages/ui/src/theme/css/component/visuallyHidden.scss
+++ b/packages/ui/src/theme/css/component/visuallyHidden.scss
@@ -1,11 +1,11 @@
 .amplify-visually-hidden {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  padding: 0 !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  white-space: nowrap !important;
-  border-width: 0 !important;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }

--- a/packages/ui/src/theme/css/component/visuallyHidden.scss
+++ b/packages/ui/src/theme/css/component/visuallyHidden.scss
@@ -1,0 +1,11 @@
+.amplify-visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border-width: 0 !important;
+}

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -17,18 +17,6 @@ html {
   all: unset; /* protect against external styles */
 }
 
-.sr-only {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  padding: 0 !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  white-space: nowrap !important;
-  border-width: 0 !important;
-}
-
 // <View>-only components
 @import './component/text.scss';
 @import './component/button.scss';
@@ -47,3 +35,6 @@ html {
 
 // Layout
 @import './component/flex.scss';
+
+// sr-only
+@import './component/visuallyHidden.scss';

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -36,5 +36,5 @@ html {
 // Layout
 @import './component/flex.scss';
 
-// sr-only
+// Accessibility
 @import './component/visuallyHidden.scss';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds a `VisuallyHidden` and removes `.sr-only` css class usage in favor of it

![Screen Shot 2021-09-01 at 11 18 49 AM](https://user-images.githubusercontent.com/40295569/131726452-38793530-4014-4364-8442-05e42f55082e.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
