### PR TITLE
remove prebuild step from vue/angular example

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -5,7 +5,6 @@
     "ng": "ng",
     "dev": "ng serve --port 3000",
     "start": "serve dist/angular -s -p 3000",
-    "prebuild": "yarn --cwd ../../ workspace @aws-amplify/ui-angular build",
     "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -4,7 +4,6 @@
   "private": "true",
   "scripts": {
     "dev": "vite --port 3000",
-    "prebuild": "yarn --cwd ../../ workspace @aws-amplify/ui-vue build",
     "build": "vue-tsc --noEmit && vite build",
     "serve": "vite preview",
     "start": "vite preview --port 3000"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Removes `prebuild` steps from angular and vue examples, as packages are already getting built with post-install hook:

https://github.com/aws-amplify/amplify-ui/blob/71f5a394aeb582cab2b88c43825870da30933a19/package.json#L4

Should make CI runs faster as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
