### PR TITLE
fix(angular): Render authenticated content outside amplify-authenticator

### DIFF
--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.html
@@ -126,12 +126,12 @@
     *ngIf="actorState?.matches('confirmVerifyUser')"
   >
   </ng-container>
-
-  <!-- signedIn content -->
-  <ng-container
-    [ngTemplateOutlet]="customComponents.authenticated || authenticated"
-    [ngTemplateOutletContext]="context"
-    *ngIf="authenticatorState.matches('authenticated')"
-  >
-  </ng-container>
 </div>
+
+<!-- signedIn content is rendered outside authenticator so it's not styled by authenticator -->
+<ng-container
+  [ngTemplateOutlet]="customComponents.authenticated || authenticated"
+  [ngTemplateOutletContext]="context"
+  *ngIf="authenticatorState.matches('authenticated')"
+>
+</ng-container>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The user content when `state.matches('authenticated')` should not be under `amplify-authenticated` so that it's free of authenticator styles.

Before:

![image](https://user-images.githubusercontent.com/43682783/135161890-ddbfd99d-f0d0-41ce-b011-78efaafd4fb3.png)

After:

![image](https://user-images.githubusercontent.com/43682783/135162003-0ddfefff-b48b-47cd-8970-b7508a51d0cd.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
