### PR TITLE
Fix Authenticate on reload

### DIFF
--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -62,6 +62,10 @@ When('I click the {string} radio button', (label: string) => {
   });
 });
 
+When('I reload the page', () => {
+  cy.reload();
+});
+
 Then('I see {string}', (message: string) => {
   cy.findByRole('document').contains(new RegExp(escapeRegExp(message), 'i'));
 });

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-username.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-username.feature
@@ -30,6 +30,8 @@ Feature: Sign In with Username
     And I type my password
     And I click the "Sign in" button
     Then I see "Sign out"
+    When I reload the page
+    Then I see "Sign out"
 
   # FORCE_CHANGE_PASSWORD tests are skipped as the temporary passwords used for these
   # test accounts will expire in Cognito.

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -23,7 +23,7 @@ export function createAuthenticatorMachine({
   return createMachine<AuthContext, AuthEvent>(
     {
       id: 'authenticator',
-      initial: initialState,
+      initial: 'idle',
       context: {
         user: undefined,
         config: {
@@ -123,8 +123,8 @@ export function createAuthenticatorMachine({
         }),
         applyAmplifyConfig: assign({
           config(context, event) {
-            const configuredLoginMechanisms = event.data.aws_cognito_login_mechanisms?.map(
-              (login) => {
+            const configuredLoginMechanisms =
+              event.data.aws_cognito_login_mechanisms?.map((login) => {
                 switch (login) {
                   case 'PREFERRED_USERNAME':
                     return 'username';
@@ -142,17 +142,15 @@ export function createAuthenticatorMachine({
                       `Unknown login mechanism from Amplify CLI: ${login}.\nOpen an issue: https://github.com/aws-amplify/amplify-ui/issues/choose`
                     );
                 }
-              }
-            );
+              });
 
             const defaultLoginMechanisms = configuredLoginMechanisms ?? [
               'username',
             ];
 
             // Prefer explicitly set login mechanisms from machine instantiation over defaults
-            const {
-              login_mechanisms = defaultLoginMechanisms,
-            } = context.config;
+            const { login_mechanisms = defaultLoginMechanisms } =
+              context.config;
 
             return { login_mechanisms };
           },


### PR DESCRIPTION
*Issue #, if available:* Closes #470

*Description of changes:*

`initialState` was being used for `initial`, which bypassed the `idle` checks.

https://user-images.githubusercontent.com/15182/136095045-51c22719-0101-4ff2-9ec3-befd8fdb8f49.mp4


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
