### PR TITLE
withAuthenticator supports AuthenticatorProps

### DIFF
--- a/packages/react/src/components/Authenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/index.tsx
@@ -111,7 +111,7 @@ Authenticator.SignUp = SignUp;
 
 export function withAuthenticator(
   Component,
-  props: Omit<AuthenticatorProps, 'children'>
+  props?: Omit<AuthenticatorProps, 'children'>
 ) {
   return function WrappedWithAuthenticator() {
     return (

--- a/packages/react/src/components/Authenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/index.tsx
@@ -109,10 +109,13 @@ Authenticator.ConfirmSignUp = ConfirmSignUp;
 Authenticator.SignIn = SignIn;
 Authenticator.SignUp = SignUp;
 
-export function withAuthenticator(Component) {
+export function withAuthenticator(
+  Component,
+  props: Omit<AuthenticatorProps, 'children'>
+) {
   return function WrappedWithAuthenticator() {
     return (
-      <Authenticator>
+      <Authenticator {...props}>
         {(facade: ReturnType<typeof getServiceFacade>) => (
           <Component {...facade} />
         )}


### PR DESCRIPTION
*Description of changes:*

- [x] `withAuthenticator(App, props)` is equivalent to `<Authenticator {...props}>`

> ![Screen Shot 2021-09-29 at 11 10 12 AM](https://user-images.githubusercontent.com/15182/135317880-30f8481e-a059-405d-aa31-4aada890b599.png)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
