### PR TITLE
Use safe imports of 'aws-amplify' library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Whenever `yarn angular build` is run, such as part of postinstall script, you wa
    ```js
    // examples/next/pages/components/authenticator/sign-up-with-username.tsx
    import { Authenticator } from '@aws-amplify/ui-react';
-   import { Amplify } from 'aws-amplify';
+   import { Amplify } from '@aws-amplify/core';
    import awsExports from '../../../../../environments/auth-with-username-no-attributes/src/aws-exports';
 
    Amplify.configure(awsExports);

--- a/docs/src/components/StepperFieldPropControls.tsx
+++ b/docs/src/components/StepperFieldPropControls.tsx
@@ -8,7 +8,7 @@ import {
 } from '@aws-amplify/ui-react';
 
 import { DemoBox } from './DemoBox';
-import { label } from 'aws-amplify';
+import { label } from '@aws-amplify/ui';
 
 export interface StepperFieldPropControlsProps extends StepperFieldProps {
   setLabel: (min: React.SetStateAction<StepperFieldProps['label']>) => void;

--- a/docs/src/pages/ui/components/authenticator/quick-start.vue.mdx
+++ b/docs/src/pages/ui/components/authenticator/quick-start.vue.mdx
@@ -4,7 +4,7 @@ For Vue, import and add to your template the `Authenticator` component:
 <script setup>
   import { Authenticator } from "@aws-amplify/ui-vue";
   import "@aws-amplify/ui-vue/styles.css";
-  import Amplify from 'aws-amplify';
+  import { Amplify } from '@aws-amplify/core';
   import awsconfig from './aws-exports';
 
   Amplify.configure(aws-exports);

--- a/examples/angular/src/pages/ui/components/authenticator/auth-with-multi-alias/auth-with-multi-alias.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/auth-with-multi-alias/auth-with-multi-alias.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import awsExports from '@environments/auth-with-multi-alias/src/aws-exports';
 
 @Component({

--- a/examples/angular/src/pages/ui/components/authenticator/i18n/i18n.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/i18n/i18n.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import awsExports from '@environments/auth-with-email/src/aws-exports';
-import Amplify, { I18n } from 'aws-amplify';
+import Amplify, { I18n } from '@aws-amplify/core';
 @Component({
   selector: 'i18n',
   templateUrl: 'i18n.component.html',

--- a/examples/angular/src/pages/ui/components/authenticator/reset-password/reset-password.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/reset-password/reset-password.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';
 

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-federated/sign-in-federated.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-federated/sign-in-federated.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import awsExports from '@environments/auth-with-federated/src/aws-exports';
 
 @Component({

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-sms-mfa/sign-in-sms-mfa.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-sms-mfa/sign-in-sms-mfa.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import awsExports from '@environments/auth-with-phone-and-sms-mfa/src/aws-exports';
 

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-totp-mfa/sign-in-totp-mfa.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-totp-mfa/sign-in-totp-mfa.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import awsExports from '@environments/auth-with-totp-mfa/src/aws-exports';
 

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-totp-sms/sign-in-totp-sms.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-totp-sms/sign-in-totp-sms.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import awsExports from '@environments/auth-with-totp-and-sms-mfa/src/aws-exports';
 

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import awsExports from '@environments/auth-with-email/src/aws-exports';
 
 @Component({

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-phone/sign-in-with-phone.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-phone/sign-in-with-phone.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import awsExports from '@environments/auth-with-phone-number/src/aws-exports';
 
 @Component({

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-username/sign-in-with-username.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-username/sign-in-with-username.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';
 

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import awsExports from '@environments/auth-with-email/src/aws-exports';
 
 @Component({

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-phone/sign-up-with-phone.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-phone/sign-up-with-phone.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import awsExports from '@environments/auth-with-phone-number/src/aws-exports';
 
 @Component({

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-username/sign-up-with-username.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-username/sign-up-with-username.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';
 

--- a/examples/next/pages/ui/components/amplify-authenticator/sign-in-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/amplify-authenticator/sign-in-with-email/index.page.tsx
@@ -1,6 +1,6 @@
 import { AmplifyAuthenticator } from '@aws-amplify/ui-react/legacy';
 import awsExports from '@environments/auth-with-email/src/aws-exports';
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 Amplify.configure(awsExports);
 

--- a/examples/next/pages/ui/components/authenticator/auth-with-multi-alias/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/auth-with-multi-alias/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import {
   // Access the default `Authenticator.SignUp.FormFields` for re-use

--- a/examples/next/pages/ui/components/authenticator/i18n/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/i18n/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify, I18n } from 'aws-amplify';
+import { Amplify, I18n } from '@aws-amplify/core';
 
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/reset-password/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/reset-password/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/sign-in-federated/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-federated/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/sign-in-sms-mfa/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-sms-mfa/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/sign-in-totp-mfa/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-totp-mfa/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/sign-in-totp-sms-mfa/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-totp-sms-mfa/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-phone/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-phone/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-username/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-username/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-attributes/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-attributes/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-phone/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-phone/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-username/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-username/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/authenticator/withAuthenticator/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/withAuthenticator/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/vue/src/pages/ui/components/authenticator/auth-with-multi-alias/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/auth-with-multi-alias/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '@environments/auth-with-multi-alias/src/aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/i18n/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/i18n/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Authenticator } from '@aws-amplify/ui-vue';
-import { Amplify, I18n } from 'aws-amplify';
+import { Amplify, I18n } '@aws-amplify/core';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '@environments/auth-with-username-no-attributes/src/aws-exports';
 

--- a/examples/vue/src/pages/ui/components/authenticator/reset-password/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/reset-password/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '@environments/auth-with-username-no-attributes/src/aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-federated/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-federated/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '@environments/auth-with-federated/src/aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-sms-mfa/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-sms-mfa/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import '@aws-amplify/ui-vue/styles.css';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import aws_exports from '@environments/auth-with-phone-and-sms-mfa/src/aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-totp-mfa/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-totp-mfa/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '@environments/auth-with-totp-mfa/src/aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '@environments/auth-with-email/src/aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-with-phone/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-with-phone/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '@environments/auth-with-phone-number/src/aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-with-username/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-with-username/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '@environments/auth-with-username-no-attributes/src/aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '@environments/auth-with-email/src/aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-up-with-phone/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-up-with-phone/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '@environments/auth-with-phone-number/src/aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-up-with-username/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-up-with-username/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import { Amplify } from '@aws-amplify/core';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '@environments/auth-with-username-no-attributes/src/aws-exports';

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.ts
@@ -14,7 +14,7 @@ import {
   translate,
   translations,
 } from '@aws-amplify/ui';
-import { I18n } from 'aws-amplify';
+import { I18n } from '@aws-amplify/core';
 import { CustomComponents } from '../../../../common';
 import { AmplifySlotDirective } from '../../../../directives/amplify-slot.directive';
 import { AuthPropService } from '../../../../services/authenticator-context.service';

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.ts
@@ -6,7 +6,7 @@ import {
   OnInit,
   TemplateRef,
 } from '@angular/core';
-import { Logger } from 'aws-amplify';
+import { Logger } from '@aws-amplify/core';
 import { Subscription } from 'xstate';
 import {
   AuthChallengeNames,

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.ts
@@ -8,7 +8,7 @@ import {
   TemplateRef,
 } from '@angular/core';
 import { Subscription } from 'xstate';
-import { Logger } from 'aws-amplify';
+import { Logger } from '@aws-amplify/core';
 import {
   AuthMachineState,
   getActorContext,

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-setup-totp/amplify-setup-totp.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-setup-totp/amplify-setup-totp.component.ts
@@ -8,7 +8,8 @@ import {
 } from '@angular/core';
 import { Subscription } from 'xstate';
 import QRCode from 'qrcode';
-import { Auth, Logger } from 'aws-amplify';
+import { Auth } from '@aws-amplify/auth';
+import { Logger } from '@aws-amplify/core';
 import {
   AuthMachineState,
   getActorContext,

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-in/amplify-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-in/amplify-sign-in.component.ts
@@ -1,4 +1,4 @@
-import { Logger } from 'aws-amplify';
+import { Logger } from '@aws-amplify/core';
 import {
   AfterContentInit,
   Component,

--- a/packages/react/src/components/Authenticator/Authenticator.tsx
+++ b/packages/react/src/components/Authenticator/Authenticator.tsx
@@ -1,5 +1,5 @@
 import { translations } from '@aws-amplify/ui';
-import { I18n } from 'aws-amplify';
+import { I18n } from '@aws-amplify/core';
 import * as React from 'react';
 
 import { Provider, ProviderProps } from './Provider';

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -1,4 +1,5 @@
-import { Auth, Logger } from 'aws-amplify';
+import { Auth } from '@aws-amplify/auth';
+import { Logger } from '@aws-amplify/core';
 import { getActorState, SignInState, translate } from '@aws-amplify/ui';
 
 import QRCode from 'qrcode';

--- a/packages/ui/src/i18n/translations.ts
+++ b/packages/ui/src/i18n/translations.ts
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { I18n } from 'aws-amplify';
+import { I18n } from '@aws-amplify/core';
 import { NoInfer } from '../types';
 import { deDict, esDict, frDict, itDict, jaDict, zhDict } from './dictionaries';
 

--- a/packages/ui/src/machines/authenticator/actors/resetPassword.ts
+++ b/packages/ui/src/machines/authenticator/actors/resetPassword.ts
@@ -1,4 +1,4 @@
-import { Auth } from 'aws-amplify';
+import { Auth } from '@aws-amplify/auth';
 import { createMachine, sendUpdate } from 'xstate';
 
 import { AuthEvent, ResetPasswordContext } from '../../../types';

--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -1,4 +1,4 @@
-import { Auth } from 'aws-amplify';
+import { Auth } from '@aws-amplify/auth';
 import { get, isEmpty } from 'lodash';
 import { createMachine, sendUpdate } from 'xstate';
 

--- a/packages/ui/src/machines/authenticator/actors/signOut.ts
+++ b/packages/ui/src/machines/authenticator/actors/signOut.ts
@@ -1,7 +1,7 @@
 import { createMachine } from 'xstate';
 
 import { AuthEvent, SignOutContext } from '../../../types';
-import { Auth } from 'aws-amplify';
+import { Auth } from '@aws-amplify/auth';
 
 export const signOutActor = createMachine<SignOutContext, AuthEvent>(
   {

--- a/packages/ui/src/machines/authenticator/defaultServices.ts
+++ b/packages/ui/src/machines/authenticator/defaultServices.ts
@@ -1,5 +1,5 @@
-import { Amplify, Auth } from 'aws-amplify';
-
+import { Auth } from '@aws-amplify/auth';
+import { Amplify } from '@aws-amplify/core';
 import { ValidatorResult } from '../../types';
 
 export const defaultServices = {

--- a/packages/ui/src/machines/authenticator/signUp.ts
+++ b/packages/ui/src/machines/authenticator/signUp.ts
@@ -1,4 +1,4 @@
-import { Auth } from 'aws-amplify';
+import { Auth } from '@aws-amplify/auth';
 import { get, pickBy } from 'lodash';
 import { createMachine, sendUpdate } from 'xstate';
 

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -286,7 +286,7 @@
 <script setup lang="ts">
 import { ref, provide, computed, useAttrs, watch, onBeforeMount } from 'vue';
 import { useActor, useInterpret } from '@xstate/vue';
-import { I18n } from 'aws-amplify';
+import { I18n } from '@aws-amplify/core';
 import {
   getActorState,
   getServiceFacade,

--- a/packages/vue/src/components/setup-totp.vue
+++ b/packages/vue/src/components/setup-totp.vue
@@ -104,7 +104,8 @@ import {
 } from 'vue';
 import QRCode from 'qrcode';
 
-import { Auth, Logger } from 'aws-amplify';
+import { Auth } from '@aws-amplify/auth';
+import { Logger } from '@aws-amplify/core';
 import { getActorState, SignInState, translate } from '@aws-amplify/ui';
 
 import { useAuth } from '../composables/useAuth';


### PR DESCRIPTION
This is a copy of the https://github.com/aws-amplify/amplify-ui/pull/577, which made against my personal fork and didn't have e2e permissions.

-------

When you use an import like `import {I18n} from 'aws-amplify'`, it includes all the code from 'aws-amplify' which can result in errors like:

```
Uncaught DOMException: Failed to read the 'localStorage' property from 'Window': Storage is disabled inside 'data:' URLs.
    at <anonymous>:292337:28
    at LibraryFactory (<anonymous>:294621:4)
    at ExportLibrary (<anonymous>:292323:20)
    at Object.<anonymous> (<anonymous>:292325:3)
    at Object../node_modules/paho-mqtt/paho-mqtt.js (<anonymous>:294625:30)
    at __webpack_require__ (<anonymous>:20:30)
    at Module../node_modules/@aws-amplify/pubsub/lib-esm/Providers/MqttOverWSProvider.js (<anonymous>:28992:67)
    at __webpack_require__ (<anonymous>:20:30)
```

when called from a context such as a `data:` protocol that does not support `localStorage` apis.

The heart of the issue is that AppSync code in AmplifyJS depends on library called Paho (https://github.com/aws-amplify/amplify-js/blob/main/packages/pubsub/src/Providers/MqttOverWSProvider.ts#L13) which, when imported, uses the `localStorage` api.

I want to import `withAuthenticator` using `import {withAuthenticator} from '@aws-amplify/ui-react';`, but this currently fails because the Authenticator component pulls in I18n unsafely:

https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/src/components/Authenticator/Authenticator.tsx#L2

```
import { I18n } from 'aws-amplify';

```

My use case works when I selectively _don't_ import AppSync modules:

```
import { I18n } from '@aws-amplify/core';
```

This commit updates imports to avoid this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
