### PR TITLE
ScrollView Primitive

### DIFF
--- a/docs/src/components/ScrollViewPropControls.tsx
+++ b/docs/src/components/ScrollViewPropControls.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+import { ScrollViewProps, SelectField } from '@aws-amplify/ui-react';
+
+import { DemoBox } from './DemoBox';
+
+export interface ScrollViewPropControlsProp extends ScrollViewProps {
+  setOrientation: (
+    value: React.SetStateAction<ScrollViewProps['orientation']>
+  ) => void;
+}
+export const ScrollViewPropControls: React.FC<ScrollViewPropControlsProp> = ({
+  orientation,
+  setOrientation,
+}) => (
+  <DemoBox primitiveName="ScrollView">
+    <SelectField
+      label="Orientation"
+      value={orientation}
+      onChange={(event) =>
+        setOrientation(event.target.value as ScrollViewProps['orientation'])
+      }
+    >
+      <option value="default">default</option>
+      <option value="horizontal">horizontal</option>
+      <option value="vertical">vertical</option>
+    </SelectField>
+  </DemoBox>
+);

--- a/docs/src/components/useScrollViewProps.tsx
+++ b/docs/src/components/useScrollViewProps.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+import { ScrollViewProps } from '@aws-amplify/ui-react';
+
+import { ScrollViewPropControlsProp } from './ScrollViewPropControls';
+
+interface UseScrollViewProps {
+  (initialValues?: ScrollViewProps): ScrollViewPropControlsProp;
+}
+
+export const useScrollViewProps: UseScrollViewProps = (initialValues) => {
+  const [orientation, setOrientation] = React.useState(
+    initialValues.orientation
+  );
+  return { orientation, setOrientation };
+};

--- a/docs/src/pages/ui/primitives/scrollview/demo.tsx
+++ b/docs/src/pages/ui/primitives/scrollview/demo.tsx
@@ -1,0 +1,30 @@
+import { Flex, Image, ScrollView } from '@aws-amplify/ui-react';
+
+import { Example } from '@/components/Example';
+import { useScrollViewProps } from '@/components/useScrollViewProps';
+import { ScrollViewPropControls } from '@/components/ScrollViewPropControls';
+
+export const ScrollViewDemo = () => {
+  const scrollViewProps = useScrollViewProps({});
+  return (
+    <Flex direction="column">
+      <ScrollViewPropControls {...scrollViewProps} />
+      <Example>
+        <Flex justifyContent="center">
+          <ScrollView
+            orientation={scrollViewProps.orientation}
+            height="300px"
+            width="400px"
+          >
+            <Image
+              width="800px"
+              maxWidth="800px"
+              src="https://docs.amplify.aws/assets/logo-dark.svg"
+              alt="Amplify-logo"
+            />
+          </ScrollView>
+        </Flex>
+      </Example>
+    </Flex>
+  );
+};

--- a/docs/src/pages/ui/primitives/scrollview/index.page.mdx
+++ b/docs/src/pages/ui/primitives/scrollview/index.page.mdx
@@ -1,0 +1,7 @@
+---
+title: ScrollView
+---
+
+import { Fragment } from '@/components/Fragment';
+
+<Fragment>{({ platform }) => import(`./${platform}.mdx`)}</Fragment>

--- a/docs/src/pages/ui/primitives/scrollview/react.mdx
+++ b/docs/src/pages/ui/primitives/scrollview/react.mdx
@@ -1,7 +1,11 @@
-import { Image, ScrollView } from '@aws-amplify/ui-react';
+import { Flex, Image, ScrollView } from '@aws-amplify/ui-react';
+
+import { ScrollViewDemo } from './demo';
 import { Example } from '@/components/Example';
 
 `ScrollView` is essentially a `View` that allows scrolling of its inner contents. See also [View](/ui/primitives/view?platform=react).
+
+<ScrollViewDemo />
 
 ## Usage
 
@@ -11,7 +15,7 @@ Import the ScrollView component and styles.
 import { Image, ScrollView } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
-<ScrollView height="100px" width="400px">
+<ScrollView height="300px" width="400px">
   <Image
     width="800px"
     maxWidth="800px"
