### PR TITLE
Icon size

### DIFF
--- a/.changeset/tender-bottles-notice.md
+++ b/.changeset/tender-bottles-notice.md
@@ -1,0 +1,13 @@
+---
+"@aws-amplify/ui-react": minor
+"@aws-amplify/ui": minor
+---
+
+Icon size now matches parent font-size. Allows customers to more easily use icons alongsize Headings, Buttons, etc.
+
+Example:
+```
+<Button gap="0.1rem" size="small">
+    <IconSave /> Save
+</Button>
+```

--- a/docs/src/pages/components/button/examples/iconButton.tsx
+++ b/docs/src/pages/components/button/examples/iconButton.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { Button, Flex, IconSave, View } from '@aws-amplify/ui-react';
+
+export const IconButtonExample = () => {
+  return (
+    <Flex direction="column" gap="1rem">
+      <View>
+        <Button gap="0.1rem" size="small">
+          <IconSave /> Save
+        </Button>
+        <Button gap="0.2rem">
+          <IconSave /> Save
+        </Button>
+        <Button gap="0.2rem" size="large">
+          <IconSave /> Save
+        </Button>
+      </View>
+      <View>
+        <Button size="small">
+          <IconSave />
+        </Button>
+        <Button>
+          <IconSave />
+        </Button>
+        <Button size="large">
+          <IconSave />
+        </Button>
+      </View>
+    </Flex>
+  );
+};

--- a/docs/src/pages/components/button/examples/index.ts
+++ b/docs/src/pages/components/button/examples/index.ts
@@ -1,0 +1,1 @@
+export { IconButtonExample } from './iconButton';

--- a/docs/src/pages/components/button/react.mdx
+++ b/docs/src/pages/components/button/react.mdx
@@ -290,6 +290,6 @@ _Using style props:_
 <Example>
   <Button style={{ backgroundColor: 'green', color: 'white' }}>Green</Button>
   <Button backgroundColor="purple" color="white">
-    Purple
+    {'Purple'}
   </Button>
 </Example>

--- a/docs/src/pages/components/button/react.mdx
+++ b/docs/src/pages/components/button/react.mdx
@@ -2,6 +2,7 @@ import { Button, ButtonGroup, Flex } from '@aws-amplify/ui-react';
 
 import { ButtonDemo } from './demo';
 import { Example } from '@/components/Example';
+import { IconButtonExample } from './examples';
 
 The Button primitive is used to trigger an action or event, such as submitting a form, opening a dialog, canceling an action, or performing a delete operation.
 
@@ -68,6 +69,18 @@ Use the `variation` prop to change the Button variation. Available options are `
   <Button variation="link">Link</Button>
   <Button variation="menu">Menu</Button>
   <Button>Default</Button>
+</Example>
+
+### Icon buttons
+
+Icons can be added to buttons and will adapt to the surrounding font-size.
+
+```tsx file=./examples/iconButton.tsx
+
+```
+
+<Example>
+  <IconButtonExample />
 </Example>
 
 ### Loading state

--- a/docs/src/pages/components/icon/demo.tsx
+++ b/docs/src/pages/components/icon/demo.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { Property } from 'csstype';
 
-import { Icon, IconSize, Flex } from '@aws-amplify/ui-react';
+import { Icon, Flex } from '@aws-amplify/ui-react';
 import { Example } from '@/components/Example';
 
 export const IconDemo = () => {
   const [width, setWidth] = React.useState<number>(24);
   const [height, setHeight] = React.useState<number>(24);
-  const [size, setSize] = React.useState<IconSize>();
   const [fill, setFill] = React.useState<Property.Color>('currentColor');
   const [ariaLabel, setAriaLabel] = React.useState<string>('search');
   const [pathData, setPathData] = React.useState<string>(
     `M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5
