### PR TITLE
fix: scoping down rating icon style

### DIFF
--- a/docs/src/pages/ui/primitives/icon/react.mdx
+++ b/docs/src/pages/ui/primitives/icon/react.mdx
@@ -34,7 +34,7 @@ import '@aws-amplify/ui-react/styles.css';
 ```
 
 <Example>
-  <Flex gap="2">
+  <Flex gap="2" alignItems="center">
     <span>Hello, Icon!</span>
     <Icon
       size="small"

--- a/packages/ui/src/theme/css/component/rating.scss
+++ b/packages/ui/src/theme/css/component/rating.scss
@@ -13,12 +13,14 @@
     font-size: var(--amplify-components-rating-large-size);
     line-height: var(--amplify-components-rating-large-size);
   }
+
+  .amplify-icon {
+    font-size: unset;
+    line-height: unset;
+    height: 1em;
+  }
 }
-.amplify-icon {
-  font-size: unset;
-  line-height: unset;
-  height: 1em;
-}
+
 .amplify-rating-filled {
   fill: currentColor;
   display: inline-block;


### PR DESCRIPTION
*Issue #, if available:*

Custom icon styles for `Rating` will affect Icon's base styles.

*Description of changes:*

1. Scoping down the custom icon styles to Rating specific.
2. Also fixed an alignment issue in Icon docs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
