### PR TITLE
update the password validator

### DIFF
--- a/packages/ui/src/validators/index.ts
+++ b/packages/ui/src/validators/index.ts
@@ -8,9 +8,8 @@ export const passwordMatches: Validator = (formValues: AuthFormData) => {
   if (!password && !confirm_password) {
     // these inputs are clean, don't complain yet
     return null;
-  } else if (!password || !confirm_password || password !== confirm_password) {
-    // if one of the fields have been filled, or if both fields have been filled
-    // but do not match, return error.
+  } else if (password && confirm_password && password !== confirm_password) {
+    // only return an error if both fields have text entered and the passwords do not match
     return {
       confirm_password: 'Your passwords must match',
     };


### PR DESCRIPTION
*Issue #, if available:*

https://app.asana.com/0/1201058552570744/1200974176066591/f

*Description of changes:*

Update the `passwordMatches` validator to only run if both the `password` and `confirm_password` fields have values entered. If one of the fields is blank, it will not show the error message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
