### PR TITLE
chore: Mark "Preferred Username" custom input as required

### DIFF
--- a/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.html
@@ -13,7 +13,6 @@
       label="Preferred Username"
       name="preferred_username"
       placeholder="Preferred Username"
-      [required]="false"
     ></amplify-text-field>
 
     <!-- Re-use default `Authenticator.SignUp.FormFields` -->

--- a/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
@@ -38,6 +38,7 @@ export default withAuthenticator(App, {
               labelHidden={true}
               name="preferred_username"
               placeholder="Preferred Username"
+              isRequired
             />
 
             {/* Re-use default `Authenticator.SignUp.FormFields` */}

--- a/examples/vue/src/pages/ui/components/authenticator/custom-sign-up-fields/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/custom-sign-up-fields/index.vue
@@ -41,7 +41,6 @@ const services = {
         name="preferred_username"
         placeholder="Preferred Username"
         type="text"
-        :required="false"
       ></amplify-text-field>
       <authenticator-sign-up-form-fields />
       <amplify-check-box :errorMessage="validationErrors.acknowledgement" />

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -144,3 +144,9 @@ Then('the {string} button is disabled', (name: string) => {
     name: new RegExp(`^${escapeRegExp(name)}$`, 'i'),
   }).should('be.disabled');
 });
+
+Then('the {string} field is invalid', (name: string) => {
+  cy.findInputField(name)
+    .then(($el) => $el.get(0).checkValidity())
+    .should('be.false');
+});

--- a/packages/e2e/cypress/support/commands.d.ts
+++ b/packages/e2e/cypress/support/commands.d.ts
@@ -12,7 +12,7 @@ declare namespace Cypress {
      *   placeholder value for password inputs.
      * @example cy.findInputField('Password')
      */
-    findInputField(field: string): Chainable<Element>;
+    findInputField(field: string): Chainable<JQuery<HTMLInputElement>>;
   }
 }
 

--- a/packages/e2e/features/ui/components/authenticator/custom-sign-up-fields.feature
+++ b/packages/e2e/features/ui/components/authenticator/custom-sign-up-fields.feature
@@ -30,7 +30,7 @@ Feature: Custom Sign Up Fields
     And I confirm my password
     And I click the "I agree with the Terms & Conditions" checkbox
     And I click the "Create Account" button
-    Then I see "Attributes did not conform to the schema: preferred_username: The attribute is required"
+    Then the "Preferred Username" field is invalid
 
   @angular @react @vue
   Scenario: Form successfully submits with `preferred_username` and Terms & Conditions checked


### PR DESCRIPTION
*Issue #, if available:* Fixes #590

*Description of changes:* Marks "Preferred Username" custom input as required. Also adds a cypress util for testing if an input is invalid based on native html validations using `inputHTMLElement.checkValidity()`.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
