### PR TITLE
initial styling for ConfirmSignUp

### DIFF
--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -17,7 +17,7 @@ export function ConfirmSignUp() {
   const [usernameAlias, setUsernameAlias] = useState<string>('');
   const amplifyNamespace = 'Authenticator.ConfirmSignUp';
   const {
-    components: { Box, Button, Fieldset, Form, Heading, Label, Text },
+    components: { Box, Button, FieldGroup, Flex, Form, Heading, Label, Text },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuth();
@@ -37,10 +37,6 @@ export function ConfirmSignUp() {
     placeholder: I18n.get('Enter your code'),
   };
 
-  const handleUsernameInputChange = (event): void => {
-    setUsernameAlias(event.target.value);
-  };
-
   return (
     // TODO Automatically add these namespaces again from `useAmplify`
     <Form
@@ -58,36 +54,37 @@ export function ConfirmSignUp() {
         });
       }}
     >
-      <Heading level={1}>{I18n.get('Confirm Sign Up')}</Heading>
+      <Flex direction="column">
+        <Heading level={3}>{I18n.get('Confirm Sign Up')}</Heading>
 
-      <Fieldset disabled={isPending}>
-        <UserNameAlias
-          handleInputChange={handleUsernameInputChange}
-          data-amplify-usernamealias
-        />
-
-        <Label data-amplify-confirmationcode>
+        <FieldGroup direction="column" disabled={isPending}>
           <ConfirmationCodeInput {...confirmationCodeInputProps} />
-          <Box>
-            <Text>{I18n.get('Lost your code? ')}</Text>
-            <Button
-              onClick={() => {
-                send({
-                  type: 'RESEND',
-                  data: {
-                    username: usernameAlias,
-                  },
-                });
-              }}
-              type="button"
-            >
-              {I18n.get('Resend Code')}
-            </Button>
-          </Box>
-        </Label>
-      </Fieldset>
 
-      <ConfirmSignInFooter {...footerProps} />
+          <Button
+            variation="primary"
+            isDisabled={isPending}
+            type="submit"
+            loadingText={I18n.get('Confirming')}
+            isLoading={isPending}
+          >
+            {I18n.get('Confirm')}
+          </Button>
+
+          <Button
+            variation="default"
+            onClick={() => {
+              send({
+                type: 'RESEND',
+              });
+            }}
+            type="button"
+          >
+            {I18n.get('Resend Code')}
+          </Button>
+        </FieldGroup>
+
+        {/* <ConfirmSignInFooter {...footerProps} /> */}
+      </Flex>
     </Form>
   );
 }

--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { getActorState, SignUpState } from '@aws-amplify/ui';
 import { I18n } from 'aws-amplify';
 