-     3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 
+     3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5
      4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z`
   );
 
@@ -80,25 +79,12 @@ export const IconDemo = () => {
             }}
           />
         </div>
-        <div>
-          <label htmlFor="icon-demo-size">Size</label>
-          <select
-            id="icon-demo-size"
-            value={size}
-            onChange={(event) => setSize(event.target.value as IconSize)}
-          >
-            <option value="">default</option>
-            <option value="small">small</option>
-            <option value="large">large</option>
-          </select>
-        </div>
       </Flex>
       <Example>
         <Icon
           pathData={pathData}
           viewBox={{ width, height }}
           fill={fill}
-          size={size}
           ariaLabel={ariaLabel}
           className="icon-demo-search"
         />

--- a/docs/src/pages/components/icon/react.mdx
+++ b/docs/src/pages/components/icon/react.mdx
@@ -1,10 +1,13 @@
 import {
+  Button,
   Icon,
   Flex,
   IconAdd,
   IconDone,
   IconStar,
   IconClose,
+  IconSave,
+  Text,
 } from '@aws-amplify/ui-react';
 import { IconDemo } from './demo';
 import { Example } from '@/components/Example';
@@ -25,10 +28,9 @@ import '@aws-amplify/ui-react/styles.css';
 
 // This is a favorite icon
 <Icon
-  size="small"
   ariaLabel="Favorite"
   viewBox={{ width: 24, height: 24 }}
-  pathData="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 
+  pathData="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0
   3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
 />;
 ```
@@ -37,10 +39,9 @@ import '@aws-amplify/ui-react/styles.css';
   <Flex gap="2" alignItems="center">
     <span>Hello, Icon!</span>
     <Icon
-      size="small"
       ariaLabel="Favorite"
       viewBox={{ width: 24, height: 24 }}
-      pathData="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 
+      pathData="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0
     3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
     />
   </Flex>
