### PR TITLE
feat(angular,vue): header and footer slot + style

### DIFF
--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.html
@@ -2,74 +2,81 @@
   <div data-authenticator-variation="modal" *ngIf="variationModal"></div>
 
   <div data-amplify-container>
-    <amplify-slot name="header"></amplify-slot>
-    <amplify-tabs
-      (tabChange)="onTabChange()"
-      *ngIf="route === 'signIn' || route === 'signUp'"
-    >
-      <amplify-tab-item [title]="signInTitle" [active]="route === 'signIn'">
-        <!-- signIn component -->
-        <amplify-slot name="sign-in" *ngIf="route === 'signIn'">
-          <amplify-sign-in></amplify-sign-in>
-        </amplify-slot>
-      </amplify-tab-item>
-      <amplify-tab-item [title]="signUpTitle" [active]="route === 'signUp'">
-        <!-- signUp component -->
-        <amplify-slot name="sign-up" *ngIf="route === 'signUp'">
-          <amplify-sign-up></amplify-sign-up>
-        </amplify-slot>
-      </amplify-tab-item>
-    </amplify-tabs>
+    <div data-amplify-header>
+      <amplify-slot name="header"></amplify-slot>
+    </div>
+    <div data-amplify-body>
+      <amplify-tabs
+        (tabChange)="onTabChange()"
+        *ngIf="route === 'signIn' || route === 'signUp'"
+      >
+        <amplify-tab-item [title]="signInTitle" [active]="route === 'signIn'">
+          <!-- signIn component -->
+          <amplify-slot name="sign-in" *ngIf="route === 'signIn'">
+            <amplify-sign-in></amplify-sign-in>
+          </amplify-slot>
+        </amplify-tab-item>
+        <amplify-tab-item [title]="signUpTitle" [active]="route === 'signUp'">
+          <!-- signUp component -->
+          <amplify-slot name="sign-up" *ngIf="route === 'signUp'">
+            <amplify-sign-up></amplify-sign-up>
+          </amplify-slot>
+        </amplify-tab-item>
+      </amplify-tabs>
 
-    <!-- confirmSignUp content -->
-    <amplify-slot name="confirm-sign-up" *ngIf="route === 'confirmSignUp'">
-      <amplify-confirm-sign-up></amplify-confirm-sign-up>
-    </amplify-slot>
+      <!-- confirmSignUp content -->
+      <amplify-slot name="confirm-sign-up" *ngIf="route === 'confirmSignUp'">
+        <amplify-confirm-sign-up></amplify-confirm-sign-up>
+      </amplify-slot>
 
-    <!-- confirmSignIn content -->
-    <amplify-slot name="confirm-sign-in" *ngIf="route === 'confirmSignIn'">
-      <amplify-confirm-sign-in></amplify-confirm-sign-in>
-    </amplify-slot>
+      <!-- confirmSignIn content -->
+      <amplify-slot name="confirm-sign-in" *ngIf="route === 'confirmSignIn'">
+        <amplify-confirm-sign-in></amplify-confirm-sign-in>
+      </amplify-slot>
 
-    <!-- setupTotp content -->
-    <amplify-slot name="setup-totp" *ngIf="route === 'setupTOTP'">
-      <amplify-setup-totp></amplify-setup-totp>
-    </amplify-slot>
+      <!-- setupTotp content -->
+      <amplify-slot name="setup-totp" *ngIf="route === 'setupTOTP'">
+        <amplify-setup-totp></amplify-setup-totp>
+      </amplify-slot>
 
-    <!-- forceNewPassword content -->
-    <amplify-slot
-      name="force-new-password"
-      *ngIf="route === 'forceNewPassword'"
-    >
-      <amplify-force-new-password></amplify-force-new-password>
-    </amplify-slot>
+      <!-- forceNewPassword content -->
+      <amplify-slot
+        name="force-new-password"
+        *ngIf="route === 'forceNewPassword'"
+      >
+        <amplify-force-new-password></amplify-force-new-password>
+      </amplify-slot>
 
