### PR TITLE
fix(ui): Add missing default to login_mechanisms on sign up

### DIFF
--- a/packages/ui/src/machines/actors/auth/signUp.ts
+++ b/packages/ui/src/machines/actors/auth/signUp.ts
@@ -195,7 +195,7 @@ export const signUpActor = createMachine<SignUpContext, AuthEvent>(
           login_mechanisms,
         } = context;
 
-        const [primaryAlias = 'username'] = login_mechanisms;
+        const [primaryAlias] = login_mechanisms ?? ['username'];
 
         if (formValues.phone_number) {
           formValues.phone_number =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* We need to add default value to `login_mechanisms` on `signUp` service, or else we'd get 

>login_mechanisms is not iterable

error... or even worse, 

> l is not iterable 

on production if `login_mechanisms` is not provided 😈 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