@@ -74,8 +75,8 @@ const ThumbsUpIcon = () => {
   return (
     <Icon
       ariaLabel="Thumbs up"
-      pathData="M9 21h9c.83 0 1.54-.5 
-1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 
+      pathData="M9 21h9c.83 0 1.54-.5
+1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17
 1 7.58 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2zM9 9l4.34-4.34L12 10h9v2l-3 7H9V9zM1 9h4v12H1z"
     />
   );
@@ -85,29 +86,54 @@ const ThumbsUpIcon = () => {
 <Example>
   <Icon
     ariaLabel="Thumbs up"
-    pathData="M9 21h9c.83 0 1.54-.5 
-  1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 
+    pathData="M9 21h9c.83 0 1.54-.5
+  1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17
   1 7.58 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2zM9 9l4.34-4.34L12 10h9v2l-3 7H9V9zM1 9h4v12H1z"
   />
 </Example>
 
 ### Sizes
 
-Use the `size` prop to change the Icon size. Available options are `small`, `large`, and none (default).
+Icon size matches the font-size of the container. Adjust the font-size to set a specific height.
+
+_Inherited size from button sizes_
 
 ```jsx
-import { IconAdd } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
-
-<IconAdd size="small" />;
-<IconAdd />;
-<IconAdd size="large" />;
+  <Button gap="0.1rem" size="small" >
+    <IconSave /> Save
+  </Button>
+  <Button gap="0.2rem">
+    <IconSave /> Save
+  </Button>
+  <Button  gap="0.2rem" size="large">
+    <IconSave /> Save
+  </Button>
 ```
 
 <Example>
-  <IconAdd size="small" />
+  <Button gap="0.1rem" size="small">
+    <IconSave /> {'Save'}
+  </Button>
+  <Button gap="0.2rem">
+    <IconSave /> {'Save'}
+  </Button>
+  <Button gap="0.2rem" size="large">
+    <IconSave /> {'Save'}
+  </Button>
+</Example>
+
+_Set specific font-size_
+
+```jsx
+<Text as="span" fontSize="36px">
   <IconAdd />
-  <IconAdd size="large" />
+</Text>
+```
+
+<Example>
+  <Text as="span">
+    <IconAdd fontSize="36px" />
+  </Text>
 </Example>
 
 ### Color

--- a/docs/src/pages/components/icon/react.mdx
+++ b/docs/src/pages/components/icon/react.mdx
@@ -131,8 +131,8 @@ _Set specific font-size_
 ```
 
 <Example>
-  <Text as="span">
-    <IconAdd fontSize="36px" />
+  <Text as="span" fontSize="36px">
+    <IconAdd />
   </Text>
 </Example>
 

--- a/packages/react/scripts/generateIcons.js
+++ b/packages/react/scripts/generateIcons.js
@@ -33,7 +33,6 @@ import { ComponentClassNames } from '../../shared/constants';
 export const ${iconName} = (props) => {
 	const {
 		className,
-		size,
 		fill = "currentColor",
 		ariaLabel,
 		...rest
@@ -49,7 +48,7 @@ export const ${iconName} = (props) => {
       )
       .replace(
         /width="[0-9]+"/,
-        'data-size={size} aria-label={ariaLabel} fill={fill} {...rest}'
+        'aria-label={ariaLabel} fill={fill} {...rest}'
       )}
 	);
 };`;

--- a/packages/react/src/primitives/Icon/Icon.tsx
+++ b/packages/react/src/primitives/Icon/Icon.tsx
@@ -10,7 +10,6 @@ export const Icon: Primitive<IconProps, 'svg'> = ({
   className,
   fill = 'currentColor',
   pathData,
-  size,
   viewBox = defaultViewBox,
   ...rest
 }) => {
@@ -23,7 +22,6 @@ export const Icon: Primitive<IconProps, 'svg'> = ({
     <View
       as="svg"
       className={classNames(ComponentClassNames.Icon, className)}
-      data-size={size}
       viewBox={`${minX} ${minY} ${width} ${height}`}
       {...rest}
     >

--- a/packages/react/src/primitives/Icon/__tests__/Icon.test.tsx
+++ b/packages/react/src/primitives/Icon/__tests__/Icon.test.tsx
@@ -53,20 +53,6 @@ describe('Icon component', () => {
     expect(icon.classList[1]).toContain('my-icon-component');
   });
 
-  it('can set data-size attribute', async () => {
-    render(
-      <Icon
-        testId={iconTestId}
-        pathData={pathData}
-        size="small"
-        ariaLabel="Search"
-      />
-    );
-
-    const icon = await screen.findByTestId(iconTestId);
-    expect(icon.dataset['size']).toBe('small');
-  });
-
   it('can set viewBox attribute', async () => {
     render(
       <Icon

--- a/packages/react/src/primitives/types/button.ts
+++ b/packages/react/src/primitives/types/button.ts
@@ -1,11 +1,12 @@
 import { Sizes } from './base';
 import { ViewProps } from './view';
+import { FlexContainerStyleProps } from './flex';
 
 export type ButtonSizes = Sizes;
 export type ButtonTypes = 'button' | 'reset' | 'submit';
 export type ButtonVariations = 'primary' | 'link' | 'menu';
 
-export interface ButtonProps extends ViewProps {
+export interface ButtonProps extends ViewProps, FlexContainerStyleProps {
   /**
    * If `true`, the button will be disabled.
    */

--- a/packages/react/src/primitives/types/icon.ts
+++ b/packages/react/src/primitives/types/icon.ts
@@ -36,9 +36,4 @@ export interface IconProps extends ViewProps {
    * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill
    */
   fill?: Property.Color;
-
-  /**
-   * This is used to change the icon size. Available options are "large", "medium", and "small".
-   */
-  size?: IconSize;
 }

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -31,7 +31,6 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-badge-large-padding-vertical: var(--amplify-space-small);
         --amplify-components-badge-large-padding-horizontal: var(--amplify-space-medium);
         --amplify-components-button-font-weight: bold;
-        --amplify-components-button-text-align: center;
         --amplify-components-button-border-radius: var(--amplify-components-fieldcontrol-border-radius);
         --amplify-components-button-transition-duration: var(--amplify-components-fieldcontrol-transition-duration);
         --amplify-components-button-font-size: var(--amplify-components-fieldcontrol-font-size);
@@ -71,7 +70,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-button-primary-active-background-color: var(--amplify-colors-brand-primary-100);
         --amplify-components-button-menu-border-width: 0;
         --amplify-components-button-menu-background-color: none;
-        --amplify-components-button-menu-text-align: left;
+        --amplify-components-button-menu-justify-content: start;
         --amplify-components-button-menu-hover-color: var(--amplify-colors-white);
         --amplify-components-button-menu-hover-background-color: var(--amplify-colors-brand-primary-80);
         --amplify-components-button-menu-focus-color: var(--amplify-colors-white);

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -221,9 +221,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-heading-color: var(--amplify-colors-font-primary);
         --amplify-components-heading-line-height: 1.25;
         --amplify-components-icon-line-height: 1;
-        --amplify-components-icon-height: var(--amplify-font-sizes-medium);
-        --amplify-components-icon-large-height: var(--amplify-font-sizes-large);
-        --amplify-components-icon-small-height: var(--amplify-font-sizes-small);
+        --amplify-components-icon-height: 1em;
         --amplify-components-image-max-width: 100%;
         --amplify-components-image-height: auto;
         --amplify-components-image-object-fit: initial;

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -271,9 +271,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-heading-color: var(--amplify-colors-font-primary);
         --amplify-components-heading-line-height: 1.25;
         --amplify-components-icon-line-height: 1;
-        --amplify-components-icon-height: var(--amplify-font-sizes-medium);
-        --amplify-components-icon-large-height: var(--amplify-font-sizes-large);
-        --amplify-components-icon-small-height: var(--amplify-font-sizes-small);
+        --amplify-components-icon-height: 1em;
         --amplify-components-image-max-width: 100%;
         --amplify-components-image-height: auto;
         --amplify-components-image-object-fit: initial;

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -81,7 +81,6 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-badge-large-padding-vertical: var(--amplify-space-small);
         --amplify-components-badge-large-padding-horizontal: var(--amplify-space-medium);
         --amplify-components-button-font-weight: bold;
-        --amplify-components-button-text-align: center;
         --amplify-components-button-border-radius: var(--amplify-components-fieldcontrol-border-radius);
         --amplify-components-button-transition-duration: var(--amplify-components-fieldcontrol-transition-duration);
         --amplify-components-button-font-size: var(--amplify-components-fieldcontrol-font-size);
@@ -121,7 +120,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-button-primary-active-background-color: var(--amplify-colors-brand-primary-100);
         --amplify-components-button-menu-border-width: 0;
         --amplify-components-button-menu-background-color: none;
-        --amplify-components-button-menu-text-align: left;
+        --amplify-components-button-menu-justify-content: start;
         --amplify-components-button-menu-hover-color: var(--amplify-colors-white);
         --amplify-components-button-menu-hover-background-color: var(--amplify-colors-brand-primary-80);
         --amplify-components-button-menu-focus-color: var(--amplify-colors-white);

--- a/packages/ui/src/theme/css/component/button.scss
+++ b/packages/ui/src/theme/css/component/button.scss
@@ -3,7 +3,9 @@
  */
 
 .amplify-button {
-  display: inline-block;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
   border-radius: var(--amplify-components-button-border-radius);
   box-sizing: border-box;
   font-weight: var(--amplify-components-button-font-weight);

--- a/packages/ui/src/theme/css/component/button.scss
+++ b/packages/ui/src/theme/css/component/button.scss
@@ -9,7 +9,6 @@
   border-radius: var(--amplify-components-button-border-radius);
   box-sizing: border-box;
   font-weight: var(--amplify-components-button-font-weight);
-  text-align: var(--amplify-components-button-text-align);
   transition: all var(--amplify-components-button-transition-duration);
   border-width: var(--amplify-components-button-border-width);
   border-style: var(--amplify-components-button-border-style);
@@ -65,7 +64,7 @@
   &[data-variation='menu'] {
     border-width: var(--amplify-components-button-menu-border-width);
     background-color: var(--amplify-components-button-menu-background-color);
-    text-align: var(--amplify-components-button-menu-text-align);
+    justify-content: var(--amplify-components-button-menu-justify-content);
 
     &:hover {
       color: var(--amplify-components-button-menu-hover-color);

--- a/packages/ui/src/theme/css/component/icon.scss
+++ b/packages/ui/src/theme/css/component/icon.scss
@@ -8,12 +8,4 @@
   fill: currentColor;
   height: var(--amplify-components-icon-height);
   line-height: var(--amplify-components-icon-line-height);
-
-  &[data-size='small'] {
-    height: var(--amplify-components-icon-small-height);
-  }
-
-  &[data-size='large'] {
-    height: var(--amplify-components-icon-large-height);
-  }
 }

--- a/packages/ui/src/theme/tokens/components/button.js
+++ b/packages/ui/src/theme/tokens/components/button.js
@@ -1,7 +1,6 @@
 module.exports = {
   // shared styles
   fontWeight: { value: 'bold' },
-  textAlign: { value: 'center' },
   borderRadius: { value: '{components.fieldcontrol.borderRadius.value}' },
   transitionDuration: {
     value: '{components.fieldcontrol.transitionDuration.value}',
@@ -78,7 +77,7 @@ module.exports = {
   menu: {
     borderWidth: { value: 0 },
     backgroundColor: { value: 'none' },
-    textAlign: { value: 'left' },
+    justifyContent: { value: 'start' },
     // Focus and hover styles are identical for menu variation
     // because for Menu primitive, menu items are forced to be focused even
     // for mouse interactions, making it impossible to distinguish the two interactions

--- a/packages/ui/src/theme/tokens/components/icon.js
+++ b/packages/ui/src/theme/tokens/components/icon.js
@@ -1,11 +1,4 @@
 module.exports = {
   lineHeight: { value: 1 },
-  height: { value: '{fontSizes.medium.value}' },
-
-  large: {
-    height: { value: '{fontSizes.large.value}' },
-  },
-  small: {
-    height: { value: '{fontSizes.small.value}' },
-  },
+  height: { value: '1em' }, // Should match height of parent container font-size
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9310,7 +9310,7 @@ csstype@^2.6.8:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.18.tgz#980a8b53085f34af313410af064f2bd241784218"
   integrity sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ==
 
-csstype@^3.0.2, csstype@^3.0.4, csstype@^3.0.5:
+csstype@^3.0.2, csstype@^3.0.4:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
   integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
@@ -18389,7 +18389,7 @@ react-style-singleton@^2.1.0:
     invariant "^2.2.4"
     tslib "^1.0.0"
 
-react@^17.0.2, react@latest:
+react@latest:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==


### PR DESCRIPTION
*Description of changes:*
This PR updates the Icon to be sized based on the parent container font-size rather than having explicit sizing. This makes Icons work better out of the box with minimal styling. I also updated the Button styling to be `display: inline-flex` to make it easier to create an icon + text button.

_Example code showing how IconSave will size based on Button size property_
```jsx
<Button gap="0.1rem" size="small">
    <IconSave /> Save
</Button>
```

<img width="293" alt="Screen Shot 2021-11-09 at 10 30 20 AM" src="https://user-images.githubusercontent.com/6165315/140987301-4d94c7bd-a9c6-4e61-a607-fd6b21193929.png">



I'll update all the Icon files in a separate PR to keep this PR small.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
