### PR TITLE
Zero-config + Sign in with Apple

### DIFF
--- a/environments/auth-with-federated/amplify/backend/auth/authwithfederated/authwithfederated-cloudformation-template.yml
+++ b/environments/auth-with-federated/amplify/backend/auth/authwithfederated/authwithfederated-cloudformation-template.yml
@@ -1,3 +1,4 @@
+
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
@@ -69,6 +70,10 @@ Parameters:
       
         
   requiredAttributes:
+    Type: CommaDelimitedList
+      
+        
+  aliasAttributes:
     Type: CommaDelimitedList
       
   
@@ -235,7 +240,10 @@ Resources:
       
       
       
-      AutoVerifiedAttributes: !Ref autoVerifiedAttributes
+      AutoVerifiedAttributes:
+      
+        - email
+      
       
       
       EmailVerificationMessage: !Ref emailVerificationMessage
@@ -250,6 +258,7 @@ Resources:
           RequireUppercase: true
       
       UsernameAttributes: !Ref usernameAttributes
+      
       
       MfaConfiguration: !Ref mfaConfiguration
       SmsVerificationMessage: !Ref smsVerificationMessage
@@ -328,7 +337,7 @@ Resources:
             - '};'
       Handler: index.handler
       Runtime: nodejs12.x
-      Timeout: '300'
+      Timeout: 300
       Role: !GetAtt
         - UserPoolClientRole
         - Arn
@@ -454,7 +463,7 @@ Resources:
 
       Handler: index.handler
       Runtime: nodejs12.x
-      Timeout: '300'
+      Timeout: 300
       Role: !GetAtt
         - UserPoolClientRole
         - Arn
@@ -606,7 +615,7 @@ Resources:
 
       Handler: index.handler
       Runtime: nodejs12.x
-      Timeout: '300'
+      Timeout: 300
       Role: !GetAtt
         - UserPoolClientRole
         - Arn
@@ -705,7 +714,7 @@ Resources:
 
       Handler: index.handler
       Runtime: nodejs12.x
-      Timeout: '300'
+      Timeout: 300
       Role: !GetAtt
         - UserPoolClientRole
         - Arn

--- a/environments/auth-with-federated/amplify/backend/auth/authwithfederated/parameters.json
+++ b/environments/auth-with-federated/amplify/backend/auth/authwithfederated/parameters.json
@@ -25,6 +25,7 @@
     "requiredAttributes": [
         "email"
     ],
+    "aliasAttributes": [],
     "userpoolClientGenerateSecret": false,
     "userpoolClientRefreshTokenValidity": 30,
     "userpoolClientWriteAttributes": [],
@@ -61,9 +62,10 @@
     "authProvidersUserPool": [
         "Facebook",
         "Google",
-        "LoginWithAmazon"
+        "LoginWithAmazon",
+        "SignInWithApple"
     ],
-    "hostedUIProviderMeta": "[{\"ProviderName\":\"Facebook\",\"authorize_scopes\":\"email,public_profile\",\"AttributeMapping\":{\"email\":\"email\",\"username\":\"id\"}},{\"ProviderName\":\"Google\",\"authorize_scopes\":\"openid email profile\",\"AttributeMapping\":{\"email\":\"email\",\"username\":\"sub\"}},{\"ProviderName\":\"LoginWithAmazon\",\"authorize_scopes\":\"profile profile:user_id\",\"AttributeMapping\":{\"email\":\"email\",\"username\":\"user_id\"}}]",
+    "hostedUIProviderMeta": "[{\"ProviderName\":\"Facebook\",\"authorize_scopes\":\"email,public_profile\",\"AttributeMapping\":{\"email\":\"email\",\"username\":\"id\"}},{\"ProviderName\":\"Google\",\"authorize_scopes\":\"openid email profile\",\"AttributeMapping\":{\"email\":\"email\",\"username\":\"sub\"}},{\"ProviderName\":\"LoginWithAmazon\",\"authorize_scopes\":\"profile profile:user_id\",\"AttributeMapping\":{\"email\":\"email\",\"username\":\"user_id\"}},{\"ProviderName\":\"SignInWithApple\",\"authorize_scopes\":\"email\",\"AttributeMapping\":{\"email\":\"email\"}}]",
     "oAuthMetadata": "{\"AllowedOAuthFlows\":[\"code\"],\"AllowedOAuthScopes\":[\"phone\",\"email\",\"openid\",\"profile\",\"aws.cognito.signin.user.admin\"],\"CallbackURLs\":[\"http://localhost:3000/ui/components/authenticator/sign-in-federated\"],\"LogoutURLs\":[\"http://localhost:3000/ui/components/authenticator/sign-in-federated\"]}",
     "usernameCaseSensitive": false,
     "dependsOn": []

