### PR TITLE
initial styling for totp setup and mfa code screens

### DIFF
--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -13,13 +13,10 @@ import {
   ConfirmSignInFooterProps,
 } from '../shared';
 
-/**
- * placeholder component
- */
 export const ConfirmSignIn = (): JSX.Element => {
   const amplifyNamespace = 'Authenticator.ConfirmSignIn';
   const {
-    components: { Fieldset, Form, Heading, Label },
+    components: { FieldGroup, Flex, Form, Heading },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuth();
@@ -56,18 +53,18 @@ export const ConfirmSignIn = (): JSX.Element => {
         });
       }}
     >
-      <Heading level={1}>{headerText}</Heading>
+      <Flex direction="column">
+        <Heading level={3}>{headerText}</Heading>
 
-      <Fieldset disabled={isPending}>
-        <Label data-amplify-confirmationcode>
+        <FieldGroup direction="column" disabled={isPending}>
           <ConfirmationCodeInput
             amplifyNamespace={amplifyNamespace}
             errorText={remoteError}
           />
-        </Label>
-      </Fieldset>
+        </FieldGroup>
 
-      <ConfirmSignInFooter {...footerProps} />
+        <ConfirmSignInFooter {...footerProps} />
+      </Flex>
     </Form>
   );
 };

--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -54,6 +54,7 @@ export function ConfirmSignUp() {
             type="submit"
             loadingText={I18n.get('Confirming')}
             isLoading={isPending}
+            fontWeight="normal"
           >
             {I18n.get('Confirm')}
           </Button>
@@ -66,6 +67,7 @@ export function ConfirmSignUp() {
               });
             }}
             type="button"
+            fontWeight="normal"
           >
             {I18n.get('Resend Code')}
           </Button>

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -19,7 +19,7 @@ export const SetupTOTP = (): JSX.Element => {
 
   const amplifyNamespace = 'Authenticator.ConfirmSignIn';
   const {
-    components: { Fieldset, Form, Heading, Image, Label },
+    components: { FieldGroup, Flex, Form, Heading, Image },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuth();
@@ -72,10 +72,10 @@ export const SetupTOTP = (): JSX.Element => {
         });
       }}
     >
-      <Heading level={1}>Setup TOTP</Heading>
+      <Flex direction="column">
+        <Heading level={3}>Setup TOTP</Heading>
 
-      <Fieldset disabled={isPending}>
-        <Label data-amplify-confirmationcode>
+        <FieldGroup direction="column" disabled={isPending}>
           {/* TODO: Add spinner here instead of loading text... */}
           {isLoading ? (
             <p>{I18n.get('Loading')}&hellip;</p>
@@ -83,10 +83,10 @@ export const SetupTOTP = (): JSX.Element => {
             <Image data-amplify-qrcode src={qrCode} alt="qr code"></Image>
           )}
           <ConfirmationCodeInput amplifyNamespace={amplifyNamespace} />
-        </Label>
-      </Fieldset>
+        </FieldGroup>
 
-      <ConfirmSignInFooter {...footerProps} />
+        <ConfirmSignInFooter {...footerProps} />
+      </Flex>
     </Form>
   );
 };

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -142,6 +142,7 @@ export function SignUp() {
             onClick={() => send({ type: 'SIGN_IN' })}
             type="button"
             variation="link"
+            fontWeight="normal"
           >
             {I18n.get('Sign in')}
           </Button>

--- a/packages/react/src/components/Authenticator/shared/ConfirmSignInFooter.tsx
+++ b/packages/react/src/components/Authenticator/shared/ConfirmSignInFooter.tsx
@@ -20,24 +20,32 @@ export const ConfirmSignInFooter = (
   } = props;
 
   const {
-    components: { Button, Footer, Spacer },
+    components: { Button, Flex },
   } = useAmplify(amplifyNamespace);
 
   return (
-    <Footer>
+    <Flex direction="column">
+      <Button
+        isDisabled={isPending}
+        type="submit"
+        variation="primary"
+        fontWeight="normal"
+        isLoading={isPending}
+        loadingText={I18n.get('Confirming')}
+      >
+        {I18n.get('Confirm')}
+      </Button>
       {!shouldHideReturnBtn && (
-        <Button onClick={() => send({ type: 'SIGN_IN' })} type="button">
+        <Button
+          onClick={() => send({ type: 'SIGN_IN' })}
+          type="button"
+          variation="link"
+          fontWeight="normal"
+          size="small"
+        >
           {I18n.get('Back to Sign In')}
         </Button>
       )}
-      <Spacer />
-      <Button isDisabled={isPending} type="submit">
-        {isPending ? (
-          <>{I18n.get('Confirming')}&hellip;</>
-        ) : (
-          <>{I18n.get('Confirm')}</>
-        )}
-      </Button>
-    </Footer>
+    </Flex>
   );
 };


### PR DESCRIPTION
*Issue #, if available:*

https://app.asana.com/0/1200881947262804/1200952565427110/f
https://app.asana.com/0/1200881947262804/1200952565427109/f

*Description of changes:*

Adding initial styling for `SetupTOTP` and `ConfirmSignIn` (mfa) screens.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
