### PR TITLE
Fix Collection items property validation

### DIFF
--- a/packages/react/src/primitives/Collection/Collection.tsx
+++ b/packages/react/src/primitives/Collection/Collection.tsx
@@ -12,7 +12,7 @@ export const Collection = <CollectionItemType,>({
 }: CollectionProps<CollectionItemType>): JSX.Element => {
   return (
     <Flex direction={direction} className={className} {...rest}>
-      {items.map(children)}
+      {Array.isArray(items) && items.map(children)}
     </Flex>
   );
 };

--- a/packages/react/src/primitives/Collection/__tests__/Collection.test.tsx
+++ b/packages/react/src/primitives/Collection/__tests__/Collection.test.tsx
@@ -3,7 +3,6 @@ import { kebabCase } from 'lodash';
 
 import { Collection } from '../Collection';
 import { ComponentPropsToStylePropsMap } from '../../types';
-import { ComponentClassNames } from '../../shared';
 
 const emojis = [
   {
@@ -40,6 +39,16 @@ describe('Collection component', () => {
       )
     ).toBe('column');
     expect(collection.children[0].getAttribute('aria-label')).toBe('LOL');
+  });
+
+  it('should not throw when items is not an array', () => {
+    expect(() =>
+      render(
+        <Collection type="list" testId={testList} items={null}>
+          {(item, index) => <div />}
+        </Collection>
+      )
+    ).not.toThrowError(TypeError);
   });
 
   it('can apply a custom className', async () => {


### PR DESCRIPTION
*Issue #, if available:*
#439 

*Description of changes:*
This PR fixes a bug on the `<Collection>` component, which wasn't validating the type of `items` property (it should be an array)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
