### PR TITLE
chore: add helper function to allow a flat list of sort configurations as input to Datastore.query

### DIFF
--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -1876,6 +1876,7 @@ describe('@aws-amplify/ui-react', () => {
           "VisuallyHidden",
           "Wrapper",
           "components",
+          "convertSortPredicatesToDataStore",
           "defaultCSSVariables",
           "defaultTheme",
           "extendTheming",

--- a/packages/react/src/primitives/shared/__tests__/utils.test.tsx
+++ b/packages/react/src/primitives/shared/__tests__/utils.test.tsx
@@ -1,4 +1,8 @@
-import { getConsecutiveIntArray, strHasLength } from '../utils';
+import {
+  convertSortPredicatesToDataStore,
+  getConsecutiveIntArray,
+  strHasLength,
+} from '../utils';
 import { ViewProps } from '../../types';
 
 const props: ViewProps = {
@@ -51,5 +55,51 @@ describe('strHasLength: ', () => {
 
   it('should return true for strings with a length', () => {
     expect(strHasLength('some string')).toBe(true);
+  });
+});
+
+describe('convertSortPredicatesToDataStore', () => {
+  const [firstName, lastName, age] = [jest.fn(), jest.fn(), jest.fn()];
+  const testObject = {
+    firstName,
+    lastName,
+    age,
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('transforms an empty list of predicates correctly, and the models provided are not accessed', () => {
+    convertSortPredicatesToDataStore([])(testObject);
+    expect(firstName).not.toBeCalled();
+    expect(lastName).not.toBeCalled();
+    expect(age).not.toBeCalled();
+  });
+  it('transforms a simple predicate correctly, and the model provided is only accessed directly on the `firstName` field', () => {
+    convertSortPredicatesToDataStore([
+      {
+        field: 'firstName',
+        direction: 'ASC',
+      },
+    ])(testObject);
+    expect(firstName).toBeCalled();
+    expect(lastName).not.toBeCalled();
+    expect(age).not.toBeCalled();
+  });
+  it('transforms multiple predicates correctly, and the model provided is only accessed via the `firstName` and `age` fields', () => {
+    convertSortPredicatesToDataStore([
+      {
+        field: 'firstName',
+        direction: 'ASC',
+      },
+      {
+        field: 'age',
+        direction: 'DESC',
+      },
+    ])(testObject);
+    expect(firstName).toBeCalled();
+    expect(lastName).not.toBeCalled();
+    expect(age).toBeCalled();
   });
 });

--- a/packages/react/src/primitives/shared/index.ts
+++ b/packages/react/src/primitives/shared/index.ts
@@ -3,5 +3,7 @@ export {
   EscapeHatchProps,
   findChildOverrides,
   getOverrideProps,
+  SortPredicateInput,
+  convertSortPredicatesToDataStore,
 } from './utils';
 export * from './i18n';

--- a/packages/react/src/primitives/shared/utils.ts
+++ b/packages/react/src/primitives/shared/utils.ts
@@ -1,3 +1,4 @@
+import { SortDirection } from '@aws-amplify/datastore';
 import { useId } from '@radix-ui/react-id';
 
 export const strHasLength = (str: unknown): str is string =>
@@ -87,3 +88,34 @@ export const getOverrideProps = (
 export type EscapeHatchProps = {
   [elementHierarchy: string]: Record<string, string>;
 };
+
+export type SortPredicateInput = {
+  field: string;
+  direction: 'ASC' | 'DESC';
+};
+
+/**
+ * Accepts a list of sort predicate options (field name and direction) and converts into a function
+ * to be handed to the DataStore provider class.
+ */
+export function convertSortPredicatesToDataStore(
+  predicates: readonly SortPredicateInput[]
+): (s: any) => any {
+  const clonedPredicates = [...predicates];
+
+  return (s: Record<string, Function>) => {
+    while (clonedPredicates.length) {
+      const nextPredicate = clonedPredicates.shift();
+
+      if (nextPredicate) {
+        s[nextPredicate.field](
+          nextPredicate.direction === 'ASC'
+            ? SortDirection.ASCENDING
+            : SortDirection.DESCENDING
+        );
+      }
+    }
+
+    return s;
+  };
+}


### PR DESCRIPTION
This adds a helper function that accepts a list of Model attributes and sort order, and generates the associated sort function which will be passed into the `DataStore.query()` method call.