### PR TITLE
feat(Angular): expose relevant context from each template outlet

### DIFF
--- a/examples/angular/src/pages/ui/components/authenticator/sign-up/sign-up.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up/sign-up.component.html
@@ -1,1 +1,10 @@
-<amplify-authenticator></amplify-authenticator>
+<amplify-authenticator>
+  <ng-template
+    amplifyOverride="authenticated"
+    let-user="user"
+    let-signOut="signOut"
+  >
+    <h2>Welcome, {{ user.username }}!</h2>
+    <button (click)="signOut($event)">Sign Out</button>
+  </ng-template>
+</amplify-authenticator>

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up/sign-up.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up/sign-up.component.html
@@ -5,6 +5,6 @@
     let-signOut="signOut"
   >
     <h2>Welcome, {{ user.username }}!</h2>
-    <button (click)="signOut($event)">Sign Out</button>
+    <button (click)="signOut()">Sign Out</button>
   </ng-template>
 </amplify-authenticator>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.html
@@ -38,7 +38,7 @@
 <!-- signIn component -->
 <ng-container
   [ngTemplateOutlet]="customComponents.signIn || signIn"
-  [ngTemplateOutletContext]="context()"
+  [ngTemplateOutletContext]="context"
   *ngIf="actorState?.matches('signIn')"
 >
 </ng-container>
@@ -46,7 +46,7 @@
 <!-- signUp component -->
 <ng-container
   [ngTemplateOutlet]="customComponents.signUp || signUp"
-  [ngTemplateOutletContext]="context()"
+  [ngTemplateOutletContext]="context"
   *ngIf="actorState?.matches('signUp')"
 >
 </ng-container>
@@ -54,7 +54,7 @@
 <!-- confirmSignUp content -->
 <ng-container
   [ngTemplateOutlet]="customComponents.confirmSignUp || confirmSignUp"
-  [ngTemplateOutletContext]="context()"
+  [ngTemplateOutletContext]="context"
   *ngIf="actorState?.matches('confirmSignUp')"
 >
 </ng-container>
@@ -62,7 +62,7 @@
 <!-- confirmSignIn content -->
 <ng-container
   [ngTemplateOutlet]="customComponents.confirmSignIn || confirmSignIn"
-  [ngTemplateOutletContext]="context()"
+  [ngTemplateOutletContext]="context"
   *ngIf="actorState?.matches('confirmSignIn')"
 >
 </ng-container>
@@ -70,7 +70,7 @@
 <!-- setupTotp content -->
 <ng-container
   [ngTemplateOutlet]="customComponents.setupTOTP || setupTOTP"
-  [ngTemplateOutletContext]="context()"
+  [ngTemplateOutletContext]="context"
   *ngIf="actorState?.matches('setupTOTP')"
 >
 </ng-container>
@@ -78,7 +78,7 @@
 <!-- forceNewPassword content -->
 <ng-container
   [ngTemplateOutlet]="customComponents.forceNewPassword || forceNewPassword"
-  [ngTemplateOutletContext]="context()"
+  [ngTemplateOutletContext]="context"
   *ngIf="actorState?.matches('forceNewPassword')"
 >
 </ng-container>
@@ -86,7 +86,7 @@
 <!-- resetPassword content -->
 <ng-container
   [ngTemplateOutlet]="customComponents.resetPassword || resetPassword"
-  [ngTemplateOutletContext]="context()"
+  [ngTemplateOutletContext]="context"
   *ngIf="actorState?.matches('resetPassword')"
 >
 </ng-container>
@@ -96,7 +96,7 @@
   [ngTemplateOutlet]="
     customComponents.confirmResetPassword || confirmResetPassword
   "
-  [ngTemplateOutletContext]="context()"
+  [ngTemplateOutletContext]="context"
   *ngIf="actorState?.matches('confirmResetPassword')"
 >
 </ng-container>
@@ -104,7 +104,7 @@
 <!-- signedIn content -->
 <ng-container
   [ngTemplateOutlet]="customComponents.authenticated || authenticated"
