### PR TITLE
refactor(Angular): Use tsconfig paths to simplify imports

### DIFF
--- a/packages/angular/angular.json
+++ b/packages/angular/angular.json
@@ -12,12 +12,12 @@
         "build": {
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
-            "tsConfig": "projects/ui-angular/tsconfig.lib.json",
+            "tsConfig": "projects/ui-angular/tsconfig.json",
             "project": "projects/ui-angular/ng-package.json"
           },
           "configurations": {
             "production": {
-              "tsConfig": "projects/ui-angular/tsconfig.lib.prod.json"
+              "tsConfig": "projects/ui-angular/tsconfig.prod.json"
             }
           }
         },
@@ -33,7 +33,7 @@
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
             "tsConfig": [
-              "projects/ui-angular/tsconfig.lib.json",
+              "projects/ui-angular/tsconfig.json",
               "projects/ui-angular/tsconfig.spec.json"
             ],
             "exclude": ["**/node_modules/**"]

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/authenticator.module.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/authenticator.module.ts
@@ -32,7 +32,7 @@ import { PhoneNumberFieldComponent } from '../../primitives/phone-number-field/p
 import { TabItemComponent } from '../../primitives/tab-item/tab-item.component';
 import { TabsComponent } from '../../primitives/tabs/tabs.component';
 
