### PR TITLE
Fix docs by removing missing/unneeded theme styles CSS

### DIFF
--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import '@aws-amplify/ui/dist/style.css';
 import '../styles/styles.css';
 import '@aws-amplify/ui-react/styles.css';
 import '../styles/primitivesStyles.css';


### PR DESCRIPTION
This PR fixes app page import by removing the import of the theme style file. This file isn't needed because it's already exported via `@aws-amplify/ui-react/styles.css`

Error message when running `yarn docs dev`:
```
error - ./src/pages/_app.page.tsx:2:0
Module not found: Package path ./dist/style.css is not exported from package /Volumes/workplace/amplify-ui/node_modules/@aws-amplify/ui (see exports field in /Volumes/workplace/amplify-ui/node_modules/@aws-amplify/ui/package.json)
  1 | import Head from 'next/head';
> 2 | import '@aws-amplify/ui/dist/style.css';
  3 | import '../styles/styles.css';
  4 | import '@aws-amplify/ui-react/styles.css';
  5 | import '../styles/primitivesStyles.css';
```

Tested running `yarn docs dev` after making this change and they build. Manually tested the docs site and it and looks correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
