### PR TITLE
Apply `box-sizing: border-box` to all Amplify theme children

### DIFF
--- a/.changeset/shaggy-ladybugs-crash.md
+++ b/.changeset/shaggy-ladybugs-crash.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+Apply `box-sizing: border-box` styling to all Amplify theme children

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -17,6 +17,12 @@ html {
   all: unset; /* protect against external styles */
 }
 
+// Must be defined AFTER `[class*='amplify']
+// or rules will be unset to initial/default
+[data-amplify-theme] * {
+  box-sizing: border-box;
+}
+
 .sr-only {
   position: absolute !important;
   width: 1px !important;


### PR DESCRIPTION
*Description of changes:*
Applies styling rule `box-sizing: border-box` to all children of Amplify theme element.

![2021-11-02 17 17 18](https://user-images.githubusercontent.com/6165315/139968853-e703a055-e65d-4d46-ac40-eb9b17f5929a.gif)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
