### PR TITLE
ci: wrap changeset commands with npm scripts

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -35,7 +35,7 @@ jobs:
         # There needs to be a changeset for @aws-amplify/ui[-framework] to publish.
         run: cp .github/changeset-presets/bump-versions.md .changeset
       - name: Run changeset version to next tag
-        run: yarn changeset version --snapshot next
+        run: yarn version:next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build packages
@@ -47,4 +47,4 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish to next tag
-        run: yarn changeset publish --tag next
+        run: yarn publish:next

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "environments": "yarn workspace environments",
     "build:icons": "yarn react build:icons",
     "test": "yarn react test && yarn e2e test",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "version:next": "yarn changeset version --snapshot next",
+    "publish:next": "yarn changeset publish --tag next"
   },
   "workspaces": [
     "docs",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Wraps `changeset` commands with npm scripts to reduce the risk of accidentally publishing to `next`. Will update our runbook shortly to reflect this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
