### PR TITLE
fix(angular): Fix typo in federated example + add federated sign up

### DIFF
--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-federated/sign-in-federated.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-federated/sign-in-federated.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import Amplify from 'aws-amplify';
-import awsExports from '@environments/auth-with-email/src/aws-exports';
+import awsExports from '@environments/auth-with-federated/src/aws-exports';
 
 @Component({
   selector: 'sign-in-federated',

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-up/amplify-sign-up.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-sign-up/amplify-sign-up.component.html
@@ -24,6 +24,7 @@
 
 <ng-template #signUpFieldset>
   <fieldset data-amplify-fieldset [disabled]="isPending">
+    <amplify-federated-sign-in></amplify-federated-sign-in>
     <ng-container
       [ngTemplateOutlet]="customComponents.signUpUsername || signUpUsername"
       [ngTemplateOutletContext]="context"

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,13 +216,6 @@
   dependencies:
     tslib "^2.0.0"
 
-"@angular/forms@~11.2.14":
-  version "11.2.14"
-  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-11.2.14.tgz#dc858408f7647f4fd033996a03aa74df18a02079"
-  integrity sha512-4LWqY6KEIk1AZQFnk+4PJSOCamlD4tumuVN06gO4D0dZo9Cx+GcvW6pM6N0CPubRvPs3sScCnu20WT11HNWC1w==
-  dependencies:
-    tslib "^2.0.0"
-
 "@angular/platform-browser-dynamic@~11.2.14", "@angular/platform-browser-dynamic@~11.2.4":
   version "11.2.14"
   resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-11.2.14.tgz#3c7fff1a1daacba5390acf033d28c377ec281166"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
- [x] Fix typo on `sign-in-federated` example so that it references `auth-with-federated` example
- [x] Add federated sign in to sign up screen

## MP4

https://user-images.githubusercontent.com/43682783/133345375-5fcee603-9665-4034-9543-4a992b586bd4.mp4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
