### PR TITLE
fix: fixing kebab case usage in Loader circle prop

### DIFF
--- a/packages/react/src/primitives/Loader/Loader.tsx
+++ b/packages/react/src/primitives/Loader/Loader.tsx
@@ -46,7 +46,7 @@ export const Loader: Primitive<LoaderProps, 'svg'> = ({
         cx="50%"
         cy="50%"
         r="42%"
-        stroke-width="8%"
+        strokeWidth="8%"
         style={{ stroke: emptyColor }}
         data-testid={CIRCULAR_EMPTY}
       />
@@ -54,7 +54,7 @@ export const Loader: Primitive<LoaderProps, 'svg'> = ({
         cx="50%"
         cy="50%"
         r="42%"
-        stroke-width="8%"
+        strokeWidth="8%"
         style={{ stroke: filledColor }}
         data-testid={CIRCULAR_FILLED}
       />


### PR DESCRIPTION
*Issue #, if available:*
```
Warning: Invalid DOM property `stroke-width`. Did you mean `strokeWidth`?
```

*Description of changes:*
Update `stroke-width` to `strokeWidth` in favor of camel case in JSX to remove the warning

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
