### PR TITLE
feat(angular): add sign-up-form-fields component

### DIFF
--- a/.changeset/cold-yaks-laugh.md
+++ b/.changeset/cold-yaks-laugh.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-angular": patch
+---
+
+Add `sign-up-form-field` slot and component

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/authenticator.module.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/authenticator.module.ts
@@ -17,6 +17,7 @@ import { AmplifyResetPasswordComponent } from './components/amplify-reset-passwo
 import { AmplifySetupTotpComponent } from './components/amplify-setup-totp/amplify-setup-totp.component';
 import { AmplifySignInComponent } from './components/amplify-sign-in/amplify-sign-in.component';
 import { AmplifySignUpComponent } from './components/amplify-sign-up/amplify-sign-up.component';
+import { AmplifySignUpFormFieldsComponent } from './components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component';
 import { AmplifyVerifyUserComponent } from './components/amplify-verify-user/amplify-verify-user.component';
 import { ConfirmResetPasswordComponent } from './components/confirm-reset-password/amplify-confirm-reset-password.component';
 import { ConfirmVerifyUserComponent } from './components/confirm-verify-user/amplify-confirm-verify-user.component';
@@ -52,6 +53,7 @@ import { AmplifySlotDirective } from '../../utilities/amplify-slot/amplify-slot.
     AmplifySetupTotpComponent,
     AmplifySignInComponent,
     AmplifySignUpComponent,
+    AmplifySignUpFormFieldsComponent,
     AmplifySlotComponent,
     AmplifySlotDirective,
     AmplifyTextFieldComponent,
@@ -64,6 +66,10 @@ import { AmplifySlotDirective } from '../../utilities/amplify-slot/amplify-slot.
     TabsComponent,
   ],
   imports: [CommonModule, BrowserModule],
-  exports: [AmplifyAuthenticatorComponent, AmplifySlotDirective],
+  exports: [
+    AmplifyAuthenticatorComponent,
+    AmplifySignUpFormFieldsComponent,
+    AmplifySlotDirective,
+  ],
 })
 export class AmplifyAuthenticatorModule {}

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/amplify-sign-up.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/amplify-sign-up.component.html
@@ -1,34 +1,10 @@
-<ng-template #signUpFormFields>
-  <div
-    class="amplify-flex"
-    style="flex-direction: column"
-    data-amplify-fieldset
-  >
-    <amplify-user-name-alias [name]="primaryAlias"></amplify-user-name-alias>
-    <amplify-form-field
-      name="password"
-      autocomplete="new-password"
-    ></amplify-form-field>
-    <amplify-form-field
-      name="confirm_password"
-      label="Confirm Password"
-      type="password"
-      autocomplete="new-password"
-    ></amplify-form-field>
-
-    <ng-container *ngFor="let secondaryAlias of secondaryAliases">
-      <amplify-form-field [name]="secondaryAlias"></amplify-form-field>
-    </ng-container>
-  </div>
-</ng-template>
-
 <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
   <div class="amplify-flex" style="flex-direction: column">
     <h3 class="amplify-heading">{{ this.headerText }}</h3>
 
     <div class="amplify-flex" style="flex-direction: column">
       <amplify-slot name="sign-up-form-fields" [context]="context">
-        <ng-container *ngTemplateOutlet="signUpFormFields"></ng-container>
+        <amplify-sign-up-form-fields></amplify-sign-up-form-fields>
       </amplify-slot>
 
       <amplify-error *ngIf="remoteError">

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/amplify-sign-up.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/amplify-sign-up.component.ts
@@ -6,17 +6,14 @@ import {
   OnInit,
 } from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
