### PR TITLE
Default preferred_username to username for all sign ups

### DIFF
--- a/packages/ui/src/machines/actors/auth/signUp.ts
+++ b/packages/ui/src/machines/actors/auth/signUp.ts
@@ -223,7 +223,11 @@ export const signUpActor = createMachine<SignUpContext, AuthEvent>(
         const result = await Auth.signUp({
           username,
           password,
-          attributes: formValues,
+          attributes: {
+            // Default `preferred_username`, since Amplify Admin UI & CLI creates backends with this property
+            preferred_username: username,
+            ...formValues,
+          },
         });
 
         // TODO `cond`itionally transition to `signUp.confirm` or `resolved` based on result


### PR DESCRIPTION
*Issue #, if available:* https://app.asana.com/0/0/1200991090147208/f

*Description of changes:*

## All `Authenticator`s (new & old) are broken out-of-the-box if `preferred_username` is a required attribtue

When using `@environments/auth-with-username`, the backend automatically had `preferred_username` set as an attribute by Admin UI.

As a result, **Sign Up is broken out-of-the-box for new backends**:

> ![Screen Shot 2021-09-30 at 11 45 30 AM](https://user-images.githubusercontent.com/15182/135505898-50592431-8bcd-4d38-bd80-5f836689e696.png)

- [x] By defaulting `preferred_username`, sign up works as expected.
- [x] On `@environments/auth-with-username-no-attributes`, sendings this value still creates the user, but with `preferred_username`.

## This PR defaults `preferred_username` for _all_ signups

**Even if attributes aren't required, standard attributes can be set**

> ![Screen Shot 2021-09-30 at 1 04 03 PM](https://user-images.githubusercontent.com/15182/135507958-2e4e9ef8-c7a6-4f28-9a59-f0e5b899ae84.png)

> ![Screen Shot 2021-09-30 at 1 01 23 PM](https://user-images.githubusercontent.com/15182/135507954-f87704c8-5eb2-48a9-82d9-d71d48ebeeef.png)


**Invalid attributes throw an error, even if accompanied by standard attributes**:

> ![Screen Shot 2021-09-30 at 12 55 03 PM](https://user-images.githubusercontent.com/15182/135507840-19657b3a-8658-4c71-9c01-fd8768990b28.png)


> ![Screen Shot 2021-09-30 at 12 59 15 PM](https://user-images.githubusercontent.com/15182/135507864-bb92cc13-faa2-4b20-bb24-57f68a4e719a.png)
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
