### PR TITLE
fix: fixing React hook dependency array in usePropStyles

### DIFF
--- a/packages/react/src/primitives/shared/styleUtils.ts
+++ b/packages/react/src/primitives/shared/styleUtils.ts
@@ -72,7 +72,7 @@ export const usePropStyles = (props: ViewProps, style: React.CSSProperties) => {
           breakpoints,
         })
       ),
-    [props, style, breakpoints, breakpoint]
+    [propStyles, style, breakpoints, breakpoint]
   );
 };
 


### PR DESCRIPTION
*Issue #, if available:*

The hook dependency is incorrect in `usePropStyles`

*Description of changes:*

Update the dependency array from `[props, style, breakpoints, breakpoint]` to `[propStyles, style, breakpoints, breakpoint]`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
