### PR TITLE
ButtonGroup Primitive

### DIFF
--- a/docs/src/pages/ui/primitives/button/react.mdx
+++ b/docs/src/pages/ui/primitives/button/react.mdx
@@ -1,4 +1,4 @@
-import { Button } from '@aws-amplify/ui-react';
+import { Button, ButtonGroup, Flex } from '@aws-amplify/ui-react';
 import { ButtonDemo } from './demo';
 import { Example } from '@/components/Example';
 
@@ -103,6 +103,78 @@ Setting an `aria-label` attribute for an icon Button:
 
 <Example>
   <Button ariaLabel="To the moon!">🚀</Button>
+</Example>
+
+### ButtonGroup
+
+Use a `ButtonGroup` to group buttons with the same `size` or `variation`.
+
+```jsx
+import { Button, ButtonGroup } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+// same size
+<ButtonGroup size="small">
+  <Button>🚀</Button>
+  <Button>🚀</Button>
+  <Button>🚀</Button>
+</ButtonGroup>;
+
+// same variation
+<ButtonGroup variation="primary">
+  <Button>🚀</Button>
+  <Button>🚀</Button>
+  <Button>🚀</Button>
+</ButtonGroup>;
+```
+
+<Example>
+  <Flex direction="column">
+    <ButtonGroup size="small">
+      <Button>🚀</Button>
+      <Button>🚀</Button>
+      <Button>🚀</Button>
+    </ButtonGroup>
+    <ButtonGroup variation="primary">
+      <Button>🚀</Button>
+      <Button>🚀</Button>
+      <Button>🚀</Button>
+    </ButtonGroup>
+  </Flex>
+</Example>
+
+`ButtonGroup` is also a flex container, so any flex props can apply to it for layout purpose. See [Flex](/ui/primitives/flex?platform=react).
+
+```jsx
+import { Button, ButtonGroup } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+<ButtonGroup justifyContent="center">
+  <Button>🚀</Button>
+  <Button>🚀</Button>
+  <Button>🚀</Button>
+</ButtonGroup>
+
+<ButtonGroup direction="column">
+  <Button>🚀</Button>
+  <Button>🚀</Button>
+  <Button>🚀</Button>
+</ButtonGroup>;
+```
+
+<Example>
+  <Flex direction="column">
+    <ButtonGroup justifyContent="center">
+      <Button>🚀</Button>
+      <Button>🚀</Button>
+      <Button>🚀</Button>
+    </ButtonGroup>
+    <ButtonGroup direction="column">
+      <Button>🚀</Button>
+      <Button>🚀</Button>
+      <Button>🚀</Button>
+    </ButtonGroup>
+  </Flex>
 </Example>
 
 ## CSS Styling

