### PR TITLE
Re-export AmplifySignIn & AmplifySignOut for @aws-amplify/ui-react/legacy

### DIFF
--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -1909,6 +1909,8 @@ describe('@aws-amplify/ui-react/legacy', () => {
           "AmplifyS3ImagePicker",
           "AmplifyS3Text",
           "AmplifyS3TextPicker",
+          "AmplifySignIn",
+          "AmplifySignOut",
           "withAuthenticator",
         ]
       `);

--- a/packages/react/src/legacy.tsx
+++ b/packages/react/src/legacy.tsx
@@ -1,6 +1,8 @@
 export {
   /** @deprecated `AmplifyAuthenticator` is the v1 release. Prefer the latest `Authenticator` for continued support. */
   AmplifyAuthenticator,
+  AmplifySignIn,
+  AmplifySignOut,
   AmplifyChatbot,
   AmplifyPhotoPicker,
   AmplifyPicker,


### PR DESCRIPTION
*Issue #, if available:* Fixes #514

*Description of changes:*

- [x] Re-export `AmplifySignIn` from `@aws-amplify/ui-react/legacy`
- [x] Re-export `AmplifySignOut` from `@aws-amplify/ui-react/legacy`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
