### PR TITLE
Use fixture for missing preferred_username

### DIFF
--- a/packages/e2e/cypress/fixtures/custom-sign-up-fields-missing-preferred_username.json
+++ b/packages/e2e/cypress/fixtures/custom-sign-up-fields-missing-preferred_username.json
@@ -1,0 +1,4 @@
+{
+  "__type": "InvalidParameterException",
+  "message": "Attributes did not conform to the schema: preferred_username: The attribute is required\n"
+}

--- a/packages/e2e/features/ui/components/authenticator/custom-sign-up-fields.feature
+++ b/packages/e2e/features/ui/components/authenticator/custom-sign-up-fields.feature
@@ -24,6 +24,7 @@ Feature: Custom Sign Up Fields
 
   @todo-angular @react @todo-vue
   Scenario: Form is valid when I check the Terms & Conditions checkbox, but missing `preferred_username` for Cognito
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with error fixture "custom-sign-up-fields-missing-preferred_username"
     When I type a new "email"
     And I type my password
     And I confirm my password


### PR DESCRIPTION
*Description of changes:*

E2E tests were failing due to the dreaded SES limits.

- [x] Use fixture for error instead

> ![Screen Shot 2021-10-28 at 2 58 35 PM](https://user-images.githubusercontent.com/15182/139326753-d9a633da-7b39-4f44-88a9-477512d2ef67.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
