### PR TITLE
Remove nohoist from React package

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,12 +47,6 @@
     "react": ">= 16.8.0",
     "react-dom": ">= 16.8.0"
   },
-  "workspaces": {
-    "nohoist": [
-      "@types/testing-library__jest-dom",
-      "@types/testing-library__jest-dom/**"
-    ]
-  },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",


### PR DESCRIPTION

*Issue #, if available:* https://app.asana.com/0/0/1200984303035950/f

*Description of changes:*

Fixes this warning:

```
$ yarn install @aws-amplify/ui-react@next
> warning nohoist config is ignored in "@aws-amplify/ui-react" because it is not a private package. If you think nohoist should be allowed in public packages, please submit an issue for your use case.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