@@ -22,21 +26,23 @@ import '@aws-amplify/ui-react/styles.css';
 ```
 
 <Example>
-  <ScrollView height="100px" width="400px">
-    <Image
-      width="800px"
-      maxWidth="800px"
-      src="https://docs.amplify.aws/assets/logo-dark.svg"
-      alt="Amplify-logo"
-    />
-  </ScrollView>
+  <Flex justifyContent="center">
+    <ScrollView height="300px" width="400px">
+      <Image
+        width="800px"
+        maxWidth="800px"
+        src="https://docs.amplify.aws/assets/logo-dark.svg"
+        alt="Amplify-logo"
+      />
+    </ScrollView>
+  </Flex>
 </Example>
 
 ### Orientation
 
 Specify scroll `orientation` as `horizontal`, `vertical` or none(default). None(default) maps to `overflow: scroll`, while `horizontal` and `vertical` map to `overflow-x: scroll` and `overflow-y: scroll` respectively.
 
-_Notes: In order for overflow to have an effect, the block-level container must have set attributes like height(or max-height), width(or maxWidth), word-break, overflow-wrap or white-space. See [overflow - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)_
+_Notes: In order for overflow to have an effect, the block-level container must have a set height (height or max-height), or other attributes that set the behavior for an element's overflow (e.g. overflow-wrap set to normal, white-space set to nowrap etc.). See [overflow - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)_
 
 **Default(Horizontal and Vertical)**
 
@@ -44,7 +50,7 @@ _Notes: In order for overflow to have an effect, the block-level container must 
 import { Image, ScrollView } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
-<ScrollView height="100px" width="400px">
+<ScrollView height="300px" width="400px">
   <Image
     width="800px"
     maxWidth="800px"
@@ -55,14 +61,16 @@ import '@aws-amplify/ui-react/styles.css';
 ```
 
 <Example>
-  <ScrollView height="100px" width="400px">
-    <Image
-      width="800px"
-      maxWidth="800px"
-      src="https://docs.amplify.aws/assets/logo-dark.svg"
-      alt="Amplify-logo"
-    />
-  </ScrollView>
+  <Flex justifyContent="center">
+    <ScrollView height="300px" width="400px">
+      <Image
+        width="800px"
+        maxWidth="800px"
+        src="https://docs.amplify.aws/assets/logo-dark.svg"
+        alt="Amplify-logo"
+      />
+    </ScrollView>
+  </Flex>
 </Example>
 
 **Horizontal**
@@ -80,14 +88,22 @@ import '@aws-amplify/ui-react/styles.css';
 
 import './style.css';
 
-<ScrollView width="200px" className="horizontal-example">
+<ScrollView
+  width="200px"
+  className="horizontal-example"
+  orientation="horizontal"
+>
   The value of Pi is 3.1415926535897932384626433832795029. The value of e is
   2.7182818284590452353602874713526625.
 </ScrollView>;
 ```
 
 <Example>
-  <ScrollView width="200px" className="horizontal-example">
+  <ScrollView
+    width="200px"
+    className="horizontal-example"
+    orientation="horizontal"
+  >
     {
       'The value of Pi is 3.1415926535897932384626433832795029. The value of e is 2.7182818284590452353602874713526625.'
     }
@@ -100,7 +116,7 @@ import './style.css';
 import { Image, ScrollView } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
-<ScrollView height="100px" width="200px">
+<ScrollView height="100px" width="200px" orientation="vertical">
   Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn
   Hall. Implacable November weather. As much mud in the streets as if the waters
   had but newly retired from the face of the earth.
@@ -108,7 +124,74 @@ import '@aws-amplify/ui-react/styles.css';
 ```
 
 <Example>
