### PR TITLE
CI: Change reset password button text and escape regex

### DIFF
--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-in/amplify-sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-in/amplify-sign-in.component.html
@@ -16,10 +16,7 @@
         type="password"
         autocomplete="current-password"
       ></amplify-form-input>
-      <div>
-        Forgot your password?
-        <button (click)="toResetPassword()">Reset password</button>
-      </div>
+      <button (click)="toResetPassword()">Forgot your password?</button>
       <div data-amplify-footer>
         <div>
           No account?{{ ' ' }}

--- a/packages/e2e/cypress/integration/common/index.tsx
+++ b/packages/e2e/cypress/integration/common/index.tsx
@@ -2,6 +2,7 @@
 /// <reference types="cypress" />
 
 import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { escapeRegExp } from 'lodash';
 
 Given("I'm running the example {string}", (url) => {
   cy.visit(url);
@@ -16,9 +17,11 @@ And('I type a valid password {string}', (password: string) => {
 });
 
 When('I click the {string} button', (name: string) => {
-  cy.findByRole('button', { name: new RegExp(name, 'i') }).click();
+  cy.findByRole('button', {
+    name: new RegExp(escapeRegExp(name), 'i'),
+  }).click();
 });
 
 Then('I see {string}', (message: string) => {
-  cy.findByRole('document').contains(new RegExp(message, 'i'));
+  cy.findByRole('document').contains(new RegExp(escapeRegExp(message), 'i'));
 });

--- a/packages/e2e/cypress/integration/ui/components/authenticator/reset-password/reset-password.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/reset-password/reset-password.steps.ts
@@ -15,8 +15,3 @@ And('I type an invalid username {string}', (username: string) => {
 Then('I will be redirected to the confirm forgot password page', () => {
   cy.findByRole('textbox', { label: 'New password' }).should('exist');
 });
-
-Then('I see {string}', (message: string) => {
-  const [messageString, username] = message.split(' ');
-  cy.get('body').contains([messageString, Cypress.env(username)].join(' '));
-});

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-sms-mfa/sign-in-sms-mfa.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-sms-mfa/sign-in-sms-mfa.steps.ts
@@ -24,9 +24,3 @@ And('I type a valid password {string}', (password: string) => {
 Then('I will be redirected to the confirm sms mfa page', () => {
   cy.get('[data-amplify-authenticator-confirmsignin]').should('be.visible');
 });
-
-// TODO - this test is failing in the new Authenticator until we add in the error handling in the component
-Then('I see {string}', (message: string) => {
-  const [messageString, username] = message.split(' ');
-  cy.get('body').contains([messageString, Cypress.env(username)].join(' '));
-});

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-totp-mfa/sign-in-totp-mfa.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-totp-mfa/sign-in-totp-mfa.steps.ts
@@ -27,9 +27,3 @@ Then('I will be redirected to the confirm totp mfa page', () => {
 Then('I will be redirected to the setup mfa page', () => {
   cy.get('[data-amplify-qrcode]').should('be.visible');
 });
-
-// TODO - this test is failing in the new Authenticator until we add in the error handling in the component
-Then('I see {string}', (message: string) => {
-  const [messageString, username] = message.split(' ');
-  cy.get('body').contains([messageString, Cypress.env(username)].join(' '));
-});

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-email/sign-in-with-email.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-email/sign-in-with-email.steps.ts
@@ -11,7 +11,3 @@ When('I type the valid email {string}', (email: string) => {
 And('I type the valid password {string}', (password: string) => {
   cy.findByLabelText(/password/i).type(Cypress.env(password));
 });
-
-Then('I see {string}', (message: string) => {
-  cy.findByRole('document').contains(new RegExp(message, 'i'));
-});

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-multi-alias/sign-in-with-multi-alias.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-multi-alias/sign-in-with-multi-alias.steps.ts
@@ -13,11 +13,3 @@ When('I type the valid login mechanism {string}', (alias: string) => {
 And('I type the valid password {string}', (password: string) => {
   cy.findByPlaceholderText(/password/i).type(Cypress.env(password));
 });
-
-And('I click the {string} button', (name: string) => {
-  cy.findByRole('button', { name }).click();
-});
-
-Then('I see {string}', (message: string) => {
-  cy.findByRole('document').contains(new RegExp(message, 'i'));
-});

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-phone/sign-in-with-phone.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-phone/sign-in-with-phone.steps.ts
@@ -13,7 +13,3 @@ When('I type the valid phone number {string}', (phoneNumber: string) => {
 And('I type the valid password {string}', (password: string) => {
   cy.findByPlaceholderText(/password/i).type(Cypress.env(password));
 });
-
-Then('I see {string}', (message: string) => {
-  cy.findByRole('document').contains(new RegExp(message, 'i'));
-});

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-username/sign-in-with-username.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-with-username/sign-in-with-username.steps.ts
@@ -11,7 +11,3 @@ When('I type the valid username {string}', (username: string) => {
 And('I type the valid password {string}', (password: string) => {
   cy.findByPlaceholderText(/password/i).type(Cypress.env(password));
 });
-
-Then('I see {string}', (message: string) => {
-  cy.findByRole('document').contains(new RegExp(message, 'i'));
-});

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-up-with-email/sign-up-with-email.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-up-with-email/sign-up-with-email.steps.ts
@@ -29,7 +29,3 @@ And('I type the password {string}', (password: string) => {
 And('I confirm the password {string}', (password: string) => {
   cy.findByLabelText(/confirm password/i).type(Cypress.env(password));
 });
-
-Then('I see {string}', (message: string) => {
-  cy.findByRole('document').contains(message);
-});

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-up-with-phone/sign-up-with-phone.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-up-with-phone/sign-up-with-phone.steps.ts
@@ -27,7 +27,3 @@ And('I type the password {string}', (password: string) => {
 And('I confirm the password {string}', (password: string) => {
   cy.findByLabelText(/confirm password/i).type(Cypress.env(password));
 });
-
-Then('I see {string}', (message: string) => {
-  cy.findByRole('document').contains(message);
-});

--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-up/sign-up.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-up/sign-up.steps.ts
@@ -31,7 +31,3 @@ And('I type the email {string}', (email) => {
 And('I type the phone number {string}', (phone) => {
   cy.findByLabelText('Phone Number').type(phone);
 });
-
-Then('I see {string}', (message: string) => {
-  cy.get('body').contains(message);
-});

--- a/packages/e2e/cypress/integration/ui/components/authenticator/verify-user/verify-user.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/verify-user/verify-user.steps.ts
@@ -16,10 +16,6 @@ And('I type a valid password {string}', (password: string) => {
   cy.findByLabelText(/password/i).type(Cypress.env(password));
 });
 
-And('I click the {string} button', (name: string) => {
-  cy.findByRole('button', { name }).click();
-});
-
 And('I click on the first radio button', () => {
   cy.findByRole('radio').click();
 });
@@ -30,9 +26,4 @@ Then('I will be redirected to the verify user page', () => {
 
 Then('I will be redirected to the confirm verify user page', () => {
   cy.findByRole('document').contains(new RegExp('Code *', 'i'));
-});
-
-Then('I see {string}', (message: string) => {
-  const [messageString, username] = message.split(' ');
-  cy.get('body').contains([messageString, Cypress.env(username)].join(' '));
 });

--- a/packages/vue/src/components/sign-in-password-control.vue
+++ b/packages/vue/src/components/sign-in-password-control.vue
@@ -4,6 +4,7 @@
     <base-input
       name="password"
       autocomplete="current-password"
+      placeholder="{{ passwordLabel }}"
       required
       type="password"
     />
@@ -11,10 +12,10 @@
 </template>
 
 <script lang="ts">
-import BaseText from "./primitives/base-text.vue";
-import BaseInput from "./primitives/base-input.vue";
+import BaseText from './primitives/base-text.vue';
+import BaseInput from './primitives/base-input.vue';
 
-import { PASSWORD_LABEL } from "../defaults/DefaultTexts";
+import { PASSWORD_LABEL } from '../defaults/DefaultTexts';
 export default {
   components: {
     BaseText,

--- a/packages/vue/src/components/sign-in.vue
+++ b/packages/vue/src/components/sign-in.vue
@@ -38,12 +38,11 @@
                 name="forgot-password-section"
                 :onForgotPasswordClicked="onForgotPasswordClicked"
               >
-                <base-text> {{ forgotYourPasswordText }}</base-text>
                 <base-button
                   type="button"
                   @click.prevent="onForgotPasswordClicked"
                 >
-                  {{ resetPasswordLink }}
+                  {{ forgotYourPasswordLink }}
                 </base-button>
               </slot>
             </base-box>
@@ -113,11 +112,10 @@ import FederatedSignIn from './federated-sign-in.vue';
 import {
   SIGN_IN_TEXT,
   AUTHENTICATOR,
-  RESET_PASSWORD_LINK,
   NO_ACCOUNT,
   CREATE_ACCOUNT_LINK,
+  FORGOT_YOUR_PASSWORD_LINK,
   SIGN_IN_BUTTON_TEXT,
-  FORGOT_YOUR_PASSWORD_TEXT,
   PASSWORD_LABEL,
   SIGNING_IN_BUTTON_TEXT,
 } from '../defaults/DefaultTexts';
@@ -133,12 +131,11 @@ export default {
   name: 'Sign In',
   computed: {
     signIntoAccountText: (): string => I18n.get(SIGN_IN_TEXT),
-    resetPasswordLink: (): string => I18n.get(RESET_PASSWORD_LINK),
     noAccount: (): string => I18n.get(NO_ACCOUNT),
     createAccountLink: (): string => I18n.get(CREATE_ACCOUNT_LINK),
+    forgotYourPasswordLink: (): string => I18n.get(FORGOT_YOUR_PASSWORD_LINK),
     signInButtonText: (): string => I18n.get(SIGN_IN_BUTTON_TEXT),
     signIngButtonText: (): string => I18n.get(SIGNING_IN_BUTTON_TEXT),
-    forgotYourPasswordText: (): string => I18n.get(FORGOT_YOUR_PASSWORD_TEXT),
     passwordLabel: (): string => I18n.get(PASSWORD_LABEL),
   },
   inheritAttrs: false,

--- a/packages/vue/src/defaults/DefaultTexts.ts
+++ b/packages/vue/src/defaults/DefaultTexts.ts
@@ -1,10 +1,9 @@
 export const AUTHENTICATOR = 'Authenticator';
-export const RESET_PASSWORD_LINK = 'Reset password';
 export const NO_ACCOUNT = 'No account? ';
 export const CREATE_ACCOUNT_LINK = 'Create account';
+export const FORGOT_YOUR_PASSWORD_LINK = 'Forgot your password? ';
 export const SIGN_IN_BUTTON_TEXT = 'Sign in';
 export const SIGNING_IN_BUTTON_TEXT = 'Signing in';
-export const FORGOT_YOUR_PASSWORD_TEXT = 'Forgot your password? ';
 export const PASSWORD_LABEL = 'Password';
 export const CONFIRM_PASSWORD_LABEL = 'Confirm Password';
 export const CHANGE_PASSWORD_LABEL = 'Change password';


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* With [PR 336](https://github.com/aws-amplify/amplify-ui/pull/336) we updated the reset password text at the sign in component to be `Forgot your password?`. This PR makes some changes to fix CI and bring Angular and Vue implementations in-line with the new e2e test format:

1. Change Angular reset password text to `Forgot your password?`
2. Change Vue reset password text to `Forgot your password?`
3. Add placeholder text to password field in Vue for Cypress query selector
4. Escape strings used to form regex in Cypress steps so the `?` in `Forgot your password?` isn't treated as a special character


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
