### PR TITLE
Add Primitives textAlign property

### DIFF
--- a/packages/react/src/primitives/types/style.ts
+++ b/packages/react/src/primitives/types/style.ts
@@ -36,6 +36,7 @@ export interface BaseStyleProps {
   minWidth?: ResponsiveStyle<Property.MinWidth>;
   opacity?: ResponsiveStyle<Property.Opacity>;
   padding?: ResponsiveStyle<Property.Padding>;
+  textAlign?: ResponsiveStyle<Property.TextAlign>;
   textDecoration?: ResponsiveStyle<Property.TextDecoration>;
   width?: ResponsiveStyle<Property.Width>;
 }
@@ -81,6 +82,7 @@ export const ComponentPropsToStylePropsMap: ComponentPropToStyleProp = {
   objectPosition: 'objectPosition',
   opacity: 'opacity',
   padding: 'padding',
+  textAlign: 'textAlign',
   textDecoration: 'textDecoration',
   width: 'width',
   wrap: 'flexWrap',


### PR DESCRIPTION
*Description of changes:*
- Adds a `textAlign` property (similar to CSS text-align)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
