### PR TITLE
chore: removing references to deprecated codegen feature flags

### DIFF
--- a/environments/auth-with-all-attributes/amplify/cli.json
+++ b/environments/auth-with-all-attributes/amplify/cli.json
@@ -19,11 +19,6 @@
       "forcealiasattributes": false
     },
     "codegen": {
-      "useappsyncmodelgenplugin": true,
-      "usedocsgeneratorplugin": true,
-      "usetypesgeneratorplugin": true,
-      "cleangeneratedmodelsdirectory": true,
-      "retaincasestyle": true,
       "addtimestampfields": true,
       "handlelistnullabilitytransparently": true,
       "emitauthprovider": true,

--- a/environments/auth-with-email/amplify/cli.json
+++ b/environments/auth-with-email/amplify/cli.json
@@ -18,11 +18,6 @@
             "breakcirculardependency": true
         },
         "codegen": {
-            "useappsyncmodelgenplugin": true,
-            "usedocsgeneratorplugin": true,
-            "usetypesgeneratorplugin": true,
-            "cleangeneratedmodelsdirectory": true,
-            "retaincasestyle": true,
             "addtimestampfields": true,
             "handlelistnullabilitytransparently": true,
             "emitauthprovider": true,

--- a/environments/auth-with-federated/amplify/cli.json
+++ b/environments/auth-with-federated/amplify/cli.json
@@ -18,11 +18,6 @@
             "breakcirculardependency": true
         },
         "codegen": {
-            "useappsyncmodelgenplugin": true,
-            "usedocsgeneratorplugin": true,
-            "usetypesgeneratorplugin": true,
-            "cleangeneratedmodelsdirectory": true,
-            "retaincasestyle": true,
             "addtimestampfields": true,
             "handlelistnullabilitytransparently": true,
             "emitauthprovider": true,

--- a/environments/auth-with-multi-alias/amplify/cli.json
+++ b/environments/auth-with-multi-alias/amplify/cli.json
@@ -18,11 +18,6 @@
       "breakcirculardependency": true
     },
     "codegen": {
-      "useappsyncmodelgenplugin": true,
-      "usedocsgeneratorplugin": true,
-      "usetypesgeneratorplugin": true,
-      "cleangeneratedmodelsdirectory": true,
-      "retaincasestyle": true,
       "addtimestampfields": true,
       "handlelistnullabilitytransparently": true,
       "emitauthprovider": true,

--- a/environments/auth-with-phone-and-sms-mfa/amplify/cli.json
+++ b/environments/auth-with-phone-and-sms-mfa/amplify/cli.json
@@ -18,11 +18,6 @@
             "breakcirculardependency": true
         },
         "codegen": {
-            "useappsyncmodelgenplugin": true,
-            "usedocsgeneratorplugin": true,
-            "usetypesgeneratorplugin": true,
-            "cleangeneratedmodelsdirectory": true,
-            "retaincasestyle": true,
             "addtimestampfields": true,
             "handlelistnullabilitytransparently": true,
             "emitauthprovider": true,

--- a/environments/auth-with-phone-number/amplify/cli.json
+++ b/environments/auth-with-phone-number/amplify/cli.json
@@ -18,11 +18,6 @@
             "breakcirculardependency": true
         },
         "codegen": {
-            "useappsyncmodelgenplugin": true,
-            "usedocsgeneratorplugin": true,
-            "usetypesgeneratorplugin": true,
-            "cleangeneratedmodelsdirectory": true,
-            "retaincasestyle": true,
             "addtimestampfields": true,
             "handlelistnullabilitytransparently": true,
             "emitauthprovider": true,

--- a/environments/auth-with-totp-and-sms-mfa/amplify/cli.json
+++ b/environments/auth-with-totp-and-sms-mfa/amplify/cli.json
@@ -18,11 +18,6 @@
             "breakcirculardependency": true
         },
         "codegen": {
-            "useappsyncmodelgenplugin": true,
-            "usedocsgeneratorplugin": true,
-            "usetypesgeneratorplugin": true,
-            "cleangeneratedmodelsdirectory": true,
-            "retaincasestyle": true,
             "addtimestampfields": true,
             "handlelistnullabilitytransparently": true,
             "emitauthprovider": true,

--- a/environments/auth-with-totp-mfa/amplify/cli.json
+++ b/environments/auth-with-totp-mfa/amplify/cli.json
@@ -18,11 +18,6 @@
             "breakcirculardependency": true
         },
         "codegen": {
-            "useappsyncmodelgenplugin": true,
-            "usedocsgeneratorplugin": true,
-            "usetypesgeneratorplugin": true,
-            "cleangeneratedmodelsdirectory": true,
-            "retaincasestyle": true,
             "addtimestampfields": true,
             "handlelistnullabilitytransparently": true,
             "emitauthprovider": true,

--- a/environments/auth-with-username-no-attributes/amplify/cli.json
+++ b/environments/auth-with-username-no-attributes/amplify/cli.json
@@ -17,11 +17,6 @@
       "breakcirculardependency": true
     },
     "codegen": {
-      "useappsyncmodelgenplugin": true,
-      "usedocsgeneratorplugin": true,
-      "usetypesgeneratorplugin": true,
-      "cleangeneratedmodelsdirectory": true,
-      "retaincasestyle": true,
       "addtimestampfields": true,
       "handlelistnullabilitytransparently": true
     },

--- a/environments/auth-with-username/amplify/cli.json
+++ b/environments/auth-with-username/amplify/cli.json
@@ -17,11 +17,6 @@
             "breakcirculardependency": true
         },
         "codegen": {
-            "useappsyncmodelgenplugin": true,
-            "usedocsgeneratorplugin": true,
-            "usetypesgeneratorplugin": true,
-            "cleangeneratedmodelsdirectory": true,
-            "retaincasestyle": true,
             "addtimestampfields": true,
             "handlelistnullabilitytransparently": true
         },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

These feature flags have been defaulting to true for some time now, and we're planning to deprecate them as they're past the 6 month milestone. Removing references in amplify-ui environment configurations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
