### PR TITLE
CODEOWNERS for legacy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# The amplify-ui team is marked as required reviewers for all pull requests to legacy.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+@aws-amplify/amplify-ui


### PR DESCRIPTION
*Issue #, if available:* SecOps

*Description of changes:* As `legacy` is a protected branch of the repository, we should add a `CODEOWNERS` file which requires approval of pull requests to `legacy` by a member of the amplify-ui team.

See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