-import { AmplifySlotDirective } from '../../directives/amplify-slot.directive';
+import { AmplifySlotDirective } from '@/directives/amplify-slot.directive';
 
 @NgModule({
   declarations: [

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.ts
@@ -15,10 +15,10 @@ import {
   translations,
 } from '@aws-amplify/ui';
 import { I18n } from 'aws-amplify';
-import { CustomComponents } from '../../../../common';
-import { AmplifySlotDirective } from '../../../../directives/amplify-slot.directive';
-import { AuthPropService } from '../../../../services/authenticator-context.service';
-import { StateMachineService } from '../../../../services/state-machine.service';
+import { CustomComponents } from '@/common';
+import { AmplifySlotDirective } from '@/directives/amplify-slot.directive';
+import { AuthPropService } from '@/services/authenticator-context.service';
+import { StateMachineService } from '@/services/state-machine.service';
 
 @Component({
   selector: 'amplify-authenticator',

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.ts
@@ -16,8 +16,8 @@ import {
   SignInContext,
   SignInState,
 } from '@aws-amplify/ui';
-import { StateMachineService } from '../../../../services/state-machine.service';
-import { AuthPropService } from '../../../../services/authenticator-context.service';
+import { StateMachineService } from '@/services/state-machine.service';
+import { AuthPropService } from '@/services/authenticator-context.service';
 import { translate } from '@aws-amplify/ui';
 
 const logger = new Logger('ConfirmSignIn');

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.ts
@@ -7,8 +7,8 @@ import {
   SignUpState,
 } from '@aws-amplify/ui';
 import { Subscription } from 'xstate';
-import { StateMachineService } from '../../../../services/state-machine.service';
-import { AuthPropService } from '../../../../services/authenticator-context.service';
+import { StateMachineService } from '@/services/state-machine.service';
+import { AuthPropService } from '@/services/authenticator-context.service';
 import { translate } from '@aws-amplify/ui';
 @Component({
   selector: 'amplify-confirm-sign-up',

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-federated-sign-in-button/amplify-federated-sign-in-button.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-federated-sign-in-button/amplify-federated-sign-in-button.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { FederatedIdentityProviders } from '@aws-amplify/ui';
-import { StateMachineService } from '../../../../services/state-machine.service';
+import { StateMachineService } from '@/services/state-machine.service';
 
 @Component({
   selector: 'amplify-federated-sign-in-button',

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-federated-sign-in/amplify-federated-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-federated-sign-in/amplify-federated-sign-in.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FederatedIdentityProviders } from '@aws-amplify/ui';
-import { StateMachineService } from '../../../../services/state-machine.service';
+import { StateMachineService } from '@/services/state-machine.service';
 import { translate } from '@aws-amplify/ui';
 
 @Component({

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.ts
@@ -16,8 +16,8 @@ import {
   SignInContext,
   SignInState,
 } from '@aws-amplify/ui';
-import { StateMachineService } from '../../../../services/state-machine.service';
-import { AuthPropService } from '../../../../services/authenticator-context.service';
+import { StateMachineService } from '@/services/state-machine.service';
+import { AuthPropService } from '@/services/authenticator-context.service';
 import { translate } from '@aws-amplify/ui';
 
 const logger = new Logger('ForceNewPassword');

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-reset-password/amplify-reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-reset-password/amplify-reset-password.component.ts
@@ -9,8 +9,8 @@ import {
 } from '@angular/core';
 import { AuthMachineState, getActorState, SignInState } from '@aws-amplify/ui';
 import { Subscription } from 'xstate';
-import { AuthPropService } from '../../../../services/authenticator-context.service';
-import { StateMachineService } from '../../../../services/state-machine.service';
+import { AuthPropService } from '@/services/authenticator-context.service';
+import { StateMachineService } from '@/services/state-machine.service';
 import { translate } from '@aws-amplify/ui';
 
 @Component({

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-setup-totp/amplify-setup-totp.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-setup-totp/amplify-setup-totp.component.ts
@@ -16,8 +16,8 @@ import {
   SignInContext,
   SignInState,
 } from '@aws-amplify/ui';
-import { StateMachineService } from '../../../../services/state-machine.service';
-import { AuthPropService } from '../../../../services/authenticator-context.service';
+import { StateMachineService } from '@/services/state-machine.service';
+import { AuthPropService } from '@/services/authenticator-context.service';
 import { translate } from '@aws-amplify/ui';
 
 const logger = new Logger('SetupTotp');

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-in/amplify-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-in/amplify-sign-in.component.ts
@@ -9,9 +9,8 @@ import {
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
-// TODO: import from '@/services/...'
-import { StateMachineService } from '../../../../services/state-machine.service';
-import { AuthPropService } from '../../../../services/authenticator-context.service';
+import { StateMachineService } from '@/services/state-machine.service';
+import { AuthPropService } from '@/services/authenticator-context.service';
 import { Subscription } from 'xstate';
 import { AuthMachineState, getActorState, SignInState } from '@aws-amplify/ui';
 import { translate } from '@aws-amplify/ui';

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/amplify-sign-up.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/amplify-sign-up.component.ts
@@ -7,8 +7,8 @@ import {
   OnInit,
   TemplateRef,
 } from '@angular/core';
-import { StateMachineService } from '../../../../services/state-machine.service';
-import { AuthPropService } from '../../../../services/authenticator-context.service';
+import { StateMachineService } from '@/services/state-machine.service';
+import { AuthPropService } from '@/services/authenticator-context.service';
 import { isEmpty } from 'lodash';
 import { Subscription } from 'xstate';
 import {

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-verify-user/amplify-verify-user.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-verify-user/amplify-verify-user.component.ts
@@ -15,9 +15,9 @@ import {
   translate,
 } from '@aws-amplify/ui';
 import { Subscription } from 'xstate';
-import { StateMachineService } from '../../../../services/state-machine.service';
-import { AuthPropService } from '../../../../services/authenticator-context.service';
-import { getAttributeMap } from '../../../../common';
+import { StateMachineService } from '@/services/state-machine.service';
+import { AuthPropService } from '@/services/authenticator-context.service';
+import { getAttributeMap } from '@/common';
 import { nanoid } from 'nanoid';
 @Component({
   selector: 'amplify-verify-user',

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
@@ -9,8 +9,8 @@ import {
 } from '@angular/core';
 import { AuthMachineState, getActorState, SignInState } from '@aws-amplify/ui';
 import { Subscription } from 'xstate';
-import { AuthPropService } from '../../../../services/authenticator-context.service';
-import { StateMachineService } from '../../../../services/state-machine.service';
+import { AuthPropService } from '@/services/authenticator-context.service';
+import { StateMachineService } from '@/services/state-machine.service';
 import { translate } from '@aws-amplify/ui';
 
 @Component({

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.ts
@@ -14,8 +14,8 @@ import {
   translate,
 } from '@aws-amplify/ui';
 import { Subscription } from 'xstate';
-import { AuthPropService } from '../../../../services/authenticator-context.service';
-import { StateMachineService } from '../../../../services/state-machine.service';
+import { AuthPropService } from '@/services/authenticator-context.service';
+import { StateMachineService } from '@/services/state-machine.service';
 
 @Component({
   selector: 'amplify-confirm-verify-user',

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.ts
@@ -7,8 +7,8 @@ import {
   countryDialCodes,
 } from '@aws-amplify/ui';
 import { nanoid } from 'nanoid';
-import { getAttributeMap } from '../../common';
-import { StateMachineService } from '../../services/state-machine.service';
+import { getAttributeMap } from '@/common';
+import { StateMachineService } from '@/services/state-machine.service';
 
 /**
  * Input interface opinionated for authenticator usage.

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-user-name-alias/amplify-user-name-alias.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-user-name-alias/amplify-user-name-alias.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { StateMachineService } from '../../services/state-machine.service';
+import { StateMachineService } from '@/services/state-machine.service';
 import { getAliasInfoFromContext } from '@aws-amplify/ui';
 
 @Component({

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator-context.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator-context.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CustomComponents, PropContext } from '../common';
+import { CustomComponents, PropContext } from '@/common';
 
 @Injectable({
   providedIn: 'root',

--- a/packages/angular/projects/ui-angular/tsconfig.json
+++ b/packages/angular/projects/ui-angular/tsconfig.json
@@ -8,7 +8,13 @@
     "declarationMap": true,
     "inlineSources": true,
     "types": [],
-    "lib": ["dom", "es2019", "dom.iterable"]
+    "lib": ["dom", "es2019", "dom.iterable"],
+    "baseUrl": ".",
+    "paths": {
+      "@/services/*": ["./src/lib/services/*"],
+      "@/directives/*": ["./src/lib/directives/*"],
+      "@/common": ["./src/lib/common"]
+    }
   },
   "angularCompilerOptions": {
     "skipTemplateCodegen": true,

--- a/packages/angular/projects/ui-angular/tsconfig.prod.json
+++ b/packages/angular/projects/ui-angular/tsconfig.prod.json
@@ -1,6 +1,6 @@
 /* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
-  "extends": "./tsconfig.lib.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "declarationMap": false
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use `tsconfig`'s [path](https://www.typescriptlang.org/tsconfig#paths) options to simplify imports. This also makes imports agnostic to any changes in directory structure.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
