### PR TITLE
fix: pin trim to ^0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "packages/angular/projects/ui-angular"
   ],
   "resolutions": {
-    "@mdx-js/mdx/**/trim": "^0.0.3",
+    "trim": "^0.0.3",
     "fs-extra": "^10.0.0",
     "next": "^11.0.1",
     "ws": "^7.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -414,6 +414,7 @@
     uuid "^8.2.0"
 
 "@aws-amplify/ui-react-v1@npm:@aws-amplify/ui-react", "@aws-amplify/ui-react@^1.2.5":
+  name "@aws-amplify/ui-react-v1"
   version "1.2.18"
   resolved "https://registry.yarnpkg.com/@aws-amplify/ui-react/-/ui-react-1.2.18.tgz#c2911b6e6573b704b7c8c3ab9926dfebad6e431b"
   integrity sha512-xQsA8evH0+5Oyp2gBaXWf89zkLIzlgpQaskgZdzESgp/latm1lcxwYkqelQV1FOL0CJSB8R16IkZES5GqgCXGQ==
@@ -20535,12 +20536,7 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
-
-trim@^0.0.3:
+trim@0.0.1, trim@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
   integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==


### PR DESCRIPTION
*Description of changes:*

Fixes security issue in `docs` where `trim` should be at least `0.0.3`.


[CVE-2020-7753](https://github.com/advisories/GHSA-w5p7-h5w8-2hfq)
```
high severity
Vulnerable versions: < 0.0.3
Patched version: 0.0.3

All versions of package trim lower than 0.0.3 are vulnerable to Regular Expression Denial of Service (ReDoS) via trim().
````

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
