### PR TITLE
Use `browser` for .css paths instead of `exports`

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,8 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": "./dist/esm/index.js",
-    "./legacy": "./dist/esm/legacy.js"
+    "./legacy": "./dist/esm/legacy.js",
+    "./styles.css": "./dist/index.css"
   },
   "browser": {
     "./styles.css": "./dist/index.css"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,8 @@
   },
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "legacy"
   ],
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,9 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": "./dist/esm/index.js",
-    "./legacy": "./dist/esm/legacy.js",
+    "./legacy": "./dist/esm/legacy.js"
+  },
+  "browser": {
     "./styles.css": "./dist/index.css"
   },
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,7 +4,9 @@
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "exports": {
-    ".": "./dist/esm/index.js",
+    ".": "./dist/esm/index.js"
+  },
+  "browser": {
     "./styles.css": "./dist/styles.css",
     "./theme.css": "./dist/theme.css"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,7 +4,9 @@
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "exports": {
-    ".": "./dist/esm/index.js"
+    ".": "./dist/esm/index.js",
+    "./styles.css": "./dist/styles.css",
+    "./theme.css": "./dist/theme.css"
   },
   "browser": {
     "./styles.css": "./dist/styles.css",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -5,9 +5,7 @@
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "exports": {
-    ".": "./dist/index.js",
-    "./styles.css": "./dist/style.css",
-    "./dist/style.css": "./dist/style.css"
+    ".": "./dist/index.js"
   },
   "browser": {
     "./styles.css": "./dist/style.css"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./styles.css": "./dist/style.css"
   },
   "browser": {
     "./styles.css": "./dist/style.css"


### PR DESCRIPTION
*Issue #, if available:*

- https://app.asana.com/0/0/1200982218231966/f
- https://app.asana.com/0/0/1200982218231967/f

*Description of changes:*

`exports` isn't supported by CRA, but `browser` appears to based on @ErikCH .

- [x] Move `.css` paths from `exports` to `browser`
- [x] Publish `legacy` folder so CRA can find `@aws-amplify/ui-react/legacy`

Tested the `legacy` usage with:

```diff
diff --git a/package.json b/package.json
index 8b58ec5..5d311fd 100644
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@aws-amplify/ui-react": "^2.0.1-next.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "aws-amplify": "^4.2.9",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
diff --git a/src/App.js b/src/App.js
index 3784575..5bb0923 100644
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,11 @@
+import { Amplify } from "aws-amplify"
+import { withAuthenticator } from '@aws-amplify/ui-react/legacy';
+
 import logo from './logo.svg';
 import './App.css';

+Amplify.configure({ ... })
+
 function App() {
   return (
     <div className="App">
@@ -22,4 +27,4 @@ function App() {
   );
 }

-export default App;
+export default withAuthenticator(App);
```

> ![Screen Shot 2021-09-14 at 12 56 16 PM](https://user-images.githubusercontent.com/15182/133315241-e2b1cb17-af32-46d2-bbfa-90d4f6feb1b1.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
