### PR TITLE
useStorageURL React hook

### DIFF
--- a/.changeset/moody-clocks-rest.md
+++ b/.changeset/moody-clocks-rest.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+useStorageURL React hook

--- a/docs/src/pages/ui/hooks/storage/index.page.mdx
+++ b/docs/src/pages/ui/hooks/storage/index.page.mdx
@@ -1,0 +1,7 @@
+---
+title: Storage
+---
+
+import { Fragment } from '@/components/Fragment';
+
+<Fragment>{({ platform }) => import(`./${platform}.mdx`)}</Fragment>

--- a/docs/src/pages/ui/hooks/storage/react.mdx
+++ b/docs/src/pages/ui/hooks/storage/react.mdx
@@ -1,0 +1,42 @@
+## useStorageURL
+
+Get a signed URL address for an [Amplify Storage](https://docs.amplify.aws/lib/storage/getting-started/q/platform/js/) file.
+
+```jsx
+const { url, error, isLoading } = useStorageURL(
+  key, // <-- Storage file path
+  options?: StorageGetConfig // <-- Storage file options [1]
+)
+```
+
+[1] Available options described in [Amplify Storage.get documentation](https://docs.amplify.aws/lib/storage/download/q/platform/js/#get)
+
+Returns an object containing:
+
+- `url`: signed URL address for requested file
+- `isLoading`: Indicates if url is being requested (`true` or `false`)
+- `error`: If something fails while fetching file URL, it will contain details about the failure.
+
+Note:
+
+- `url` value is `undefined` while signed URL is being computed. Use `isLoading` value to manage UI status (e.g displaying a [Loader](/components/loader) or [Placeholder](/components/placeholder) component)
+
+The following example implements a S3Image component, which loads an image stored in Amplify Storage:
+
+```jsx
+import { useStorageURL, Image, Text } from '@aws-amplify/ui-react';
+
+const S3Image = ({ path, altText, level = 'public' }) => {
+  const { url, error, isLoading } = useStorageURL(path, { level });
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  if (error) {
+    return <Text variation="error">Error loading image: {error}</Text>;
+  }
+
+  return <Image src={url} alt={altText} />;
+};
+```

--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -1898,6 +1898,7 @@ describe('@aws-amplify/ui-react', () => {
           "useDataStoreCollection",
           "useDataStoreItem",
           "usePagination",
+          "useStorageURL",
           "useTheme",
           "withAuthenticator",
         ]

--- a/packages/react/src/hooks/__tests__/useStorageURL.test.ts
+++ b/packages/react/src/hooks/__tests__/useStorageURL.test.ts
@@ -1,0 +1,92 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useStorageURL } from '../useStorageURL';
+import { S3ProviderGetConfig, Storage } from '@aws-amplify/storage';
+import { act } from 'react-dom/test-utils';
+
+jest.mock('@aws-amplify/storage');
+
+describe('useStorageURL', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  const storageKey = 'file.jpg';
+  const storageOptions: S3ProviderGetConfig = { level: 'public' };
+  const storageUrl = 'https://amplify.s3.amazonaws.com/path/to/the/file.jpg';
+
+  it('should return expected values at initialization', async () => {
+    (Storage.get as jest.Mock).mockResolvedValue(undefined);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useStorageURL(storageKey)
+    );
+
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.url).toBeUndefined();
+
+    // Force next render to prevent test warning
+    await waitForNextUpdate();
+  });
+
+  it('should return a Storage URL', async () => {
+    (Storage.get as jest.Mock).mockResolvedValue(storageUrl);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useStorageURL(storageKey)
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.url).toBe(storageUrl);
+  });
+
+  it('should invoke Storage.get on fetch', async () => {
+    const mockStorageGet = jest.fn(() => Promise.resolve());
+
+    (Storage.get as jest.Mock).mockImplementation(mockStorageGet);
+
+    const { waitForNextUpdate } = renderHook(() =>
+      useStorageURL(storageKey, storageOptions)
+    );
+
+    await waitForNextUpdate();
+
+    expect(mockStorageGet).toHaveBeenCalledWith(storageKey, storageOptions);
+  });
+
+  it('should set an error when Storage.get fails', async () => {
+    const customError = new Error('Something wrong happen');
+
+    (Storage.get as jest.Mock).mockRejectedValue(customError);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useStorageURL(storageKey)
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.error).toBe(customError);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.url).toBeUndefined();
+  });
+
+  it('should cancel Storage.get request on unmount', async () => {
+    const mockStorageCancel = jest.fn();
+
+    (Storage.get as jest.Mock).mockResolvedValue(undefined);
+    (Storage.cancel as jest.Mock).mockImplementation(mockStorageCancel);
+
+    const { waitForNextUpdate, unmount } = renderHook(() =>
+      useStorageURL(storageKey)
+    );
+
+    // Start Storage fetch
+    await waitForNextUpdate();
+
+    // Unmount!
+    act(() => unmount());
+
+    expect(mockStorageCancel).toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/hooks/index.tsx
+++ b/packages/react/src/hooks/index.tsx
@@ -8,4 +8,6 @@ export {
   useDataStoreItem,
 } from './useDataStore';
 
+export { useStorageURL } from './useStorageURL';
+
 export { useTheme } from './useTheme';

--- a/packages/react/src/hooks/useStorageURL.ts
+++ b/packages/react/src/hooks/useStorageURL.ts
@@ -1,0 +1,32 @@
+import { S3ProviderGetConfig, Storage } from '@aws-amplify/storage';
+import { useEffect, useState } from 'react';
+
+export interface UseStorageURLResult {
+  url?: string;
+  error?: Error;
+  isLoading: boolean;
+}
+
+export const useStorageURL = (key: string, options?: S3ProviderGetConfig) => {
+  const [result, setResult] = useState<UseStorageURLResult>({
+    isLoading: true,
+  });
+
+  const fetch = () => {
+    setResult({ isLoading: true });
+
+    const promise = Storage.get(key, options);
+
+    // Attempt to fetch storage object url
+    promise
+      .then((url) => setResult({ url, isLoading: false }))
+      .catch((error) => setResult({ error, isLoading: false }));
+
+    // Cancel current promise on unmount
+    return () => Storage.cancel(promise);
+  };
+
+  useEffect(fetch, []);
+
+  return { ...result, fetch };
+};

--- a/packages/react/src/hooks/useStorageURL.ts
+++ b/packages/react/src/hooks/useStorageURL.ts
@@ -12,6 +12,10 @@ export const useStorageURL = (key: string, options?: S3ProviderGetConfig) => {
     isLoading: true,
   });
 
+  // Used to prevent an infinite loop on useEffect, because `options`
+  // will have a different reference on every render
+  const serializedOptions = JSON.stringify(options);
+
   const fetch = () => {
     setResult({ isLoading: true });
 
@@ -26,7 +30,7 @@ export const useStorageURL = (key: string, options?: S3ProviderGetConfig) => {
     return () => Storage.cancel(promise);
   };
 
-  useEffect(fetch, []);
+  useEffect(fetch, [key, serializedOptions]);
 
   return { ...result, fetch };
 };


### PR DESCRIPTION
*Description of changes:*
This PR introduces a new `useStorageURL` React hook to easily get a signed URL for an Amplify Storage object

- [x] Implementation
- [x] Unit tests
- [x] Documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