-import { isEmpty } from 'lodash';
 import { Subscription } from 'xstate';
 import {
   AuthMachineState,
   getActorContext,
   getActorState,
-  getConfiguredAliases,
   SignUpContext,
   SignUpState,
   translate,
-  ValidationError,
 } from '@aws-amplify/ui';
 
 @Component({
@@ -30,9 +27,6 @@ export class AmplifySignUpComponent implements OnInit, OnDestroy {
 
   public remoteError = '';
   public isPending = false;
-  public primaryAlias = '';
-  public secondaryAliases: string[] = [];
-  public validationError: ValidationError = {};
 
   private authSubscription: Subscription;
 
@@ -44,14 +38,12 @@ export class AmplifySignUpComponent implements OnInit, OnDestroy {
   public get context() {
     const { change, signIn, submit } = this.authenticator.services;
     const remoteError = this.remoteError;
-    const validationError = this.validationError;
 
     return {
       change,
       remoteError,
       signIn,
       submit,
-      validationError,
     };
   }
 
@@ -59,22 +51,6 @@ export class AmplifySignUpComponent implements OnInit, OnDestroy {
     this.authSubscription = this.authenticator.subscribe((state) =>
       this.onStateUpdate(state)
     );
-
-    const context = this.authenticator.context;
-    const { primaryAlias, secondaryAliases } = getConfiguredAliases(context);
-
-    /**
-     * If the login_mechanisms are configured to use ONLY username, we need
-     * to ask for some sort of secondary contact information in order to
-     * verify the user for Cognito. Currently matching this to how Vue is
-     * set up.
-     */
-    if (primaryAlias === 'username' && isEmpty(secondaryAliases)) {
-      secondaryAliases.push('email', 'phone_number');
-    }
-
-    this.primaryAlias = primaryAlias;
-    this.secondaryAliases = secondaryAliases;
   }
 
   ngOnDestroy(): void {
@@ -85,7 +61,6 @@ export class AmplifySignUpComponent implements OnInit, OnDestroy {
     const actorState: SignUpState = getActorState(state);
     const actorContext: SignUpContext = getActorContext(state);
     this.remoteError = actorContext.remoteError;
-    this.validationError = actorContext.validationError;
     this.isPending = !actorState.matches({
       signUp: {
         submission: 'idle',

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.html
@@ -1,0 +1,17 @@
+<div class="amplify-flex" style="flex-direction: column" data-amplify-fieldset>
+  <amplify-user-name-alias [name]="primaryAlias"></amplify-user-name-alias>
+  <amplify-form-field
+    name="password"
+    autocomplete="new-password"
+  ></amplify-form-field>
+  <amplify-form-field
+    name="confirm_password"
+    label="Confirm Password"
+    type="password"
+    autocomplete="new-password"
+  ></amplify-form-field>
+
+  <ng-container *ngFor="let secondaryAlias of secondaryAliases">
+    <amplify-form-field [name]="secondaryAlias"></amplify-form-field>
+  </ng-container>
+</div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit } from '@angular/core';
+import { AuthenticatorService } from '../../../../../services/authenticator.service';
+import { isEmpty } from 'lodash';
+import { getConfiguredAliases } from '@aws-amplify/ui';
+
+@Component({
+  selector: 'amplify-sign-up-form-fields',
+  templateUrl: './sign-up-form-fields.component.html',
+})
+export class AmplifySignUpFormFieldsComponent implements OnInit {
+  public primaryAlias = '';
+  public secondaryAliases: string[] = [];
+
+  constructor(private authenticator: AuthenticatorService) {}
+
+  ngOnInit(): void {
+    const context = this.authenticator.context;
+    const { primaryAlias, secondaryAliases } = getConfiguredAliases(context);
+
+    /**
+     * If the login_mechanisms are configured to use ONLY username, we need
+     * to ask for some sort of secondary contact information in order to
+     * verify the user for Cognito. Currently matching this to how Vue is
+     * set up.
+     */
+    if (primaryAlias === 'username' && isEmpty(secondaryAliases)) {
+      secondaryAliases.push('email', 'phone_number');
+    }
+
+    this.primaryAlias = primaryAlias;
+    this.secondaryAliases = secondaryAliases;
+  }
+}

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/index.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/index.ts
@@ -8,6 +8,7 @@ export { AmplifyResetPasswordComponent } from './amplify-reset-password/amplify-
 export { AmplifySetupTotpComponent } from './amplify-setup-totp/amplify-setup-totp.component';
 export { AmplifySignInComponent } from './amplify-sign-in/amplify-sign-in.component';
 export { AmplifySignUpComponent } from './amplify-sign-up/amplify-sign-up.component';
+export { AmplifySignUpFormFieldsComponent } from './amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component';
 export { AmplifyVerifyUserComponent } from './amplify-verify-user/amplify-verify-user.component';
 export { ConfirmResetPasswordComponent } from './confirm-reset-password/amplify-confirm-reset-password.component';
 export { ConfirmVerifyUserComponent } from './confirm-verify-user/amplify-confirm-verify-user.component';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This adds `sign-up-form-fields` slot and component. 

`useAuthenticator` changes in angular will be in a later PR! (that'll be the last one for sign-up customization).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