-    <!-- resetPassword content -->
-    <amplify-slot name="reset-password" *ngIf="route === 'resetPassword'">
-      <amplify-reset-password></amplify-reset-password>
-    </amplify-slot>
+      <!-- resetPassword content -->
+      <amplify-slot name="reset-password" *ngIf="route === 'resetPassword'">
+        <amplify-reset-password></amplify-reset-password>
+      </amplify-slot>
 
-    <!-- confirmResetPassword content -->
-    <amplify-slot
-      name="confirm-reset-password"
-      *ngIf="route === 'confirmResetPassword'"
-    >
-      <amplify-confirm-reset-password></amplify-confirm-reset-password>
-    </amplify-slot>
+      <!-- confirmResetPassword content -->
+      <amplify-slot
+        name="confirm-reset-password"
+        *ngIf="route === 'confirmResetPassword'"
+      >
+        <amplify-confirm-reset-password></amplify-confirm-reset-password>
+      </amplify-slot>
 
-    <!-- verifyUser content -->
-    <amplify-slot name="verify-user" *ngIf="route === 'verifyUser'">
-      <amplify-verify-user></amplify-verify-user>
-    </amplify-slot>
+      <!-- verifyUser content -->
+      <amplify-slot name="verify-user" *ngIf="route === 'verifyUser'">
+        <amplify-verify-user></amplify-verify-user>
+      </amplify-slot>
 
-    <!-- confirmVerifyUser content -->
-    <amplify-slot
-      name="confirm-verify-user"
-      *ngIf="route === 'confirmVerifyUser'"
-    >
-      <amplify-confirm-verify-user></amplify-confirm-verify-user>
-    </amplify-slot>
-    <amplify-slot name="footer"></amplify-slot>
+      <!-- confirmVerifyUser content -->
+      <amplify-slot
+        name="confirm-verify-user"
+        *ngIf="route === 'confirmVerifyUser'"
+      >
+        <amplify-confirm-verify-user></amplify-confirm-verify-user>
+      </amplify-slot>
+    </div>
+
+    <div data-amplify-footer>
+      <amplify-slot name="footer" data-amplify-footer></amplify-slot>
+    </div>
   </div>
 </div>
 

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.html
@@ -75,7 +75,7 @@
     </div>
 
     <div data-amplify-footer>
-      <amplify-slot name="footer" data-amplify-footer></amplify-slot>
+      <amplify-slot name="footer"></amplify-slot>
     </div>
   </div>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.html
@@ -2,6 +2,7 @@
   <div data-authenticator-variation="modal" *ngIf="variationModal"></div>
 
   <div data-amplify-container>
+    <amplify-slot name="header"></amplify-slot>
     <amplify-tabs
       (tabChange)="onTabChange()"
       *ngIf="route === 'signIn' || route === 'signUp'"
@@ -68,6 +69,7 @@
     >
       <amplify-confirm-verify-user></amplify-confirm-verify-user>
     </amplify-slot>
+    <amplify-slot name="footer"></amplify-slot>
   </div>
 </div>
 

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-in/amplify-confirm-sign-in.component.html
@@ -6,7 +6,9 @@
       data-amplify-fieldset
       [disabled]="authenticator.isPending"
     >
-      <h3 class="amplify-heading">{{ headerText }}</h3>
+      <amplify-slot name="confirm-sign-in-header">
+        <h3 class="amplify-heading">{{ headerText }}</h3>
+      </amplify-slot>
       <amplify-form-field
         name="confirmation_code"
         label="Code *"
@@ -31,5 +33,6 @@
         {{ authenticator.error }}
       </amplify-error>
     </fieldset>
+    <amplify-slot name="confirm-sign-in-footer"></amplify-slot>
   </form>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-confirm-sign-up/amplify-confirm-sign-up.component.html
@@ -6,7 +6,9 @@
       data-amplify-fieldset
       [disabled]="context.isPending"
     >
-      <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      <amplify-slot name="confirm-sign-up-header">
+        <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      </amplify-slot>
       <amplify-form-field
         name="confirmation_code"
         autocomplete="one-time-code"
@@ -27,5 +29,6 @@
     <amplify-error *ngIf="context.error">
       {{ authenticator.error }}
     </amplify-error>