--- a/environments/auth-with-totp-and-sms-mfa/amplify/backend/auth/authwithtotpandsmsmf/parameters.json
+++ b/environments/auth-with-totp-and-sms-mfa/amplify/backend/auth/authwithtotpandsmsmf/parameters.json
@@ -2,5 +2,24 @@
   "authSelections": "userPoolOnly",
   "resourceName": "authwithtotpandsmsmf",
   "serviceType": "imported",
-  "region": "us-east-1"
+  "region": "us-east-1",
+  "usernameAttributes": [
+    "email"
+  ],
+  "requiredAttributes": [],
+  "passwordPolicyMinLength": 8,
+  "passwordPolicyCharacters": [
+    "Requires Lowercase",
+    "Requires Uppercase",
+    "Requires Numbers",
+    "Requires Symbols"
+  ],
+  "mfaConfiguration": "ON",
+  "autoVerifiedAttributes": [
+    "email"
+  ],
+  "mfaTypes": [
+    "SMS Text Message",
+    "TOTP"
+  ]
 }

--- a/environments/auth-with-totp-mfa/amplify/backend/auth/authwithtotpmfa/parameters.json
+++ b/environments/auth-with-totp-mfa/amplify/backend/auth/authwithtotpmfa/parameters.json
@@ -2,5 +2,23 @@
   "authSelections": "userPoolOnly",
   "resourceName": "authwithtotpmfa",
   "serviceType": "imported",
-  "region": "us-east-1"
+  "region": "us-east-1",
+  "usernameAttributes": [
+    "email"
+  ],
+  "requiredAttributes": [],
+  "passwordPolicyMinLength": 8,
+  "passwordPolicyCharacters": [
+    "Requires Lowercase",
+    "Requires Uppercase",
+    "Requires Numbers",
+    "Requires Symbols"
+  ],
+  "mfaConfiguration": "ON",
+  "autoVerifiedAttributes": [
+    "email"
+  ],
+  "mfaTypes": [
+    "TOTP"
+  ]
 }

--- a/environments/auth-with-username/amplify/backend/auth/authwithusername/authwithusername-cloudformation-template.yml
+++ b/environments/auth-with-username/amplify/backend/auth/authwithusername/authwithusername-cloudformation-template.yml
@@ -1,3 +1,4 @@
+
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
@@ -71,6 +72,10 @@ Parameters:
   requiredAttributes:
     Type: CommaDelimitedList
       
+        
+  aliasAttributes:
+    Type: CommaDelimitedList
+      
   
   userpoolClientGenerateSecret:
     Type: String
@@ -113,7 +118,6 @@ Parameters:
     Type: String
   
             
-            
   useDefault:
     Type: String
   
@@ -129,7 +133,6 @@ Parameters:
   
   adminQueries:
     Type: String
-            
             
   
   thirdPartyAuth:
@@ -147,6 +150,11 @@ Parameters:
   dependsOn:
     Type: CommaDelimitedList
       
+            
+  
+  hostedUI:
+    Type: String
+            
 Conditions:
   ShouldNotCreateEnvResources: !Equals [ !Ref env, NONE ]
   
@@ -208,7 +216,10 @@ Resources:
       
       
       
