### PR TITLE
build: version clean up

### DIFF
--- a/.changeset/cold-yaks-laugh.md
+++ b/.changeset/cold-yaks-laugh.md
@@ -1,5 +1,5 @@
 ---
-"@aws-amplify/ui-angular": patch
+"@aws-amplify/ui-angular": minor
 ---
 
 Add `sign-up-form-field` slot and component

--- a/.changeset/stale-zoos-rescue.md
+++ b/.changeset/stale-zoos-rescue.md
@@ -1,7 +1,7 @@
 ---
-'@aws-amplify/ui': patch
-'@aws-amplify/ui-vue': patch
-'@aws-amplify/ui-angular': patch
+'@aws-amplify/ui': minor
+'@aws-amplify/ui-vue': minor
+'@aws-amplify/ui-angular': minor
 ---
 
 This implements `AuthenticatorService` that can be used internally and externally to access common Authenticator context and helpers.

--- a/.changeset/wet-candles-warn.md
+++ b/.changeset/wet-candles-warn.md
@@ -1,5 +1,5 @@
 ---
-'@aws-amplify/ui-react': patch
+'@aws-amplify/ui-react': minor
 ---
 
 AmplifyProvider accepts a partial list of primitives as `components`:

--- a/.changeset/wicked-cups-tie.md
+++ b/.changeset/wicked-cups-tie.md
@@ -1,5 +1,5 @@
 ---
-'@aws-amplify/ui-angular': patch
+'@aws-amplify/ui-angular': minor
 ---
 
 Add and expose amplify-checkbox

--- a/.changeset/wise-bananas-protect.md
+++ b/.changeset/wise-bananas-protect.md
@@ -1,5 +1,5 @@
 ---
-"@aws-amplify/ui-angular": patch
+"@aws-amplify/ui-angular": minor
 ---
 
 Add `services` prop and custom-sign-up example. See documentation for usage notes.

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "~11.2.14",
     "@angular/platform-browser-dynamic": "~11.2.14",
     "@angular/router": "~11.2.14",