+    <amplify-slot name="confirm-sign-up-footer"></amplify-slot>
   </form>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-force-new-password/amplify-force-new-password.component.html
@@ -6,7 +6,9 @@
       data-amplify-fieldset
       [disabled]="authenticator.isPending"
     >
-      <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      <amplify-slot name="force-new-password-header">
+        <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      </amplify-slot>
       <amplify-form-field
         name="password"
         type="password"
@@ -38,5 +40,6 @@
         {{ authenticator.error }}
       </amplify-error>
     </fieldset>
+    <amplify-slot name="force-new-password-footer"> </amplify-slot>
   </form>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-reset-password/amplify-reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-reset-password/amplify-reset-password.component.html
@@ -6,7 +6,9 @@
       data-amplify-fieldset
       [disabled]="authenticator.isPending"
     >
-      <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      <amplify-slot name="reset-password-header">
+        <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      </amplify-slot>
       <amplify-form-field
         name="username"
         type="username"
@@ -29,5 +31,6 @@
         {{ authenticator.error }}
       </amplify-error>
     </fieldset>
+    <amplify-slot name="reset-password-footer"> </amplify-slot>
   </form>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-setup-totp/amplify-setup-totp.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-setup-totp/amplify-setup-totp.component.html
@@ -6,7 +6,9 @@
       data-amplify-fieldset
       [disabled]="authenticator.isPending"
     >
-      <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      <amplify-slot name="setup-totp-header">
+        <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      </amplify-slot>
       <p *ngIf="!qrCodeSource">Loading...</p>
       <img
         *ngIf="qrCodeSource"
@@ -39,5 +41,6 @@
         {{ authenticator.error }}
       </amplify-error>
     </fieldset>
+    <amplify-slot name="setup-totp-footer"> </amplify-slot>
   </form>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-in/amplify-sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-in/amplify-sign-in.component.html
@@ -6,7 +6,9 @@
       data-amplify-fieldset
       [disabled]="authenticator.isPending"
     >
-      <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      <amplify-slot name="sign-in-header">
+        <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      </amplify-slot>
       <amplify-user-name-alias></amplify-user-name-alias>
       <amplify-form-field
         data-amplify-password
@@ -31,5 +33,6 @@
       </amplify-error>
     </fieldset>
     <amplify-federated-sign-in></amplify-federated-sign-in>
+    <amplify-slot name="sign-in-footer"> </amplify-slot>
   </form>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/amplify-sign-up.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/amplify-sign-up.component.html
@@ -1,7 +1,8 @@
 <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
   <div class="amplify-flex" style="flex-direction: column">
-    <h3 class="amplify-heading">{{ this.headerText }}</h3>
-
+    <amplify-slot name="sign-up-header">
+      <h3 class="amplify-heading">{{ this.headerText }}</h3>
+    </amplify-slot>
     <div class="amplify-flex" style="flex-direction: column">
       <amplify-slot name="sign-up-form-fields" [context]="context">
         <amplify-sign-up-form-fields></amplify-sign-up-form-fields>
@@ -26,5 +27,6 @@
       </button>
     </amplify-slot>
     <amplify-federated-sign-in></amplify-federated-sign-in>
+    <amplify-slot name="sign-up-footer"> </amplify-slot>
   </div>
 </form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-verify-user/amplify-verify-user.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-verify-user/amplify-verify-user.component.html
@@ -6,7 +6,9 @@
       data-amplify-fieldset
       [disabled]="authenticator.isPending"
     >
-      <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      <amplify-slot name="verify-user-header">
+        <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      </amplify-slot>
 
       <div *ngFor="let unverifiedAttribute of unverifiedAttributes | keyvalue">
         <input
@@ -39,5 +41,6 @@
         {{ authenticator.error }}
       </amplify-error>
     </fieldset>
+    <amplify-slot name="verify-user-footer"> </amplify-slot>
   </form>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
@@ -6,7 +6,9 @@
       data-amplify-fieldset
       [disabled]="authenticator.isPending"
     >