-      AutoVerifiedAttributes: !Ref autoVerifiedAttributes
+      AutoVerifiedAttributes:
+      
+        - email
+      
       
       
       EmailVerificationMessage: !Ref emailVerificationMessage
@@ -221,6 +232,7 @@ Resources:
           RequireNumbers: true
           RequireSymbols: true
           RequireUppercase: true
+      
       
       MfaConfiguration: !Ref mfaConfiguration
       SmsVerificationMessage: !Ref smsVerificationMessage
@@ -299,7 +311,7 @@ Resources:
             - '};'
       Handler: index.handler
       Runtime: nodejs12.x
-      Timeout: '300'
+      Timeout: 300
       Role: !GetAtt
         - UserPoolClientRole
         - Arn
@@ -425,6 +437,7 @@ Outputs :
   AppClientSecret:
     Value: !GetAtt UserPoolClientInputs.appSecret
     Condition: ShouldOutputAppClientSecrets
+  
   
   
   

--- a/environments/auth-with-username/amplify/backend/auth/authwithusername/parameters.json
+++ b/environments/auth-with-username/amplify/backend/auth/authwithusername/parameters.json
@@ -25,6 +25,7 @@
     "requiredAttributes": [
         "preferred_username"
     ],
+    "aliasAttributes": [],
     "userpoolClientGenerateSecret": false,
     "userpoolClientRefreshTokenValidity": 30,
     "userpoolClientWriteAttributes": [],
@@ -54,5 +55,6 @@
     "thirdPartyAuth": false,
     "authProviders": [],
     "usernameCaseSensitive": false,
-    "dependsOn": []
+    "dependsOn": [],
+    "hostedUI": false
 }

--- a/packages/e2e/features/ui/components/authenticator/sign-in-federated.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-federated.feature
@@ -9,6 +9,7 @@ Feature: Sign In with Federation
 
   @angular @react @vue
   Scenario: Sign in using OAUTH
-    And I see the "Google" sign in button
-    And I see the "Facebook" sign in button
     And I see the "Amazon" sign in button
+    And I see the "Apple" sign in button
+    And I see the "Facebook" sign in button
+    And I see the "Google" sign in button

