### PR TITLE
docs: add missing angular docs

### DIFF
--- a/docs/src/pages/ui/components/authenticator/headless.angular.mdx
+++ b/docs/src/pages/ui/components/authenticator/headless.angular.mdx
@@ -1,33 +1,16 @@
-The `Authenticator`'s UI is powered by a state machine. You can use the `StateMachineService`composable
-to get access to it and customizing behavior or your own UI:
-
-_app.component.ts_
-
-```ts
-import { StateMachineService } from '@aws-amplify/ui-angular';
-
-export class AppComponent {
-  constructor(private stateMachine: StateMachineService) {}
-
-  signOut() {
-    this.stateMachine.services.signOut();
-  }
-
-  get user() {
-    return this.stateMachine.context.user;
-  }
-
-  get state() {
-    return this.stateMachine.authState;
-  }
-}
-```
+Use the `user` and `signOut` slot props to customize your UI:
 
 _app.component.html_
 
 ```html
-<div *ngIf="state.matches("authenticated")">
-  <h1>Welcome {user.username}!</h1>
-  <button (click)="signOut()">Sign Out</button>
-</div>
+<amplify-authenticator>
+  <ng-template
+    amplifyOverride="authenticated"
+    let-user="user"
+    let-signOut="signOut"
+  >
+    <h2>Welcome, {{ user.username }}!</h2>
+    <button (click)="signOut()">Sign Out</button>
+  </ng-template>
+</amplify-authenticator>
 ```

--- a/docs/src/pages/ui/components/authenticator/sign-up-with-email.angular.mdx
+++ b/docs/src/pages/ui/components/authenticator/sign-up-with-email.angular.mdx
@@ -1,0 +1,3 @@
+```html{1} file=../../../../../../examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.html#L1-L10
+
+```

--- a/docs/src/pages/ui/components/authenticator/sign-up-with-phone.angular.mdx
+++ b/docs/src/pages/ui/components/authenticator/sign-up-with-phone.angular.mdx
@@ -1,0 +1,3 @@
+```html{1} file=../../../../../../examples/angular/src/pages/ui/components/authenticator/sign-up-with-phone/sign-up-with-phone.component.html#L1-L10
+
+```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adds `sign-up-with-{email,phone}.angular.mdx` that were missing. Also updates headless docs to use template variable instead of `StateMachineService`, which needs more research.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