-      <h3 class="amplify-heading">{{ headerText }}</h3>
+      <amplify-slot name="confirm-reset-password-header">
+        <h3 class="amplify-heading">{{ headerText }}</h3>
+      </amplify-slot>
       <amplify-form-field
         name="confirmation_code"
         type="number"
@@ -44,5 +46,6 @@
         {{ authenticator.error }}
       </amplify-error>
     </fieldset>
+    <amplify-slot name="confirm-reset-password-footer"> </amplify-slot>
   </form>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.html
@@ -6,7 +6,9 @@
       data-amplify-fieldset
       [disabled]="authenticator.isPending"
     >
-      <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      <amplify-slot name="confirm-verify-user-header">
+        <h3 class="amplify-heading">{{ this.headerText }}</h3>
+      </amplify-slot>
       <amplify-form-field
         name="confirmation_code"
         type="number"
@@ -22,7 +24,7 @@
         variation="link"
         fontWeight="normal"
         fullWidth="true"
-        (click)="(authenticator.skipVerification)"
+        (click)="authenticator.skipVerification()"
       >
         {{ skipText }}
       </button>
@@ -30,5 +32,6 @@
         {{ authenticator.error }}
       </amplify-error>
     </fieldset>
+    <amplify-slot name="confirm-verify-user-footer"> </amplify-slot>
   </form>
 </div>

