### PR TITLE
fix-657

### DIFF
--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -141,6 +141,7 @@ h3:hover > a .icon-link {
 [data-amplify-theme='amplify-docs'] {
   background-color: var(--amplify-colors-background-primary);
   color: var(--amplify-colors-font-primary);
+  min-height: 100vh;
   
   --amplify-components-fieldcontrol-line-height: 1.5;
   --amplify-borders-primary: var(--amplify-border-widths-small) solid


### PR DESCRIPTION
*Issue #, if available:* #657

*Description of changes:* Background color was only being applied to `[data-amplify-theme]` selector, which on certain pages in tall screens did not take up 100% of the viewport height. Added some CSS so that element is always at least 100% viewport height.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