-  <ScrollView height="100px" width="200px">
+  <ScrollView height="100px" width="200px" orientation="vertical">
+    {
+      "Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth."
+    }
+  </ScrollView>
+</Example>
+
+## CSS Styling
+
+### Local styling
+
+To override styling on a specific View, you can use a class selector or style props.
+
+_Using a class selector:_
+
+```css
+/* styles.css */
+.my-scrollview {
+  height: 100px;
+  width: 200px;
+  background-color: var(--amplify-colors-blue-40);
+}
+```
+
+```jsx
+import { ScrollView } from '@aws-amplify/ui-react';
+
+import './styles.css';
+
+<Example>
+  <ScrollView className="my-scrollview">
+    {
+      "Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth."
+    }
+  </ScrollView>
+</Example>;
+```
+
+<Example>
+  <ScrollView className="my-scrollview">
+    {
+      "Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth."
+    }
+  </ScrollView>
+</Example>
+
+_Using style props:_
+
+```jsx
+import { ScrollView } from '@aws-amplify/ui-react';
+
+<ScrollView
+  height="100px"
+  width="200px"
+  backgroundColor="var(--amplify-colors-blue-40)"
+>
+  {
+    "Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth."
+  }
+</ScrollView>;
+```
+
+<Example>
+  <ScrollView
+    height="100px"
+    width="200px"
+    backgroundColor="var(--amplify-colors-blue-40)"
+  >
     {
       "Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth."
     }

--- a/docs/src/pages/ui/primitives/scrollview/react.mdx
+++ b/docs/src/pages/ui/primitives/scrollview/react.mdx
@@ -1,0 +1,116 @@
+import { Image, ScrollView } from '@aws-amplify/ui-react';
+import { Example } from '@/components/Example';
+
+`ScrollView` is essentially a `View` that allows scrolling of its inner contents. See also [View](/ui/primitives/view?platform=react).
+
+## Usage
+
+Import the ScrollView component and styles.
+
+```jsx
+import { Image, ScrollView } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+<ScrollView height="100px" width="400px">
+  <Image
+    width="800px"
+    maxWidth="800px"
+    src="https://docs.amplify.aws/assets/logo-dark.svg"
+    alt="Amplify-logo"
+  />
+</ScrollView>;
+```
+
+<Example>
+  <ScrollView height="100px" width="400px">
+    <Image
+      width="800px"
+      maxWidth="800px"
+      src="https://docs.amplify.aws/assets/logo-dark.svg"
+      alt="Amplify-logo"
+    />
+  </ScrollView>
+</Example>
+
+### Orientation
+
+Specify scroll `orientation` as `horizontal`, `vertical` or none(default). None(default) maps to `overflow: scroll`, while `horizontal` and `vertical` map to `overflow-x: scroll` and `overflow-y: scroll` respectively.
+
+_Notes: In order for overflow to have an effect, the block-level container must have set attributes like height(or max-height), width(or maxWidth), word-break, overflow-wrap or white-space. See [overflow - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)_
+
+**Default(Horizontal and Vertical)**
+
+```jsx
+import { Image, ScrollView } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+<ScrollView height="100px" width="400px">
+  <Image
+    width="800px"
+    maxWidth="800px"
+    src="https://docs.amplify.aws/assets/logo-dark.svg"
+    alt="Amplify-logo"
+  />
+</ScrollView>;
+```
+
+<Example>
+  <ScrollView height="100px" width="400px">
+    <Image
+      width="800px"
+      maxWidth="800px"
+      src="https://docs.amplify.aws/assets/logo-dark.svg"
+      alt="Amplify-logo"
+    />
+  </ScrollView>
+</Example>
+
+**Horizontal**
+
+```css
+/* style.css */
+.horizontal-example {
+  overflow-wrap: normal;
+}
+```
+
+```jsx
+import { Image, ScrollView } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+import './style.css';
+
+<ScrollView width="200px" className="horizontal-example">
+  The value of Pi is 3.1415926535897932384626433832795029. The value of e is
+  2.7182818284590452353602874713526625.
+</ScrollView>;
+```
+
+<Example>
+  <ScrollView width="200px" className="horizontal-example">
+    {
+      'The value of Pi is 3.1415926535897932384626433832795029. The value of e is 2.7182818284590452353602874713526625.'
+    }
+  </ScrollView>
+</Example>
+
+**Vertical**
+
+```jsx
+import { Image, ScrollView } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+<ScrollView height="100px" width="200px">
+  Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn
+  Hall. Implacable November weather. As much mud in the streets as if the waters
+  had but newly retired from the face of the earth.
+</ScrollView>;
+```
+
+<Example>
+  <ScrollView height="100px" width="200px">
+    {
+      "Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth."
+    }
+  </ScrollView>
+</Example>

--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -21,6 +21,7 @@
 @import './placeholderStyles.css';
 @import './radioStyles.css';
 @import './ratingStyles.css';
