### PR TITLE
fixing styles by replacing FieldGroup with Flex

### DIFF
--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -16,7 +16,7 @@ import {
 export const ConfirmSignIn = (): JSX.Element => {
   const amplifyNamespace = 'Authenticator.ConfirmSignIn';
   const {
-    components: { FieldGroup, Flex, Form, Heading },
+    components: { Flex, Form, Heading },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuthenticator();
@@ -56,12 +56,12 @@ export const ConfirmSignIn = (): JSX.Element => {
       <Flex direction="column">
         <Heading level={3}>{headerText}</Heading>
 
-        <FieldGroup direction="column" disabled={isPending}>
+        <Flex direction="column">
           <ConfirmationCodeInput
             amplifyNamespace={amplifyNamespace}
             errorText={remoteError}
           />
-        </FieldGroup>
+        </Flex>
 
         <ConfirmSignInFooter {...footerProps} />
       </Flex>

--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -12,7 +12,7 @@ import {
 export function ConfirmSignUp() {
   const amplifyNamespace = 'Authenticator.ConfirmSignUp';
   const {
-    components: { Button, FieldGroup, Flex, Form, Heading },
+    components: { Button, Flex, Form, Heading },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuthenticator();
@@ -45,7 +45,7 @@ export function ConfirmSignUp() {
       <Flex direction="column">
         <Heading level={3}>{I18n.get('Confirm Sign Up')}</Heading>
 
-        <FieldGroup direction="column" disabled={isPending}>
+        <Flex direction="column">
           <ConfirmationCodeInput {...confirmationCodeInputProps} />
 
           <Button
@@ -71,7 +71,7 @@ export function ConfirmSignUp() {
           >
             {I18n.get('Resend Code')}
           </Button>
-        </FieldGroup>
+        </Flex>
       </Flex>
     </Form>
   );

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -11,15 +11,7 @@ import { useAmplify, useAuthenticator } from '../../../hooks';
 export const ForceNewPassword = (): JSX.Element => {
   const amplifyNamespace = 'Authenticator.ForceNewPassword';
   const {
-    components: {
-      Button,
-      FieldGroup,
-      Flex,
-      Form,
-      Heading,
-      PasswordField,
-      Text,
-    },
+    components: { Button, Flex, Form, Heading, PasswordField, Text },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuthenticator();
@@ -60,7 +52,7 @@ export const ForceNewPassword = (): JSX.Element => {
       <Flex direction="column">
         <Heading level={3}>{headerText}</Heading>
 
-        <FieldGroup direction="column" disabled={isPending}>
+        <Flex direction="column">
           <PasswordField
             data-amplify-password
             placeholder={passwordLabel}
@@ -83,7 +75,7 @@ export const ForceNewPassword = (): JSX.Element => {
           {!!validationError['confirm_password'] && (
             <Text variation="error">{validationError['confirm_password']}</Text>
           )}
-        </FieldGroup>
+        </Flex>
 
         {!!remoteError && (
           <Text className="forceNewPasswordErrorText" variation="error">

--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -11,7 +11,7 @@ import {
 export const ConfirmResetPassword = (): JSX.Element => {
   const amplifyNamespace = 'Authenticator.ConfirmResetPassword';
   const {
-    components: { FieldGroup, Flex, Form, Heading, PasswordField },
+    components: { Flex, Form, Heading, PasswordField },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuthenticator();
@@ -49,7 +49,7 @@ export const ConfirmResetPassword = (): JSX.Element => {
       <Flex direction="column">
         <Heading level={3}>{headerText}</Heading>
 
-        <FieldGroup direction="column" disabled={isPending}>
+        <Flex direction="column">
           <ConfirmationCodeInput amplifyNamespace={amplifyNamespace} />
 
           <PasswordField
@@ -61,7 +61,7 @@ export const ConfirmResetPassword = (): JSX.Element => {
             label={passwordText}
             labelHidden={true}
           />
-        </FieldGroup>
+        </Flex>
 
         <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
         <TwoButtonSubmitFooter

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -7,7 +7,7 @@ import { RemoteErrorMessage, TwoButtonSubmitFooter } from '../shared';
 export const ResetPassword = (): JSX.Element => {
   const amplifyNamespace = 'Authenticator.ResetPassword';
   const {
-    components: { FieldGroup, Flex, Form, Heading, TextField },
+    components: { Flex, Form, Heading, TextField },
   } = useAmplify(amplifyNamespace);
 
   const [state, send] = useAuthenticator();
@@ -51,7 +51,7 @@ export const ResetPassword = (): JSX.Element => {
       <Flex direction="column">
         <Heading level={3}>{headerText}</Heading>
 
-        <FieldGroup direction="column" disabled={isPending}>
+        <Flex direction="column">
           <TextField
             autoComplete="username"
             name="username"
@@ -61,7 +61,7 @@ export const ResetPassword = (): JSX.Element => {
             required={true}
             type="username"
           />
-        </FieldGroup>
+        </Flex>
 
         <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
         <TwoButtonSubmitFooter

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -20,7 +20,7 @@ export const SetupTOTP = (): JSX.Element => {
 
   const amplifyNamespace = 'Authenticator.ConfirmSignIn';
   const {
-    components: { FieldGroup, Flex, Form, Heading, Image },
+    components: { Flex, Form, Heading, Image },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuthenticator();
@@ -76,7 +76,7 @@ export const SetupTOTP = (): JSX.Element => {
       <Flex direction="column">
         <Heading level={3}>Setup TOTP</Heading>
 
-        <FieldGroup direction="column" disabled={isPending}>
+        <Flex direction="column">
           {/* TODO: Add spinner here instead of loading text... */}
           {isLoading ? (
             <p>{I18n.get('Loading')}&hellip;</p>
@@ -85,7 +85,7 @@ export const SetupTOTP = (): JSX.Element => {
           )}
           <ConfirmationCodeInput amplifyNamespace={amplifyNamespace} />
           <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
-        </FieldGroup>
+        </Flex>
 
         <ConfirmSignInFooter {...footerProps} />
       </Flex>

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -8,7 +8,7 @@ import { RemoteErrorMessage, UserNameAlias } from '../shared';
 export function SignIn() {
   const amplifyNamespace = 'Authenticator.SignIn';
   const {
-    components: { Button, FieldGroup, Flex, Form, Heading, PasswordField },
+    components: { Button, Flex, Form, Heading, PasswordField },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuthenticator();
@@ -44,7 +44,7 @@ export function SignIn() {
       <Flex direction="column">
         <Heading level={3}>{I18n.get('Sign in to your account')}</Heading>
 
-        <FieldGroup disabled={isPending} direction="column">
+        <Flex direction="column">
           <UserNameAlias data-amplify-usernamealias />
           <PasswordField
             data-amplify-password
@@ -56,7 +56,7 @@ export function SignIn() {
             autoComplete="current-password"
             labelHidden={true}
           />
-        </FieldGroup>
+        </Flex>
 
         <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
 

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -19,15 +19,7 @@ import {
 export function SignUp() {
   const amplifyNamespace = 'Authenticator.SignUp';
   const {
-    components: {
-      Button,
-      FieldGroup,
-      Flex,
-      Form,
-      Heading,
-      PasswordField,
-      Text,
-    },
+    components: { Button, Flex, Form, Heading, PasswordField, Text },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuthenticator();
@@ -82,7 +74,7 @@ export function SignUp() {
       <Flex direction="column">
         <Heading level={3}>{I18n.get('Create a new account')}</Heading>
 
-        <FieldGroup disabled={isPending} direction="column">
+        <Flex direction="column">
           <UserNameAliasComponent
             data-amplify-usernamealias
             alias={primaryAlias}
@@ -123,7 +115,7 @@ export function SignUp() {
           ))}
 
           <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
-        </FieldGroup>
+        </Flex>
 
         <Button
           borderRadius={0}

--- a/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
@@ -11,7 +11,7 @@ import {
 export const ConfirmVerifyUser = (): JSX.Element => {
   const amplifyNamespace = 'Authenticator.ConfirmVerifyUser';
   const {
-    components: { Flex, FieldGroup, Form, Heading },
+    components: { Flex, Form, Heading },
   } = useAmplify(amplifyNamespace);
 
   const [_state, send] = useAuthenticator();
@@ -41,9 +41,9 @@ export const ConfirmVerifyUser = (): JSX.Element => {
       <Flex direction="column">
         <Heading level={3}>{headerText}</Heading>
 
-        <FieldGroup direction="column" disabled={isPending}>
+        <Flex direction="column">
           <ConfirmationCodeInput amplifyNamespace={amplifyNamespace} />
-        </FieldGroup>
+        </Flex>
 
         <RemoteErrorMessage amplifyNamespace={amplifyNamespace} />
 


### PR DESCRIPTION
*Issue #, if available:*

https://app.asana.com/0/1201058552570744/1201090845906805/f

*Description of changes:*

Fixing styles that got messed up by removing Tailwind. Really, the only thing that needed changing was replacing `FieldGroup` with `Flex`. `FieldGroup` doesn't respect the `justify-content: space-between` style prop.

I watched as I ran each of the tests, and all the screens looked back to normal.

Screenshot showing fixed on one of the screens.

<img width="656" alt="Screen Shot 2021-09-29 at 2 05 25 PM" src="https://user-images.githubusercontent.com/17255334/135350555-88959dcb-1eb6-47ee-937a-a14682b40867.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
