### PR TITLE
ci: push @next git `tag` to origin

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -42,5 +42,11 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Setup GitHub user # requried for creating git tags
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
       - name: Publish to next tag
         run: yarn publish:next
+      - name: Push snapshot to GitHub
+        run: git push --tags


### PR DESCRIPTION
*Issue #, if available:* Fixes #644

*Description of changes:* This runs `git push --tags` on every deployment to `@next`.

This is demonstrated in my poc repo: [Publish to @next #29](https://github.com/wlee221/changeset-poc/runs/4146605213?check_suite_focus=true). 

```
To https://github.com/wlee221/changeset-poc
 * [new tag]         @wlee221-changeset-poc/bar@0.0.0-next-202110905812 -> @wlee221-changeset-poc/bar@0.0.0-next-202110905812
 * [new tag]         @wlee221-changeset-poc/core@0.0.0-next-202110905812 -> @wlee221-changeset-poc/core@0.0.0-next-202110905812
 * [new tag]         @wlee221-changeset-poc/foo@0.0.0-next-202110905812 -> @wlee221-changeset-poc/foo@0.0.0-next-202110905812
```

This will generate a *lot* of tags, because we're essentially tagging every push to `main`. Any reviews on that is appreciated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
