### PR TITLE
SelectField styling: nowrap and min-width

### DIFF
--- a/packages/ui/src/theme/css/component/select.scss
+++ b/packages/ui/src/theme/css/component/select.scss
@@ -14,5 +14,15 @@
 
 .amplify-select {
   @extend %amplify-field-control;
+  // default styles
   padding-inline-end: var(--amplify-components-select-padding-inline-end);
+  min-width: var(--amplify-components-select-min-width);
+  white-space: var(--amplify-components-select-white-space);
+
+  &[data-size='small'] {
+    min-width: var(--amplify-components-select-small-min-width);
+  }
+  &[data-size='large'] {
+    min-width: var(--amplify-components-select-large-min-width);
+  }
 }

--- a/packages/ui/src/theme/tokens/components/select.js
+++ b/packages/ui/src/theme/tokens/components/select.js
@@ -13,4 +13,12 @@ module.exports = {
     right: { value: '{space.medium.value}' },
     pointerEvents: { value: 'none' },
   },
+  whiteSpace: { value: 'nowrap' },
+  minWidth: { value: '6.5rem' },
+  small: {
+    minWidth: { value: '5.5rem' },
+  },
+  large: {
+    minWidth: { value: '7.5rem' },
+  },
 };


### PR DESCRIPTION
*Issue #, if available:* [Asana](https://app.asana.com/0/1201168263097047/1201098075583859)

*Description of changes:* Currently, the `SelectField` primitive has odd behavior when showing values that are longer than the field box. This PR adds some global styling which will prevent long select options from wrapping (causing the `SelectField` height to expand) as well as add `min-width` styling based on the `size` attribute of the field.

### Before
![wrapping](https://user-images.githubusercontent.com/26472139/137005050-5a6de1dc-0575-44e2-8a72-38611b1c77ff.gif)

### After
![nowrap](https://user-images.githubusercontent.com/26472139/137005098-23ae9413-d210-4dea-ab1e-c4325b26c455.gif)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