+@import './scrollView.css';
 @import './selectFieldStyles.css';
 @import './switchFieldStyles.css';
 @import './searchFieldStyles.css';

--- a/docs/src/styles/scrollView.css
+++ b/docs/src/styles/scrollView.css
@@ -1,3 +1,9 @@
 .horizontal-example {
   overflow-wrap: normal;
 }
+
+.my-scrollview {
+  height: 100px;
+  width: 200px;
+  background-color: var(--amplify-colors-blue-40);
+}

--- a/docs/src/styles/scrollView.css
+++ b/docs/src/styles/scrollView.css
@@ -1,0 +1,3 @@
+.horizontal-example {
+  overflow-wrap: normal;
+}

--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -1858,6 +1858,7 @@ describe('@aws-amplify/ui-react', () => {
           "Radio",
           "RadioGroupField",
           "Rating",
+          "ScrollView",
           "SearchField",
           "SelectField",
           "SharedText",

--- a/packages/react/src/primitives/ScrollView/ScrollView.tsx
+++ b/packages/react/src/primitives/ScrollView/ScrollView.tsx
@@ -7,7 +7,7 @@ import { ComponentClassNames } from '../shared/constants';
 export const ScrollView: React.FC<ScrollViewProps> = ({
   children,
   className,
-  orientation = 'both',
+  orientation,
   ...rest
 }) => (
   <View

--- a/packages/react/src/primitives/ScrollView/ScrollView.tsx
+++ b/packages/react/src/primitives/ScrollView/ScrollView.tsx
@@ -1,0 +1,20 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import { View } from '../View';
+import { ScrollViewProps } from '../types/scrollView';
+import { ComponentClassNames } from '../shared/constants';
+export const ScrollView: React.FC<ScrollViewProps> = ({
+  children,
+  className,
+  orientation = 'both',
+  ...rest
+}) => (
+  <View
+    className={classNames(ComponentClassNames.ScrollView, className)}
+    data-orientation={orientation}
+    {...rest}
+  >
+    {children}
+  </View>
+);

--- a/packages/react/src/primitives/ScrollView/__tests__/ScrollView.test.tsx
+++ b/packages/react/src/primitives/ScrollView/__tests__/ScrollView.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+
+import { ScrollView } from '../ScrollView';
+import { ComponentClassNames } from '../../shared/constants';
+
+describe('ScrollView: ', () => {
+  it('should render classname and custom classname', async () => {
+    render(<ScrollView className="class-test" testId="test-id" />);
+    const scrollView = await screen.findByTestId('test-id');
+    expect(scrollView).toHaveClass(
+      ComponentClassNames.ScrollView,
+      'class-test'
+    );
+  });
+
+  it('should set data-orientation correctly', async () => {
+    render(<ScrollView orientation="horizontal" testId="test-id" />);
+    const scrollView = await screen.findByTestId('test-id');
+    expect(scrollView).toHaveAttribute('data-orientation', 'horizontal');
+  });
+});

--- a/packages/react/src/primitives/ScrollView/index.ts
+++ b/packages/react/src/primitives/ScrollView/index.ts
@@ -1,0 +1,1 @@
+export * from './ScrollView';

--- a/packages/react/src/primitives/index.tsx
+++ b/packages/react/src/primitives/index.tsx
@@ -18,6 +18,7 @@ export * from './PasswordField';
 export * from './Radio';
 export * from './RadioGroupField';
 export * from './Rating';
+export * from './ScrollView';
 export * from './SelectField';
 export * from './SearchField';
 export * from './SwitchField';

--- a/packages/react/src/primitives/shared/constants.ts
+++ b/packages/react/src/primitives/shared/constants.ts
@@ -38,6 +38,7 @@ export enum ComponentClassNames {
   RadioGroupField = 'amplify-radiogroupfield',
   RadioGroup = 'amplify-radiogroup',
   Rating = 'amplify-rating',
+  ScrollView = 'amplify-scrollview',
   Select = 'amplify-select',
   SelectField = 'amplify-selectfield',
   SearchField = 'amplify-searchfield',

--- a/packages/react/src/primitives/types/index.ts
+++ b/packages/react/src/primitives/types/index.ts
@@ -21,6 +21,7 @@ export * from './placeholder';
 export * from './radio';
 export * from './radioGroupField';
 export * from './rating';
+export * from './scrollView';
 export * from './searchField';
 export * from './selectField';
 export * from './style';

--- a/packages/react/src/primitives/types/scrollView.ts
+++ b/packages/react/src/primitives/types/scrollView.ts
@@ -1,6 +1,6 @@
 import { ViewProps } from './view';
 
-type ScrollViewOrientation = 'vertical' | 'horizontal' | 'block' | 'inline';
+type ScrollViewOrientation = 'horizontal' | 'vertical';
 
 export interface ScrollViewProps extends ViewProps {
   orientation?: ScrollViewOrientation;

--- a/packages/react/src/primitives/types/scrollView.ts
+++ b/packages/react/src/primitives/types/scrollView.ts
@@ -1,0 +1,13 @@
+import { Property } from 'csstype';
+import { ViewProps } from './view';
+
+type ScrollViewOrientation =
+  | 'vertical'
+  | 'horizontal'
+  | 'block'
+  | 'inline'
+  | 'both';
+
+export interface ScrollViewProps extends ViewProps {
+  orientation?: ScrollViewOrientation;
+}

--- a/packages/react/src/primitives/types/scrollView.ts
+++ b/packages/react/src/primitives/types/scrollView.ts
@@ -1,12 +1,6 @@
-import { Property } from 'csstype';
 import { ViewProps } from './view';
 
-type ScrollViewOrientation =
-  | 'vertical'
-  | 'horizontal'
-  | 'block'
-  | 'inline'
-  | 'both';
+type ScrollViewOrientation = 'vertical' | 'horizontal' | 'block' | 'inline';
 
 export interface ScrollViewProps extends ViewProps {
   orientation?: ScrollViewOrientation;

--- a/packages/ui/src/theme/css/component/scrollView.scss
+++ b/packages/ui/src/theme/css/component/scrollView.scss
@@ -1,0 +1,19 @@
+.amplify-scrollview {
+  overflow: scroll;
+
+  &[data-orientation='horizontal'] {
+    overflow-x: scroll;
+  }
+
+  &[data-orientation='vertical'] {
+    overflow-y: scroll;
+  }
+
+  &[data-orientation='inline'] {
+    overflow-inline: scroll;
+  }
+
+  &[data-orientation='block'] {
+    overflow-block: scroll;
+  }
+}

--- a/packages/ui/src/theme/css/component/scrollView.scss
+++ b/packages/ui/src/theme/css/component/scrollView.scss
@@ -1,19 +1,14 @@
 .amplify-scrollview {
+  display: block;
   overflow: scroll;
 
   &[data-orientation='horizontal'] {
     overflow-x: scroll;
+    overflow-y: initial;
   }
 
   &[data-orientation='vertical'] {
+    overflow-x: initial;
     overflow-y: scroll;
-  }
-
-  &[data-orientation='inline'] {
-    overflow-inline: scroll;
-  }
-
-  &[data-orientation='block'] {
-    overflow-block: scroll;
   }
 }

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -43,6 +43,7 @@ html {
 // Layout
 @import './component/flex.scss';
 @import './component/grid.scss';
+@import './component/scrollView.scss';
 
 // Composed components
 @import './component/alert.scss';


### PR DESCRIPTION
*Description of changes:*

This PR will be adding `ScrollView` primitive. A `ScrollView` is essentially a `View` that allows scrolling of its inner contents.

Note: The `horizontal` and `vertical` scrolling orientation look no difference and behave the same as the default(`overflow: scroll`) because setting one axis to `visible` (the initial) while setting the other to a different value results in `visible` behaving as `auto`. See [overflow - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)

![2021-10-05 10 39 18](https://user-images.githubusercontent.com/40295569/136074771-5d79dd49-6014-4ade-8695-107823479bf3.gif)

![2021-10-05 12 20 41](https://user-images.githubusercontent.com/40295569/136088981-e703074b-e461-48cf-8adb-288db6f26dfa.gif)

![2021-10-05 12 20 55](https://user-images.githubusercontent.com/40295569/136088999-88562b31-6bd2-4a64-9849-8b9b09f5fac0.gif)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
