### PR TITLE
initial styling for ResetPassword flow

### DIFF
--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -18,7 +18,7 @@ export const ConfirmResetPassword = (): JSX.Element => {
   const actorState = getActorState(_state) as ResetPasswordState;
   const isPending = actorState.matches('confirmResetPassword.pending');
 
-  const headerText = I18n.get('Reset your Password');
+  const headerText = I18n.get('Reset your password');
   const passwordText = I18n.get('New password');
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -5,14 +5,13 @@ import { useAmplify, useAuth } from '../../../hooks';
 import {
   ConfirmationCodeInput,
   ErrorText,
-  PasswordInput,
   TwoButtonSubmitFooter,
 } from '../shared';
 
 export const ConfirmResetPassword = (): JSX.Element => {
   const amplifyNamespace = 'Authenticator.ConfirmResetPassword';
   const {
-    components: { Box, Button, Fieldset, Form, Heading, Input, Label, Text },
+    components: { FieldGroup, Flex, Form, Heading, PasswordField },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuth();
@@ -20,6 +19,7 @@ export const ConfirmResetPassword = (): JSX.Element => {
   const isPending = actorState.matches('confirmResetPassword.pending');
 
   const headerText = I18n.get('Reset your Password');
+  const passwordText = I18n.get('New password');
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
@@ -46,42 +46,31 @@ export const ConfirmResetPassword = (): JSX.Element => {
       }}
       onChange={handleChange}
     >
-      <Heading level={1}>{headerText}</Heading>
+      <Flex direction="column">
+        <Heading level={3}>{headerText}</Heading>
 
-      <Fieldset disabled={isPending}>
-        <Label data-amplify-confirmresetpasswordcode-label="">
+        <FieldGroup direction="column" disabled={isPending}>
           <ConfirmationCodeInput amplifyNamespace={amplifyNamespace} />
-        </Label>
 
-        <Label data-amplify-confirmresetpasswordnew-label="">
-          <PasswordInput
-            amplifyNamespace={amplifyNamespace}
-            label={I18n.get('New password')}
+          <PasswordField
+            data-amplify-password
+            className="password-field"
+            placeholder={passwordText}
+            required
+            name="password"
+            label={passwordText}
+            labelHidden={true}
           />
-        </Label>
+        </FieldGroup>
 
-        <Box>
-          <Text>{I18n.get('Lost your code? ')}</Text>
-          <Button
-            onClick={() => {
-              send({
-                type: 'RESEND',
-              });
-            }}
-            type="button"
-          >
-            {I18n.get('Resend Code')}
-          </Button>
-        </Box>
-      </Fieldset>
-
-      <ErrorText amplifyNamespace={amplifyNamespace} />
-      <TwoButtonSubmitFooter
-        cancelButtonSendType="SIGN_IN"
-        cancelButtonText={I18n.get('Sign in')}
-        amplifyNamespace={amplifyNamespace}
-        isPending={isPending}
-      />
+        <ErrorText amplifyNamespace={amplifyNamespace} />
+        <TwoButtonSubmitFooter
+          cancelButtonSendType="RESEND"
+          cancelButtonText={I18n.get('Resend Code')}
+          amplifyNamespace={amplifyNamespace}
+          isPending={isPending}
+        />
+      </Flex>
     </Form>
   );
 };

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -7,7 +7,7 @@ import { ErrorText, TwoButtonSubmitFooter } from '../shared';
 export const ResetPassword = (): JSX.Element => {
   const amplifyNamespace = 'Authenticator.ResetPassword';
   const {
-    components: { Fieldset, Footer, Form, Heading, Input, Label, Text },
+    components: { FieldGroup, Flex, Form, Heading, TextField },
   } = useAmplify(amplifyNamespace);
 
   const [state, send] = useAuth();
@@ -29,6 +29,8 @@ export const ResetPassword = (): JSX.Element => {
     });
   };
 
+  const inputLabel = I18n.get('Enter your username');
+
   return (
     <Form
       data-amplify-authenticator-resetpassword=""
@@ -46,29 +48,30 @@ export const ResetPassword = (): JSX.Element => {
         });
       }}
     >
-      <Heading level={1}>{headerText}</Heading>
+      <Flex direction="column">
+        <Heading level={3}>{headerText}</Heading>
 
