### PR TITLE
Make Authenticator modal adjacent to the form

### DIFF
--- a/docs/src/components/Example.tsx
+++ b/docs/src/components/Example.tsx
@@ -7,7 +7,7 @@ interface ExampleProps {
   className?: string;
 }
 
-export function Example({ children, className }: ExampleProps) {
+export function Example({ children, className = 'example' }: ExampleProps) {
   return (
     <View
       backgroundColor="rgba(249, 250, 251, 1)"

--- a/docs/src/styles/styles.css
+++ b/docs/src/styles/styles.css
@@ -47,3 +47,21 @@ ul {
 .algolia-autocomplete + img[alt='search'] {
   display: none !important;
 }
+
+/* Inline the Authenticator instead of full-screen */
+.example [data-amplify-authenticator] {
+  position: relative;
+  width: 100%;
+  height: auto;
+
+  /* Don't go on top of docs' nav */
+  z-index: auto;
+
+  /* Allow space for shadows */
+  padding: 1rem;
+}
+
+.example [data-amplify-authenticator] [data-amplify-modal] {
+  /* Hide the modal texture */
+  display: none;
+}

--- a/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/amplify-authenticator/amplify-authenticator.component.html
@@ -39,106 +39,104 @@
 -->
 
 <div data-amplify-authenticator>
-  <div data-amplify-modal>
-    <div data-amplify-container>
-      <amplify-tabs
-        (tabChange)="onTabChange()"
-        *ngIf="actorState?.matches('signIn') || actorState?.matches('signUp')"
-      >
-        <amplify-tab-item
-          [title]="signInTitle"
-          [active]="actorState?.matches('signIn')"
-        >
-          <!-- signIn component -->
-          <ng-container
-            [ngTemplateOutlet]="customComponents.signIn || signIn"
-            [ngTemplateOutletContext]="context"
-            *ngIf="actorState?.matches('signIn')"
-          ></ng-container>
-        </amplify-tab-item>
-        <amplify-tab-item
-          [title]="signUpTitle"
-          [active]="actorState?.matches('signUp')"
-        >
-          <!-- signUp component -->
-          <ng-container
-            [ngTemplateOutlet]="customComponents.signUp || signUp"
-            [ngTemplateOutletContext]="context"
-            *ngIf="actorState?.matches('signUp')"
-          ></ng-container>
-        </amplify-tab-item>
-      </amplify-tabs>
+  <div data-amplify-modal></div>
 
-      <!-- confirmSignUp content -->
-      <ng-container
-        [ngTemplateOutlet]="customComponents.confirmSignUp || confirmSignUp"
-        [ngTemplateOutletContext]="context"
-        *ngIf="actorState?.matches('confirmSignUp')"
+  <div data-amplify-container>
+    <amplify-tabs
+      (tabChange)="onTabChange()"
+      *ngIf="actorState?.matches('signIn') || actorState?.matches('signUp')"
+    >
+      <amplify-tab-item
+        [title]="signInTitle"
+        [active]="actorState?.matches('signIn')"
       >
-      </ng-container>
+        <!-- signIn component -->
+        <ng-container
+          [ngTemplateOutlet]="customComponents.signIn || signIn"
+          [ngTemplateOutletContext]="context"
+          *ngIf="actorState?.matches('signIn')"
+        ></ng-container>
+      </amplify-tab-item>
+      <amplify-tab-item
+        [title]="signUpTitle"
+        [active]="actorState?.matches('signUp')"
+      >
+        <!-- signUp component -->
+        <ng-container
+          [ngTemplateOutlet]="customComponents.signUp || signUp"
+          [ngTemplateOutletContext]="context"
+          *ngIf="actorState?.matches('signUp')"
+        ></ng-container>
+      </amplify-tab-item>
+    </amplify-tabs>
 
-      <!-- confirmSignIn content -->
-      <ng-container
-        [ngTemplateOutlet]="customComponents.confirmSignIn || confirmSignIn"
-        [ngTemplateOutletContext]="context"
-        *ngIf="actorState?.matches('confirmSignIn')"
-      >
-      </ng-container>
+    <!-- confirmSignUp content -->
+    <ng-container
+      [ngTemplateOutlet]="customComponents.confirmSignUp || confirmSignUp"
+      [ngTemplateOutletContext]="context"
+      *ngIf="actorState?.matches('confirmSignUp')"
+    >
+    </ng-container>
 
-      <!-- setupTotp content -->
-      <ng-container
-        [ngTemplateOutlet]="customComponents.setupTOTP || setupTOTP"
-        [ngTemplateOutletContext]="context"
-        *ngIf="actorState?.matches('setupTOTP')"
-      >
-      </ng-container>
+    <!-- confirmSignIn content -->
+    <ng-container
+      [ngTemplateOutlet]="customComponents.confirmSignIn || confirmSignIn"
+      [ngTemplateOutletContext]="context"
+      *ngIf="actorState?.matches('confirmSignIn')"
+    >
+    </ng-container>
 
-      <!-- forceNewPassword content -->
-      <ng-container
-        [ngTemplateOutlet]="
-          customComponents.forceNewPassword || forceNewPassword
-        "
-        [ngTemplateOutletContext]="context"
-        *ngIf="actorState?.matches('forceNewPassword')"
-      >
-      </ng-container>
+    <!-- setupTotp content -->
+    <ng-container
+      [ngTemplateOutlet]="customComponents.setupTOTP || setupTOTP"
+      [ngTemplateOutletContext]="context"
+      *ngIf="actorState?.matches('setupTOTP')"
+    >
+    </ng-container>
 
-      <!-- resetPassword content -->
-      <ng-container
-        [ngTemplateOutlet]="customComponents.resetPassword || resetPassword"
-        [ngTemplateOutletContext]="context"
-        *ngIf="actorState?.matches('resetPassword')"
-      >
-      </ng-container>
+    <!-- forceNewPassword content -->
+    <ng-container
+      [ngTemplateOutlet]="customComponents.forceNewPassword || forceNewPassword"
+      [ngTemplateOutletContext]="context"
+      *ngIf="actorState?.matches('forceNewPassword')"
+    >
+    </ng-container>
 
-      <!-- confirmResetPassword content -->
-      <ng-container
-        [ngTemplateOutlet]="
-          customComponents.confirmResetPassword || confirmResetPassword
-        "
-        [ngTemplateOutletContext]="context"
-        *ngIf="actorState?.matches('confirmResetPassword')"
-      >
-      </ng-container>
+    <!-- resetPassword content -->
+    <ng-container
+      [ngTemplateOutlet]="customComponents.resetPassword || resetPassword"
+      [ngTemplateOutletContext]="context"
+      *ngIf="actorState?.matches('resetPassword')"
+    >
+    </ng-container>
 
-      <!-- verifyUser content -->
-      <ng-container
-        [ngTemplateOutlet]="customComponents.verifyUser || verifyUser"
-        [ngTemplateOutletContext]="context"
-        *ngIf="actorState?.matches('verifyUser')"
-      >
-      </ng-container>
+    <!-- confirmResetPassword content -->
+    <ng-container
+      [ngTemplateOutlet]="
+        customComponents.confirmResetPassword || confirmResetPassword
+      "
+      [ngTemplateOutletContext]="context"
+      *ngIf="actorState?.matches('confirmResetPassword')"
+    >
+    </ng-container>
 
-      <!-- confirmVerifyUser content -->
-      <ng-container
-        [ngTemplateOutlet]="
-          customComponents.confirmVerifyUser || confirmVerifyUser
-        "
-        [ngTemplateOutletContext]="context"
-        *ngIf="actorState?.matches('confirmVerifyUser')"
-      >
-      </ng-container>
-    </div>
+    <!-- verifyUser content -->
+    <ng-container
+      [ngTemplateOutlet]="customComponents.verifyUser || verifyUser"
+      [ngTemplateOutletContext]="context"
+      *ngIf="actorState?.matches('verifyUser')"
+    >
+    </ng-container>
+
+    <!-- confirmVerifyUser content -->
+    <ng-container
+      [ngTemplateOutlet]="
+        customComponents.confirmVerifyUser || confirmVerifyUser
+      "
+      [ngTemplateOutletContext]="context"
+      *ngIf="actorState?.matches('confirmVerifyUser')"
+    >
+    </ng-container>
   </div>
 </div>
 

--- a/packages/angular/projects/ui-angular/styles/component.css
+++ b/packages/angular/projects/ui-angular/styles/component.css
@@ -1,9 +1,4 @@
 [data-amplify-authenticator] {
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 36rem;
-  overflow: hidden;
-  border-radius: 0.375rem;
   font-size: 1rem;
   line-height: 1.5rem;
   --tw-text-opacity: 1;

--- a/packages/react/src/components/Authenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/index.tsx
@@ -54,37 +54,37 @@ export function Authenticator({
   return (
     <AuthenticatorContext.Provider value={service}>
       <View className={className} data-amplify-authenticator="">
-        <View data-amplify-modal="">
-          <View data-amplify-container="">
-            {(() => {
-              switch (true) {
-                case state.matches('authenticate'):
-                  return null;
-                case actorState?.matches('confirmSignUp'):
-                  return <ConfirmSignUp />;
-                case actorState?.matches('confirmSignIn'):
-                  return <ConfirmSignIn />;
-                case actorState?.matches('setupTOTP'):
-                  return <SetupTOTP />;
-                case actorState?.matches('signIn'):
-                case actorState?.matches('signUp'):
-                  return <SignInSignUpTabs />;
-                case actorState?.matches('forceNewPassword'):
-                  return <ForceNewPassword />;
-                case actorState?.matches('resetPassword'):
-                  return <ResetPassword />;
-                case actorState?.matches('confirmResetPassword'):
-                  return <ConfirmResetPassword />;
-                case actorState?.matches('verifyUser'):
-                  return <VerifyUser />;
-                case actorState?.matches('confirmVerifyUser'):
-                  return <ConfirmVerifyUser />;
-                default:
-                  console.warn('Unhandled Auth state', state.value);
-                  return null;
-              }
-            })()}
-          </View>
+        <View data-amplify-modal="" />
+
+        <View data-amplify-container="">
+          {(() => {
+            switch (true) {
+              case state.matches('idle'):
+                return null;
+              case actorState?.matches('confirmSignUp'):
+                return <ConfirmSignUp />;
+              case actorState?.matches('confirmSignIn'):
+                return <ConfirmSignIn />;
+              case actorState?.matches('setupTOTP'):
+                return <SetupTOTP />;
+              case actorState?.matches('signIn'):
+              case actorState?.matches('signUp'):
+                return <SignInSignUpTabs />;
+              case actorState?.matches('forceNewPassword'):
+                return <ForceNewPassword />;
+              case actorState?.matches('resetPassword'):
+                return <ResetPassword />;
+              case actorState?.matches('confirmResetPassword'):
+                return <ConfirmResetPassword />;
+              case actorState?.matches('verifyUser'):
+                return <VerifyUser />;
+              case actorState?.matches('confirmVerifyUser'):
+                return <ConfirmVerifyUser />;
+              default:
+                console.warn('Unhandled Auth state', state.value);
+                return null;
+            }
+          })()}
         </View>
       </View>
     </AuthenticatorContext.Provider>

--- a/packages/ui/src/theme/css/component/authenticator.scss
+++ b/packages/ui/src/theme/css/component/authenticator.scss
@@ -1,6 +1,5 @@
-[data-amplify-authenticator] [data-amplify-modal] {
+[data-amplify-authenticator] {
   display: grid;
-  background-color: var(--amplify-colors-neutral-10, #e1e5e9);
   width: 100vw;
   height: 100vh;
   overflow: auto;
@@ -9,13 +8,25 @@
   position: fixed;
   top: 0;
   left: 0;
+
+  /* Having a z-index at least "wins" by default */
+  z-index: 1;
+}
+
+[data-amplify-authenticator] [data-amplify-modal] {
+  // Fill Authenticator space
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: var(--amplify-colors-neutral-10, #e1e5e9);
 }
 
 /* Texture for modal */
 [data-amplify-authenticator] [data-amplify-modal]::before {
-  position: fixed;
-  height: 100vh;
-  width: 100vw;
+  // Fill modal space, but don't scroll
+  position: absolute;
+  width: 100%;
+  height: 100%;
 
   content: '';
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='texture' data-v-1d260e0e=''%3E%3Cfilter id='noise' data-v-1d260e0e=''%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.8' numOctaves='4' stitchTiles='stitch' data-v-1d260e0e=''%3E%3C/feTurbulence%3E%3CfeColorMatrix type='saturate' values='0' data-v-1d260e0e=''%3E%3C/feColorMatrix%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' data-v-1d260e0e=''%3E%3C/rect%3E%3C/svg%3E");

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -1,275 +1,270 @@
 <template>
   <div v-bind="$attrs" data-amplify-authenticator>
-    <div data-amplify-modal>
-      <div data-amplify-container>
-        <base-two-tabs
-          v-if="actorState?.matches('signIn') || actorState?.matches('signUp')"
-        >
-          <base-two-tab-item
-            :active="actorState?.matches('signIn')"
-            :id="44472"
-            :label="createAccountLabel"
-            @click="send('SIGN_IN')"
+    <div data-amplify-modal />
+    <div data-amplify-container>
+      <base-two-tabs
+        v-if="actorState?.matches('signIn') || actorState?.matches('signUp')"
+      >
+        <base-two-tab-item
+          :active="actorState?.matches('signIn')"
+          :id="44472"
+          :label="createAccountLabel"
+          @click="send('SIGN_IN')"
+        />
+        <base-two-tab-item
+          :active="actorState?.matches('signUp')"
+          :id="44471"
+          :label="signInLabel"
+          @click="send('SIGN_UP')"
+        />
+      </base-two-tabs>
+      <sign-in
+        v-if="actorState?.matches('signIn')"
+        @sign-in-submit="onSignInSubmitI"
+        ref="signInComponent"
+      >
+        <template #signInSlotI>
+          <slot name="sign-in"></slot>
+        </template>
+
+        <template #forgot-password-section="{ onForgotPasswordClicked }">
+          <slot
+            name="sign-in-forgot-password-section"
+            :onForgotPasswordClicked="onForgotPasswordClicked"
           />
-          <base-two-tab-item
-            :active="actorState?.matches('signUp')"
-            :id="44471"
-            :label="signInLabel"
-            @click="send('SIGN_UP')"
-          />
-        </base-two-tabs>
-        <sign-in
-          v-if="actorState?.matches('signIn')"
-          @sign-in-submit="onSignInSubmitI"
-          ref="signInComponent"
+        </template>
+
+        <template #sign-in-button="{ onSignInSubmit }">
+          <slot name="sign-in-button" :onSignInSubmit="onSignInSubmit" />
+        </template>
+
+        <template
+          #form="{
+            info,
+            onSignInSubmit,
+            onCreateAccountClicked,
+            onForgotPasswordClicked,
+          }"
         >
-          <template #signInSlotI>
-            <slot name="sign-in"></slot>
-          </template>
+          <slot
+            name="sign-in-form"
+            :info="info"
+            :onSignInSubmit="onSignInSubmit"
+            :onCreateAccountClicked="onCreateAccountClicked"
+            :onForgotPasswordClicked="onForgotPasswordClicked"
+          ></slot>
+        </template>
 
-          <template #forgot-password-section="{ onForgotPasswordClicked }">
-            <slot
-              name="sign-in-forgot-password-section"
-              :onForgotPasswordClicked="onForgotPasswordClicked"
-            />
-          </template>
+        <template #heading>
+          <slot name="sign-in-heading"></slot>
+        </template>
 
-          <template #sign-in-button="{ onSignInSubmit }">
-            <slot name="sign-in-button" :onSignInSubmit="onSignInSubmit" />
-          </template>
-
-          <template
-            #form="{
-              info,
-              onSignInSubmit,
-              onCreateAccountClicked,
-              onForgotPasswordClicked,
-            }"
+        <template #footer="{ info, onSignInSubmit, onCreateAccountClicked }">
+          <slot
+            name="sign-in-footer"
+            :info="info"
+            :onSignInSubmit="onSignInSubmit"
+            :onCreateAccountClicked="onCreateAccountClicked"
           >
-            <slot
-              name="sign-in-form"
-              :info="info"
-              :onSignInSubmit="onSignInSubmit"
-              :onCreateAccountClicked="onCreateAccountClicked"
-              :onForgotPasswordClicked="onForgotPasswordClicked"
-            ></slot>
-          </template>
+          </slot>
+        </template>
 
-          <template #heading>
-            <slot name="sign-in-heading"></slot>
-          </template>
-
-          <template #footer="{ info, onSignInSubmit, onCreateAccountClicked }">
-            <slot
-              name="sign-in-footer"
-              :info="info"
-              :onSignInSubmit="onSignInSubmit"
-              :onCreateAccountClicked="onCreateAccountClicked"
-            >
-            </slot>
-          </template>
-
-          <template
-            #additional-fields="{ onSignInSubmit, onCreateAccountClicked }"
+        <template
+          #additional-fields="{ onSignInSubmit, onCreateAccountClicked }"
+        >
+          <slot
+            name="sign-in-additional-fields"
+            :onSignInSubmit="onSignInSubmit"
+            :onCreateAccountClicked="onCreateAccountClicked"
           >
-            <slot
-              name="sign-in-additional-fields"
-              :onSignInSubmit="onSignInSubmit"
-              :onCreateAccountClicked="onCreateAccountClicked"
-            >
-            </slot>
-          </template>
-          <template #signin-fields="{ info }">
-            <slot name="sign-in-fields" :info="info"></slot>
-          </template>
-        </sign-in>
-        <sign-up
-          v-if="actorState?.matches('signUp')"
-          @sign-up-submit="onSignUpSubmitI"
-          ref="signUpComponent"
-        >
-          <template #signup-fields="{ info }">
-            <slot name="sign-up-fields" :info="info"></slot>
-          </template>
+          </slot>
+        </template>
+        <template #signin-fields="{ info }">
+          <slot name="sign-in-fields" :info="info"></slot>
+        </template>
+      </sign-in>
+      <sign-up
+        v-if="actorState?.matches('signUp')"
+        @sign-up-submit="onSignUpSubmitI"
+        ref="signUpComponent"
+      >
+        <template #signup-fields="{ info }">
+          <slot name="sign-up-fields" :info="info"></slot>
+        </template>
 
-          <template #signUpSlotI>
-            <slot name="sign-up"></slot>
-          </template>
+        <template #signUpSlotI>
+          <slot name="sign-up"></slot>
+        </template>
 
-          <template #footer="{ onHaveAccountClicked, onSignUpSubmit, info }">
-            <slot
-              name="sign-up-footer"
-              :info="info"
-              :onHaveAccountClicked="onHaveAccountClicked"
-              :onSignUpSubmit="onSignUpSubmit"
-            >
-            </slot>
-          </template>
-        </sign-up>
-        <div v-if="actorState?.matches('signIn.rejected')">
-          Error! Can't sign in!
-        </div>
-
-        <confirm-sign-up
-          v-if="actorState?.matches('confirmSignUp')"
-          @confirm-sign-up-submit="onConfirmSignUpSubmitI"
-          ref="confirmSignUpComponent"
-        >
-          <template #confirmSignUpSlotI>
-            <slot name="confirm-sign-up"></slot>
-          </template>
-          <template #footer="{ info, onConfirmSignUpSubmit }">
-            <slot
-              name="sign-in-footer"
-              :info="info"
-              :onConfirmSignUpSubmit="onConfirmSignUpSubmit"
-            >
-            </slot>
-          </template>
-        </confirm-sign-up>
-
-        <reset-password
-          v-if="actorState?.matches('resetPassword')"
-          @reset-password-submit="onResetPasswordSubmitI"
-          ref="resetPasswordComponent"
-        >
-          <template #resetPasswordSlotI>
-            <slot name="reset-password"></slot>
-          </template>
-          <template
-            #footer="{ info, onResetPasswordSubmit, onBackToSignInClicked }"
+        <template #footer="{ onHaveAccountClicked, onSignUpSubmit, info }">
+          <slot
+            name="sign-up-footer"
+            :info="info"
+            :onHaveAccountClicked="onHaveAccountClicked"
+            :onSignUpSubmit="onSignUpSubmit"
           >
-            <slot
-              name="sign-in-footer"
-              :info="info"
-              :onResetPasswordSubmit="onResetPasswordSubmit"
-              :onBackToSignInClicked="onBackToSignInClicked"
-            >
-            </slot>
-          </template>
-        </reset-password>
-
-        <confirm-reset-password
-          v-if="actorState?.matches('confirmResetPassword')"
-          @confirm-reset-password-submit="onConfirmResetPasswordSubmitI"
-          ref="confirmResetPasswordComponent"
-        >
-          <template #confirmResetPasswordSlotI>
-            <slot name="confirm-reset-password"></slot>
-          </template>
-          <template #footer="{ info, onConfirmResetPasswordSubmit }">
-            <slot
-              name="sign-in-footer"
-              :info="info"
-              :onConfirmResetPasswordSubmit="onConfirmResetPasswordSubmit"
-            >
-            </slot>
-          </template>
-        </confirm-reset-password>
-
-        <confirm-sign-in
-          v-if="actorState?.matches('confirmSignIn')"
-          @confirm-sign-in-submit="onConfirmSignInSubmitI"
-          ref="confirmSignInComponent"
-        >
-          <template #confirmSignInSlotI>
-            <slot name="confirm-sign-in"></slot>
-          </template>
-          <template
-            #footer="{ info, onConfirmSignInSubmit, onBackToSignInClicked }"
-          >
-            <slot
-              name="sign-in-footer"
-              :info="info"
-              :onConfirmSignInSubmit="onConfirmSignInSubmit"
-              :onBackToSignInClicked="onBackToSignInClicked"
-            >
-            </slot>
-          </template>
-        </confirm-sign-in>
-
-        <setup-totp
-          v-if="actorState?.matches('setupTOTP')"
-          @confirm-setup-totp-submit="onConfirmSetupTOTPSubmitI"
-          ref="confirmSetupTOTPComponent"
-        >
-          <template #confirmSetupTOTPI>
-            <slot name="confirm-setup-totp"></slot>
-          </template>
-          <template
-            #footer="{ info, onSetupTOTPSubmit, onBackToSignInClicked }"
-          >
-            <slot
-              name="sign-in-footer"
-              :info="info"
-              :onSetupTOTPSubmit="onSetupTOTPSubmit"
-              :onBackToSignInClicked="onBackToSignInClicked"
-            >
-            </slot>
-          </template>
-        </setup-totp>
-
-        <force-new-password
-          v-if="actorState?.matches('forceNewPassword')"
-          @force-new-password-submit="onForceNewPasswordSubmitI"
-          ref="forceNewPasswordComponent"
-        >
-          <template #forceNewPasswordI>
-            <slot name="force-new-password"></slot>
-          </template>
-          <template
-            #footer="{ info, onHaveAccountClicked, onForceNewPasswordSubmit }"
-          >
-            <slot
-              name="sign-in-footer"
-              :info="info"
-              :onForceNewPasswordSubmit="onForceNewPasswordSubmit"
-              :onBackToSignInClicked="onHaveAccountClicked"
-            >
-            </slot>
-          </template>
-        </force-new-password>
-
-        <verify-user
-          v-if="actorState?.matches('verifyUser')"
-          @verify-user-submit="onVerifyUserSubmitI"
-          ref="verifyUserComponent"
-        >
-          <template #verifyUserSlotI>
-            <slot name="verify-user"></slot>
-          </template>
-          <template #footer="{ info, onVerifyUserSubmit, onSkipClicked }">
-            <slot
-              name="sign-in-footer"
-              :info="info"
-              :onVerifyUserSubmit="onVerifyUserSubmit"
-              :onSkipClicked="onSkipClicked"
-            >
-            </slot>
-          </template>
-        </verify-user>
-
-        <confirm-verify-user
-          v-if="actorState?.matches('confirmVerifyUser')"
-          @confirm-verify-user-submit="onConfirmVerifyUserSubmitI"
-          ref="confirmVerifyUserComponent"
-        >
-          <template #confirmVerifyUserSlotI>
-            <slot name="confirm-verify-user"></slot>
-          </template>
-          <template
-            #footer="{ info, onConfirmVerifyUserSubmit, onSkipClicked }"
-          >
-            <slot
-              name="sign-in-footer"
-              :info="info"
-              :onConfirmVerifyUserSubmit="onConfirmVerifyUserSubmit"
-              :onSkipClicked="onSkipClicked"
-            >
-            </slot>
-          </template>
-        </confirm-verify-user>
+          </slot>
+        </template>
+      </sign-up>
+      <div v-if="actorState?.matches('signIn.rejected')">
+        Error! Can't sign in!
       </div>
+
+      <confirm-sign-up
+        v-if="actorState?.matches('confirmSignUp')"
+        @confirm-sign-up-submit="onConfirmSignUpSubmitI"
+        ref="confirmSignUpComponent"
+      >
+        <template #confirmSignUpSlotI>
+          <slot name="confirm-sign-up"></slot>
+        </template>
+        <template #footer="{ info, onConfirmSignUpSubmit }">
+          <slot
+            name="sign-in-footer"
+            :info="info"
+            :onConfirmSignUpSubmit="onConfirmSignUpSubmit"
+          >
+          </slot>
+        </template>
+      </confirm-sign-up>
+
+      <reset-password
+        v-if="actorState?.matches('resetPassword')"
+        @reset-password-submit="onResetPasswordSubmitI"
+        ref="resetPasswordComponent"
+      >
+        <template #resetPasswordSlotI>
+          <slot name="reset-password"></slot>
+        </template>
+        <template
+          #footer="{ info, onResetPasswordSubmit, onBackToSignInClicked }"
+        >
+          <slot
+            name="sign-in-footer"
+            :info="info"
+            :onResetPasswordSubmit="onResetPasswordSubmit"
+            :onBackToSignInClicked="onBackToSignInClicked"
+          >
+          </slot>
+        </template>
+      </reset-password>
+
+      <confirm-reset-password
+        v-if="actorState?.matches('confirmResetPassword')"
+        @confirm-reset-password-submit="onConfirmResetPasswordSubmitI"
+        ref="confirmResetPasswordComponent"
+      >
+        <template #confirmResetPasswordSlotI>
+          <slot name="confirm-reset-password"></slot>
+        </template>
+        <template #footer="{ info, onConfirmResetPasswordSubmit }">
+          <slot
+            name="sign-in-footer"
+            :info="info"
+            :onConfirmResetPasswordSubmit="onConfirmResetPasswordSubmit"
+          >
+          </slot>
+        </template>
+      </confirm-reset-password>
+
+      <confirm-sign-in
+        v-if="actorState?.matches('confirmSignIn')"
+        @confirm-sign-in-submit="onConfirmSignInSubmitI"
+        ref="confirmSignInComponent"
+      >
+        <template #confirmSignInSlotI>
+          <slot name="confirm-sign-in"></slot>
+        </template>
+        <template
+          #footer="{ info, onConfirmSignInSubmit, onBackToSignInClicked }"
+        >
+          <slot
+            name="sign-in-footer"
+            :info="info"
+            :onConfirmSignInSubmit="onConfirmSignInSubmit"
+            :onBackToSignInClicked="onBackToSignInClicked"
+          >
+          </slot>
+        </template>
+      </confirm-sign-in>
+
+      <setup-totp
+        v-if="actorState?.matches('setupTOTP')"
+        @confirm-setup-totp-submit="onConfirmSetupTOTPSubmitI"
+        ref="confirmSetupTOTPComponent"
+      >
+        <template #confirmSetupTOTPI>
+          <slot name="confirm-setup-totp"></slot>
+        </template>
+        <template #footer="{ info, onSetupTOTPSubmit, onBackToSignInClicked }">
+          <slot
+            name="sign-in-footer"
+            :info="info"
+            :onSetupTOTPSubmit="onSetupTOTPSubmit"
+            :onBackToSignInClicked="onBackToSignInClicked"
+          >
+          </slot>
+        </template>
+      </setup-totp>
+
+      <force-new-password
+        v-if="actorState?.matches('forceNewPassword')"
+        @force-new-password-submit="onForceNewPasswordSubmitI"
+        ref="forceNewPasswordComponent"
+      >
+        <template #forceNewPasswordI>
+          <slot name="force-new-password"></slot>
+        </template>
+        <template
+          #footer="{ info, onHaveAccountClicked, onForceNewPasswordSubmit }"
+        >
+          <slot
+            name="sign-in-footer"
+            :info="info"
+            :onForceNewPasswordSubmit="onForceNewPasswordSubmit"
+            :onBackToSignInClicked="onHaveAccountClicked"
+          >
+          </slot>
+        </template>
+      </force-new-password>
+
+      <verify-user
+        v-if="actorState?.matches('verifyUser')"
+        @verify-user-submit="onVerifyUserSubmitI"
+        ref="verifyUserComponent"
+      >
+        <template #verifyUserSlotI>
+          <slot name="verify-user"></slot>
+        </template>
+        <template #footer="{ info, onVerifyUserSubmit, onSkipClicked }">
+          <slot
+            name="sign-in-footer"
+            :info="info"
+            :onVerifyUserSubmit="onVerifyUserSubmit"
+            :onSkipClicked="onSkipClicked"
+          >
+          </slot>
+        </template>
+      </verify-user>
+
+      <confirm-verify-user
+        v-if="actorState?.matches('confirmVerifyUser')"
+        @confirm-verify-user-submit="onConfirmVerifyUserSubmitI"
+        ref="confirmVerifyUserComponent"
+      >
+        <template #confirmVerifyUserSlotI>
+          <slot name="confirm-verify-user"></slot>
+        </template>
+        <template #footer="{ info, onConfirmVerifyUserSubmit, onSkipClicked }">
+          <slot
+            name="sign-in-footer"
+            :info="info"
+            :onConfirmVerifyUserSubmit="onConfirmVerifyUserSubmit"
+            :onSkipClicked="onSkipClicked"
+          >
+          </slot>
+        </template>
+      </confirm-verify-user>
     </div>
   </div>
 


### PR DESCRIPTION
*Description of changes:*

> <img width="1172" alt="Screen Shot 2021-10-06 at 1 02 01 PM" src="https://user-images.githubusercontent.com/15182/136258367-5c50a2dd-7e78-45e3-b43e-57c9cfd199df.png">

- [x] Fix Authenticator modal appearing over docs:

    > https://ui.docs.amplify.aws/ui/components/authenticator#sign-up

	> <img width="807" alt="Screen Shot 2021-10-06 at 1 03 56 PM" src="https://user-images.githubusercontent.com/15182/136258712-8adf9ef5-b910-443e-b4a5-73fa23b47105.png">



- [x] Update `[data-amplify-modal]` to be adjacent to screen, so that customers can style/hide the modal **without affecting the sub-screen**.

	For example, I could use this style to make it more like an "overlay":

	```css
	[data-amplify-authenticator] { backdrop-filter: blur(2px) lightness(0.5); }
	[data-amplify-modal] { opacity: 0.5; }
	```


- [x] Update React
- [x] Update Vue
- [x] Update Angular

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
