### PR TITLE
Update docs to reference sign-up-with-username

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Internally, this content is served by a single, Next.js [optional catch all rout
    For your `aws-exports.js`, you can [reference an existing or create a new environment](environments).
 
    ```js
-   // examples/next/pages/components/authenticator/sign-up.tsx
+   // examples/next/pages/components/authenticator/sign-up-with-username.tsx
    import { Authenticator } from '@aws-amplify/ui-react';
    import { Amplify } from 'aws-amplify';
    import awsExports from '../../../../../environments/auth-with-username-no-attributes/src/aws-exports';
@@ -48,7 +48,7 @@ Internally, this content is served by a single, Next.js [optional catch all rout
    }
    ```
 
-1. Visit your example (e.g. <http://localhost:3000/components/authenticator/sign-up>)
+1. Visit your example (e.g. <http://localhost:3000/ui/components/authenticator/sign-up-with-username>)
 1. Make changes to [`@aws-amplify/ui-react`](packages/react) & save.
 
    Next.js should automatically hot-reload your changes in the example.

--- a/docs/src/pages/ui/components/authenticator/index.page.mdx
+++ b/docs/src/pages/ui/components/authenticator/index.page.mdx
@@ -41,12 +41,12 @@ when users authenticate.
 
 ## Features
 
-### Sign Up
+### Sign Up with Username
 
 By default, `Authenticator` creates new users in the Amazon Cognito UserPool
 based on a unique `username` using [`Auth.signUp`](https://docs.amplify.aws/lib/auth/emailpassword/q/platform/js).
 
-<Feature name="sign-up" />
+<Feature name="sign-up-with-username" />
 
 ### Sign Up with Email
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* As part of [PR 340](https://github.com/aws-amplify/amplify-ui/pull/340), the `sign-up` examples and e2e tests were updated to be the more specific `sign-up-with-username`. This PR updates docs in this repository to reflect that change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