-  [ngTemplateOutletContext]="context()"
+  [ngTemplateOutletContext]="context"
   *ngIf="authenticatorState.matches('authenticated')"
 >
 </ng-container>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.ts
@@ -50,9 +50,9 @@ export class AmplifyAuthenticatorComponent implements AfterContentInit {
    * Class Functions
    */
   public get context() {
-    const user = this.stateMachine.user;
     const { signOut } = this.stateMachine.services;
-    return { user, signOut };
+    const user = this.stateMachine.user;
+    return { signOut, user };
   }
 
   public get actorState() {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.ts
@@ -49,6 +49,12 @@ export class AmplifyAuthenticatorComponent implements AfterContentInit {
   /**
    * Class Functions
    */
+  public get context() {
+    const user = this.stateMachine.user;
+    const { signOut } = this.stateMachine.services;
+    return { user, signOut };
+  }
+
   public get actorState() {
     return getActorState(this.stateMachine.authState);
   }
@@ -67,11 +73,5 @@ export class AmplifyAuthenticatorComponent implements AfterContentInit {
     });
 
     return customComponents;
-  }
-
-  public get context() {
-    const user = this.stateMachine.user;
-    const { signOut } = this.stateMachine.services;
-    return { user, signOut };
   }
 }

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.ts
@@ -31,11 +31,6 @@ export class AmplifyAuthenticatorComponent implements AfterContentInit {
   @ContentChildren(AmplifyOverrideDirective)
   private customComponentQuery: QueryList<AmplifyOverrideDirective> = null;
   public customComponents: CustomComponents = {};
-  public context = () => ({
-    user: this.stateMachine.user,
-    username: this.stateMachine.user?.username,
-  }); // use a function so that this is reevaluated whenever context is requested
-
   constructor(
     private stateMachine: StateMachineService,
     private contextService: AuthPropService
@@ -72,5 +67,11 @@ export class AmplifyAuthenticatorComponent implements AfterContentInit {
     });
 
     return customComponents;
+  }
+
+  public get context() {
+    const user = this.stateMachine.user;
+    const { signOut } = this.stateMachine.services;
+    return { user, signOut };
   }
 }

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.html
@@ -20,7 +20,7 @@
           [ngTemplateOutlet]="
             customComponents.confirmSignInButton || confirmSignInButton
           "
-          [ngTemplateOutletContext]="context()"
+          [ngTemplateOutletContext]="context"
         >
         </ng-container>
       </div>
@@ -40,7 +40,7 @@
   <h2 data-amplify-header>{{ this.headerText }}</h2>
   <ng-container
     [ngTemplateOutlet]="customComponents.signInForm || confirmSignInForm"
-    [ngTemplateOutletContext]="context()"
+    [ngTemplateOutletContext]="context"
   >
   </ng-container>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.ts
@@ -33,7 +33,6 @@ export class AmplifyConfirmSignInComponent
   public customComponents: Record<string, TemplateRef<any>> = {};
   public remoteError = '';
   public isPending = false;
-  public context = () => ({});
   public headerText = '';
 
   private authSubscription: Subscription;
