### PR TITLE
Disable minification on React package

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "tsup --minify",
+    "build": "tsup",
     "dev": "tsup --watch src",
     "update:icons": "node scripts/updateIcons.js",
     "build:icons": "yarn run clean:icons && node scripts/generateIcons.js",

--- a/packages/react/tsup.config.js
+++ b/packages/react/tsup.config.js
@@ -5,10 +5,11 @@ module.exports = {
   dts: true,
   entryPoints: ['src/index.tsx', 'src/legacy.tsx'],
   // `aws-amplify` is external, but sub-dependencies weren't automatically externalized ("require" statements were included)
-  external: ['`aws-amplify', /^@aws-amplify\//],
+  external: ['`aws-amplify', /^@aws-amplify\//, 'lodash'],
   format: ['cjs', 'esm'],
   // ! .cjs/.mjs doesn't work with Angular's webpack4 config by default!
   legacyOutput: true,
   sourcemap: 'external',
+  minify: false,
   splitting: false,
 };


### PR DESCRIPTION
*Description of changes:*
`esbuild` minification cause some errors on Jest tests, as it removes important identificators (e.g component names). 

Additionally, `lodash` was marked as external dependency to prevent extra bundling (it's already a dependency of `@aws-amplify/ui`)

Minification will be restored after https://github.com/aws-amplify/amplify-ui/issues/487 is solved


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
