### PR TITLE
Default I18n Support

### DIFF
--- a/docs/src/pages/ui/components/authenticator/index.page.mdx
+++ b/docs/src/pages/ui/components/authenticator/index.page.mdx
@@ -107,7 +107,7 @@ can sign in with Google, Amazon or Facebook.
 
 ### Internationalization (I18n)
 
-The `Authenticator` ships with translations for:
+The `Authenticator` ships with [translations](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts) for:
 
 - `en` – English (default)
 - `zh` – Chinese
@@ -117,7 +117,7 @@ The `Authenticator` ships with translations for:
 - `ja` – Japenese
 - `es` – Spanish
 
-These translations can be customized using the [Amplify JS' `I18n`](https://docs.amplify.aws/lib/utilities/i18n/q/platform/js/) module:
+These [translations](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts) can be customized using the [Amplify JS' `I18n`](https://docs.amplify.aws/lib/utilities/i18n/q/platform/js/) module:
 
 ```js
 I18n.setLanguage('fr');

--- a/docs/src/pages/ui/components/authenticator/index.page.mdx
+++ b/docs/src/pages/ui/components/authenticator/index.page.mdx
@@ -105,6 +105,37 @@ can sign in with Google, Amazon or Facebook.
 
 <Feature name="sign-in-federated" />
 
+### Internationalization (I18n)
+
+The `Authenticator` ships with translations for:
+
+- `en` – English (default)
+- `zh` – Chinese
+- `fr` – French
+- `de` – German
+- `it` – Italian
+- `ja` – Japenese
+- `es` – Spanish
+
+These translations can be customized using the [Amplify JS' `I18n`](https://docs.amplify.aws/lib/utilities/i18n/q/platform/js/) module:
+
+```js
+I18n.setLanguage('fr');
+
+I18n.putVocabularies({
+  fr: {
+    'Sign In': 'Se connecter',
+    'Sign Up': "S'inscrire",
+  },
+  es: {
+    'Sign In': 'Registrarse',
+    'Sign Up': 'Regístrate',
+  },
+});
+```
+
+<Feature name="i18n" />
+
 ## Headless Usage
 
 The `Authenticator`'s UI is powered by a state machine that you can hook into to customize behavior or create your own API.

--- a/examples/angular/src/pages/ui/components/authenticator/auth-with-translations/auth-with-translations.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/auth-with-translations/auth-with-translations.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import Amplify, { I18n } from 'aws-amplify';
-import { translations, DefaultTexts } from '@aws-amplify/ui';
+import { DefaultTexts } from '@aws-amplify/ui';
 import awsExports from '@environments/auth-with-email/src/aws-exports';
+import Amplify, { I18n } from 'aws-amplify';
 @Component({
   selector: 'auth-with-translations',
   templateUrl: 'auth-with-translations.component.html',
@@ -17,7 +17,6 @@ export class AuthWithTranslationsComponent implements OnInit {
   }
 
   ngOnInit() {
-    I18n.putVocabularies(translations); // TODO: this should be done by amplify
     I18n.setLanguage('ja');
 
     // Provide missing translations

--- a/examples/next/pages/ui/components/authenticator/i18n/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/i18n/index.page.tsx
@@ -4,7 +4,6 @@ import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure(awsExports);
 
-I18n.putVocabularies(translations);
 I18n.setLanguage('fr');
 
 function App({ state, send }) {

--- a/examples/next/pages/ui/components/authenticator/i18n/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/i18n/index.page.tsx
@@ -1,4 +1,4 @@
-import { translations, withAuthenticator } from '@aws-amplify/ui-react';
+import { withAuthenticator } from '@aws-amplify/ui-react';
 import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';
 import { Amplify, I18n } from 'aws-amplify';
 

--- a/examples/next/pages/ui/components/authenticator/i18n/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/i18n/index.page.tsx
@@ -1,0 +1,19 @@
+import { translations, withAuthenticator } from '@aws-amplify/ui-react';
+import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';
+import { Amplify, I18n } from 'aws-amplify';
+
+Amplify.configure(awsExports);
+
+I18n.putVocabularies(translations);
+I18n.setLanguage('fr');
+
+function App({ state, send }) {
+  return (
+    <>
+      <h1>Hello {state.context.user.username}</h1>
+      <button onClick={() => send('SIGN_OUT')}>Sign out</button>
+    </>
+  );
+}
+
+export default withAuthenticator(App);

--- a/examples/next/pages/ui/components/authenticator/sign-in-federated/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-federated/index.page.tsx
@@ -1,6 +1,7 @@
-import { Authenticator, translations } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
+
 import awsExports from '@environments/auth-with-federated/src/aws-exports';
-import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure({
   ...awsExports,
@@ -8,8 +9,6 @@ Amplify.configure({
     login_mechanisms: ['email', 'facebook', 'google', 'amazon'],
   },
 });
-
-I18n.putVocabularies(translations);
 
 export default function AuthenticatorWithFacebook() {
   return (

--- a/examples/next/pages/ui/components/authenticator/sign-in-sms-mfa/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-sms-mfa/index.page.tsx
@@ -1,6 +1,7 @@
-import { Authenticator, translations } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
+
 import awsExports from '@environments/auth-with-phone-and-sms-mfa/src/aws-exports';
-import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure({
   ...awsExports,
@@ -8,8 +9,6 @@ Amplify.configure({
     login_mechanisms: ['phone_number'],
   },
 });
-
-I18n.putVocabularies(translations);
 
 export default function AuthenticatorWithSmsMfa() {
   return (

--- a/examples/next/pages/ui/components/authenticator/sign-in-totp-mfa/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-totp-mfa/index.page.tsx
@@ -1,6 +1,7 @@
-import { Authenticator, translations } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
+
 import awsExports from '@environments/auth-with-totp-mfa/src/aws-exports';
-import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure({
   ...awsExports,
@@ -8,8 +9,6 @@ Amplify.configure({
     login_mechanisms: ['email'],
   },
 });
-
-I18n.putVocabularies(translations);
 
 export default function SignInTotpMfa() {
   return (

--- a/examples/next/pages/ui/components/authenticator/sign-in-totp-sms-mfa/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-totp-sms-mfa/index.page.tsx
@@ -1,6 +1,7 @@
-import { Authenticator, translations } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
+
 import awsExports from '@environments/auth-with-totp-and-sms-mfa/src/aws-exports';
-import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure({
   ...awsExports,
@@ -8,8 +9,6 @@ Amplify.configure({
     login_mechanisms: ['email'],
   },
 });
-
-I18n.putVocabularies(translations);
 
 export default function SignInTotpSmsMfa() {
   return <Authenticator />;

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
@@ -1,6 +1,7 @@
-import { Authenticator, translations } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
+
 import awsExports from '@environments/auth-with-email/src/aws-exports';
-import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure({
   ...awsExports,
@@ -8,8 +9,6 @@ Amplify.configure({
     login_mechanisms: ['email'],
   },
 });
-
-I18n.putVocabularies(translations);
 
 export default function AuthenticatorWithEmail() {
   return (

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-phone/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-phone/index.page.tsx
@@ -1,6 +1,7 @@
-import { Authenticator, translations } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
+
 import awsExports from '@environments/auth-with-phone-number/src/aws-exports';
-import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure({
   ...awsExports,
@@ -8,8 +9,6 @@ Amplify.configure({
     login_mechanisms: ['phone_number'],
   },
 });
-
-I18n.putVocabularies(translations);
 
 export default function AuthenticatorWithPhoneNumber() {
   return (

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-username/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-username/index.page.tsx
@@ -1,6 +1,7 @@
-import { Authenticator, translations } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
+
 import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';
-import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure({
   ...awsExports,
@@ -8,8 +9,6 @@ Amplify.configure({
     login_mechanisms: ['username'],
   },
 });
-
-I18n.putVocabularies(translations);
 
 export default function AuthenticatorWithUsername() {
   return (

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
@@ -1,6 +1,7 @@
-import { Authenticator, translations } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
+
 import awsExports from '@environments/auth-with-email/src/aws-exports';
-import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure({
   ...awsExports,
@@ -8,8 +9,6 @@ Amplify.configure({
     login_mechanisms: ['email'],
   },
 });
-
-I18n.putVocabularies(translations);
 
 export default function AuthenticatorWithEmail() {
   return <Authenticator />;

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-phone/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-phone/index.page.tsx
@@ -1,6 +1,7 @@
-import { Authenticator, translations } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
+
 import awsExports from '@environments/auth-with-phone-number/src/aws-exports';
-import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure({
   ...awsExports,
@@ -8,8 +9,6 @@ Amplify.configure({
     login_mechanisms: ['phone_number'],
   },
 });
-
-I18n.putVocabularies(translations);
 
 export default function AuthenticatorWithPhone() {
   return (

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-username/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-username/index.page.tsx
@@ -1,9 +1,9 @@
-import { Authenticator, translations } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
+
 import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';
-import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure(awsExports);
-I18n.putVocabularies(translations);
 
 export default function AuthenticatorWithUsername() {
   return <Authenticator />;

--- a/examples/next/pages/ui/components/authenticator/withAuthenticator/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/withAuthenticator/index.page.tsx
@@ -1,10 +1,9 @@
-import { translations, withAuthenticator } from '@aws-amplify/ui-react';
+import { withAuthenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
+
 import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';
-import { Amplify, I18n } from 'aws-amplify';
 
 Amplify.configure(awsExports);
-
-I18n.putVocabularies(translations);
 
 function App({ state, send }) {
   return (

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.ts
@@ -8,12 +8,13 @@ import {
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
+import { getActorState, translations } from '@aws-amplify/ui';
+import { I18n } from 'aws-amplify';
+import { CustomComponents } from '../../common';
 import { AuthState } from '../../common/types';
 import { AmplifyOverrideDirective } from '../../directives/amplify-override.directive';
-import { StateMachineService } from '../../services/state-machine.service';
 import { AuthPropService } from '../../services/authenticator-context.service';
-import { CustomComponents } from '../../common';
-import { getActorState } from '@aws-amplify/ui';
+import { StateMachineService } from '../../services/state-machine.service';
 
 @Component({
   selector: 'amplify-authenticator',
@@ -34,7 +35,9 @@ export class AmplifyAuthenticatorComponent implements AfterContentInit {
   constructor(
     private stateMachine: StateMachineService,
     private contextService: AuthPropService
-  ) {}
+  ) {
+    I18n.putVocabularies(translations);
+  }
 
   /**
    * Lifecycle Methods

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -5,8 +5,14 @@
 import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 import { escapeRegExp } from 'lodash';
 
+let language = 'en-US';
+
 Given("I'm running the example {string}", (example: string) => {
-  cy.visit(example);
+  cy.visit(example, {
+    onBeforeLoad(win) {
+      Object.defineProperty(win.navigator, 'language', { value: language });
+    },
+  });
 });
 
 Given(
@@ -29,6 +35,12 @@ When('I type a new {string}', (loginMechanism: string) => {
     loginMechanism,
     `${Date.now()}`
   );
+});
+
+When('I click the {string} tab', (label: string) => {
+  cy.findByRole('tab', {
+    name: new RegExp(`^${escapeRegExp(label)}$`, 'i'),
+  }).click();
 });
 
 When('I click the {string} button', (name: string) => {

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -9,6 +9,7 @@ let language = 'en-US';
 
 Given("I'm running the example {string}", (example: string) => {
   cy.visit(example, {
+    // See: https://glebbahmutov.com/blog/cypress-tips-and-tricks/#control-navigatorlanguage
     onBeforeLoad(win) {
       Object.defineProperty(win.navigator, 'language', { value: language });
     },

--- a/packages/e2e/cypress/integration/common/sign-up.ts
+++ b/packages/e2e/cypress/integration/common/sign-up.ts
@@ -18,9 +18,3 @@ Then('I see {string} as an input field', (name: string) => {
 Then("I don't see {string} as an input field", (name: string) => {
   cy.findByRole('textbox', { name }).should('not.exist');
 });
-
-And('I click the Create Account tab', () => {
-  cy.findByRole('tab', {
-    name: new RegExp(`^${escapeRegExp('Create Account')}$`, 'i'),
-  }).click();
-});

--- a/packages/e2e/cypress/integration/common/sign-up.ts
+++ b/packages/e2e/cypress/integration/common/sign-up.ts
@@ -1,7 +1,6 @@
 /// <reference types="@testing-library/cypress" />
 /// <reference types="cypress" />
-import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
-import { escapeRegExp } from 'lodash';
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 Given('I click {string}', (text: string) => {
   cy.findByText(text).click();

--- a/packages/e2e/features/ui/components/authenticator/i18n.feature
+++ b/packages/e2e/features/ui/components/authenticator/i18n.feature
@@ -1,0 +1,11 @@
+Feature: Internationalization (I18n)
+
+  The `Authenticator` contains translations using `I18n`.
+
+  Background:
+    Given I'm running the example "ui/components/authenticator/i18n"
+
+  @angular @react @vue
+  Scenario: Authenticator reflects `I18n.setLanguage('fr')`
+    When I click the "Créer un compte" tab
+    Then I see "Créer un nouveau compte"

--- a/packages/e2e/features/ui/components/authenticator/i18n.feature
+++ b/packages/e2e/features/ui/components/authenticator/i18n.feature
@@ -5,7 +5,7 @@ Feature: Internationalization (I18n)
   Background:
     Given I'm running the example "ui/components/authenticator/i18n"
 
-  @angular @react @vue
+  @angular @todo-angular @react @vue @todo-vue
   Scenario: Authenticator reflects `I18n.setLanguage('fr')`
     When I click the "Créer un compte" tab
     Then I see "Créer un nouveau compte"

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
@@ -4,7 +4,7 @@ Feature: Sign Up with Email
 
   Background:
     Given I'm running the example "ui/components/authenticator/sign-up-with-email"
-    And I click the Create Account tab
+    And I click the "Create Account" tab
 
   @todo-angular @react @todo-vue
   Scenario: Login mechanism set to "email"

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-phone.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-phone.feature
@@ -4,7 +4,7 @@ Feature: Sign Up with Phone
 
   Background:
     Given I'm running the example "ui/components/authenticator/sign-up-with-phone/"
-    And I click the Create Account tab
+    And I click the "Create Account" tab
     And intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-phone"
 
   @todo-angular @react @todo-vue

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-username.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-username.feature
@@ -4,7 +4,7 @@ Feature: Sign Up with Username
 
   Background:
     Given I'm running the example "ui/components/authenticator/sign-up-with-username"
-    And I click the Create Account tab
+    And I click the "Create Account" tab
 
   @todo-angular @react @todo-vue
   Scenario: Login mechanism set to "username"

--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -1877,7 +1877,6 @@ describe('@aws-amplify/ui-react', () => {
           "primitives",
           "strHasLength",
           "theme",
-          "translations",
           "useAmplify",
           "useAmplifyFieldID",
           "useAuth",

--- a/packages/react/src/components/Authenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/index.tsx
@@ -1,17 +1,19 @@
-import { authMachine, getActorState } from '@aws-amplify/ui';
-import { useAmplify } from '../../hooks';
+import { authMachine, getActorState, translations } from '@aws-amplify/ui';
 import { useActor, useInterpret } from '@xstate/react';
+import { I18n } from 'aws-amplify';
+import * as React from 'react';
 
+import { useAmplify } from '../../hooks';
 import { AuthenticatorContext } from './AuthenticatorContext';
 import { ConfirmSignIn } from './ConfirmSignIn';
 import { ConfirmSignUp } from './ConfirmSignUp';
 import { ForceNewPassword } from './ForceNewPassword';
 import { ConfirmResetPassword, ResetPassword } from './ResetPassword';
 import { SetupTOTP } from './SetupTOTP';
+import { SignInSignUpTabs } from './shared';
 import { SignIn } from './SignIn';
 import { SignUp } from './SignUp';
 import { ConfirmVerifyUser, VerifyUser } from './VerifyUser';
-import { SignInSignUpTabs } from './shared';
 
 export function Authenticator({
   className = null,
@@ -22,6 +24,10 @@ export function Authenticator({
   });
 
   const [state, send] = useActor(service);
+
+  React.useEffect(() => {
+    I18n.putVocabularies(translations);
+  }, []);
 
   const {
     components: {

--- a/packages/react/src/components/Authenticator/shared/UserNameAlias.tsx
+++ b/packages/react/src/components/Authenticator/shared/UserNameAlias.tsx
@@ -56,7 +56,7 @@ export function UserNameAlias(props: UserNameAliasProps) {
         name={alias ?? 'username'}
         required
         placeholder={i18nLabel}
-        label={label}
+        label={i18nLabel}
         labelHidden={true}
         autoComplete="username"
         errorMessage={error}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -8,4 +8,4 @@ export * from './theming';
 export * as components from './components';
 export * as primitives from './primitives';
 
-export { theme, translations } from '@aws-amplify/ui';
+export { theme } from '@aws-amplify/ui';


### PR DESCRIPTION
*Issue #, if available:* https://app.asana.com/0/0/1200973733971731/f

*Description of changes:*

- [x] Call `I18n.putVocabularies(translations)` by default
- [x] Document I18n
- [x] Add `.feature` tests
- [ ] ~Listen for `I18n.setLanguage` changes~
  
  Can't do this yet without a PR to send `Hub` events in Amplify JS

- [ ] ~Default using `window.navigation.language`~
 
  Not doing this explicitly because this would be a change in behavior where _by simply adding the new `Authenticator`_ could potentially change the entire page's language. (If the customer is using `I18n` anywhere else)

> ![Screen Shot 2021-09-21 at 4 52 48 PM](https://user-images.githubusercontent.com/15182/134252940-6628dbed-1d4f-4cd1-b7d9-149da5313085.png)
![Screen Shot 2021-09-21 at 4 52 57 PM](https://user-images.githubusercontent.com/15182/134252944-2e65912a-dd9e-4df0-83eb-51cc08050825.png)





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
