### PR TITLE
build: prepend commit hash before date to @next versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:icons": "yarn react build:icons",
     "test": "yarn react test && yarn e2e test",
     "prepare": "husky install",
-    "version:next": "yarn changeset version --snapshot next && yarn build",
+    "version:next": "yarn changeset version --snapshot next-$(git rev-parse --short=7 HEAD) && yarn build",
     "publish:next": "yarn changeset publish --tag next",
     "version:latest": "echo \"not implemented until stable release\"",
     "publish:latest": "echo \"not implemented until stable release\""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Prepends commit hash so that the versions look like 

```
next-[commit_sha]-timestamp
```

which will increase the specificity of each versions in case customers are interested in pinning to one of them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