-      <Fieldset disabled={isPending}>
-        <Label data-amplify-resetpassword-label="">
-          <Text>{I18n.get('Username')}</Text>
-          <Input
+        <FieldGroup direction="column" disabled={isPending}>
+          <TextField
             autoComplete="username"
             name="username"
-            placeholder={I18n.get('Enter your username')}
+            placeholder={inputLabel}
+            label={inputLabel}
+            labelHidden={true}
             required={true}
             type="username"
           />
-        </Label>
-      </Fieldset>
+        </FieldGroup>
 
-      <ErrorText amplifyNamespace={amplifyNamespace} />
-      <TwoButtonSubmitFooter
-        amplifyNamespace={amplifyNamespace}
-        cancelButtonText={I18n.get('Sign in')}
-        cancelButtonSendType="SIGN_IN"
-        isPending={isPending}
-        submitButtonText={submitText}
-      />
+        <ErrorText amplifyNamespace={amplifyNamespace} />
+        <TwoButtonSubmitFooter
+          amplifyNamespace={amplifyNamespace}
+          cancelButtonText={I18n.get('Back to Sign In')}
+          cancelButtonSendType="SIGN_IN"
+          isPending={isPending}
+          submitButtonText={submitText}
+        />
+      </Flex>
     </Form>
   );
 };

--- a/packages/react/src/components/Authenticator/shared/ErrorText.tsx
+++ b/packages/react/src/components/Authenticator/shared/ErrorText.tsx
@@ -15,5 +15,7 @@ export const ErrorText = (props: ErrorTextProps): JSX.Element => {
   const actorContext: ActorContextWithForms = getActorContext(_state);
   const { remoteError } = actorContext;
 
-  return <Text variation="error">{remoteError}</Text>;
+  return (
+    <>{remoteError ? <Text variation="error">{remoteError}</Text> : null}</>
+  );
 };

--- a/packages/react/src/components/Authenticator/shared/TwoButtonSubmitFooter.tsx
+++ b/packages/react/src/components/Authenticator/shared/TwoButtonSubmitFooter.tsx
@@ -23,7 +23,7 @@ export const TwoButtonSubmitFooter = (
   } = props;
 
   const {
-    components: { Button, Footer, Spacer },
+    components: { Button, Flex, Spacer },
   } = useAmplify(amplifyNamespace);
 
   const [state, send] = useAuth();
@@ -36,17 +36,25 @@ export const TwoButtonSubmitFooter = (
   const submitText = submitButtonText || defaultSubmitText;
 
   return (
-    <Footer>
+    <Flex direction="column">
+      <Button
+        fontWeight="normal"
+        variation="primary"
+        isDisabled={isPending}
+        type="submit"
+      >
+        {submitText}
+      </Button>
+
       <Button
         onClick={() => send({ type: cancelButtonSendType })}
         type="button"
+        variation="link"
+        fontWeight="normal"
+        size="small"
       >
         {cancelButtonText}
       </Button>
-      <Spacer />
-      <Button isDisabled={isPending} type="submit">
-        {submitText}
-      </Button>
-    </Footer>
+    </Flex>
   );
 };

--- a/packages/react/src/components/Authenticator/shared/TwoButtonSubmitFooter.tsx
+++ b/packages/react/src/components/Authenticator/shared/TwoButtonSubmitFooter.tsx
@@ -23,7 +23,7 @@ export const TwoButtonSubmitFooter = (
   } = props;
 
   const {
-    components: { Button, Flex, Spacer },
+    components: { Button, Flex },
   } = useAmplify(amplifyNamespace);
 
   const [state, send] = useAuth();


### PR DESCRIPTION
*Issue #, if available:*

https://app.asana.com/0/1200881947262804/1200935010977981/f

*Description of changes:*

Initial styling pass through for the reset password flow. This flow is actually not in the mocks for some reason, so I'm just following the example of other screens.

!!! Fixed the title string in the screenshots below so both should be the same now (`Reset your password`). Don't feel like taking a new screenshot though.

<img width="524" alt="Screen Shot 2021-09-09 at 1 29 18 PM" src="https://user-images.githubusercontent.com/17255334/132758278-abc9b1c9-e380-4d1d-8d1d-4776ca28e078.png">

<img width="491" alt="Screen Shot 2021-09-09 at 1 29 25 PM" src="https://user-images.githubusercontent.com/17255334/132758206-e432716e-0842-4d9f-9bd0-e2f9d22909e0.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