@@ -56,6 +55,11 @@ export class AmplifyConfirmSignInComponent
 
   ngOnDestroy(): void {
     this.authSubscription.unsubscribe();
+  }
+
+  public get context() {
+    const { change, signIn, submit } = this.stateMachine.services;
+    return { change, signIn, submit };
   }
 
   setHeaderText(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.ts
@@ -59,7 +59,8 @@ export class AmplifyConfirmSignInComponent
 
   public get context() {
     const { change, signIn, submit } = this.stateMachine.services;
-    return { change, signIn, submit };
+    const remoteError = this.remoteError;
+    return { change, remoteError, signIn, submit };
   }
 
   setHeaderText(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.html
@@ -32,7 +32,7 @@
           [ngTemplateOutlet]="
             customComponents.confirmSignUpButton || confirmSignUpButton
           "
-          [ngTemplateOutletContext]="context()"
+          [ngTemplateOutletContext]="context"
         >
         </ng-container>
       </div>
@@ -52,7 +52,7 @@
   <h2 data-amplify-header>Confirm Your Account</h2>
   <ng-container
     [ngTemplateOutlet]="customComponents.confirmSignUpForm || confirmSignUpForm"
-    [ngTemplateOutletContext]="context()"
+    [ngTemplateOutletContext]="context"
   >
   </ng-container>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.ts
@@ -71,8 +71,7 @@ export class AmplifyConfirmSignUpComponent {
 
   public get context() {
     const { change, resend, signIn, submit } = this.stateMachine.services;
-    const user = this.stateMachine.user;
-    return { change, resend, signIn, submit, user };
+    return { change, resend, signIn, submit };
   }
 
   toSignIn(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.ts
@@ -24,7 +24,6 @@ export class AmplifyConfirmSignUpComponent {
   public username: string;
   public remoteError = '';
   public isPending = false;
-  public context = () => ({});
 
   constructor(
     private stateMachine: StateMachineService,
@@ -68,6 +67,12 @@ export class AmplifyConfirmSignUpComponent {
     const actorState: SignUpState = getActorState(state);
     this.remoteError = actorState.context.remoteError;
     this.isPending = !actorState.matches('confirmSignUp.edit');
+  }
+
+  public get context() {
+    const { change, resend, signIn, submit } = this.stateMachine.services;
+    const user = this.stateMachine.user;
+    return { change, resend, signIn, submit, user };
   }
 
   toSignIn(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.ts
@@ -71,7 +71,9 @@ export class AmplifyConfirmSignUpComponent {
 
   public get context() {
     const { change, resend, signIn, submit } = this.stateMachine.services;
-    return { change, resend, signIn, submit };
+    const remoteError = this.remoteError;
+    const username = this.username;
+    return { change, remoteError, resend, signIn, submit, username };
   }
 
   toSignIn(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-force-new-password/amplify-force-new-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-force-new-password/amplify-force-new-password.component.html
@@ -26,7 +26,7 @@
             customComponents.forceNewPasswordSubmitButton ||
             forceNewPasswordSubmitButton
           "
-          [ngTemplateOutletContext]="context()"
+          [ngTemplateOutletContext]="context"
         >
         </ng-container>
       </div>
@@ -45,7 +45,7 @@
   <h2 data-amplify-header>{{ this.headerText }}</h2>
   <ng-container
     [ngTemplateOutlet]="customComponents.signInForm || signInForm"
-    [ngTemplateOutletContext]="context()"
+    [ngTemplateOutletContext]="context"
   >
   </ng-container>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-force-new-password/amplify-force-new-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-force-new-password/amplify-force-new-password.component.ts
@@ -35,7 +35,6 @@ export class AmplifyForceNewPasswordComponent
   public customComponents: Record<string, TemplateRef<any>> = {};
   public remoteError = '';
   public isPending = false;
-  public context = () => ({});
 
   private authSubscription: Subscription;
 
@@ -63,6 +62,12 @@ export class AmplifyForceNewPasswordComponent
     const actorState: SignInState = getActorState(state);
     this.remoteError = actorState.context.remoteError;
     this.isPending = !actorState.matches('forceNewPassword.edit');
+  }
+
+  public get context() {
+    const { change, signIn, submit } = this.stateMachine.services;
+    const user = this.stateMachine.user;
+    return { change, signIn, submit, user };
   }
 
   toSignIn(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-force-new-password/amplify-force-new-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-force-new-password/amplify-force-new-password.component.ts
@@ -67,7 +67,8 @@ export class AmplifyForceNewPasswordComponent
   public get context() {
     const { change, signIn, submit } = this.stateMachine.services;
     const user = this.stateMachine.user;
-    return { change, signIn, submit, user };
+    const remoteError = this.remoteError;
+    return { change, remoteError, signIn, submit, user };
   }
 
   toSignIn(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-reset-password/amplify-reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-reset-password/amplify-reset-password.component.html
@@ -15,7 +15,7 @@
       [ngTemplateOutlet]="
         customComponents.resetPasswordSubmitButton || resetPasswordSubmitButton
       "
-      [ngTemplateOutletContext]="context()"
+      [ngTemplateOutletContext]="context"
     >
     </ng-container>
   </div>
@@ -39,7 +39,7 @@
         [ngTemplateOutlet]="
           customComponents.resetPasswordFooter || resetPasswordFooter
         "
-        [ngTemplateOutletContext]="context()"
+        [ngTemplateOutletContext]="context"
       ></ng-container>
     </fieldset>
 
@@ -56,7 +56,7 @@
   <h2 data-amplify-header>{{ this.headerText }}</h2>
   <ng-container
     [ngTemplateOutlet]="customComponents.resetPasswordForm || resetPasswordForm"
-    [ngTemplateOutletContext]="context()"
+    [ngTemplateOutletContext]="context"
   >
   </ng-container>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-reset-password/amplify-reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-reset-password/amplify-reset-password.component.ts
@@ -25,7 +25,6 @@ export class AmplifyResetPasswordComponent
   public customComponents: Record<string, TemplateRef<any>> = {};
   public remoteError = '';
   public isPending = false;
-  public context = () => ({});
 
   private authSubscription: Subscription;
 
@@ -48,6 +47,17 @@ export class AmplifyResetPasswordComponent
     this.authSubscription.unsubscribe();
   }
 
+  onStateUpdate(state: AuthMachineState): void {
+    const actorState: SignInState = getActorState(state);
+    this.remoteError = actorState.context.remoteError;
+    this.isPending = !actorState.matches('resetPassword.edit');
+  }
+
+  public get context() {
+    const { change, signIn, submit } = this.stateMachine.services;
+    return { change, signIn, submit };
+  }
+
   toSignIn(): void {
     this.stateMachine.send('SIGN_IN');
   }
@@ -64,11 +74,5 @@ export class AmplifyResetPasswordComponent
   onSubmit(event: Event) {
     event.preventDefault();
     this.stateMachine.send('SUBMIT');
-  }
-
-  onStateUpdate(state: AuthMachineState): void {
-    const actorState: SignInState = getActorState(state);
-    this.remoteError = actorState.context.remoteError;
-    this.isPending = !actorState.matches('resetPassword.edit');
   }
 }

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-reset-password/amplify-reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-reset-password/amplify-reset-password.component.ts
@@ -55,7 +55,8 @@ export class AmplifyResetPasswordComponent
 
   public get context() {
     const { change, signIn, submit } = this.stateMachine.services;
-    return { change, signIn, submit };
+    const remoteError = this.remoteError;
+    return { change, remoteError, signIn, submit };
   }
 
   toSignIn(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-setup-totp/amplify-setup-totp.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-setup-totp/amplify-setup-totp.component.html
@@ -22,7 +22,7 @@
           [ngTemplateOutlet]="
             customComponents.setupTotpButton || setupTotpButton
           "
-          [ngTemplateOutletContext]="context()"
+          [ngTemplateOutletContext]="context"
         >
         </ng-container>
       </div>
@@ -41,7 +41,7 @@
   <h2 data-amplify-header>{{ this.headerText }}</h2>
   <ng-container
     [ngTemplateOutlet]="customComponents.setupTotpForm || setupTotpForm"
-    [ngTemplateOutletContext]="context()"
+    [ngTemplateOutletContext]="context"
   >
   </ng-container>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-setup-totp/amplify-setup-totp.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-setup-totp/amplify-setup-totp.component.ts
@@ -26,7 +26,6 @@ export class AmplifySetupTotpComponent
   public customComponents: Record<string, TemplateRef<any>> = {};
   public remoteError = '';
   public isPending = false;
-  public context = () => ({});
   public headerText = 'Setup TOTP';
   public qrCodeSource = '';
 
@@ -56,6 +55,12 @@ export class AmplifySetupTotpComponent
     const actorState: SignInState = getActorState(state);
     this.remoteError = actorState.context.remoteError;
     this.isPending = !actorState.matches('setupTOTP.edit');
+  }
+
+  public get context() {
+    const { change, submit } = this.stateMachine.services;
+    const user = this.stateMachine.user;
+    return { change, submit, user };
   }
 
   async generateQRCode() {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-setup-totp/amplify-setup-totp.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-setup-totp/amplify-setup-totp.component.ts
@@ -59,8 +59,9 @@ export class AmplifySetupTotpComponent
 
   public get context() {
     const { change, submit } = this.stateMachine.services;
+    const remoteError = this.remoteError;
     const user = this.stateMachine.user;
-    return { change, submit, user };
+    return { change, remoteError, submit, user };
   }
 
   async generateQRCode() {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-in/amplify-sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-in/amplify-sign-in.component.html
@@ -18,7 +18,9 @@
       ></amplify-form-input>
       <div>
         Forgot your password?
-        <button (click)="toResetPassword()">Reset password</button>
+        <button type="button" (click)="toResetPassword()">
+          Reset password
+        </button>
       </div>
       <div data-amplify-footer>
         <div>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-in/amplify-sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-in/amplify-sign-in.component.html
@@ -29,7 +29,7 @@
         </div>
         <ng-container
           [ngTemplateOutlet]="customComponents.signInButton || signInButton"
-          [ngTemplateOutletContext]="context()"
+          [ngTemplateOutletContext]="context"
         >
         </ng-container>
       </div>
@@ -49,7 +49,7 @@
   <h2 data-amplify-header>{{ this.headerText }}</h2>
   <ng-container
     [ngTemplateOutlet]="customComponents.signInForm || signInForm"
-    [ngTemplateOutletContext]="context()"
+    [ngTemplateOutletContext]="context"
   >
   </ng-container>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-in/amplify-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-in/amplify-sign-in.component.ts
@@ -62,7 +62,8 @@ export class AmplifySignInComponent
   public get context() {
     const { change, resetPassword, signUp, submit } =
       this.stateMachine.services;
-    return { change, resetPassword, signUp, submit };
+    const remoteError = this.remoteError;
+    return { change, remoteError, resetPassword, signUp, submit };
   }
 
   toSignUp(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-in/amplify-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-in/amplify-sign-in.component.ts
@@ -30,7 +30,6 @@ export class AmplifySignInComponent
   public customComponents: Record<string, TemplateRef<any>> = {};
   public remoteError = '';
   public isPending = false;
-  public context = () => ({});
 
   private authSubscription: Subscription;
 
@@ -58,6 +57,12 @@ export class AmplifySignInComponent
     const actorState: SignInState = getActorState(state);
     this.remoteError = actorState.context.remoteError;
     this.isPending = !actorState.matches('signIn.edit');
+  }
+
+  public get context() {
+    const { change, resetPassword, signUp, submit } =
+      this.stateMachine.services;
+    return { change, resetPassword, signUp, submit };
   }
 
   toSignUp(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-up/amplify-sign-up.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-up/amplify-sign-up.component.html
@@ -29,19 +29,19 @@
   <fieldset data-amplify-fieldset [disabled]="isPending">
     <ng-container
       [ngTemplateOutlet]="customComponents.signUpUsername || signUpUsername"
-      [ngTemplateOutletContext]="context()"
+      [ngTemplateOutletContext]="context"
     ></ng-container>
 
     <ng-container
       [ngTemplateOutlet]="customComponents.signUpPassword || signUpPassword"
-      [ngTemplateOutletContext]="context()"
+      [ngTemplateOutletContext]="context"
     ></ng-container>
 
     <ng-container
       [ngTemplateOutlet]="
         customComponents.signUpConfirmPassword || signUpConfirmPassword
       "
-      [ngTemplateOutletContext]="context()"
+      [ngTemplateOutletContext]="context"
     ></ng-container>
 
     <ng-container *ngFor="let secondaryAlias of secondaryAliases">
@@ -64,7 +64,7 @@
   >
     <ng-container
       [ngTemplateOutlet]="customComponents.signUpFieldset || signUpFieldset"
-      [ngTemplateOutletContext]="context()"
+      [ngTemplateOutletContext]="context"
     ></ng-container>
 
     <div data-amplify-footer>
@@ -74,7 +74,7 @@
       </div>
       <ng-container
         [ngTemplateOutlet]="customComponents.signUpButton || signUpButton"
-        [ngTemplateOutletContext]="context()"
+        [ngTemplateOutletContext]="context"
       >
       </ng-container>
     </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-up/amplify-sign-up.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-up/amplify-sign-up.component.ts
@@ -18,7 +18,6 @@ import {
   SignUpState,
 } from '@aws-amplify/ui';
 
-const logger = new Logger('SignUp');
 @Component({
   selector: 'amplify-sign-up',
   templateUrl: './amplify-sign-up.component.html',
@@ -29,7 +28,6 @@ export class AmplifySignUpComponent
   @HostBinding('attr.data-amplify-authenticator-signup') dataAttr = '';
   @Input() headerText = 'Create a new account';
   public customComponents: Record<string, TemplateRef<any>>;
-  public context = () => ({});
   public remoteError = '';
   public isPending = false;
   public primaryAlias = '';
@@ -41,6 +39,11 @@ export class AmplifySignUpComponent
     private stateMachine: StateMachineService,
     private contextService: AuthPropService
   ) {}
+
+  public get context() {
+    const { change, signIn, submit } = this.stateMachine.services;
+    return { change, signIn, submit };
+  }
 
   ngOnInit(): void {
     this.authSubscription = this.stateMachine.authService.subscribe((state) =>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-up/amplify-sign-up.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-up/amplify-sign-up.component.ts
@@ -16,7 +16,10 @@ import {
   getActorState,
   getConfiguredAliases,
   SignUpState,
+  ValidationError,
 } from '@aws-amplify/ui';
+import { getActorContext } from '@aws-amplify/ui';
+import { SignUpContext } from '@aws-amplify/ui';
 
 @Component({
   selector: 'amplify-sign-up',
@@ -32,6 +35,7 @@ export class AmplifySignUpComponent
   public isPending = false;
   public primaryAlias = '';
   public secondaryAliases: string[] = [];
+  public validationError: ValidationError = {};
 
   private authSubscription: Subscription;
 
@@ -42,7 +46,16 @@ export class AmplifySignUpComponent
 
   public get context() {
     const { change, signIn, submit } = this.stateMachine.services;
-    return { change, signIn, submit };
+    const remoteError = this.remoteError;
+    const validationError = this.validationError;
+
+    return {
+      change,
+      remoteError,
+      signIn,
+      submit,
+      validationError,
+    };
   }
 
   ngOnInit(): void {
@@ -67,7 +80,9 @@ export class AmplifySignUpComponent
 
   private onStateUpdate(state: AuthMachineState): void {
     const actorState: SignUpState = getActorState(state);
-    this.remoteError = actorState.context.remoteError;
+    const actorContext: SignUpContext = getActorContext(state);
+    this.remoteError = actorContext.remoteError;
+    this.validationError = actorContext.validationError;
     this.isPending = !actorState.matches({
       signUp: {
         submission: 'idle',

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-verify-user/amplify-verify-user.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-verify-user/amplify-verify-user.component.html
@@ -25,7 +25,7 @@
         [ngTemplateOutlet]="
           customComponents.verifyUserFooter || verifyUserFooter
         "
-        [ngTemplateOutletContext]="context()"
+        [ngTemplateOutletContext]="context"
       >
       </ng-container>
     </fieldset>
@@ -43,7 +43,7 @@
   <h2 data-amplify-header>{{ this.headerText }}</h2>
   <ng-container
     [ngTemplateOutlet]="customComponents.verifyUserForm || verifyUserForm"
-    [ngTemplateOutletContext]="context()"
+    [ngTemplateOutletContext]="context"
   >
   </ng-container>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-verify-user/amplify-verify-user.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-verify-user/amplify-verify-user.component.ts
@@ -29,7 +29,6 @@ export class AmplifyVerifyUserComponent
   public unverifiedAttributes = {};
   public remoteError = '';
   public isPending = false;
-  public context = () => ({});
 
   private authSubscription: Subscription;
 
@@ -57,6 +56,12 @@ export class AmplifyVerifyUserComponent
     this.unverifiedAttributes = actorState.context.unverifiedAttributes;
     this.remoteError = actorState.context.remoteError;
     this.isPending = !actorState.matches('verifyUser.edit');
+  }
+
+  public get context() {
+    const { change, skip, submit } = this.stateMachine.services;
+    const remoteError = this.remoteError;
+    return { change, remoteError, skip, submit };
   }
 
   skipVerify(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/confirm-reset-password/amplify-confirm-reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/confirm-reset-password/amplify-confirm-reset-password.component.html
@@ -16,7 +16,7 @@
         customComponents.confirmResetPasswordSubmitButton ||
         confirmResetPasswordSubmitButton
       "
-      [ngTemplateOutletContext]="context()"
+      [ngTemplateOutletContext]="context"
     >
     </ng-container>
   </div>
@@ -53,7 +53,7 @@
           customComponents.confirmResetPasswordFooter ||
           confirmResetPasswordFooter
         "
-        [ngTemplateOutletContext]="context()"
+        [ngTemplateOutletContext]="context"
       ></ng-container>
     </fieldset>
 
@@ -72,7 +72,7 @@
     [ngTemplateOutlet]="
       customComponents.confirmResetPasswordForm || confirmResetPasswordForm
     "
-    [ngTemplateOutletContext]="context()"
+    [ngTemplateOutletContext]="context"
   >
   </ng-container>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
@@ -25,7 +25,6 @@ export class ConfirmResetPasswordComponent
   public customComponents: Record<string, TemplateRef<any>> = {};
   public remoteError = '';
   public isPending = false;
-  public context = () => ({});
   private authSubscription: Subscription;
 
   constructor(
@@ -51,6 +50,12 @@ export class ConfirmResetPasswordComponent
     const actorState: SignInState = getActorState(state);
     this.remoteError = actorState.context.remoteError;
     this.isPending = !actorState.matches('confirmResetPassword.edit');
+  }
+
+  public get context() {
+    const { change, resend, signIn, submit } = this.stateMachine.services;
+    const remoteError = this.remoteError;
+    return { change, resend, remoteError, signIn, submit };
   }
 
   toSignIn(): void {

--- a/packages/angular/projects/ui-angular/src/lib/components/confirm-verify-user/amplify-confirm-verify-user.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/confirm-verify-user/amplify-confirm-verify-user.component.html
@@ -21,7 +21,7 @@
         [ngTemplateOutlet]="
           customComponents.verifyUserFooter || verifyUserFooter
         "
-        [ngTemplateOutletContext]="context()"
+        [ngTemplateOutletContext]="context"
       >
       </ng-container>
     </fieldset>
@@ -41,7 +41,7 @@
     [ngTemplateOutlet]="
       customComponents.confirmVerifyUserForm || confirmVerifyUserForm
     "
-    [ngTemplateOutletContext]="context()"
+    [ngTemplateOutletContext]="context"
   >
   </ng-container>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/confirm-verify-user/amplify-confirm-verify-user.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/confirm-verify-user/amplify-confirm-verify-user.component.ts
@@ -27,7 +27,6 @@ export class ConfirmVerifyUserComponent
   public customComponents: Record<string, TemplateRef<any>> = {};
   public remoteError = '';
   public isPending = false;
-  public context = () => ({});
   private authSubscription: Subscription;
 
   constructor(
@@ -53,6 +52,12 @@ export class ConfirmVerifyUserComponent
     const actorState: SignInState = getActorState(state);
     this.remoteError = actorState.context.remoteError;
     this.isPending = !actorState.matches('confirmVerifyUser.edit');
+  }
+
+  public get context() {
+    const { skip, submit } = this.stateMachine.services;
+    const remoteError = this.remoteError;
+    return { remoteError, skip, submit };
   }
 
   skipVerify(): void {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This adds context to every template outlet that customers can use to get `helper` functions or relevant context like `user`.

This enables in-template use cases like 

```tsx
<amplify-authenticator>
  <ng-template amplifyOverride="authenticated" let-user="user">
    <h1>Welcome, {{ user.username }}</h1>
  </ng-template>
</amplify-authenticator>
```

where `let-user="user"` is coming from template outlet context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