--- a/packages/react/src/components/Authenticator/Authenticator.tsx
+++ b/packages/react/src/components/Authenticator/Authenticator.tsx
@@ -14,6 +14,7 @@ export function Authenticator({
   initialState,
   loginMechanisms,
   services,
+  socialProviders,
 }: AuthenticatorProps) {
   return (
     <Provider
@@ -21,6 +22,7 @@ export function Authenticator({
       initialState={initialState}
       loginMechanisms={loginMechanisms}
       services={services}
+      socialProviders={socialProviders}
     >
       <Router className={className} children={children} />
     </Provider>

--- a/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignIn.tsx
+++ b/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignIn.tsx
@@ -5,44 +5,62 @@ import { useAuthenticator } from '..';
 import { Divider, Flex } from '../../..';
 import { FederatedSignInButton } from './FederatedSignInButtons';
 
-export const FederatedSignIn = (): JSX.Element => {
+export function FederatedSignIn() {
   const { _state } = useAuthenticator();
-  const loginMechanisms = get(_state, 'context.config.login_mechanisms');
+  const { socialProviders = [] } = _state.context.config;
 
-  const facebookButton = includes(loginMechanisms, 'facebook') ? (
-    <FederatedSignInButton
-      icon="facebook"
-      text={translate('Sign In with Facebook')}
-      provider={FederatedIdentityProviders.Facebook}
-    />
-  ) : null;
-  const googleButton = includes(loginMechanisms, 'google') ? (
-    <FederatedSignInButton
-      icon="google"
-      text={translate('Sign In with Google')}
-      provider={FederatedIdentityProviders.Google}
-    />
-  ) : null;
-  const amazonButton = includes(loginMechanisms, 'amazon') ? (
-    <FederatedSignInButton
-      icon="amazon"
-      text={translate('Sign In with Amazon')}
-      provider={FederatedIdentityProviders.Amazon}
-    />
-  ) : null;
+  if (socialProviders.length === 0) {
+    return null;
+  }
 
-  const shouldShowFederatedSignIn =
-    facebookButton || googleButton || amazonButton;
-
-  const component = shouldShowFederatedSignIn ? (
+  return (
     <Flex direction="column" className="federated-sign-in-container">
       <Divider size="small" />
 
-      {googleButton}
-      {facebookButton}
-      {amazonButton}
+      {socialProviders.map((provider) => {
+        switch (provider) {
+          case 'amazon':
+            return (
+              <FederatedSignInButton
+                icon="amazon"
+                key={provider}
+                provider={FederatedIdentityProviders.Amazon}
+                text={translate('Sign In with Amazon')}
+              />
+            );
+          case 'apple':
+            return (
+              <FederatedSignInButton
+                icon="apple"
+                key={provider}
+                provider={FederatedIdentityProviders.Apple}
+                text={translate('Sign In with Apple')}
+              />
+            );
+          case 'facebook':
+            return (
+              <FederatedSignInButton
+                icon="facebook"
+                key={provider}
+                provider={FederatedIdentityProviders.Facebook}
+                text={translate('Sign In with Facebook')}
+              />
+            );
+          case 'google':
+            return (
+              <FederatedSignInButton
+                icon="google"
+                key={provider}
+                provider={FederatedIdentityProviders.Google}
+                text={translate('Sign In with Google')}
+              />
+            );
+          default:
+            console.error(
+              `Authenicator does not support ${provider}. Please open an issue: https://github.com/aws-amplify/amplify-ui/issues/choose`
+            );
+        }
+      })}
     </Flex>
-  ) : null;
-
-  return component;
-};
+  );
+}

--- a/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignInButtons/FederatedSignInButton.tsx
+++ b/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignInButtons/FederatedSignInButton.tsx
@@ -1,13 +1,30 @@
-import { FederatedIdentityProviders } from '@aws-amplify/ui';
+import { FederatedIdentityProviders, SocialProvider } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '../..';
 import { Button, Flex, Icon, Text } from '../../../..';
 
 export interface FederatedSignInButtonProps {
-  icon?: 'facebook' | 'google' | 'amazon';
+  icon?: SocialProvider;
   provider: FederatedIdentityProviders;
   text: string;
 }
+
+const AppleIcon = (): JSX.Element => {
+  return (
+    <svg
+      aria-label="Apple icon"
+      className="amplify-icon federated-sign-in-icon"
+      fill="#000"
+      preserveAspectRatio="xMidYMid"
+      stroke="#000"
+      strokeWidth="0"
+      viewBox="0 0 1024 1024"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M747.4 535.7c-.4-68.2 30.5-119.6 92.9-157.5-34.9-50-87.7-77.5-157.3-82.8-65.9-5.2-138 38.4-164.4 38.4-27.9 0-91.7-36.6-141.9-36.6C273.1 298.8 163 379.8 163 544.6c0 48.7 8.9 99 26.7 150.8 23.8 68.2 109.6 235.3 199.1 232.6 46.8-1.1 79.9-33.2 140.8-33.2 59.1 0 89.7 33.2 141.9 33.2 90.3-1.3 167.9-153.2 190.5-221.6-121.1-57.1-114.6-167.2-114.6-170.7zm-105.1-305c50.7-60.2 46.1-115 44.6-134.7-44.8 2.6-96.6 30.5-126.1 64.8-32.5 36.8-51.6 82.3-47.5 133.6 48.4 3.7 92.6-21.2 129-63.7z"></path>
+    </svg>
+  );
+};
 
 const GoogleIcon = (): JSX.Element => {
   return (
@@ -86,6 +103,8 @@ export const FederatedSignInButton = (
     iconComponent = <GoogleIcon />;
   } else if (icon === 'amazon') {
     iconComponent = <AmazonIcon />;
+  } else if (icon === 'apple') {
+    iconComponent = <AppleIcon />;
   }
 
   return (

--- a/packages/react/src/components/Authenticator/Provider/index.tsx
+++ b/packages/react/src/components/Authenticator/Provider/index.tsx
@@ -18,11 +18,17 @@ const useAuthenticatorValue = ({
   components: customComponents,
   initialState,
   loginMechanisms,
+  socialProviders,
   services,
 }: ProviderProps) => {
   const [state, send] = useMachine(
     () =>
-      createAuthenticatorMachine({ initialState, loginMechanisms, services }),
+      createAuthenticatorMachine({
+        initialState,
+        loginMechanisms,
+        services,
+        socialProviders,
+      }),
     {
       devTools: process.env.NODE_ENV === 'development',
     }

--- a/packages/react/src/components/Authenticator/SignUp/FormFields.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/FormFields.tsx
@@ -1,9 +1,9 @@
 import {
   getActorContext,
+  LoginMechanism,
+  LoginMechanismArray,
   SignUpContext,
   translate,
-  UserNameAlias,
-  userNameAliasArray,
 } from '@aws-amplify/ui';
 import { isEmpty } from 'lodash';
 
@@ -16,9 +16,10 @@ export function FormFields() {
   const { validationError } = getActorContext(_state) as SignUpContext;
 
   const [primaryAlias, ...secondaryAliases] =
-    _state.context.config?.login_mechanisms?.filter(
-      (alias: any): alias is UserNameAlias => userNameAliasArray.includes(alias)
-    ) ?? userNameAliasArray;
+    _state.context.config?.loginMechanisms?.filter(
+      (alias: any): alias is LoginMechanism =>
+        LoginMechanismArray.includes(alias)
+    ) ?? LoginMechanismArray;
 
   /**
    * If the login_mechanisms are configured to use ONLY username, we need
@@ -64,7 +65,7 @@ export function FormFields() {
         <Text variation="error">{validationError['confirm_password']}</Text>
       )}
 
-      {secondaryAliases.map((alias: UserNameAlias) => (
+      {secondaryAliases.map((alias: LoginMechanism) => (
         <UserNameAliasComponent
           data-amplify-usernamealias
           key={alias}

--- a/packages/ui/src/helpers/auth.ts
+++ b/packages/ui/src/helpers/auth.ts
@@ -1,5 +1,6 @@
 import { includes } from 'lodash';
 import { Sender } from 'xstate';
+
 import { AuthContext } from '..';
 import {
   ActorContextWithForms,
@@ -10,8 +11,8 @@ import {
   AuthEventTypes,
   AuthInputAttributes,
   AuthMachineState,
-  UserNameAlias,
-  userNameAliasArray,
+  LoginMechanism,
+  LoginMechanismArray,
 } from '../types';
 
 export const authInputAttributes: AuthInputAttributes = {
@@ -43,6 +44,7 @@ export const authInputAttributes: AuthInputAttributes = {
 };
 
 export enum FederatedIdentityProviders {
+  Apple = 'SignInWithApple',
   Amazon = 'LoginWithAmazon',
   Facebook = 'Facebook',
   Google = 'Google',
@@ -55,12 +57,13 @@ export enum FederatedIdentityProviders {
  */
 export const getAliasInfoFromContext = (
   context: AuthContext,
-  alias?: UserNameAlias
+  // TODO This function & its signature should be renamed since aliases were rolled back
+  alias?: LoginMechanism
 ) => {
-  const loginMechanisms = context.config?.login_mechanisms ?? ['username'];
+  const loginMechanisms = context.config?.loginMechanisms;
   const error = context.actorRef?.context?.validationError['username'];
 
-  if (userNameAliasArray.includes(alias)) {
+  if (LoginMechanismArray.includes(alias)) {
     return {
       label: authInputAttributes[alias].label,
       type: authInputAttributes[alias].type,
@@ -70,7 +73,7 @@ export const getAliasInfoFromContext = (
 
   let type = 'text';
   const label = loginMechanisms
-    .filter((mechanism) => includes(userNameAliasArray, mechanism))
+    .filter((mechanism) => includes(LoginMechanismArray, mechanism))
     .map((v) => {
       return (
         authInputAttributes[v]?.label ?? authInputAttributes['username'].label
@@ -90,11 +93,9 @@ export const getAliasInfoFromContext = (
  * secondaryAliases.
  */
 export const getConfiguredAliases = (context: AuthContext) => {
-  const login_mechanisms = context.config?.login_mechanisms ?? [
-    ...userNameAliasArray,
-  ];
-  const aliases = login_mechanisms.filter((mechanism) =>
-    includes(userNameAliasArray, mechanism)
+  const loginMechanisms = context.config?.loginMechanisms;
+  const aliases = loginMechanisms.filter((mechanism) =>
+    includes(LoginMechanismArray, mechanism)
   );
 
   const [primaryAlias, ...secondaryAliases] = aliases;

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -1,10 +1,15 @@
 import { assign, createMachine, forwardTo, spawn } from 'xstate';
 
-import { AuthContext, AuthEvent, LoginMechanism } from '../../types';
+import {
+  AuthContext,
+  AuthEvent,
+  LoginMechanism,
+  SocialProvider,
+} from '../../types';
 import { stopActor } from './actions';
 import { resetPasswordActor, signInActor, signOutActor } from './actors';
-import { createSignUpMachine } from './signUp';
 import { defaultServices } from './defaultServices';
+import { createSignUpMachine } from './signUp';
 
 const DEFAULT_COUNTRY_CODE = '+1';
 
@@ -12,12 +17,13 @@ export type AuthenticatorMachineOptions = {
   initialState?: 'signIn' | 'signUp' | 'resetPassword';
   loginMechanisms?: LoginMechanism[];
   services?: Partial<typeof defaultServices>;
+  socialProviders?: SocialProvider[];
 };
 
 export function createAuthenticatorMachine({
   initialState = 'signIn',
-  /** @TODO Prefer `usernameAttributes` and `socialProviders` */
   loginMechanisms,
+  socialProviders,
   services: customServices,
 }: AuthenticatorMachineOptions) {
   const services = {
@@ -32,7 +38,8 @@ export function createAuthenticatorMachine({
       context: {
         user: undefined,
         config: {
-          login_mechanisms: loginMechanisms,
+          loginMechanisms,
+          socialProviders,
         },
         actorRef: undefined,
       },
@@ -128,36 +135,29 @@ export function createAuthenticatorMachine({
         }),
         applyAmplifyConfig: assign({
           config(context, event) {
-            const configuredLoginMechanisms =
-              event.data.aws_cognito_login_mechanisms?.map((login) => {
-                switch (login) {
-                  case 'PREFERRED_USERNAME':
-                    return 'username';
+            // The CLI uses uppercased constants in `aws-exports.js`, while `parameters.json` are lowercase.
+            // We use lowercase to be consistent with previous versions' values.
+            const cliLoginMechanisms =
+              event.data.aws_cognito_username_attributes?.map((s) =>
+                s.toLowerCase()
+              ) ?? [];
 
-                  case 'EMAIL':
-                  case 'PHONE_NUMBER':
-                  case 'FACEBOOK':
-                  case 'GOOGLE':
-                  case 'AMAZON':
-                  case 'APPLE':
-                    return login.toLowerCase();
+            const cliSocialProviders =
+              event.data.aws_cognito_social_providers?.map((s) =>
+                s.toLowerCase()
+              ) ?? [];
 
-                  default:
-                    console.warn(
-                      `Unknown login mechanism from Amplify CLI: ${login}.\nOpen an issue: https://github.com/aws-amplify/amplify-ui/issues/choose`
-                    );
-                }
-              });
+            // By default, Cognito assumes `username`, so there isn't a different username attribute like `email`.
+            // We explicitly add it as a login mechanism to be consistent with Admin UI's language.
+            if (cliLoginMechanisms.length === 0) {
+              cliLoginMechanisms.push('username');
+            }
 
-            const defaultLoginMechanisms = configuredLoginMechanisms ?? [
-              'username',
-            ];
-
-            // Prefer explicitly set login mechanisms from machine instantiation over defaults
-            const { login_mechanisms = defaultLoginMechanisms } =
-              context.config;
-
-            return { login_mechanisms };
+            // Prefer explicitly configured settings over default CLI values
+            return {
+              loginMechanisms: loginMechanisms ?? cliLoginMechanisms,
+              socialProviders: socialProviders ?? cliSocialProviders.sort(),
+            };
           },
         }),
         spawnSignInActor: assign({
@@ -181,7 +181,8 @@ export function createAuthenticatorMachine({
               intent: event.data?.intent,
               formValues: {},
               validationError: {},
-              login_mechanisms: context.config?.login_mechanisms,
+              loginMechanisms: context.config?.loginMechanisms,
+              socialProviders: context.config?.socialProviders,
             });
             return spawn(actor, { name: 'signUpActor' });
           },

--- a/packages/ui/src/machines/authenticator/signUp.ts
+++ b/packages/ui/src/machines/authenticator/signUp.ts
@@ -226,8 +226,8 @@ export function createSignUpMachine({ services }: SignUpMachineOptions) {
           return result;
         },
         async signUp(context, _event) {
-          const { formValues, login_mechanisms } = context;
-          const [primaryAlias] = login_mechanisms ?? ['username'];
+          const { formValues, loginMechanisms } = context;
+          const [primaryAlias] = loginMechanisms ?? ['username'];
 
           if (formValues.phone_number) {
             formValues.phone_number =

--- a/packages/ui/src/types/authMachine.ts
+++ b/packages/ui/src/types/authMachine.ts
@@ -7,7 +7,8 @@ export type AuthFormData = Record<string, string>;
 export interface AuthContext {
   actorRef?: any;
   config?: {
-    login_mechanisms: LoginMechanism[];
+    loginMechanisms?: LoginMechanism[];
+    socialProviders?: SocialProvider[];
   };
   user?: CognitoUserAmplify;
 }
@@ -30,7 +31,8 @@ export interface SignInContext extends BaseFormContext {
 }
 
 export interface SignUpContext extends BaseFormContext {
-  login_mechanisms?: string[];
+  loginMechanisms: AuthContext['config']['loginMechanisms'];
+  socialProviders: AuthContext['config']['socialProviders'];
   unverifiedAttributes?: Record<string, string>;
 }
 
@@ -94,26 +96,18 @@ export interface InputAttributes {
   placeholder: string;
 }
 
-export const userNameAliasArray = [
+export const LoginMechanismArray = [
   'username',
   'email',
   'phone_number',
 ] as const;
 
-export type UserNameAlias = typeof userNameAliasArray[number];
+export type LoginMechanism = typeof LoginMechanismArray[number];
 
-export const socialProviderLoginMechanisms = [
-  'amazon',
-  'google',
-  'facebook',
-] as const;
-
-export type SocialProviderAlias = typeof socialProviderLoginMechanisms[number];
-
-export type LoginMechanism = UserNameAlias | SocialProviderAlias;
+export type SocialProvider = 'amazon' | 'apple' | 'facebook' | 'google';
 
 // other non-alias inputs that Cognito would require
-export type AuthInputNames = UserNameAlias | 'confirmation_code' | 'password';
+export type AuthInputNames = LoginMechanism | 'confirmation_code' | 'password';
 
 export type AuthInputAttributes = Record<AuthInputNames, InputAttributes>;
 


### PR DESCRIPTION
*Description of changes:*

- [x] Updates `authMachine` to have both `loginMechanisms` and `socialProviders` based on new Amplify CLI zero-config `aws-exports.js`. (Closes #609)
- [x] Adds `Sign in with Apple` button (Closes #607)
- [ ] Fix React to use `loginMechanisms` and `socialProviders`
- [ ] Fix Angular to use `loginMechanisms` and `socialProviders`
- [ ] Fix Vue to use `loginMechanisms` and `socialProviders`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
