### PR TITLE
Docs - update secondary nav & grid logic

### DIFF
--- a/docs/src/components/Layout/SecondaryNav.tsx
+++ b/docs/src/components/Layout/SecondaryNav.tsx
@@ -1,6 +1,24 @@
 import Link from 'next/link';
-import { Heading } from '@aws-amplify/ui-react';
+import { Heading, Collection } from '@aws-amplify/ui-react';
 import { useRouter } from 'next/router';
+
+import {
+  baseComponents,
+  ComponentNavItem,
+  connectedComponents,
+  dataDisplayComponents,
+  feedbackComponents,
+  inputComponents,
+  layoutComponents,
+  navigationComponents,
+  utilityComponents,
+} from '../../data/links';
+
+const NavLinks = ({ items }: { items: ComponentNavItem[] }) => (
+  <Collection type="list" items={items}>
+    {({ href, label }) => <NavLink href={href}>{label}</NavLink>}
+  </Collection>
+);
 
 const NavLink = ({ href, children }) => {
   const { pathname } = useRouter();
@@ -43,52 +61,28 @@ export const SecondaryNav = () => {
     return (
       <Sidebar>
         <Heading level={6}>Connected Components</Heading>
-        <NavLink href="/components/authenticator">Authenticator</NavLink>
-        <NavLink href="/components/chatbot">Chatbot</NavLink>
-        <NavLink href="/components/chatbot">S3 Album</NavLink>
+        <NavLinks items={connectedComponents} />
 
         <Heading level={6}>Base</Heading>
-        <NavLink href="/components/view">View</NavLink>
-        <NavLink href="/components/text">Text</NavLink>
-        <NavLink href="/components/heading">Heading</NavLink>
-        <NavLink href="/components/link">Link</NavLink>
-        <NavLink href="/components/image">Image</NavLink>
-        <NavLink href="/components/divider">Divider</NavLink>
-        <NavLink href="/components/icon">Icon</NavLink>
+        <NavLinks items={baseComponents} />
 
         <Heading level={6}>Feedback</Heading>
-        <NavLink href="/components/alert">Alert</NavLink>
-        <NavLink href="/components/pagination">Pagination</NavLink>
-        <NavLink href="/components/placeholder">Placeholder</NavLink>
-        <NavLink href="/components/loader">Loader</NavLink>
+        <NavLinks items={feedbackComponents} />
+
+        <Heading level={6}>Navigation</Heading>
+        <NavLinks items={navigationComponents} />
 
         <Heading level={6}>Inputs</Heading>
-        <NavLink href="/components/textfield">Text Field</NavLink>
-        <NavLink href="/components/selectfield">Select Field</NavLink>
-        <NavLink href="/components/stepperField">Stepper Field</NavLink>
-        <NavLink href="/components/searchfield">Search Field</NavLink>
-        <NavLink href="/components/passwordfield">Password Field</NavLink>
-        <NavLink href="/components/phonenumberfield">
-          Phone Number Field
-        </NavLink>
-        <NavLink href="/components/switchfield">Switch Field</NavLink>
-        <NavLink href="/components/radiogroupfield">Radio Group Field</NavLink>
-        <NavLink href="/components/checkboxfield">Checkbox Field</NavLink>
-        <NavLink href="/components/togglebutton">Toggle Button</NavLink>
-        <NavLink href="/components/button">Button</NavLink>
+        <NavLinks items={inputComponents} />
 
         <Heading level={6}>Layout</Heading>
-        <NavLink href="/components/collection">Collection</NavLink>
-        <NavLink href="/components/flex">Flex</NavLink>
-        <NavLink href="/components/grid">Grid</NavLink>
-        <NavLink href="/components/table">Table</NavLink>
+        <NavLinks items={layoutComponents} />
 
         <Heading level={6}>Data Display</Heading>
-        <NavLink href="/components/badge">Badge</NavLink>
-        <NavLink href="/components/rating">Rating</NavLink>
+        <NavLinks items={dataDisplayComponents} />
 
         <Heading level={6}>Utilities</Heading>
-        <NavLink href="/components/visuallyhidden">Visually Hidden</NavLink>
+        <NavLinks items={utilityComponents} />
       </Sidebar>
     );
   }

--- a/docs/src/data/links.ts
+++ b/docs/src/data/links.ts
@@ -1,0 +1,134 @@
+export interface ComponentNavItem {
+  href: string;
+  label: string;
+  body: string;
+}
+
+const sortByLabel = (a: ComponentNavItem, b: ComponentNavItem) =>
+  a.label < b.label ? -1 : a.label > b.label ? 1 : 0;
+
+export const baseComponents: ComponentNavItem[] = [
+  {
+    href: '/components/view',
+    label: 'View',
+    body: `An Alert displays a brief, important message in a way that attracts the user's attention without interrupting the user's task. Alerts are typically intended to be read out dynamically by a screen reader.`,
+  },
+  {
+    href: '/components/text',
+    label: 'Text',
+    body: `The Text primitive is used to display simple strings of text in an interface.`,
+  },
+  {
+    href: '/components/heading',
+    label: 'Heading',
+    body: ``,
+  },
+  {
+    href: '/components/icon',
+    label: 'Icon',
+    body: ``,
+  },
+  {
+    href: '/components/image',
+    label: 'Image',
+    body: ``,
+  },
+  {
+    href: '/components/divider',
+    label: 'Divider',
+    body: ``,
+  },
+].sort(sortByLabel);
+
+export const connectedComponents = [
+  {
+    href: '/components/authenticator',
+    label: 'Authenticator',
+    body: 'The Authenticator component adds complete authentication flows to your application with minimal boilerplate.',
+  },
+  {
+    href: '/components/chatbot',
+    label: 'Chatbot',
+    body: 'Chatbot automatically renders a complete chat messaging interface that can be used out-of-the-box, or it can be customized using theming support.',
+  },
+  {
+    href: '/components/s3album',
+    label: 'S3 Album',
+    body: 'Renders a list of S3Image objects.',
+  },
+].sort(sortByLabel);
+
+export const dataDisplayComponents = [
+  { href: '/components/badge', label: 'Badge', body: `` },
+  { href: '/components/rating', label: 'Rating', body: `` },
+].sort(sortByLabel);
+
+export const feedbackComponents: ComponentNavItem[] = [
+  {
+    href: '/components/alert',
+    label: 'Alert',
+    body: `An Alert displays a brief, important message in a way that attracts the user's attention without interrupting the user's task. Alerts are typically intended to be read out dynamically by a screen reader.`,
+  },
+  {
+    href: '/components/pagination',
+    label: 'Pagination',
+    body: `Pagination provides navigation to allow customers to move between large sets of content that are distributed across multiple pages.`,
+  },
+  {
+    href: '/components/placeholder',
+    label: 'Placeholder',
+    body: `The Placeholder component is used to fill out the interface while content is loaded asynchronously.`,
+  },
+  {
+    href: '/components/Loader',
+    label: 'Loader',
+    body: ``,
+  },
+].sort(sortByLabel);
+
+export const inputComponents = [
+  { href: '/components/textfield', label: 'Text Field', body: `` },
+  { href: '/components/selectfield', label: 'Select Field', body: `` },
+  { href: '/components/stepperField', label: 'Stepper Field', body: `` },
+  { href: '/components/searchfield', label: 'Search Field', body: `` },
+  { href: '/components/passwordfield', label: 'Password Field', body: `` },
+  {
+    href: '/components/phonenumberfield',
+    label: 'Phone Number Field',
+    body: ``,
+  },
+  { href: '/components/switchfield', label: 'Switch Field', body: `` },
+  { href: '/components/radiogroupfield', label: 'Radio Group Field', body: `` },
+  { href: '/components/checkboxfield', label: 'Checkbox Field', body: `` },
+  { href: '/components/togglebutton', label: 'Toggle Button', body: `` },
+  { href: '/components/button', label: 'Button', body: `` },
+].sort(sortByLabel);
+
+export const layoutComponents = [
+  { href: '/components/collection', label: 'Collection', body: `` },
+  { href: '/components/flex', label: 'Flex', body: `` },
+  { href: '/components/grid', label: 'Grid', body: `` },
+  { href: '/components/table', label: 'Table', body: `` },
+].sort(sortByLabel);
+
+export const navigationComponents: ComponentNavItem[] = [
+  {
+    href: '/components/link',
+    label: 'Link',
+    body: ``,
+  },
+  {
+    href: '/components/menu',
+    label: 'Menu',
+    body: ``,
+  },
+  {
+    href: '/components/tabs',
+    label: 'Tabs',
+    body: ``,
+  },
+].sort(sortByLabel);
+
+export const utilityComponents = [
+  { href: '/components/visuallyhidden', label: 'Visually Hidden', body: `` },
+].sort(sortByLabel);

--- a/docs/src/pages/components/ComponentsGrid.tsx
+++ b/docs/src/pages/components/ComponentsGrid.tsx
@@ -38,16 +38,16 @@ export const ComponentsGrid = () => {
       <Heading level={3}>Navigation components</Heading>
       <ComponentGrid components={navigationComponents} />
 
-      <Heading level={6}>Input components</Heading>
+      <Heading level={3}>Input components</Heading>
       <ComponentGrid components={inputComponents} />
 
-      <Heading level={6}>Layout components</Heading>
+      <Heading level={3}>Layout components</Heading>
       <ComponentGrid components={layoutComponents} />
 
-      <Heading level={6}>Data display components</Heading>
+      <Heading level={3}>Data display components</Heading>
       <ComponentGrid components={dataDisplayComponents} />
 
-      <Heading level={6}>Utility components</Heading>
+      <Heading level={3}>Utility components</Heading>
       <ComponentGrid components={utilityComponents} />
     </Flex>
   );

--- a/docs/src/pages/components/ComponentsGrid.tsx
+++ b/docs/src/pages/components/ComponentsGrid.tsx
@@ -1,83 +1,15 @@
 import Link from 'next/link';
 import { Card, Grid, Heading, Alert, Badge, Flex } from '@aws-amplify/ui-react';
-
-const feedbackComponents = [
-  {
-    href: '/components/alert',
-    label: 'Alert',
-    body: `An Alert displays a brief, important message in a way that attracts the user's attention without interrupting the user's task. Alerts are typically intended to be read out dynamically by a screen reader.`,
-  },
-  {
-    href: '/components/pagination',
-    label: 'Pagination',
-    body: `Pagination provides navigation to allow customers to move between large sets of content that are distributed across multiple pages.`,
-  },
-  {
-    href: '/components/placeholder',
-    label: 'Placeholder',
-    body: `The Placeholder component is used to fill out the interface while content is loaded asynchronously.`,
-    // },{
-    //   href: '/components/Loader',
-    //   label: 'Loader',
-    //   body: ``
-  },
-];
-
-const baseComponents = [
-  {
-    href: '/components/view',
-    label: 'View',
-    body: `An Alert displays a brief, important message in a way that attracts the user's attention without interrupting the user's task. Alerts are typically intended to be read out dynamically by a screen reader.`,
-  },
-  {
-    href: '/components/text',
-    label: 'Text',
-    body: `The Text primitive is used to display simple strings of text in an interface.`,
-  },
-  {
-    href: '/components/heading',
-    label: 'Heading',
-    body: ``,
-  },
-  {
-    href: '/components/link',
-    label: 'Link',
-    body: ``,
-  },
-  {
-    href: '/components/icon',
-    label: 'Icon',
-    body: ``,
-  },
-  {
-    href: '/components/image',
-    label: 'Image',
-    body: ``,
-  },
-  {
-    href: '/components/divider',
-    label: 'Divider',
-    body: ``,
-  },
-];
-
-const connectedComponents = [
-  {
-    href: '/components/authenticator',
-    label: 'Authenticator',
-    body: 'The Authenticator component adds complete authentication flows to your application with minimal boilerplate.',
-  },
-  {
-    href: '/components/chatbot',
-    label: 'Chatbot',
-    body: 'Chatbot automatically renders a complete chat messaging interface that can be used out-of-the-box, or it can be customized using theming support.',
-  },
-  {
-    href: '/components/s3album',
-    label: 'S3 Album',
-    body: 'Renders a list of S3Image objects.',
-  },
-];
+import {
+  baseComponents,
+  connectedComponents,
+  dataDisplayComponents,
+  feedbackComponents,
+  inputComponents,
+  layoutComponents,
+  navigationComponents,
+  utilityComponents,
+} from '@/data/links';
 
 const ComponentGrid = ({ components }) => {
   return (
@@ -103,6 +35,20 @@ export const ComponentsGrid = () => {
       <ComponentGrid components={baseComponents} />
       <Heading level={3}>Feedback components</Heading>
       <ComponentGrid components={feedbackComponents} />
+      <Heading level={3}>Navigation components</Heading>
+      <ComponentGrid components={navigationComponents} />
+
+      <Heading level={6}>Input components</Heading>
+      <ComponentGrid components={inputComponents} />
+
+      <Heading level={6}>Layout components</Heading>
+      <ComponentGrid components={layoutComponents} />
+
+      <Heading level={6}>Data display components</Heading>
+      <ComponentGrid components={dataDisplayComponents} />
+
+      <Heading level={6}>Utility components</Heading>
+      <ComponentGrid components={utilityComponents} />
     </Flex>
   );
 };


### PR DESCRIPTION
*Description of changes:*
This PR updates the secondary navigation and components grid logic. It alphabetizes all the links and adds some missing components.

<img width="235" alt="Screen Shot 2021-11-09 at 3 03 21 PM" src="https://user-images.githubusercontent.com/6165315/141019610-19601185-a04a-405e-a2a5-981e2168c13b.png">

<img width="866" alt="Screen Shot 2021-11-09 at 3 04 04 PM" src="https://user-images.githubusercontent.com/6165315/141019624-4497dcf8-0d62-49eb-99b1-1ac4e7a071e2.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
