### PR TITLE
Fix SSR warning

### DIFF
--- a/examples/next/pages/_app.page.tsx
+++ b/examples/next/pages/_app.page.tsx
@@ -1,0 +1,10 @@
+import { AmplifyProvider } from '@aws-amplify/ui-react';
+
+export default function ExampleApp({ Component, pageProps }) {
+  console.log('Render');
+  return (
+    <AmplifyProvider>
+      <Component {...pageProps} />
+    </AmplifyProvider>
+  );
+}

--- a/examples/next/pages/_app.page.tsx
+++ b/examples/next/pages/_app.page.tsx
@@ -1,7 +1,6 @@
 import { AmplifyProvider } from '@aws-amplify/ui-react';
 
 export default function ExampleApp({ Component, pageProps }) {
-  console.log('Render');
   return (
     <AmplifyProvider>
       <Component {...pageProps} />

--- a/packages/react/src/components/AmplifyProvider/index.tsx
+++ b/packages/react/src/components/AmplifyProvider/index.tsx
@@ -6,7 +6,7 @@ import { defaultTheme, defaultCSSVariables, Theme } from '../../theming';
 
 interface AmplifyProviderProps {
   children: ReactNode;
-  components: Record<string, ReactNode>;
+  components?: Record<string, ReactNode>;
   theming?: { theme: Theme; CSSVariables: {} };
 }
 export function AmplifyProvider({
@@ -15,12 +15,7 @@ export function AmplifyProvider({
   theming = { theme: defaultTheme, CSSVariables: defaultCSSVariables },
 }: AmplifyProviderProps) {
   return (
-    <AmplifyContext.Provider
-      value={{
-        components,
-        theming,
-      }}
-    >
+    <AmplifyContext.Provider value={{ components, theming }}>
       <IdProvider>
         <div data-amplify-theme="">{children}</div>
       </IdProvider>


### PR DESCRIPTION
*Issue #, if available:* #450

*Description of changes:*

When running http://localhost:3000/ui/components/authenticator/withAuthenticator, I still get warnings:

```console
When server rendering, you must wrap your application in an <IdProvider> to ensure consistent ids are generated between the client and server.
When server rendering, you must wrap your application in an <IdProvider> to ensure consistent ids are generated between the client and server.
When server rendering, you must wrap your application in an <IdProvider> to ensure consistent ids are generated between the client and server.
```

I also confirmed that the `AmplifyProvider` is wrapping the page, including the `IdProvider`:

> ![Screen Shot 2021-10-05 at 3 19 25 PM](https://user-images.githubusercontent.com/15182/136096776-f43fa81f-bd43-4833-b231-80050273faff.png)
> ![Screen Shot 2021-10-05 at 3 19 34 PM](https://user-images.githubusercontent.com/15182/136096781-5d093f77-df21-49cd-9664-153e4ad9fe92.png)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
