### PR TITLE
adding error message component to setupTotp screen

### DIFF
--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -9,6 +9,7 @@ import {
   ConfirmationCodeInput,
   ConfirmSignInFooter,
   ConfirmSignInFooterProps,
+  RemoteErrorMessage,
 } from '../shared';
 
 const logger = new Logger('SetupTOTP-logger');
@@ -83,6 +84,7 @@ export const SetupTOTP = (): JSX.Element => {
             <Image data-amplify-qrcode src={qrCode} alt="qr code"></Image>
           )}
           <ConfirmationCodeInput amplifyNamespace={amplifyNamespace} />
+          <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
         </FieldGroup>
 
         <ConfirmSignInFooter {...footerProps} />


### PR DESCRIPTION
*Issue #, if available:*

https://app.asana.com/0/0/1200981579819726/f

*Description of changes:*

adding `RemoteErrorMessage` component to the `SetupTOTP` screen.

<img width="654" alt="Screen Shot 2021-09-27 at 10 05 31 AM" src="https://user-images.githubusercontent.com/17255334/134954309-a783247b-33c8-4946-9904-1c7de1605ccd.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
