### PR TITLE
initial styling for SignUp

### DIFF
--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-up-with-email/sign-up-with-email.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-up-with-email/sign-up-with-email.steps.ts
@@ -23,11 +23,11 @@ When('I type the email {string}', (email: string) => {
 });
 
 And('I type the password {string}', (password: string) => {
-  cy.findByLabelText(/^password$/i).type(Cypress.env(password));
+  cy.findByPlaceholderText(/^password$/i).type(Cypress.env(password));
 });
 
 And('I confirm the password {string}', (password: string) => {
-  cy.findByLabelText(/confirm password/i).type(Cypress.env(password));
+  cy.findByPlaceholderText(/confirm password/i).type(Cypress.env(password));
 });
 
 Then('I see {string}', (message: string) => {

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-up-with-phone/sign-up-with-phone.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-up-with-phone/sign-up-with-phone.steps.ts
@@ -21,11 +21,11 @@ When('I type the phone number {string}', (phone: string) => {
 });
 
 And('I type the password {string}', (password: string) => {
-  cy.findByLabelText(/^password$/i).type(Cypress.env(password));
+  cy.findByPlaceholderText(/^password$/i).type(Cypress.env(password));
 });
 
 And('I confirm the password {string}', (password: string) => {
-  cy.findByLabelText(/confirm password/i).type(Cypress.env(password));
+  cy.findByPlaceholderText(/confirm password/i).type(Cypress.env(password));
 });
 
 Then('I see {string}', (message: string) => {

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-up/sign-up.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-up/sign-up.steps.ts
@@ -17,11 +17,11 @@ When('I type a new username', () => {
 });
 
 And('I type a new password', () => {
-  cy.findByLabelText(/^password$/i).type(`${password}`);
+  cy.findByPlaceholderText(/^password$/i).type(`${password}`);
 });
 
 And('I type a new confirm password', () => {
-  cy.findByLabelText(/^confirm password$/i).type(`${password}`);
+  cy.findByPlaceholderText(/^confirm password$/i).type(`${password}`);
 });
 
 And('I type the email {string}', (email) => {

--- a/packages/react/src/components/Authenticator/shared/ErrorText.tsx
+++ b/packages/react/src/components/Authenticator/shared/ErrorText.tsx
@@ -15,9 +15,5 @@ export const ErrorText = (props: ErrorTextProps): JSX.Element => {
   const actorContext: ActorContextWithForms = getActorContext(_state);
   const { remoteError } = actorContext;
 
-  return (
-    <Text className="errorText" variant="error">
-      {remoteError}
-    </Text>
-  );
+  return <Text variation="error">{remoteError}</Text>;
 };


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

Initial styling for the `SignUp` page. The "Sign In" button will be removed once the `Tabs` component is ready.

Old sign up page - 
<img width="522" alt="Screen Shot 2021-09-07 at 3 43 22 PM" src="https://user-images.githubusercontent.com/17255334/132420281-b75e73b7-e93a-47e6-afd9-5836c6a4b3f1.png">

New sign up page -
<img width="523" alt="Screen Shot 2021-09-07 at 3 44 41 PM" src="https://user-images.githubusercontent.com/17255334/132420292-ea65c00e-c3e4-4b6f-b82b-d6c8a539d9ba.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