--- a/packages/ui/src/theme/css/component/authenticator.scss
+++ b/packages/ui/src/theme/css/component/authenticator.scss
@@ -37,14 +37,23 @@
 [data-amplify-authenticator] [data-amplify-container] {
   /* Fix z-index of texture being over the Authenticator */
   position: relative;
-
-  background-color: var(--amplify-colors-background-primary);
-  box-shadow: var(--amplify-shadows-small);
   place-self: center;
   width: 30rem;
   @media (max-width: 30rem) {
     width: 100%;
   }
+}
+
+[data-amplify-authenticator] [data-amplify-container] > {
+  [data-amplify-header],
+  [data-amplify-footer] {
+    text-align: center;
+  }
+}
+
+[data-amplify-authenticator] [data-amplify-container] > [data-amplify-body] {
+  background-color: var(--amplify-colors-background-primary);
+  box-shadow: var(--amplify-shadows-small);
 }
 
 [data-amplify-authenticator] [data-amplify-form] {

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -4,250 +4,259 @@
     data-amplify-authenticator
     v-if="!state?.matches('authenticated')"
   >
-    <slot name="header"> </slot>
     <div data-authenticator-variation="modal" v-if="variationModal" />
     <div data-amplify-container>
-      <base-two-tabs
-        v-if="actorState?.matches('signIn') || actorState?.matches('signUp')"
-      >
-        <base-two-tab-item
-          :active="actorState?.matches('signIn')"
-          :id="44472"
-          :label="createAccountLabel"
-          @click="send('SIGN_IN')"
-        />
-        <base-two-tab-item
-          :active="actorState?.matches('signUp')"
-          :id="44471"
-          :label="signInLabel"
-          @click="send('SIGN_UP')"
-        />
-      </base-two-tabs>
-      <sign-in
-        v-if="actorState?.matches('signIn')"
-        @sign-in-submit="onSignInSubmitI"
-        ref="signInComponent"
-      >
-        <template #signInSlotI>
-          <slot name="sign-in"></slot>
-        </template>
-
-        <template
-          #form="{ info, onSignInSubmit, onForgotPasswordClicked, onInput }"
+      <div data-amplify-header>
+        <slot name="header"> </slot>
+      </div>
+      <div data-amplify-body>
+        <base-two-tabs
+          v-if="actorState?.matches('signIn') || actorState?.matches('signUp')"
         >
-          <slot
-            name="sign-in-form"
-            :info="info"
-            :onInput="onInput"
-            :onSignInSubmit="onSignInSubmit"
-            :onForgotPasswordClicked="onForgotPasswordClicked"
-          ></slot>
-        </template>
-
-        <template #header>
-          <slot name="sign-in-header"></slot>
-        </template>
-
-        <template #footer="{ onSignInSubmit, onForgotPasswordClicked }">
-          <slot
-            name="sign-in-footer"
-            :onSignInSubmit="onSignInSubmit"
-            :onForgotPasswordClicked="onForgotPasswordClicked"
-          >
-          </slot>
-        </template>
-      </sign-in>
-      <sign-up
-        v-if="actorState?.matches('signUp')"
-        @sign-up-submit="onSignUpSubmitI"
-        ref="signUpComponent"
-      >
-        <template #signUpSlotI>
-          <slot name="sign-up"></slot>
-        </template>
-        <template #header>
-          <slot name="sign-up-header"></slot>
-        </template>
-        <template #signup-fields="{ info }">
-          <slot name="sign-up-fields" :info="info"></slot>
-        </template>
-
-        <template #footer="{ onSignUpSubmit }">
-          <slot name="sign-up-footer" :onSignUpSubmit="onSignUpSubmit"> </slot>
-        </template>
-      </sign-up>
-
-      <confirm-sign-up
-        v-if="actorState?.matches('confirmSignUp')"
-        @confirm-sign-up-submit="onConfirmSignUpSubmitI"
-        ref="confirmSignUpComponent"
-      >
-        <template #confirmSignUpSlotI>
-          <slot name="confirm-sign-up"></slot>
-        </template>
-        <template #header>
-          <slot name="confirm-sign-up-header"></slot>
-        </template>
-        <template #footer="{ onConfirmSignUpSubmit, onLostCodeClicked }">
-          <slot
-            name="confirm-sign-up-footer"
-            :onConfirmSignUpSubmit="onConfirmSignUpSubmit"
-            :onLostCodeClicked="onLostCodeClicked"
-          >
-          </slot>
-        </template>
-      </confirm-sign-up>
-
-      <reset-password
-        v-if="actorState?.matches('resetPassword')"
-        @reset-password-submit="onResetPasswordSubmitI"
-        ref="resetPasswordComponent"
-      >
-        <template #resetPasswordSlotI>
-          <slot name="reset-password"></slot>
-        </template>
-        <template #header>
-          <slot name="reset-password-header"></slot>
-        </template>
-        <template #footer="{ onResetPasswordSubmit, onBackToSignInClicked }">
-          <slot
-            name="reset-password-footer"
-            :onResetPasswordSubmit="onResetPasswordSubmit"
-            :onBackToSignInClicked="onBackToSignInClicked"
-          >
-          </slot>
-        </template>
-      </reset-password>
-
-      <confirm-reset-password
-        v-if="actorState?.matches('confirmResetPassword')"
-        @confirm-reset-password-submit="onConfirmResetPasswordSubmitI"
-        ref="confirmResetPasswordComponent"
-      >
-        <template #confirmResetPasswordSlotI>
-          <slot name="confirm-reset-password"></slot>
-        </template>
-        <template #header>
-          <slot name="confirm-reset-password-header"></slot>
-        </template>
-        <template
-          #footer="{ onConfirmResetPasswordSubmit, onLostYourCodeClicked }"
+          <base-two-tab-item
+            :active="actorState?.matches('signIn')"
+            :id="44472"
+            :label="createAccountLabel"
+            @click="send('SIGN_IN')"
+          />
+          <base-two-tab-item
+            :active="actorState?.matches('signUp')"
+            :id="44471"
+            :label="signInLabel"
+            @click="send('SIGN_UP')"
+          />
+        </base-two-tabs>
+        <sign-in
+          v-if="actorState?.matches('signIn')"
+          @sign-in-submit="onSignInSubmitI"
+          ref="signInComponent"
         >
-          <slot
-            name="confirm-reset-password-footer"
-            :onConfirmResetPasswordSubmit="onConfirmResetPasswordSubmit"
-            :onLostYourCodeClicked="onLostYourCodeClicked"
-          >
-          </slot>
-        </template>
-      </confirm-reset-password>
+          <template #signInSlotI>
+            <slot name="sign-in"></slot>
+          </template>
 
-      <confirm-sign-in
-        v-if="actorState?.matches('confirmSignIn')"
-        @confirm-sign-in-submit="onConfirmSignInSubmitI"
-        ref="confirmSignInComponent"
-      >
-        <template #confirmSignInSlotI>
-          <slot name="confirm-sign-in"></slot>
-        </template>
-        <template #header>
-          <slot name="confirm-sign-in-header"></slot>
-        </template>
-        <template #footer="{ onConfirmSignInSubmit, onBackToSignInClicked }">
-          <slot
-            name="confirm-sign-in-footer"
-            :onConfirmSignInSubmit="onConfirmSignInSubmit"
-            :onBackToSignInClicked="onBackToSignInClicked"
+          <template
+            #form="{ info, onSignInSubmit, onForgotPasswordClicked, onInput }"
           >
-          </slot>
-        </template>
-      </confirm-sign-in>
+            <slot
+              name="sign-in-form"
+              :info="info"
+              :onInput="onInput"
+              :onSignInSubmit="onSignInSubmit"
+              :onForgotPasswordClicked="onForgotPasswordClicked"
+            ></slot>
+          </template>
 
-      <setup-totp
-        v-if="actorState?.matches('setupTOTP')"
-        @confirm-setup-totp-submit="onConfirmSetupTOTPSubmitI"
-        ref="confirmSetupTOTPComponent"
-      >
-        <template #confirmSetupTOTPI>
-          <slot name="setup-totp"></slot>
-        </template>
-        <template #header>
-          <slot name="setup-totp-header"></slot>
-        </template>
-        <template #footer="{ onSetupTOTPSubmit, onBackToSignInClicked }">
-          <slot
-            name="setup-totp-footer"
-            :onSetupTOTPSubmit="onSetupTOTPSubmit"
-            :onBackToSignInClicked="onBackToSignInClicked"
-          >
-          </slot>
-        </template>
-      </setup-totp>
+          <template #header>
+            <slot name="sign-in-header"></slot>
+          </template>
 
-      <force-new-password
-        v-if="actorState?.matches('forceNewPassword')"
-        @force-new-password-submit="onForceNewPasswordSubmitI"
-        ref="forceNewPasswordComponent"
-      >
-        <template #forceNewPasswordI>
-          <slot name="force-new-password"></slot>
-        </template>
-        <template #header>
-          <slot name="force-new-password-header"></slot>
-        </template>
-        <template #footer="{ onHaveAccountClicked, onForceNewPasswordSubmit }">
-          <slot
-            name="force-new-password-footer"
-            :onForceNewPasswordSubmit="onForceNewPasswordSubmit"
-            :onBackToSignInClicked="onHaveAccountClicked"
-          >
-          </slot>
-        </template>
-      </force-new-password>
+          <template #footer="{ onSignInSubmit, onForgotPasswordClicked }">
+            <slot
+              name="sign-in-footer"
+              :onSignInSubmit="onSignInSubmit"
+              :onForgotPasswordClicked="onForgotPasswordClicked"
+            >
+            </slot>
+          </template>
+        </sign-in>
+        <sign-up
+          v-if="actorState?.matches('signUp')"
+          @sign-up-submit="onSignUpSubmitI"
+          ref="signUpComponent"
+        >
+          <template #signUpSlotI>
+            <slot name="sign-up"></slot>
+          </template>
+          <template #header>
+            <slot name="sign-up-header"></slot>
+          </template>
+          <template #signup-fields="{ info }">
+            <slot name="sign-up-fields" :info="info"></slot>
+          </template>
 
-      <verify-user
-        v-if="actorState?.matches('verifyUser')"
-        @verify-user-submit="onVerifyUserSubmitI"
-        ref="verifyUserComponent"
-      >
-        <template #verifyUserSlotI>
-          <slot name="verify-user"></slot>
-        </template>
-        <template #header>
-          <slot name="verify-user-header"></slot>
-        </template>
-        <template #footer="{ onVerifyUserSubmit, onSkipClicked }">
-          <slot
-            name="verify-user-footer"
-            :onVerifyUserSubmit="onVerifyUserSubmit"
-            :onSkipClicked="onSkipClicked"
-          >
-          </slot>
-        </template>
-      </verify-user>
+          <template #footer="{ onSignUpSubmit }">
+            <slot name="sign-up-footer" :onSignUpSubmit="onSignUpSubmit">
+            </slot>
+          </template>
+        </sign-up>
 
-      <confirm-verify-user
-        v-if="actorState?.matches('confirmVerifyUser')"
-        @confirm-verify-user-submit="onConfirmVerifyUserSubmitI"
-        ref="confirmVerifyUserComponent"
-      >
-        <template #confirmVerifyUserSlotI>
-          <slot name="confirm-verify-user"></slot>
-        </template>
-        <template #header>
-          <slot name="confirm-verify-user-header"></slot>
-        </template>
-        <template #footer="{ onConfirmVerifyUserSubmit, onSkipClicked }">
-          <slot
-            name="confirm-verify-user-footer"
-            :onConfirmVerifyUserSubmit="onConfirmVerifyUserSubmit"
-            :onSkipClicked="onSkipClicked"
+        <confirm-sign-up
+          v-if="actorState?.matches('confirmSignUp')"
+          @confirm-sign-up-submit="onConfirmSignUpSubmitI"
+          ref="confirmSignUpComponent"
+        >
+          <template #confirmSignUpSlotI>
+            <slot name="confirm-sign-up"></slot>
+          </template>
+          <template #header>
+            <slot name="confirm-sign-up-header"></slot>
+          </template>
+          <template #footer="{ onConfirmSignUpSubmit, onLostCodeClicked }">
+            <slot
+              name="confirm-sign-up-footer"
+              :onConfirmSignUpSubmit="onConfirmSignUpSubmit"
+              :onLostCodeClicked="onLostCodeClicked"
+            >
+            </slot>
+          </template>
+        </confirm-sign-up>
+
+        <reset-password
+          v-if="actorState?.matches('resetPassword')"
+          @reset-password-submit="onResetPasswordSubmitI"
+          ref="resetPasswordComponent"
+        >
+          <template #resetPasswordSlotI>
+            <slot name="reset-password"></slot>
+          </template>
+          <template #header>
+            <slot name="reset-password-header"></slot>
+          </template>
+          <template #footer="{ onResetPasswordSubmit, onBackToSignInClicked }">
+            <slot
+              name="reset-password-footer"
+              :onResetPasswordSubmit="onResetPasswordSubmit"
+              :onBackToSignInClicked="onBackToSignInClicked"
+            >
+            </slot>
+          </template>
+        </reset-password>
+
+        <confirm-reset-password
+          v-if="actorState?.matches('confirmResetPassword')"
+          @confirm-reset-password-submit="onConfirmResetPasswordSubmitI"
+          ref="confirmResetPasswordComponent"
+        >
+          <template #confirmResetPasswordSlotI>
+            <slot name="confirm-reset-password"></slot>
+          </template>
+          <template #header>
+            <slot name="confirm-reset-password-header"></slot>
+          </template>
+          <template
+            #footer="{ onConfirmResetPasswordSubmit, onLostYourCodeClicked }"
           >
-          </slot>
-        </template>
-      </confirm-verify-user>
+            <slot
+              name="confirm-reset-password-footer"
+              :onConfirmResetPasswordSubmit="onConfirmResetPasswordSubmit"
+              :onLostYourCodeClicked="onLostYourCodeClicked"
+            >
+            </slot>
+          </template>
+        </confirm-reset-password>
+
+        <confirm-sign-in
+          v-if="actorState?.matches('confirmSignIn')"
+          @confirm-sign-in-submit="onConfirmSignInSubmitI"
+          ref="confirmSignInComponent"
+        >
+          <template #confirmSignInSlotI>
+            <slot name="confirm-sign-in"></slot>
+          </template>
+          <template #header>
+            <slot name="confirm-sign-in-header"></slot>
+          </template>
+          <template #footer="{ onConfirmSignInSubmit, onBackToSignInClicked }">
+            <slot
+              name="confirm-sign-in-footer"
+              :onConfirmSignInSubmit="onConfirmSignInSubmit"
+              :onBackToSignInClicked="onBackToSignInClicked"
+            >
+            </slot>
+          </template>
+        </confirm-sign-in>
+
+        <setup-totp
+          v-if="actorState?.matches('setupTOTP')"
+          @confirm-setup-totp-submit="onConfirmSetupTOTPSubmitI"
+          ref="confirmSetupTOTPComponent"
+        >
+          <template #confirmSetupTOTPI>
+            <slot name="setup-totp"></slot>
+          </template>
+          <template #header>
+            <slot name="setup-totp-header"></slot>
+          </template>
+          <template #footer="{ onSetupTOTPSubmit, onBackToSignInClicked }">
+            <slot
+              name="setup-totp-footer"
+              :onSetupTOTPSubmit="onSetupTOTPSubmit"
+              :onBackToSignInClicked="onBackToSignInClicked"
+            >
+            </slot>
+          </template>
+        </setup-totp>
+
+        <force-new-password
+          v-if="actorState?.matches('forceNewPassword')"
+          @force-new-password-submit="onForceNewPasswordSubmitI"
+          ref="forceNewPasswordComponent"
+        >
+          <template #forceNewPasswordI>
+            <slot name="force-new-password"></slot>
+          </template>
+          <template #header>
+            <slot name="force-new-password-header"></slot>
+          </template>
+          <template
+            #footer="{ onHaveAccountClicked, onForceNewPasswordSubmit }"
+          >
+            <slot
+              name="force-new-password-footer"
+              :onForceNewPasswordSubmit="onForceNewPasswordSubmit"
+              :onBackToSignInClicked="onHaveAccountClicked"
+            >
+            </slot>
+          </template>
+        </force-new-password>
+
+        <verify-user
+          v-if="actorState?.matches('verifyUser')"
+          @verify-user-submit="onVerifyUserSubmitI"
+          ref="verifyUserComponent"
+        >
+          <template #verifyUserSlotI>
+            <slot name="verify-user"></slot>
+          </template>
+          <template #header>
+            <slot name="verify-user-header"></slot>
+          </template>
+          <template #footer="{ onVerifyUserSubmit, onSkipClicked }">
+            <slot
+              name="verify-user-footer"
+              :onVerifyUserSubmit="onVerifyUserSubmit"
+              :onSkipClicked="onSkipClicked"
+            >
+            </slot>
+          </template>
+        </verify-user>
+
+        <confirm-verify-user
+          v-if="actorState?.matches('confirmVerifyUser')"
+          @confirm-verify-user-submit="onConfirmVerifyUserSubmitI"
+          ref="confirmVerifyUserComponent"
+        >
+          <template #confirmVerifyUserSlotI>
+            <slot name="confirm-verify-user"></slot>
+          </template>
+          <template #header>
+            <slot name="confirm-verify-user-header"></slot>
+          </template>
+          <template #footer="{ onConfirmVerifyUserSubmit, onSkipClicked }">
+            <slot
+              name="confirm-verify-user-footer"
+              :onConfirmVerifyUserSubmit="onConfirmVerifyUserSubmit"
+              :onSkipClicked="onSkipClicked"
+            >
+            </slot>
+          </template>
+        </confirm-verify-user>
+      </div>
+      <div data-amplify-footer>
+        <slot name="footer"></slot>
+      </div>
     </div>
-    <slot name="footer"></slot>
   </div>
 
   <slot


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Applying #647 changes to Angular as well.

Only meaningful html change is organizing authenticator content into header, body, and footer:

```diff
<div amplify-authenticator>
  ...
  <div amplify-container>
+   <div data-amplify-header> ... </div>
+   <div data-amplify-body> ... </div>
+   <div data-amplify-footer> ... </div>
  </div>
</div>
```

## Screenshots

#### Angular

![Screen Shot 2021-11-09 at 3 26 06 PM](https://user-images.githubusercontent.com/43682783/141022878-5be3990f-9ff2-4375-8675-8b3b4ba84795.png)

#### Vue

![Screen Shot 2021-11-09 at 3 26 43 PM](https://user-images.githubusercontent.com/43682783/141022885-ace364ec-c7c9-44f6-ab36-c787b4b5a850.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
