### PR TITLE
Fix ui theme build - change imports

### DIFF
--- a/packages/ui/.gitignore
+++ b/packages/ui/.gitignore
@@ -1,1 +1,3 @@
 dist
+src/theme/theme.ts
+src/theme/tokens.ts

--- a/packages/ui/src/theme/baseTheme.ts
+++ b/packages/ui/src/theme/baseTheme.ts
@@ -1,4 +1,4 @@
-import { tokens } from './tokens';
+import tokens from './tokens';
 import { breakpoints } from './breakpoints';
 import { BaseTheme } from './types';
 

--- a/packages/ui/src/theme/createTheme.ts
+++ b/packages/ui/src/theme/createTheme.ts
@@ -5,8 +5,10 @@ import flattenProperties from 'style-dictionary/lib/utils/flattenProperties';
 import { baseTheme as _baseTheme } from './baseTheme';
 import { Theme, BaseTheme, BrowserTheme, Override } from './types';
 import { cssValue, cssNameTransform } from './utils';
-import { Tokens } from './tokens';
+import Tokens from './tokens';
 import { DesignToken, DesignTokenValue } from './tokens/types/designToken';
+
+type Tokens = typeof Tokens;
 
 interface SetupToken extends DesignToken {
   name: string;

--- a/packages/ui/src/theme/types.ts
+++ b/packages/ui/src/theme/types.ts
@@ -1,8 +1,10 @@
 import { PartialDeep } from 'type-fest';
-import { Tokens } from './tokens';
+import tokens from './tokens';
 import { Breakpoints } from './breakpoints';
 
 export { DesignToken } from './tokens/types/designToken';
+
+type Tokens = typeof tokens;
 
 /**
  * An override is a set of tokens that override others


### PR DESCRIPTION
*Description of changes:*
This PR fixes a build issue I had on `main` building the `ui` package. I am getting the following error message:
```bash
✖ @aws-amplify/ui at packages/ui 1.641s
  ✖ build 1.217s
    │ changes:
    │   + src/theme/baseTheme.ts
    │   + src/theme/createTheme.ts
    │   + src/theme/types.ts
    ✔ prebuild 75ms
      ✔ $ rimraf dist 75ms
    ✖ build:sd 1.137s
      ✖ $ ts-node --transpile-only sd.config.ts 1.137s
        │ /Volumes/workplace/amplify-ui-2/packages/ui/src/theme/createTheme.ts:47
        │   if (obj.hasOwnProperty('value')) {
        │           ^
        │ TypeError: Cannot read property 'hasOwnProperty' of undefined
        │     at setupTokens
        │ (/Volumes/workplace/amplify-ui-2/packages/ui/src/theme/createTheme.ts:47:11)
        │     at createTheme
        │ (/Volumes/workplace/amplify-ui-2/packages/ui/src/theme/createTheme.ts:81:26)
        │     at Object.<anonymous>
        │ (/Volumes/workplace/amplify-ui-2/packages/ui/src/theme/index.ts:7:40)
        │     at Module._compile (internal/modules/cjs/loader.js:1072:14)
        │     at Module.m._compile
        │ (/Volumes/workplace/amplify-ui-2/node_modules/ts-node/src/index.ts:1365:23)
        │     at Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
        │     at Object.require.extensions.<computed> [as .ts]
        │ (/Volumes/workplace/amplify-ui-2/node_modules/ts-node/src/index.ts:1368:12)
        │     at Module.load (internal/modules/cjs/loader.js:937:32)
        │     at Function.Module._load (internal/modules/cjs/loader.js:778:12)
        │     at Module.require (internal/modules/cjs/loader.js:961:19)
        │
error
error Command ts-node failed with exit code 1
```

The issue appears to be that the tokens are undefined due to the `tokens.ts` file being a default export rather than a named export. I updated the import to use the default import instead, and the build works now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