-    "@aws-amplify/ui-angular": "^2.0.0",
+    "@aws-amplify/ui-angular": "^1.0.31",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.3"

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@aws-amplify/ui-react": "^2.0.0",
+    "@aws-amplify/ui-react": "^1.2.22",
     "@types/node": "^15.12.4",
     "@types/react": "^17.0.11",
     "next": "latest",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -9,7 +9,7 @@
     "start": "vite preview --port 3000"
   },
   "dependencies": {
-    "@aws-amplify/ui-vue": "^2.0.0",
+    "@aws-amplify/ui-vue": "^1.1.16",
     "aws-amplify": "^4.1.3",
     "vue": "^3.0.5",
     "vue-router": "4"

--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-components": "^1.7.0",
-    "@aws-amplify/ui": "2.0.3",
+    "@aws-amplify/ui": "2.1.0",
     "@stencil/core": "^2.7.0",
     "nanoid": "^3.1.25",
     "qrcode": "^1.4.4",

--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-components": "^1.7.0",
-    "@aws-amplify/ui": "3.0.0",
+    "@aws-amplify/ui": "2.0.3",
     "@stencil/core": "^2.7.0",
     "nanoid": "^3.1.25",
     "qrcode": "^1.4.4",

--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/ui-angular",
-  "version": "2.0.0",
+  "version": "1.0.31",
   "scripts": {
     "build": "yarn --cwd ../../ build",
     "dev": "yarn --cwd ../../ dev",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -13,7 +13,7 @@
     "stepDefinitions": "features"
   },
   "devDependencies": {
-    "@aws-amplify/ui": "^2.0.3",
+    "@aws-amplify/ui": "^2.1.0",
     "@testing-library/cypress": "^7.0.6",
     "@types/cypress-cucumber-preprocessor": "^4.0.0",
     "cypress": "^8.5.0",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -13,7 +13,7 @@
     "stepDefinitions": "features"
   },
   "devDependencies": {
-    "@aws-amplify/ui": "^3.0.0",
+    "@aws-amplify/ui": "^2.0.3",
     "@testing-library/cypress": "^7.0.6",
     "@types/cypress-cucumber-preprocessor": "^4.0.0",
     "cypress": "^8.5.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,7 @@
     "test:unit:watch": "jest --watch"
   },
   "dependencies": {
-    "@aws-amplify/ui": "2.0.3",
+    "@aws-amplify/ui": "2.1.0",
     "@aws-amplify/ui-react-v1": "npm:@aws-amplify/ui-react@1.2.9",
     "@radix-ui/react-id": "^0.1.0",
     "@radix-ui/react-tabs": "0.0.16",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/ui-react",
-  "version": "2.0.0",
+  "version": "1.2.22",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,7 @@
     "test:unit:watch": "jest --watch"
   },
   "dependencies": {
-    "@aws-amplify/ui": "3.0.0",
+    "@aws-amplify/ui": "2.0.3",
     "@aws-amplify/ui-react-v1": "npm:@aws-amplify/ui-react@1.2.9",
     "@radix-ui/react-id": "^0.1.0",
     "@radix-ui/react-tabs": "0.0.16",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/ui",
-  "version": "3.0.0",
+  "version": "2.0.3",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/ui",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -29,7 +29,7 @@
     "test:unit:watch": "jest --watch"
   },
   "dependencies": {
-    "@aws-amplify/ui": "3.0.0",
+    "@aws-amplify/ui": "2.0.3",
     "@xstate/vue": "^0.8.0",
     "qrcode": "^1.4.4"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/ui-vue",
-  "version": "2.0.0",
+  "version": "1.1.16",
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -29,7 +29,7 @@
     "test:unit:watch": "jest --watch"
   },
   "dependencies": {
-    "@aws-amplify/ui": "2.0.3",
+    "@aws-amplify/ui": "2.1.0",
     "@xstate/vue": "^0.8.0",
     "qrcode": "^1.4.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -451,7 +451,7 @@
     qrcode "^1.4.4"
     uuid "^8.2.0"
 
-"@aws-amplify/ui-react-v1@npm:@aws-amplify/ui-react":
+"@aws-amplify/ui-react-v1@npm:@aws-amplify/ui-react", "@aws-amplify/ui-react@^1.2.5":
   version "1.2.21"
   resolved "https://registry.yarnpkg.com/@aws-amplify/ui-react/-/ui-react-1.2.21.tgz#b723fded8006e7ef212905a0a93ef7ae866a2a05"
   integrity sha512-+0AQlrLQei66y+gKBhBxNJnx92OeFzZ2Uls9U3vNf2c4ocEtUzErXu/YLjxmYyX9rVxACrRLHd6zuBuA91Ubmw==
@@ -6323,7 +6323,7 @@ amazon-cognito-identity-js@5.2.1:
     isomorphic-unfetch "^3.0.0"
     js-cookie "^2.2.1"
 
-amplify-docs@aws-amplify/docs#8a0d3a0:
+"amplify-docs@github:https://github.com/aws-amplify/docs#8a0d3a0":
   version "2.0.0"
   resolved "https://codeload.github.com/aws-amplify/docs/tar.gz/8a0d3a0ff2e91ed5caf1ed57ae7fe050a62cab20"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -451,7 +451,7 @@
     qrcode "^1.4.4"
     uuid "^8.2.0"
 
-"@aws-amplify/ui-react-v1@npm:@aws-amplify/ui-react", "@aws-amplify/ui-react@^1.2.5":
+"@aws-amplify/ui-react-v1@npm:@aws-amplify/ui-react":
   version "1.2.21"
   resolved "https://registry.yarnpkg.com/@aws-amplify/ui-react/-/ui-react-1.2.21.tgz#b723fded8006e7ef212905a0a93ef7ae866a2a05"
   integrity sha512-+0AQlrLQei66y+gKBhBxNJnx92OeFzZ2Uls9U3vNf2c4ocEtUzErXu/YLjxmYyX9rVxACrRLHd6zuBuA91Ubmw==
@@ -6323,7 +6323,7 @@ amazon-cognito-identity-js@5.2.1:
     isomorphic-unfetch "^3.0.0"
     js-cookie "^2.2.1"
 
-"amplify-docs@github:https://github.com/aws-amplify/docs#8a0d3a0":
+amplify-docs@aws-amplify/docs#8a0d3a0:
   version "2.0.0"
   resolved "https://codeload.github.com/aws-amplify/docs/tar.gz/8a0d3a0ff2e91ed5caf1ed57ae7fe050a62cab20"
   dependencies:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Puts `ui` and `ui-[framework]` versions to current latest NPM version. This helps us to be more flexible about the version bump types we put on changesets.

Before/On GA, We can follow this up with adding changesets that makes "major" version bumps. This will bump everything to `2.0.0` (and `3.0.0` for `ui`). Maybe we can add one for the authenticator and one for primtives!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