--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -14,6 +14,7 @@ describe('@aws-amplify/ui-react', () => {
           "Badge",
           "Box",
           "Button",
+          "ButtonGroup",
           "Card",
           "CheckboxField",
           "Collection",

--- a/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,42 @@
+import classNames from 'classnames';
+import * as React from 'react';
+
+import { Flex } from '../Flex';
+import { ButtonProps } from '../types/button';
+import { ButtonGroupProps } from '../types/buttonGroup';
+import { ComponentClassNames } from '../shared/constants';
+
+export const ButtonGroup: React.FC<ButtonGroupProps> = ({
+  alignContent,
+  alignItems,
+  ariaLabel,
+  className,
+  children,
+  direction,
+  gap,
+  justifyContent,
+  size,
+  variation,
+  wrap,
+  ...rest
+}) => (
+  <Flex
+    alignContent={alignContent}
+    alignItems={alignItems}
+    aria-label={ariaLabel}
+    className={classNames(ComponentClassNames.ButtonGroup, className)}
+    direction={direction}
+    gap={gap}
+    justifyContent={justifyContent}
+    role="group"
+    wrap={wrap}
+    {...rest}
+  >
+    {React.Children.map(children, (child) => {
+      if (React.isValidElement<ButtonProps>(child)) {
+        return React.cloneElement(child, { size, variation });
+      }
+      return child;
+    })}
+  </Flex>
+);

--- a/packages/react/src/primitives/ButtonGroup/__tests__/ButtonGroup.test.tsx
+++ b/packages/react/src/primitives/ButtonGroup/__tests__/ButtonGroup.test.tsx
@@ -1,3 +1,55 @@
 import { render, screen } from '@testing-library/react';
 
-describe('ButtonGroup: ', () => {});
+import { Button } from '../../Button';
+import { ButtonGroup } from '../ButtonGroup';
+import { ButtonGroupProps } from '../../types';
+import { ComponentClassNames } from '../../shared/constants';
+import {
+  testFlexProps,
+  expectFlexStyleProps,
+} from '../../Flex/__tests__/Flex.test';
+
+describe('ButtonGroup: ', () => {
+  const getButtonGroup = (props: Partial<ButtonGroupProps>) => {
+    return (
+      <ButtonGroup {...props}>
+        <Button>Button 1</Button>
+        <Button>Button 2</Button>
+        <Button>Button 3</Button>
+      </ButtonGroup>
+    );
+  };
+  it('should render classname and custom classname', async () => {
+    const className = 'class-test';
+    render(getButtonGroup({ className }));
+
+    const buttonGroup = await screen.findByRole('group');
+    expect(buttonGroup).toHaveClass(ComponentClassNames.ButtonGroup, className);
+  });
+
+  it('should render all flex style props', async () => {
+    render(getButtonGroup(testFlexProps));
+    const buttonGroup = await screen.findByRole('group');
+    expectFlexStyleProps(buttonGroup);
+  });
+
+  it('should set size for each child button correctly', async () => {
+    const size = 'large';
+    render(getButtonGroup({ size }));
+
+    const buttons = await screen.findAllByRole('button');
+    expect(buttons[0]).toHaveAttribute('data-size', size);
+    expect(buttons[1]).toHaveAttribute('data-size', size);
+    expect(buttons[2]).toHaveAttribute('data-size', size);
+  });
+
+  it('should set variation for each child button correctly', async () => {
+    const variation = 'primary';
+    render(getButtonGroup({ variation }));
+
+    const buttons = await screen.findAllByRole('button');
+    expect(buttons[0]).toHaveAttribute('data-variation', variation);
+    expect(buttons[1]).toHaveAttribute('data-variation', variation);
+    expect(buttons[2]).toHaveAttribute('data-variation', variation);
+  });
+});

--- a/packages/react/src/primitives/ButtonGroup/__tests__/ButtonGroup.test.tsx
+++ b/packages/react/src/primitives/ButtonGroup/__tests__/ButtonGroup.test.tsx
@@ -1,0 +1,3 @@
+import { render, screen } from '@testing-library/react';
+
+describe('ButtonGroup: ', () => {});

--- a/packages/react/src/primitives/ButtonGroup/index.ts
+++ b/packages/react/src/primitives/ButtonGroup/index.ts
@@ -1,0 +1,1 @@
+export * from './ButtonGroup';

--- a/packages/react/src/primitives/index.tsx
+++ b/packages/react/src/primitives/index.tsx
@@ -1,6 +1,7 @@
 export * from './Alert';
 export * from './Badge';
 export * from './Button';
+export * from './ButtonGroup';
 export * from './Card';
 export * from './CheckboxField';
 export * from './Collection';

--- a/packages/react/src/primitives/shared/constants.ts
+++ b/packages/react/src/primitives/shared/constants.ts
@@ -3,6 +3,7 @@ export enum ComponentClassNames {
   AlertHeading = 'amplify-alert-heading',
   Badge = 'amplify-badge',
   Button = 'amplify-button',
+  ButtonGroup = 'amplify-buttongroup',
   Card = 'amplify-card',
   Checkbox = 'amplify-checkbox',
   CheckboxButton = 'amplify-checkbox__button',

--- a/packages/react/src/primitives/types/buttonGroup.ts
+++ b/packages/react/src/primitives/types/buttonGroup.ts
@@ -1,0 +1,9 @@
+import { AriaProps } from './base';
+import { BaseStyleProps } from './style';
+import { ButtonProps } from './button';
+import { FlexProps } from './flex';
+export interface ButtonGroupProps
+  extends AriaProps,
+    BaseStyleProps,
+    FlexProps,
+    Pick<ButtonProps, 'size' | 'variation'> {}

--- a/packages/react/src/primitives/types/buttonGroup.ts
+++ b/packages/react/src/primitives/types/buttonGroup.ts
@@ -2,8 +2,11 @@ import { AriaProps } from './base';
 import { BaseStyleProps } from './style';
 import { ButtonProps } from './button';
 import { FlexProps } from './flex';
+import React from 'react';
 export interface ButtonGroupProps
   extends AriaProps,
     BaseStyleProps,
     FlexProps,
-    Pick<ButtonProps, 'size' | 'variation'> {}
+    Pick<ButtonProps, 'size' | 'variation'> {
+  children: React.ReactNode;
+}

--- a/packages/react/src/primitives/types/index.ts
+++ b/packages/react/src/primitives/types/index.ts
@@ -2,6 +2,7 @@ export * from './alert';
 export * from './badge';
 export * from './base';
 export * from './button';
+export * from './buttonGroup';
 export * from './card';
 export * from './checkboxField';
 export * from './collection';


### PR DESCRIPTION
*Description of changes:*

This PR will be adding `ButtonGroup` primitive. A `ButtonGroup` can be use to group buttons with the same `size` or `variation`. A `ButtonGroup` is also a flex container, so any flex props can apply to it for layout purpose.

![Screen Shot 2021-10-05 at 3 26 59 PM](https://user-images.githubusercontent.com/40295569/136113120-ee501e0b-87ab-4ddf-a3c4-d7f80326e5fe.png)

![Screen Shot 2021-10-05 at 3 27 21 PM](https://user-images.githubusercontent.com/40295569/136113133-41ad6ddc-55f3-42ac-813f-3b880c4ba157.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
