### PR TITLE
Fix getOverrideProps to return all, not just 2

### DIFF
--- a/.changeset/tricky-worms-act.md
+++ b/.changeset/tricky-worms-act.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Fix getOverrideProps to return all, not just 2

--- a/packages/react/src/primitives/shared/__tests__/utils.test.tsx
+++ b/packages/react/src/primitives/shared/__tests__/utils.test.tsx
@@ -1,9 +1,10 @@
+import { ViewProps } from '../../types';
 import {
   getConsecutiveIntArray,
+  getOverrideProps,
   getOverridesFromVariants,
   strHasLength,
 } from '../utils';
-import { ViewProps } from '../../types';
 
 const props: ViewProps = {
   backgroundColor: 'blue',
@@ -55,6 +56,48 @@ describe('strHasLength: ', () => {
 
   it('should return true for strings with a length', () => {
     expect(strHasLength('some string')).toBe(true);
+  });
+});
+
+describe('getOverrideProps', () => {
+  const overrides = {
+    View: {
+      width: '436px',
+      padding: '0px 0px 0px 0px',
+      backgroundColor: 'rgba(50.36245197057724,0,251.81250303983688,1)',
+      overflow: 'hidden',
+      position: 'relative',
+      height: '98px',
+    },
+    'View.Text[0]': {
+      fontSize: '12px',
+      color: 'red',
+    },
+  };
+
+  it('returns the correct overrides when path matches', () => {
+    const result = getOverrideProps(overrides, 'View');
+    expect(result).toEqual({
+      width: '436px',
+      padding: '0px 0px 0px 0px',
+      backgroundColor: 'rgba(50.36245197057724,0,251.81250303983688,1)',
+      overflow: 'hidden',
+      position: 'relative',
+      height: '98px',
+    });
+  });
+
+  it('returns the correct overrides when path matches complex', () => {
+    const result = getOverrideProps(overrides, 'View.Text[0]');
+    expect(result).toEqual({
+      fontSize: '12px',
+      color: 'red',
+    });
+  });
+
+  it('returns an empty object when nothing matches', () => {
+    const result = getOverrideProps(overrides, 'Flex');
+    expect(result).toEqual({});
   });
 });
 

--- a/packages/react/src/primitives/shared/utils.ts
+++ b/packages/react/src/primitives/shared/utils.ts
@@ -81,11 +81,8 @@ export const getOverrideProps = (
   }
 
   const componentOverrides = Object.entries(overrides)
-    .filter((m) => m[0] === elementHierarchy)
-    .flatMap((m) => {
-      const values = Object.entries(m[1]);
-      return [values[0], values[1]];
-    })
+    .filter(([key]) => key === elementHierarchy)
+    .flatMap(([, value]) => Object.entries(value))
     .filter((m) => m?.[0]);
 
   return Object.fromEntries(componentOverrides);


### PR DESCRIPTION
*Description of changes:*

`getOverrideProps` was only returning the first `2` overrides.

This is a PR for @hsspain's fix to return all overrides.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
