### PR TITLE
Vue: Bug Fixed error messages on page

### DIFF
--- a/packages/vue/src/components/confirm-reset-password.vue
+++ b/packages/vue/src/components/confirm-reset-password.vue
@@ -85,6 +85,14 @@
               >
               </slot>
             </template>
+            <base-box
+              data-ui-error
+              data-variation="error"
+              class="amplify-text"
+              v-if="!!(actorContext.validationError as ValidationError)['confirm_password']"
+            >
+              {{ (actorContext.validationError as ValidationError)['confirm_password'] }}
+            </base-box>
             <base-alert v-if="actorState?.context?.remoteError">
               {{ actorState?.context?.remoteError }}
             </base-alert>
@@ -112,13 +120,6 @@
         </base-field-set>
       </base-form>
     </base-wrapper>
-
-    <base-box
-      data-ui-error
-      v-if="!!(actorContext.validationError as ValidationError)['confirm_password']"
-    >
-      {{ (actorContext.validationError as ValidationError)['confirm_password'] }}
-    </base-box>
   </slot>
 </template>
 


### PR DESCRIPTION
*Description of changes:*
On the Confirm reset password page, the error message that was displayed if the password and confirm password did not match was appearing at the bottom of the page. It should appear above the button.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
