### PR TITLE
fix(angular): fix typo value --> initialValue

### DIFF
--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.html
@@ -22,7 +22,7 @@
     [label]="inferLabel()"
     [placeholder]="inferPlaceholder()"
     [required]="required"
-    [value]="initialValue"
+    [initialValue]="initialValue"
     [disabled]="disabled"
     [autocomplete]="autocomplete"
   ></amplify-password-field>
@@ -35,7 +35,7 @@
     [label]="inferLabel()"
     [placeholder]="inferPlaceholder()"
     [required]="required"
-    [value]="initialValue"
+    [initialValue]="initialValue"
     [disabled]="disabled"
     [autocomplete]="autocomplete"
   ></amplify-text-field>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes two typos from `amplify-form-field`. These should be `initialValue`  not`value`:

https://github.com/aws-amplify/amplify-ui/blob/3f38ab5e71b78805a8716d19afa010dd772e9b9a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-text-field/amplify-text-field.component.ts#L11

https://github.com/aws-amplify/amplify-ui/blob/3f38ab5e71b78805a8716d19afa010dd772e9b9a/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.ts#L14


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
