### PR TITLE
initial styling for ForceNewPassword

### DIFF
--- a/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-force-new-password/sign-in-force-new-password.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/sign-in-force-new-password/sign-in-force-new-password.steps.ts
@@ -10,7 +10,11 @@ And('I type in the phone number {string}', (phone: string) => {
 });
 
 And('I type in the password {string}', (password: string) => {
-  cy.findByPlaceholderText(/password/i).type(Cypress.env(password));
+  cy.findByPlaceholderText(/^password$/i).type(Cypress.env(password));
+});
+
+And('I confirm the password {string}', (password: string) => {
+  cy.findByPlaceholderText(/^confirm_password$/i).type(Cypress.env(password));
 });
 
 Then('I should see the Force Change Password screen', () => {

--- a/packages/e2e/features/ui/components/authenticator/sign-in-force-new-password.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-force-new-password.feature
@@ -21,5 +21,6 @@ Feature: Sign In with Force New Password flow
 		And I click the "Sign In" button
 		Then I should see the Force Change Password screen
     And I type in the password "INVALID_NEW_PASSWORD"
+    And I confirm the password "INVALID_NEW_PASSWORD"
     And I click the "Change password" button
     Then I should see error text

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -1,5 +1,10 @@
 import { I18n } from 'aws-amplify';
-import { getActorState, SignInState } from '@aws-amplify/ui';
+import {
+  getActorContext,
+  getActorState,
+  SignInContext,
+  SignInState,
+} from '@aws-amplify/ui';
 
 import { useAmplify, useAuth } from '../../../hooks';
 
@@ -8,13 +13,11 @@ export const ForceNewPassword = (): JSX.Element => {
   const {
     components: {
       Button,
-      Fieldset,
-      Footer,
+      FieldGroup,
+      Flex,
       Form,
       Heading,
-      Input,
-      Label,
-      Spacer,
+      PasswordField,
       Text,
     },
   } = useAmplify(amplifyNamespace);
@@ -22,14 +25,26 @@ export const ForceNewPassword = (): JSX.Element => {
   const [_state, send] = useAuth();
   const actorState: SignInState = getActorState(_state);
   const { remoteError } = actorState.context;
+  const { validationError } = getActorContext(_state) as SignInContext;
   const isPending = actorState.matches('forceNewPassword.pending');
 
-  const headerText = 'Change Password';
+  const headerText = I18n.get('Change Password');
+  const passwordLabel = I18n.get('Password');
+  const confirmPasswordLabel = I18n.get('Confirm Password');
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    send({
+      type: 'CHANGE',
+      data: { name, value },
+    });
+  };
 
   return (
     <Form
       data-amplify-authenticator-forcenewpassword=""
       method="post"
+      onChange={handleChange}
       onSubmit={(event) => {
         event.preventDefault();
 
@@ -42,38 +57,60 @@ export const ForceNewPassword = (): JSX.Element => {
         });
       }}
     >
-      <Heading level={1}>{headerText}</Heading>
+      <Flex direction="column">
+        <Heading level={3}>{headerText}</Heading>
 
-      <Fieldset disabled={isPending}>
-        <Label data-amplify-forcenewpassword-label="">
-          <Text>{I18n.get('Change Password')}</Text>
-          <Input
-            autoComplete="password"
+        <FieldGroup direction="column" disabled={isPending}>
+          <PasswordField
+            data-amplify-password
+            placeholder={passwordLabel}
+            required
             name="password"
-            placeholder="Password"
-            required={true}
-            type="password"
+            label={passwordLabel}
+            labelHidden={true}
+            hasError={!!validationError['confirm_password']}
           />
-        </Label>
-      </Fieldset>
+          <PasswordField
+            data-amplify-confirmpassword
+            placeholder={confirmPasswordLabel}
+            required
+            name="confirm_password"
+            label={confirmPasswordLabel}
+            labelHidden={true}
+            hasError={!!validationError['confirm_password']}
+          />
 
-      <Text className="forceNewPasswordErrorText" variant="error">
-        {remoteError}
-      </Text>
+          {!!validationError['confirm_password'] && (
+            <Text variation="error">{validationError['confirm_password']}</Text>
+          )}
+        </FieldGroup>
 
-      <Footer>
-        <Button onClick={() => send({ type: 'SIGN_IN' })} type="button">
+        {!!remoteError && (
+          <Text className="forceNewPasswordErrorText" variation="error">
+            {remoteError}
+          </Text>
+        )}
+
+        <Button
+          isDisabled={isPending}
+          type="submit"
+          variation="primary"
+          isLoading={isPending}
+          loadingText={I18n.get('Changing')}
+          fontWeight="normal"
+        >
+          {I18n.get('Change Password')}
+        </Button>
+        <Button
+          onClick={() => send({ type: 'SIGN_IN' })}
+          type="button"
+          fontWeight="normal"
+          variation="link"
+          size="small"
+        >
           {I18n.get('Back to Sign In')}
         </Button>
-        <Spacer />
-        <Button isDisabled={isPending} type="submit">
-          {isPending ? (
-            <>{I18n.get('Changing')}&hellip;</>
-          ) : (
-            <>{I18n.get('Change Password')}</>
-          )}
-        </Button>
-      </Footer>
+      </Flex>
     </Form>
   );
 };


### PR DESCRIPTION
*Issue #, if available:*

https://app.asana.com/0/1200881947262804/1200952565427106/f

*Description of changes:*

Initial styling for the `ForceNewPassword` screen. This adds a new `confirm_password` field to the screen. As a result, I also modified the state machine to handle validating that the passwords match each other, identical to the `SignUp` screen (literally copy/pasted most of it).

This PR *might* break functionality in Vue and Angular on the `ForceNewPassword` screen due to changes in the state machine.

<img width="508" alt="Screen Shot 2021-09-10 at 11 32 11 AM" src="https://user-images.githubusercontent.com/17255334/132901015-95738d13-d185-4546-946a-4ce099d4372f.png">
<img width="496" alt="Screen Shot 2021-09-10 at 11 33 03 AM" src="https://user-images.githubusercontent.com/17255334/132901029-3a070c04-12ba-464b-8d95-16cebc2e472d.png">
<img width="522" alt="Screen Shot 2021-09-10 at 11 33 40 AM" src="https://user-images.githubusercontent.com/17255334/132901076-c3606378-3ef2-472c-b3ef-7af0421de5c4.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