@@ -8,28 +6,18 @@ import { useAmplify, useAuth } from '../../../hooks';
 import {
   ConfirmationCodeInput,
   ConfirmationCodeInputProps,
-  ConfirmSignInFooter,
   ConfirmSignInFooterProps,
-  UserNameAlias,
 } from '../shared';
 
 export function ConfirmSignUp() {
-  const [usernameAlias, setUsernameAlias] = useState<string>('');
   const amplifyNamespace = 'Authenticator.ConfirmSignUp';
   const {
-    components: { Box, Button, FieldGroup, Flex, Form, Heading, Label, Text },
+    components: { Button, FieldGroup, Flex, Form, Heading },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuth();
   const actorState: SignUpState = getActorState(_state);
   const isPending = actorState.matches('confirmSignUp.pending');
-
-  const footerProps: ConfirmSignInFooterProps = {
-    amplifyNamespace,
-    isPending,
-    shouldHideReturnBtn: true,
-    send,
-  };
 
   const confirmationCodeInputProps: ConfirmationCodeInputProps = {
     amplifyNamespace,
@@ -82,8 +70,6 @@ export function ConfirmSignUp() {
             {I18n.get('Resend Code')}
           </Button>
         </FieldGroup>
-
-        {/* <ConfirmSignInFooter {...footerProps} /> */}
       </Flex>
     </Form>
   );

--- a/packages/react/src/components/Authenticator/shared/ConfirmationCodeInput.tsx
+++ b/packages/react/src/components/Authenticator/shared/ConfirmationCodeInput.tsx
@@ -21,26 +21,19 @@ export const ConfirmationCodeInput = (
     required = true,
   } = props;
   const {
-    components: { Input, Text },
+    components: { TextField },
   } = useAmplify(amplifyNamespace);
 
-  const errorTextComponent = errorText ? (
-    <Text data-amplify-confirmation-code-error-text variant="error">
-      {errorText}
-    </Text>
-  ) : null;
-
   return (
-    <>
-      <Text>{label}</Text>
-      <Input
-        autoComplete="one-time-code"
-        name="confirmation_code"
-        placeholder={placeholder}
-        required={required}
-        type="text"
-      />
-      {errorTextComponent}
-    </>
+    <TextField
+      name="confirmation_code"
+      label={label}
+      labelHidden={true}
+      placeholder={placeholder}
+      required={required}
+      autoComplete="one-time-code"
+      errorMessage={errorText}
+      hasError={!!errorText}
+    />
   );
 };

--- a/packages/ui/src/machines/actors/auth/signIn.ts
+++ b/packages/ui/src/machines/actors/auth/signIn.ts
@@ -13,6 +13,7 @@ import {
   setChallengeName,
   setConfirmResetPasswordIntent,
   setConfirmSignUpIntent,
+  setCredentials,
   setRemoteError,
   setUnverifiedAttributes,
   setUser,
@@ -80,10 +81,7 @@ export const signInActor = createMachine<SignInContext, AuthEvent>(
               onError: [
                 {
                   cond: 'shouldRedirectToConfirmSignUp',
-                  actions: [
-                    'setUsernameAuthAttributes',
-                    'setConfirmSignUpIntent',
-                  ],
+                  actions: ['setCredentials', 'setConfirmSignUpIntent'],
                   target: 'rejected',
                 },
                 {
@@ -296,6 +294,7 @@ export const signInActor = createMachine<SignInContext, AuthEvent>(
       setChallengeName,
       setConfirmResetPasswordIntent,
       setConfirmSignUpIntent,
+      setCredentials,
       setRemoteError,
       setUnverifiedAttributes,
       setUser,

--- a/packages/ui/src/machines/actors/auth/signUp.ts
+++ b/packages/ui/src/machines/actors/auth/signUp.ts
@@ -140,7 +140,6 @@ export const signUpActor = createMachine<SignUpContext, AuthEvent>(
       resolved: {
         type: 'final',
         data: (context) => {
-          console.log(context);
           const { username, password } = context.authAttributes;
           const canAutoSignIn = !!(username && password);
           return {

--- a/packages/ui/src/machines/actors/auth/signUp.ts
+++ b/packages/ui/src/machines/actors/auth/signUp.ts
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import { createMachine, sendUpdate } from 'xstate';
 
 import { Auth } from 'aws-amplify';
@@ -139,6 +140,7 @@ export const signUpActor = createMachine<SignUpContext, AuthEvent>(
       resolved: {
         type: 'final',
         data: (context) => {
+          console.log(context);
           const { username, password } = context.authAttributes;
           const canAutoSignIn = !!(username && password);
           return {
@@ -167,13 +169,19 @@ export const signUpActor = createMachine<SignUpContext, AuthEvent>(
       setUser,
     },
     services: {
-      async confirmSignUp(_, event) {
-        const { username, confirmation_code: code } = event.data;
+      async confirmSignUp(context, event) {
+        const { user, authAttributes } = context;
+        const { confirmation_code: code } = event.data;
+
+        const username =
+          get(user, 'username') || get(authAttributes, 'username');
 
         return Auth.confirmSignUp(username, code);
       },
       async resendConfirmationCode(context, event) {
-        const { username } = event.data;
+        const { user, authAttributes } = context;
+        const username =
+          get(user, 'username') || get(authAttributes, 'username');
 
         return Auth.resendSignUp(username);
       },


### PR DESCRIPTION
*Issue #, if available:*

https://app.asana.com/0/1200881947262804/1200935010977983/f

*Description of changes:*

Initial styling for the `ConfirmSignUp` screen. Also made some tweaks to the `signIn` and `signUp` machines in order to make the UX a bit better and remove the extra username input from the `ConfirmSignUp` screen.

<img width="522" alt="Screen Shot 2021-09-09 at 11 24 02 AM" src="https://user-images.githubusercontent.com/17255334/132742064-b48d2e27-3958-4e40-8901-3aaca17aca10.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
