### PR TITLE
Normalize style prop types

### DIFF
--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -49,7 +49,7 @@ export function SignIn() {
         <RemoteErrorMessage />
 
         <Button
-          borderRadius={0}
+          borderRadius="0"
           isDisabled={isPending}
           isFullWidth={true}
           type="submit"

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -41,7 +41,7 @@ export function SignUp() {
         </Flex>
 
         <Button
-          borderRadius={0}
+          borderRadius="0"
           isDisabled={hasValidationErrors || isPending}
           isFullWidth={true}
           type="submit"

--- a/packages/react/src/primitives/shared/styleUtils.ts
+++ b/packages/react/src/primitives/shared/styleUtils.ts
@@ -80,9 +80,10 @@ export const usePropStyles = (props: ViewProps, style: React.CSSProperties) => {
 
 export const isSpanPrimitiveValue = (
   spanValue: GridItemStyleProps['rowSpan'] | GridItemStyleProps['columnSpan']
-): spanValue is 'auto' | number => {
+): spanValue is 'auto' | string => {
   return (
-    spanValue === 'auto' || (typeof spanValue === 'number' && !isNaN(spanValue))
+    spanValue === 'auto' ||
+    (typeof spanValue === 'string' && !isNaN(parseFloat(spanValue)))
   );
 };
 
@@ -108,7 +109,7 @@ export const convertGridSpan = (
   return null;
 };
 
-export const getGridSpan = (spanValue: number | 'auto'): string => {
+export const getGridSpan = (spanValue: string | 'auto'): string => {
   return spanValue === 'auto' ? 'auto' : `span ${spanValue}`;
 };
 

--- a/packages/react/src/primitives/types/grid.ts
+++ b/packages/react/src/primitives/types/grid.ts
@@ -16,11 +16,11 @@ export interface GridItemStyleProps {
   area?: ResponsiveStyle<Property.GridArea>;
   column?: ResponsiveStyle<Property.GridColumn>;
   columnEnd?: ResponsiveStyle<Property.GridColumnEnd>;
-  columnSpan?: ResponsiveStyle<number | 'auto'>;
+  columnSpan?: ResponsiveStyle<string | 'auto'>;
   columnStart?: ResponsiveStyle<Property.GridColumnStart>;
   row?: ResponsiveStyle<Property.GridRow>;
   rowEnd?: ResponsiveStyle<Property.GridRowEnd>;
-  rowSpan?: ResponsiveStyle<number | 'auto'>;
+  rowSpan?: ResponsiveStyle<string | 'auto'>;
   rowStart?: ResponsiveStyle<Property.GridRowStart>;
 }
 

--- a/packages/react/src/primitives/types/style.ts
+++ b/packages/react/src/primitives/types/style.ts
@@ -5,6 +5,13 @@ import { GridItemStyleProps, GridContainerStyleProps } from './grid';
 import { ImageStyleProps } from './image';
 import { TextAreaStyleProps } from './textArea';
 
+/**
+ * Extract string-like types. Defaulted to string if prop doesn't allow it
+ */
+export type StyleProp<PropertyType> = PropertyType extends string
+  ? PropertyType
+  : string;
+
 export interface ResponsiveObject<PropertyType> {
   base?: PropertyType;
   small?: PropertyType;
@@ -15,9 +22,9 @@ export interface ResponsiveObject<PropertyType> {
 }
 
 export type ResponsiveStyle<PropertyType> =
-  | PropertyType
-  | PropertyType[]
-  | ResponsiveObject<PropertyType>;
+  | StyleProp<PropertyType>
+  | StyleProp<PropertyType>[]
+  | ResponsiveObject<StyleProp<PropertyType>>;
 
 export interface BaseStyleProps extends FlexItemStyleProps, GridItemStyleProps {
   alignSelf?: ResponsiveStyle<Property.AlignSelf>;


### PR DESCRIPTION
*Description of changes:*
Normalize style prop types to accept strings instead of strict `csstype` types, without losing type inference.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
