### PR TITLE
feat(angular): Implement public `AuthenticatorService` 

### DIFF
--- a/.changeset/stale-zoos-rescue.md
+++ b/.changeset/stale-zoos-rescue.md
@@ -18,7 +18,7 @@ export class AppComponent {
 _app.component.html_
 ```html
 <!-- example of "reset password" button -->
-<button (click)="authenticator.toSignUp()">Reset password</button>
+<button (click)="authenticator.toResetPassword()">Reset password</button>
 
 <!-- example of "sign up" submit button -->
 <button (click)="authenticator.submitForm()">Sign Up</button>

--- a/.changeset/stale-zoos-rescue.md
+++ b/.changeset/stale-zoos-rescue.md
@@ -1,0 +1,30 @@
+---
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-vue": patch
+"@aws-amplify/ui-angular": patch
+---
+
+This implements `AuthenticatorService` that can be used internally and externally to access common Authenticator context and helpers.
+
+*Usage*:
+
+_app.component.ts_
+```ts
+export class AppComponent {
+  constructor(public authenticator: AuthenticatorService) {}
+}
+```
+
+_app.component.html_
+```html
+<!-- example of "reset password" button -->
+<button (click)="authenticator.toSignUp()">Reset password</button>
+
+<!-- example of "sign up" submit button -->
+<button (click)="authenticator.submitForm()">Sign Up</button>
+
+<!-- disabling the submit form if submission is in progress -->
+<button (click)="authenticator.submitForm()" [disabled]="authenticator.isPending">
+  Sign Up
+</button>
+```

--- a/.changeset/stale-zoos-rescue.md
+++ b/.changeset/stale-zoos-rescue.md
@@ -23,7 +23,7 @@ _app.component.html_
 <!-- example of "sign up" submit button -->
 <button (click)="authenticator.submitForm()">Sign Up</button>
 
-<!-- disabling the submit form if submission is in progress -->
+<!-- disabling the submit button if submission is in progress -->
 <button (click)="authenticator.submitForm()" [disabled]="authenticator.isPending">
   Sign Up
 </button>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.html
@@ -1,88 +1,70 @@
-<div
-  data-amplify-authenticator
-  *ngIf="!authenticatorState.matches('authenticated')"
->
+<div data-amplify-authenticator *ngIf="route !== 'authenticated'">
   <div data-authenticator-variation="modal" *ngIf="variationModal"></div>
 
   <div data-amplify-container>
     <amplify-tabs
       (tabChange)="onTabChange()"
-      *ngIf="actorState?.matches('signIn') || actorState?.matches('signUp')"
+      *ngIf="route === 'signIn' || route === 'signUp'"
     >
-      <amplify-tab-item
-        [title]="signInTitle"
-        [active]="actorState?.matches('signIn')"
-      >
+      <amplify-tab-item [title]="signInTitle" [active]="route === 'signIn'">
         <!-- signIn component -->
-        <amplify-slot name="sign-in" *ngIf="actorState?.matches('signIn')">
+        <amplify-slot name="sign-in" *ngIf="route === 'signIn'">
           <amplify-sign-in></amplify-sign-in>
         </amplify-slot>
       </amplify-tab-item>
-      <amplify-tab-item
-        [title]="signUpTitle"
-        [active]="actorState?.matches('signUp')"
-      >
+      <amplify-tab-item [title]="signUpTitle" [active]="route === 'signUp'">
         <!-- signUp component -->
-        <amplify-slot name="sign-up" *ngIf="actorState?.matches('signUp')">
+        <amplify-slot name="sign-up" *ngIf="route === 'signUp'">
           <amplify-sign-up></amplify-sign-up>
         </amplify-slot>
       </amplify-tab-item>
     </amplify-tabs>
 
     <!-- confirmSignUp content -->
-    <amplify-slot
-      name="confirm-sign-up"
-      *ngIf="actorState?.matches('confirmSignUp')"
-    >
+    <amplify-slot name="confirm-sign-up" *ngIf="route === 'confirmSignUp'">
       <amplify-confirm-sign-up></amplify-confirm-sign-up>
     </amplify-slot>
 
     <!-- confirmSignIn content -->
-    <amplify-slot
-      name="confirm-sign-in"
-      *ngIf="actorState?.matches('confirmSignIn')"
-    >
+    <amplify-slot name="confirm-sign-in" *ngIf="route === 'confirmSignIn'">
       <amplify-confirm-sign-in></amplify-confirm-sign-in>
     </amplify-slot>
 
     <!-- setupTotp content -->
-    <amplify-slot name="setup-totp" *ngIf="actorState?.matches('setupTOTP')">
+    <amplify-slot name="setup-totp" *ngIf="route === 'setupTOTP'">
       <amplify-setup-totp></amplify-setup-totp>
     </amplify-slot>
 
     <!-- forceNewPassword content -->
     <amplify-slot
       name="force-new-password"
-      *ngIf="actorState?.matches('forceNewPassword')"
+      *ngIf="route === 'forceNewPassword'"
     >
       <amplify-force-new-password></amplify-force-new-password>
     </amplify-slot>
 
     <!-- resetPassword content -->
-    <amplify-slot
-      name="reset-password"
-      *ngIf="actorState?.matches('resetPassword')"
-    >
+    <amplify-slot name="reset-password" *ngIf="route === 'resetPassword'">
       <amplify-reset-password></amplify-reset-password>
     </amplify-slot>
 
     <!-- confirmResetPassword content -->
     <amplify-slot
       name="confirm-reset-password"
-      *ngIf="actorState?.matches('confirmResetPassword')"
+      *ngIf="route === 'confirmResetPassword'"
     >
       <amplify-confirm-reset-password></amplify-confirm-reset-password>
     </amplify-slot>
 
     <!-- verifyUser content -->
-    <amplify-slot name="verify-user" *ngIf="actorState?.matches('verifyUser')">
+    <amplify-slot name="verify-user" *ngIf="route === 'verifyUser'">
       <amplify-verify-user></amplify-verify-user>
     </amplify-slot>
 
     <!-- confirmVerifyUser content -->
     <amplify-slot
       name="confirm-verify-user"
-      *ngIf="actorState?.matches('confirmVerifyUser')"
+      *ngIf="route === 'confirmVerifyUser'"
     >
       <amplify-confirm-verify-user></amplify-confirm-verify-user>
     </amplify-slot>
@@ -93,7 +75,7 @@
 <amplify-slot
   name="authenticated"
   [context]="authenticatedContext"
-  *ngIf="authenticatorState.matches('authenticated')"
+  *ngIf="route === 'authenticated'"
 >
   <ng-content></ng-content>
 </amplify-slot>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.ts
@@ -8,11 +8,7 @@ import {
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
-import {
-  AuthenticatorMachineOptions,
-  getActorState,
-  translate,
-} from '@aws-amplify/ui';
+import { AuthenticatorMachineOptions, translate } from '@aws-amplify/ui';
 import { AmplifySlotDirective } from '../../../../utilities/amplify-slot/amplify-slot.directive';
 import { CustomComponentsService } from '../../../../services/custom-components.service';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
@@ -67,17 +63,12 @@ export class AmplifyAuthenticatorComponent implements OnInit, AfterContentInit {
 
   // context passed to "authenticated" slot
   public get authenticatedContext() {
-    const { signOut } = this.authenticator.services;
-    const user = this.authenticator.user;
-    return { signOut, user } as const;
+    const { signOut, user } = this.authenticator;
+    return { signOut, user };
   }
 
-  public get actorState() {
-    return getActorState(this.authenticator.authState);
-  }
-
-  public get authenticatorState() {
-    return this.authenticator.authState;
+  public get route() {
+    return this.authenticator.route;
   }
 
   public get variationModal() {
@@ -85,11 +76,11 @@ export class AmplifyAuthenticatorComponent implements OnInit, AfterContentInit {
   }
 
   public onTabChange() {
-    const currentState = this.authenticator.authState.value;
-    if (currentState === 'signIn') {
-      this.authenticator.send('SIGN_UP');
+    const route = this.authenticator.route;
+    if (route === 'signIn') {
+      this.authenticator.toSignUp();
     } else {
-      this.authenticator.send('SIGN_IN');
+      this.authenticator.toSignIn();
     }
   }
 

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.html
@@ -4,7 +4,7 @@
       class="amplify-flex"
       style="flex-direction: column"
       data-amplify-fieldset
-      [disabled]="isPending"
+      [disabled]="authenticator.isPending"
     >
       <h3 class="amplify-heading">{{ headerText }}</h3>
       <amplify-form-field
@@ -23,12 +23,12 @@
         variation="link"
         fontWeight="normal"
         fullWidth="true"
-        (click)="toSignIn()"
+        (click)="authenticator.toSignIn()"
       >
         {{ backToSignInText }}
       </button>
-      <amplify-error *ngIf="remoteError">
-        {{ remoteError }}
+      <amplify-error *ngIf="authenticator.error">
+        {{ authenticator.error }}
       </amplify-error>
     </fieldset>
   </form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.html
@@ -4,7 +4,7 @@
       class="amplify-flex"
       style="flex-direction: column"
       data-amplify-fieldset
-      [disabled]="isPending"
+      [disabled]="context.isPending"
     >
       <h3 class="amplify-heading">{{ this.headerText }}</h3>
       <amplify-form-field
@@ -16,13 +16,17 @@
       <button amplify-button variation="primary" fullWidth="true" type="submit">
         {{ confirmText }}
       </button>
-      <button amplify-button fontWeight="normal" (click)="resend()">
+      <button
+        amplify-button
+        fontWeight="normal"
+        (click)="authenticator.resendCode()"
+      >
         {{ resendCodeText }}
       </button>
     </fieldset>
 
-    <amplify-error *ngIf="remoteError">
-      {{ remoteError }}
+    <amplify-error *ngIf="context.error">
+      {{ authenticator.error }}
     </amplify-error>
   </form>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.ts
@@ -1,91 +1,42 @@
-import {
-  Component,
-  HostBinding,
-  Input,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
-import {
-  AuthMachineState,
-  getActorContext,
-  getActorState,
-  SignUpContext,
-  SignUpState,
-} from '@aws-amplify/ui';
-import { Subscription } from 'xstate';
+import { Component, HostBinding, Input } from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import { translate } from '@aws-amplify/ui';
 @Component({
   selector: 'amplify-confirm-sign-up',
   templateUrl: './amplify-confirm-sign-up.component.html',
 })
-export class AmplifyConfirmSignUpComponent implements OnInit, OnDestroy {
+export class AmplifyConfirmSignUpComponent {
   @Input() headerText = translate('Confirm Sign Up');
 
   @HostBinding('attr.data-amplify-authenticator-confirmsignup') dataAttr = '';
-
-  private authSubscription: Subscription;
-  public username: string;
-  public remoteError = '';
-  public isPending = false;
 
   // translated texts
   public resendCodeText = translate('Resend Code');
   public confirmText = translate('Confirm');
 
-  constructor(private authenticator: AuthenticatorService) {}
-
-  ngOnInit(): void {
-    // TODO: alias for subscribe
-    this.authSubscription = this.authenticator.subscribe((state) =>
-      this.onStateUpdate(state)
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.authSubscription.unsubscribe();
-  }
-
-  onStateUpdate(state: AuthMachineState): void {
-    const actorState: SignUpState = getActorState(state);
-    this.remoteError = actorState.context.remoteError;
-    this.isPending = !actorState.matches('confirmSignUp.edit');
-  }
+  constructor(public authenticator: AuthenticatorService) {}
 
   public get context() {
-    const { change, resend, signIn, submit } = this.authenticator.services;
-    const remoteError = this.remoteError;
-    const username = this.username;
-    return { change, remoteError, resend, signIn, submit, username };
-  }
-  resend(): void {
-    this.authenticator.send({
-      type: 'RESEND',
-      data: {
-        username: this.username,
-      },
-    });
+    const { updateForm, resendCode, isPending, submitForm, error } =
+      this.authenticator;
+
+    return {
+      updateForm,
+      resendCode,
+      isPending,
+      submitForm,
+      error,
+    };
   }
 
-  onInput($event) {
-    $event.preventDefault();
-    const { name, value } = $event.target;
-    this.authenticator.send({
-      type: 'CHANGE',
-      data: { name, value },
-    });
+  onInput(event: Event) {
+    event.preventDefault();
+    const { name, value } = <HTMLInputElement>event.target;
+    this.authenticator.updateForm({ name, value });
   }
 
   onSubmit(event: Event): void {
     event.preventDefault();
-    const state = this.authenticator.authState;
-    const actorContext: SignUpContext = getActorContext(state);
-    const { formValues } = actorContext;
-    const { username, confirmation_code } = formValues;
-
-    this.authenticator.send({
-      type: 'SUBMIT',
-      data: { username, confirmation_code },
-    });
+    this.authenticator.submitForm();
   }
 }

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.html
@@ -4,7 +4,7 @@
       class="amplify-flex"
       style="flex-direction: column"
       data-amplify-fieldset
-      [disabled]="isPending"
+      [disabled]="authenticator.isPending"
     >
       <h3 class="amplify-heading">{{ this.headerText }}</h3>
       <amplify-form-field
@@ -30,12 +30,12 @@
         variation="link"
         fontWeight="normal"
         fullWidth="true"
-        (click)="toSignIn()"
+        (click)="authenticator.toSignIn()"
       >
         {{ backToSignInText }}
       </button>
-      <amplify-error *ngIf="remoteError">
-        {{ remoteError }}
+      <amplify-error *ngIf="authenticator.error">
+        {{ authenticator.error }}
       </amplify-error>
     </fieldset>
   </form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.ts
@@ -3,8 +3,6 @@ import { Logger } from 'aws-amplify';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import { translate } from '@aws-amplify/ui';
 
-const logger = new Logger('ForceNewPassword');
-
 @Component({
   selector: 'amplify-force-new-password',
   templateUrl: './amplify-force-new-password.component.html',

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.ts
@@ -1,5 +1,4 @@
 import { Component, HostBinding, Input } from '@angular/core';
-import { Logger } from 'aws-amplify';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import { translate } from '@aws-amplify/ui';
 

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-reset-password/amplify-reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-reset-password/amplify-reset-password.component.html
@@ -4,7 +4,7 @@
       class="amplify-flex"
       style="flex-direction: column"
       data-amplify-fieldset
-      [disabled]="isPending"
+      [disabled]="authenticator.isPending"
     >
       <h3 class="amplify-heading">{{ this.headerText }}</h3>
       <amplify-form-field
@@ -21,12 +21,12 @@
         variation="link"
         fontWeight="normal"
         fullWidth="true"
-        (click)="toSignIn()"
+        (click)="authenticator.toSignIn()"
       >
         {{ backToSignInText }}
       </button>
-      <amplify-error *ngIf="remoteError">
-        {{ remoteError }}
+      <amplify-error *ngIf="authenticator.error">
+        {{ authenticator.error }}
       </amplify-error>
     </fieldset>
   </form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-reset-password/amplify-reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-reset-password/amplify-reset-password.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  HostBinding,
-  Input,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
-import { AuthMachineState, getActorState, SignInState } from '@aws-amplify/ui';
-import { Subscription } from 'xstate';
+import { Component, HostBinding, Input } from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import { translate } from '@aws-amplify/ui';
 
@@ -14,58 +6,29 @@ import { translate } from '@aws-amplify/ui';
   selector: 'amplify-reset-password',
   templateUrl: './amplify-reset-password.component.html',
 })
-export class AmplifyResetPasswordComponent implements OnInit, OnDestroy {
+export class AmplifyResetPasswordComponent {
   @HostBinding('attr.data-amplify-authenticator-resetPassword') dataAttr = '';
   @Input() public headerText = translate('Reset your password');
-
-  public remoteError = '';
-  public isPending = false;
-
-  private authSubscription: Subscription;
 
   // translated texts
   public sendCodeText = translate('Send Code');
   public backToSignInText = translate('Back to Sign In');
 
-  constructor(private authenticator: AuthenticatorService) {}
-
-  ngOnInit(): void {
-    this.authSubscription = this.authenticator.subscribe((state) =>
-      this.onStateUpdate(state)
-    );
-  }
-
-  ngOnDestroy() {
-    this.authSubscription.unsubscribe();
-  }
-
-  onStateUpdate(state: AuthMachineState): void {
-    const actorState: SignInState = getActorState(state);
-    this.remoteError = actorState.context.remoteError;
-    this.isPending = !actorState.matches('resetPassword.edit');
-  }
+  constructor(public authenticator: AuthenticatorService) {}
 
   public get context() {
-    const { change, signIn, submit } = this.authenticator.services;
-    const remoteError = this.remoteError;
-    return { change, remoteError, signIn, submit };
+    const { updateForm, toSignIn, submitForm, error } = this.authenticator;
+    return { updateForm, toSignIn, submitForm, error };
   }
 
-  toSignIn(): void {
-    this.authenticator.send('SIGN_IN');
-  }
-
-  onInput(event: Event): void {
+  onInput(event: Event) {
     event.preventDefault();
     const { name, value } = <HTMLInputElement>event.target;
-    this.authenticator.send({
-      type: 'CHANGE',
-      data: { name, value },
-    });
+    this.authenticator.updateForm({ name, value });
   }
 
   onSubmit(event: Event): void {
     event.preventDefault();
-    this.authenticator.send('SUBMIT');
+    this.authenticator.submitForm();
   }
 }

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-setup-totp/amplify-setup-totp.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-setup-totp/amplify-setup-totp.component.html
@@ -4,7 +4,7 @@
       class="amplify-flex"
       style="flex-direction: column"
       data-amplify-fieldset
-      [disabled]="isPending"
+      [disabled]="authenticator.isPending"
     >
       <h3 class="amplify-heading">{{ this.headerText }}</h3>
       <p *ngIf="!qrCodeSource">Loading...</p>
@@ -29,12 +29,12 @@
         variation="link"
         fontWeight="normal"
         fullWidth="true"
-        (click)="toSignIn()"
+        (click)="authenticator.toSignIn()"
       >
         {{ backToSignInText }}
       </button>
-      <amplify-error *ngIf="remoteError">
-        {{ remoteError }}
+      <amplify-error *ngIf="authenticator.error">
+        {{ authenticator.error }}
       </amplify-error>
     </fieldset>
   </form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-in/amplify-sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-in/amplify-sign-in.component.html
@@ -4,7 +4,7 @@
       class="amplify-flex"
       style="flex-direction: column"
       data-amplify-fieldset
-      [disabled]="isPending"
+      [disabled]="authenticator.isPending"
     >
       <h3 class="amplify-heading">{{ this.headerText }}</h3>
       <amplify-user-name-alias></amplify-user-name-alias>
@@ -22,12 +22,12 @@
         fontWeight="normal"
         size="small"
         variation="link"
-        (click)="toResetPassword()"
+        (click)="authenticator.toResetPassword()"
       >
         {{ forgotPasswordText }}
       </button>
-      <amplify-error *ngIf="remoteError">
-        {{ remoteError }}
+      <amplify-error *ngIf="authenticator.error">
+        {{ authenticator.error }}
       </amplify-error>
     </fieldset>
     <amplify-federated-sign-in></amplify-federated-sign-in>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-in/amplify-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-in/amplify-sign-in.component.ts
@@ -1,82 +1,41 @@
-import { Logger } from 'aws-amplify';
 import {
   Component,
   HostBinding,
   Input,
-  OnDestroy,
-  OnInit,
   ViewEncapsulation,
 } from '@angular/core';
-// TODO: import from '@/services/...'
 import { AuthenticatorService } from '../../../../services/authenticator.service';
-import { Subscription } from 'xstate';
-import { AuthMachineState, getActorState, SignInState } from '@aws-amplify/ui';
 import { translate } from '@aws-amplify/ui';
-
-const logger = new Logger('SignIn');
 
 @Component({
   selector: 'amplify-sign-in',
   templateUrl: './amplify-sign-in.component.html',
   encapsulation: ViewEncapsulation.None,
 })
-export class AmplifySignInComponent implements OnInit, OnDestroy {
+export class AmplifySignInComponent {
   @HostBinding('attr.data-amplify-authenticator-signin') dataAttr = '';
   @Input() public headerText = translate('Sign in to your account');
-
-  public remoteError = '';
-  public isPending = false;
 
   // translated phrases
   public forgotPasswordText = translate('Forgot your password? ');
   public signInButtonText = translate('Sign in');
 
-  private authSubscription: Subscription;
-
-  constructor(private authenticator: AuthenticatorService) {}
-
-  ngOnInit(): void {
-    this.authSubscription = this.authenticator.subscribe((state) =>
-      this.onStateUpdate(state)
-    );
-  }
-
-  ngOnDestroy(): void {
-    logger.log('sign in destroyed, unsubscribing from state machine...');
-    this.authSubscription.unsubscribe();
-  }
-
-  onStateUpdate(state: AuthMachineState): void {
-    const actorState: SignInState = getActorState(state);
-    this.remoteError = actorState.context.remoteError;
-    this.isPending = !actorState.matches('signIn.edit');
-  }
+  constructor(public authenticator: AuthenticatorService) {}
 
   public get context() {
-    const { change, resetPassword, signUp, submit } =
-      this.authenticator.services;
-    const remoteError = this.remoteError;
-    return { change, remoteError, resetPassword, signUp, submit };
+    const { updateForm, toResetPassword, toSignUp, submitForm, error } =
+      this.authenticator;
+    return { updateForm, toResetPassword, toSignUp, submitForm, error };
   }
 
-  toResetPassword(): void {
-    this.authenticator.send('RESET_PASSWORD');
-  }
-
-  onInput(event: Event): void {
+  onInput(event: Event) {
     event.preventDefault();
     const { name, value } = <HTMLInputElement>event.target;
-    this.authenticator.send({
-      type: 'CHANGE',
-      data: { name, value },
-    });
+    this.authenticator.updateForm({ name, value });
   }
 
   onSubmit(event: Event): void {
     event.preventDefault();
-
-    this.authenticator.send({
-      type: 'SUBMIT',
-    });
+    this.authenticator.submitForm();
   }
 }

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/amplify-sign-up.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/amplify-sign-up.component.html
@@ -7,14 +7,14 @@
         <amplify-sign-up-form-fields></amplify-sign-up-form-fields>
       </amplify-slot>
 
-      <amplify-error *ngIf="remoteError">
-        {{ remoteError }}
+      <amplify-error *ngIf="authenticator.error">
+        {{ authenticator.error }}
       </amplify-error>
     </div>
 
     <amplify-slot name="sign-up-button" [context]="context">
       <button
-        [disabled]="isPending"
+        [disabled]="authenticator.isPending"
         amplify-button
         variation="primary"
         fullWidth="true"

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-verify-user/amplify-verify-user.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-verify-user/amplify-verify-user.component.html
@@ -4,12 +4,11 @@
       class="amplify-flex"
       style="flex-direction: column"
       data-amplify-fieldset
-      [disabled]="isPending"
+      [disabled]="authenticator.isPending"
     >
       <h3 class="amplify-heading">{{ this.headerText }}</h3>
 
       <div *ngFor="let unverifiedAttribute of unverifiedAttributes | keyvalue">
-        <!-- TODO: match React implementation -->
         <input
           name="unverifiedAttr"
           type="radio"
@@ -31,13 +30,13 @@
         variation="link"
         fontWeight="normal"
         fullWidth="true"
-        (click)="skipVerify()"
+        (click)="authenticator.skipVerification()"
       >
         {{ skipText }}
       </button>
 
-      <amplify-error *ngIf="remoteError">
-        {{ remoteError }}
+      <amplify-error *ngIf="authenticator.error">
+        {{ authenticator.error }}
       </amplify-error>
     </fieldset>
   </form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
@@ -4,7 +4,7 @@
       class="amplify-flex"
       style="flex-direction: column"
       data-amplify-fieldset
-      [disabled]="isPending"
+      [disabled]="authenticator.isPending"
     >
       <h3 class="amplify-heading">{{ headerText }}</h3>
       <amplify-form-field
@@ -35,13 +35,13 @@
         fontWeight="normal"
         fullWidth="true"
         type="button"
-        (click)="resend()"
+        (click)="authenticator.resendCode()"
       >
         {{ resendCodeText }}
       </button>
 
-      <amplify-error *ngIf="remoteError">
-        {{ remoteError }}
+      <amplify-error *ngIf="authenticator.error">
+        {{ authenticator.error }}
       </amplify-error>
     </fieldset>
   </form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  HostBinding,
-  Input,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
-import { AuthMachineState, getActorState, SignInState } from '@aws-amplify/ui';
-import { Subscription } from 'xstate';
+import { Component, HostBinding, Input } from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import { translate } from '@aws-amplify/ui';
 
@@ -14,62 +6,31 @@ import { translate } from '@aws-amplify/ui';
   selector: 'amplify-confirm-reset-password',
   templateUrl: './amplify-confirm-reset-password.component.html',
 })
-export class ConfirmResetPasswordComponent implements OnInit, OnDestroy {
+export class ConfirmResetPasswordComponent {
   @HostBinding('attr.data-amplify-authenticator-confirmsignin') dataAttr = '';
   @Input() public headerText = translate('Reset your password');
-
-  public remoteError = '';
-  public isPending = false;
-  private authSubscription: Subscription;
 
   // translated strings
   public sendCodeText = translate('Send Code');
   public backToSignInText = translate('Back to Sign In');
   public resendCodeText = translate('Resend Code');
 
-  constructor(private authenticator: AuthenticatorService) {}
-
-  ngOnInit(): void {
-    this.authSubscription = this.authenticator.subscribe((state) =>
-      this.onStateUpdate(state)
-    );
-  }
-
-  ngOnDestroy() {
-    this.authSubscription.unsubscribe();
-  }
-
-  onStateUpdate(state: AuthMachineState): void {
-    const actorState: SignInState = getActorState(state);
-    this.remoteError = actorState.context.remoteError;
-    this.isPending = !actorState.matches('confirmResetPassword.edit');
-  }
+  constructor(public authenticator: AuthenticatorService) {}
 
   public get context() {
-    const { change, resend, signIn, submit } = this.authenticator.services;
-    const remoteError = this.remoteError;
-    return { change, resend, remoteError, signIn, submit };
+    const { updateForm, resendCode, toSignIn, submitForm, error } =
+      this.authenticator;
+    return { updateForm, resendCode, toSignIn, submitForm, error };
   }
 
-  toSignIn(): void {
-    this.authenticator.send('SIGN_IN');
-  }
-
-  resend() {
-    this.authenticator.send('RESEND');
-  }
-
-  onInput(event: Event): void {
+  onInput(event: Event) {
     event.preventDefault();
     const { name, value } = <HTMLInputElement>event.target;
-    this.authenticator.send({
-      type: 'CHANGE',
-      data: { name, value },
-    });
+    this.authenticator.updateForm({ name, value });
   }
 
   onSubmit(event: Event): void {
     event.preventDefault();
-    this.authenticator.send('SUBMIT');
+    this.authenticator.submitForm();
   }
 }

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.html
@@ -4,7 +4,7 @@
       class="amplify-flex"
       style="flex-direction: column"
       data-amplify-fieldset
-      [disabled]="isPending"
+      [disabled]="authenticator.isPending"
     >
       <h3 class="amplify-heading">{{ this.headerText }}</h3>
       <amplify-form-field
@@ -22,12 +22,12 @@
         variation="link"
         fontWeight="normal"
         fullWidth="true"
-        (click)="skipVerify()"
+        (click)="(authenticator.skipVerification)"
       >
         {{ skipText }}
       </button>
-      <amplify-error *ngIf="remoteError">
-        {{ remoteError }}
+      <amplify-error *ngIf="authenticator.error">
+        {{ authenticator.error }}
       </amplify-error>
     </fieldset>
   </form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.ts
@@ -1,81 +1,38 @@
-import {
-  Component,
-  HostBinding,
-  Input,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
-import {
-  AuthMachineState,
-  getActorState,
-  SignInState,
-  translate,
-} from '@aws-amplify/ui';
-import { Subscription } from 'xstate';
+import { Component, HostBinding, Input } from '@angular/core';
+import { translate } from '@aws-amplify/ui';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 
 @Component({
   selector: 'amplify-confirm-verify-user',
   templateUrl: './amplify-confirm-verify-user.component.html',
 })
-export class ConfirmVerifyUserComponent implements OnInit, OnDestroy {
-  @HostBinding('attr.data-amplify-authenticator-confirmverifyuser') dataAttr =
-    '';
+export class ConfirmVerifyUserComponent {
+  @HostBinding('attr.data-amplify-authenticator-confirmverifyuser')
+  dataAttr = '';
   @Input() public headerText = translate(
     'Account recovery requires verified contact information'
   );
-
-  public remoteError = '';
-  public isPending = false;
-  private authSubscription: Subscription;
 
   // translated texts
   public skipText = translate('Skip');
   public submitText = translate('Submit');
 
-  constructor(private authenticator: AuthenticatorService) {}
-
-  ngOnInit(): void {
-    this.authSubscription = this.authenticator.subscribe((state) =>
-      this.onStateUpdate(state)
-    );
-  }
-
-  ngOnDestroy() {
-    this.authSubscription.unsubscribe();
-  }
-
-  onStateUpdate(state: AuthMachineState): void {
-    const actorState: SignInState = getActorState(state);
-    this.remoteError = actorState.context.remoteError;
-    this.isPending = !actorState.matches('confirmVerifyUser.edit');
-  }
+  constructor(public authenticator: AuthenticatorService) {}
 
   public get context() {
-    const { skip, submit } = this.authenticator.services;
-    const remoteError = this.remoteError;
-    return { remoteError, skip, submit };
+    const { updateForm, skipVerification, submitForm, error } =
+      this.authenticator;
+    return { updateForm, skipVerification, submitForm, error };
   }
 
-  skipVerify(): void {
-    this.authenticator.send('SKIP');
-  }
-
-  onInput(event: Event): void {
+  onInput(event: Event) {
     event.preventDefault();
     const { name, value } = <HTMLInputElement>event.target;
-    this.authenticator.send({
-      type: 'CHANGE',
-      data: { name, value },
-    });
+    this.authenticator.updateForm({ name, value });
   }
 
   onSubmit(event: Event): void {
     event.preventDefault();
-    const formData = new FormData(event.target as HTMLFormElement);
-    this.authenticator.send({
-      type: 'SUBMIT',
-      data: Object.fromEntries(formData),
-    });
+    this.authenticator.submitForm();
   }
 }

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.ts
@@ -50,9 +50,9 @@ export class AmplifyFormFieldComponent implements OnInit {
       this.defaultCountryCode = country_code;
 
       // TODO: remove this side-effect
-      this.authenticator.send({
-        type: 'CHANGE',
-        data: { name: 'country_code', value: country_code },
+      this.authenticator.updateForm({
+        name: 'country_code',
+        value: country_code,
       });
     }
   }

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
@@ -95,7 +95,6 @@ export class AuthenticatorService implements OnDestroy {
   }
 
   public get signOut() {
-    console.log(this);
     return this._sendEventAliases.signOut;
   }
 

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
@@ -8,7 +8,7 @@ import {
   AuthMachineState,
   createAuthenticatorMachine,
   getSendEventAliases,
-  getServiceContext,
+  getServiceContextFacade,
 } from '@aws-amplify/ui';
 import { Event, interpret, Subscription } from 'xstate';
 import { AuthSubscriptionCallback } from '../common';
@@ -26,7 +26,7 @@ export class AuthenticatorService implements OnDestroy {
   private _authService: AuthInterpreter;
   private _sendEventAliases: ReturnType<typeof getSendEventAliases>;
   private _subscription: Subscription;
-  private _facade: ReturnType<typeof getServiceContext>;
+  private _facade: ReturnType<typeof getServiceContextFacade>;
 
   public startMachine({
     initialState,
@@ -43,7 +43,7 @@ export class AuthenticatorService implements OnDestroy {
 
     this._subscription = authService.subscribe((state) => {
       this._authState = state;
-      this._facade = getServiceContext(state);
+      this._facade = getServiceContextFacade(state);
     });
 
     this._sendEventAliases = getSendEventAliases(authService.send);

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
@@ -4,6 +4,7 @@ import {
   AuthContext,
   AuthenticatorMachineOptions,
   AuthEvent,
+  AuthEventData,
   AuthInterpreter,
   AuthMachineState,
   createAuthenticatorMachine,
@@ -42,6 +43,7 @@ export class AuthenticatorService implements OnDestroy {
     }).start();
 
     this._subscription = authService.subscribe((state) => {
+      this._authState = state;
       this._facade = getServiceContext(state);
     });
 
@@ -52,6 +54,10 @@ export class AuthenticatorService implements OnDestroy {
   ngOnDestroy(): void {
     if (this._subscription) this._subscription.unsubscribe();
   }
+
+  /**
+   * Context facades
+   */
 
   public get error() {
     return this._facade?.error;
@@ -73,13 +79,58 @@ export class AuthenticatorService implements OnDestroy {
     return this._facade?.user;
   }
 
-  public validationErrors() {
+  public get validationErrors() {
     return this._facade?.validationErrors;
   }
 
-  public get services() {
-    return this._sendEventAliases;
+  /**
+   * Service facades
+   */
+
+  public get updateForm() {
+    return this._sendEventAliases.updateForm;
   }
+
+  public get resendCode() {
+    return this._sendEventAliases.resendCode;
+  }
+
+  public get signOut() {
+    console.log(this);
+    return this._sendEventAliases.signOut;
+  }
+
+  public get submitForm() {
+    return this._sendEventAliases.submitForm;
+  }
+
+  /**
+   * Transition facades
+   */
+
+  public get toFederatedSignIn() {
+    return this._sendEventAliases.toFederatedSignIn;
+  }
+
+  public get toResetPassword() {
+    return this._sendEventAliases.toResetPassword;
+  }
+
+  public get toSignIn() {
+    return this._sendEventAliases.toSignIn;
+  }
+
+  public get toSignUp() {
+    return this._sendEventAliases.toSignUp;
+  }
+
+  public get skipVerification() {
+    return this._sendEventAliases.skipVerification;
+  }
+
+  /**
+   * Internal utility functions
+   */
 
   /** @deprecated For internal use only */
   public get authState(): AuthMachineState {

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
@@ -4,7 +4,6 @@ import {
   AuthContext,
   AuthenticatorMachineOptions,
   AuthEvent,
-  AuthEventData,
   AuthInterpreter,
   AuthMachineState,
   createAuthenticatorMachine,

--- a/packages/ui/src/helpers/auth.ts
+++ b/packages/ui/src/helpers/auth.ts
@@ -175,17 +175,15 @@ export const getSendEventAliases = (send: Sender<AuthEvent>) => {
   } as const;
 };
 
-export const getServiceFacade = ({ send, state }) => {
+export const getServiceContext = (state: AuthMachineState) => {
   const user = state.context?.user;
   const actorState = getActorState(state);
   const actorContext: ActorContextWithForms = getActorContext(state);
-  const sendEventAliases = getSendEventAliases(send);
   const error = actorContext?.remoteError;
   const validationErrors = { ...actorContext?.validationError };
   const hasValidationErrors = Object.keys(validationErrors).length > 0;
   const isPending =
     state.hasTag('pending') || getActorState(state)?.hasTag('pending');
-
   const route = (() => {
     switch (true) {
       case state.matches('idle'):
@@ -224,12 +222,21 @@ export const getServiceFacade = ({ send, state }) => {
   })();
 
   return {
-    ...sendEventAliases,
     error,
     hasValidationErrors,
     isPending,
     route,
     user,
     validationErrors,
+  };
+};
+
+export const getServiceFacade = ({ send, state }) => {
+  const sendEventAliases = getSendEventAliases(send);
+  const serviceContext = getServiceContext(state);
+
+  return {
+    ...sendEventAliases,
+    ...serviceContext,
   };
 };

--- a/packages/ui/src/helpers/auth.ts
+++ b/packages/ui/src/helpers/auth.ts
@@ -136,42 +136,19 @@ export const getSendEventAliases = (send: Sender<AuthEvent>) => {
   };
 
   return {
-    /** @deprecated use `updateForm` instead */
-    change: sendToMachine('CHANGE'),
-    updateForm: sendToMachine('CHANGE'),
-
-    /** @deprecated use `resendCode` instead */
-    resend: sendToMachine('RESEND'),
     resendCode: sendToMachine('RESEND'),
-
     signOut: sendToMachine('SIGN_OUT'),
+    submitForm: sendToMachine('SUBMIT'),
+    updateForm: sendToMachine('CHANGE'),
 
     // Actions that don't immediately invoke a service but instead transition to a screen
     // are prefixed with `to*`
 
-    /** @deprecated use `toFederatedSignIn` instead */
-    federatedSignIn: sendToMachine('FEDERATED_SIGN_IN'),
     toFederatedSignIn: sendToMachine('FEDERATED_SIGN_IN'),
-
-    /** @deprecated use `toResetPassword` instead */
-    resetPassword: sendToMachine('RESET_PASSWORD'),
     toResetPassword: sendToMachine('RESET_PASSWORD'),
-
-    /** @deprecated use `toSignIn` instead */
-    signIn: sendToMachine('SIGN_IN'),
     toSignIn: sendToMachine('SIGN_IN'),
-
-    /** @deprecated use `toSignUp` instead */
-    signUp: sendToMachine('SIGN_UP'),
     toSignUp: sendToMachine('SIGN_UP'),
-
-    /** @deprecated use `skipVerification` instead */
-    skip: sendToMachine('SKIP'),
     skipVerification: sendToMachine('SKIP'),
-
-    /** @deprecated Use `submitForm` instead */
-    submit: sendToMachine('SUBMIT'),
-    submitForm: sendToMachine('SUBMIT'),
   } as const;
 };
 

--- a/packages/ui/src/helpers/auth.ts
+++ b/packages/ui/src/helpers/auth.ts
@@ -152,7 +152,7 @@ export const getSendEventAliases = (send: Sender<AuthEvent>) => {
   } as const;
 };
 
-export const getServiceContext = (state: AuthMachineState) => {
+export const getServiceContextFacade = (state: AuthMachineState) => {
   const user = state.context?.user;
   const actorState = getActorState(state);
   const actorContext: ActorContextWithForms = getActorContext(state);
@@ -210,7 +210,7 @@ export const getServiceContext = (state: AuthMachineState) => {
 
 export const getServiceFacade = ({ send, state }) => {
   const sendEventAliases = getSendEventAliases(send);
-  const serviceContext = getServiceContext(state);
+  const serviceContext = getServiceContextFacade(state);
 
   return {
     ...sendEventAliases,

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -284,7 +284,7 @@
 
 <script setup lang="ts">
 import { useAuth } from '../composables/useAuth';
-import { ref, computed, useAttrs, watch } from 'vue';
+import { ref, computed, useAttrs, watch, Ref } from 'vue';
 import { useActor, useInterpret } from '@xstate/vue';
 import {
   getActorState,
@@ -292,6 +292,7 @@ import {
   AuthenticatorMachineOptions,
   createAuthenticatorMachine,
   translate,
+  CognitoUserAmplify,
 } from '@aws-amplify/ui';
 
 import SignIn from './sign-in.vue';
@@ -452,7 +453,7 @@ const onConfirmVerifyUserSubmitI = (e: Event) => {
  * Update service facade when context updates
  */
 
-const user = ref(null);
+const user: Ref<CognitoUserAmplify | null> = ref(null);
 const signOut = ref();
 
 watch(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- [x] Modifies `AuthenticatorService` to provide service facades
- [x] Mark any internal methods with `@deprecated`
- [x] Update each auth subcomponents to use the facades! 

Now, each auth subcomponents looks like how customers would implement their own components ✨ 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
