### PR TITLE
Error message styling

### DIFF
--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -4,7 +4,7 @@ import { getActorState, ResetPasswordState } from '@aws-amplify/ui';
 import { useAmplify, useAuth } from '../../../hooks';
 import {
   ConfirmationCodeInput,
-  ErrorText,
+  RemoteErrorMessage,
   TwoButtonSubmitFooter,
 } from '../shared';
 
@@ -63,7 +63,7 @@ export const ConfirmResetPassword = (): JSX.Element => {
           />
         </FieldGroup>
 
-        <ErrorText amplifyNamespace={amplifyNamespace} />
+        <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
         <TwoButtonSubmitFooter
           cancelButtonSendType="RESEND"
           cancelButtonText={I18n.get('Resend Code')}

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -2,7 +2,7 @@ import { I18n } from 'aws-amplify';
 import { getActorState, ResetPasswordState } from '@aws-amplify/ui';
 
 import { useAmplify, useAuth } from '../../../hooks';
-import { ErrorText, TwoButtonSubmitFooter } from '../shared';
+import { RemoteErrorMessage, TwoButtonSubmitFooter } from '../shared';
 
 export const ResetPassword = (): JSX.Element => {
   const amplifyNamespace = 'Authenticator.ResetPassword';
@@ -63,7 +63,7 @@ export const ResetPassword = (): JSX.Element => {
           />
         </FieldGroup>
 
-        <ErrorText amplifyNamespace={amplifyNamespace} />
+        <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
         <TwoButtonSubmitFooter
           amplifyNamespace={amplifyNamespace}
           cancelButtonText={I18n.get('Back to Sign In')}

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -3,7 +3,7 @@ import { getActorState, SignInState } from '@aws-amplify/ui';
 
 import { useAmplify, useAuth } from '../../../hooks';
 import { FederatedSignIn } from '../FederatedSignIn';
-import { ErrorText, UserNameAlias } from '../shared';
+import { RemoteErrorMessage, UserNameAlias } from '../shared';
 
 export function SignIn() {
   const amplifyNamespace = 'Authenticator.SignIn';
@@ -68,6 +68,8 @@ export function SignIn() {
           />
         </FieldGroup>
 
+        <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
+
         <Button
           borderRadius={0}
           isDisabled={isPending}
@@ -103,8 +105,6 @@ export function SignIn() {
           </Button>
         </Footer>
       </Flex>
-
-      <ErrorText amplifyNamespace={amplifyNamespace} />
 
       <Divider size="small" />
 

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -13,7 +13,9 @@ import {
 
 import { useAmplify, useAuth } from '../../../hooks';
 import { FederatedSignIn } from '../FederatedSignIn';
+import { RemoteErrorMessage } from '../shared';
 export function SignUp() {
+  const amplifyNamespace = 'Authenticator.SignUp';
   const {
     components: {
       Button,
@@ -26,7 +28,7 @@ export function SignUp() {
       PasswordField,
       Text,
     },
-  } = useAmplify('Authenticator.SignUp');
+  } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuth();
   const actorState: SignUpState = getActorState(_state);
@@ -121,7 +123,7 @@ export function SignUp() {
               />
             ))}
 
-          {!!remoteError && <Text variation="error">{remoteError}</Text>}
+          <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
         </FieldGroup>
 
         <Button

--- a/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
@@ -4,7 +4,7 @@ import { I18n } from 'aws-amplify';
 import { useAmplify, useAuth } from '../../../hooks';
 import {
   ConfirmationCodeInput,
-  ErrorText,
+  RemoteErrorMessage,
   TwoButtonSubmitFooter,
 } from '../shared';
 
@@ -44,7 +44,7 @@ export const ConfirmVerifyUser = (): JSX.Element => {
         <ConfirmationCodeInput amplifyNamespace={amplifyNamespace} />
       </Fieldset>
 
-      <ErrorText amplifyNamespace={amplifyNamespace} />
+      <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
 
       <TwoButtonSubmitFooter
         amplifyNamespace={amplifyNamespace}

--- a/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
@@ -8,7 +8,7 @@ import {
 import { I18n } from 'aws-amplify';
 
 import { useAmplify, useAuth } from '../../../hooks';
-import { ErrorText, TwoButtonSubmitFooter } from '../shared';
+import { RemoteErrorMessage, TwoButtonSubmitFooter } from '../shared';
 
 const generateRadioGroup = (
   attributes: Record<string, string>
@@ -75,7 +75,7 @@ export const VerifyUser = (): JSX.Element => {
 
       {verificationRadioGroup}
 
-      <ErrorText amplifyNamespace={amplifyNamespace} />
+      <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
 
       <TwoButtonSubmitFooter
         amplifyNamespace={amplifyNamespace}

--- a/packages/react/src/components/Authenticator/shared/RemoteErrorMessage.tsx
+++ b/packages/react/src/components/Authenticator/shared/RemoteErrorMessage.tsx
@@ -1,0 +1,29 @@
+import { ActorContextWithForms, getActorContext } from '@aws-amplify/ui';
+import { useAmplify, useAuth } from '../../../hooks';
+
+export interface RemoteErrorMessageProps {
+  amplifyNamespace: string;
+}
+
+export const RemoteErrorMessage = (
+  props: RemoteErrorMessageProps
+): JSX.Element => {
+  const { amplifyNamespace } = props;
+  const {
+    components: { Alert },
+  } = useAmplify(amplifyNamespace);
+
+  const [_state] = useAuth();
+  const actorContext: ActorContextWithForms = getActorContext(_state);
+  const { remoteError } = actorContext;
+
+  return (
+    <>
+      {!!remoteError ? (
+        <Alert variation="error" isDismissible={true}>
+          {remoteError}
+        </Alert>
+      ) : null}
+    </>
+  );
+};

--- a/packages/react/src/components/Authenticator/shared/index.ts
+++ b/packages/react/src/components/Authenticator/shared/index.ts
@@ -4,3 +4,4 @@ export * from './UserNameAlias';
 export * from './ErrorText';
 export * from './TwoButtonSubmitFooter';
 export * from './PasswordInput';
+export * from './RemoteErrorMessage';

--- a/packages/react/src/components/Authenticator/styles.css
+++ b/packages/react/src/components/Authenticator/styles.css
@@ -1,5 +1,5 @@
 [data-amplify-authenticator] {
-  @apply max-w-md mx-auto overflow-hidden text-base text-gray-700 rounded-md shadow;
+  @apply max-w-xl mx-auto overflow-hidden text-base text-gray-700 rounded-md shadow;
 }
 
 [data-amplify-authenticator] [data-amplify-heading] {


### PR DESCRIPTION
*Issue #, if available:*

https://app.asana.com/0/1200881947262804/1200960625209728/f

*Description of changes:*

Adding `Alert` primitives for `RemoteError` messages. These are distinct from `ValidationError` messages. Remote errors come from Cognito, validation errors are operations we perform (password matching, for instance).

<img width="498" alt="Screen Shot 2021-09-10 at 11 26 20 AM" src="https://user-images.githubusercontent.com/17255334/132903335-a007490d-ae38-42e3-b57a-10b8f1c8b21d.png">
<img width="475" alt="Screen Shot 2021-09-10 at 11 50 46 AM" src="https://user-images.githubusercontent.com/17255334/132903341-a48f94ba-7e38-461b-b626-bcf7a96441b7.png">

EDIT: screenshot showing new width of authenticator to better match the mocks --

<img width="688" alt="Screen Shot 2021-09-10 at 12 01 13 PM" src="https://user-images.githubusercontent.com/17255334/132904088-764bb8b4-4275-4bcd-b3f2-f19be7dcbf8d.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
