### PR TITLE
Render required attributes by default in Angular

### DIFF
--- a/examples/angular/src/app/app-routing.module.ts
+++ b/examples/angular/src/app/app-routing.module.ts
@@ -10,6 +10,7 @@ import { SignInWithEmailComponent } from 'src/pages/ui/components/authenticator/
 import { SignInWithPhoneComponent } from 'src/pages/ui/components/authenticator/sign-in-with-phone/sign-in-with-phone.component';
 import { SignInWithUsernameComponent } from 'src/pages/ui/components/authenticator/sign-in-with-username/sign-in-with-username.component';
 import { SignUpWithEmailComponent } from 'src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component';
+import { SignUpWithAttributesComponent } from 'src/pages/ui/components/authenticator/sign-up-with-attributes/sign-up-with-attributes.component';
 import { SignUpWithEmailLambdaComponent } from 'src/pages/ui/components/authenticator/sign-up-with-email-lambda/sign-up-with-email-lambda.component';
 import { SignUpWithPhoneComponent } from 'src/pages/ui/components/authenticator/sign-up-with-phone/sign-up-with-phone.component';
 import { SignUpWithUsernameComponent } from 'src/pages/ui/components/authenticator/sign-up-with-username/sign-up-with-username.component';
@@ -55,6 +56,10 @@ const routes: Routes = [
   {
     path: 'ui/components/authenticator/sign-in-with-username',
     component: SignInWithUsernameComponent,
+  },
+  {
+    path: 'ui/components/authenticator/sign-up-with-attributes',
+    component: SignUpWithAttributesComponent,
   },
   {
     path: 'ui/components/authenticator/sign-up-with-username',

--- a/examples/angular/src/app/app.module.ts
+++ b/examples/angular/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { SignInTOTPSMSComponent } from 'src/pages/ui/components/authenticator/si
 import { SignInWithEmailComponent } from 'src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component';
 import { SignInWithPhoneComponent } from 'src/pages/ui/components/authenticator/sign-in-with-phone/sign-in-with-phone.component';
 import { SignInWithUsernameComponent } from 'src/pages/ui/components/authenticator/sign-in-with-username/sign-in-with-username.component';
+import { SignUpWithAttributesComponent } from 'src/pages/ui/components/authenticator/sign-up-with-attributes/sign-up-with-attributes.component';
 import { SignUpWithEmailComponent } from 'src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component';
 import { SignUpWithEmailLambdaComponent } from 'src/pages/ui/components/authenticator/sign-up-with-email-lambda/sign-up-with-email-lambda.component';
 import { SignUpWithPhoneComponent } from 'src/pages/ui/components/authenticator/sign-up-with-phone/sign-up-with-phone.component';
@@ -34,6 +35,7 @@ import { SignUpWithUsernameComponent } from 'src/pages/ui/components/authenticat
     SignInWithEmailComponent,
     SignInWithPhoneComponent,
     SignInWithUsernameComponent,
+    SignUpWithAttributesComponent,
     SignUpWithEmailComponent,
     SignUpWithEmailComponent,
     SignUpWithEmailLambdaComponent,

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-attributes/sign-up-with-attributes.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-attributes/sign-up-with-attributes.component.html
@@ -1,0 +1,10 @@
+<amplify-authenticator initialState="signUp">
+  <ng-template
+    amplifySlot="authenticated"
+    let-user="user"
+    let-signOut="signOut"
+  >
+    <h2>Welcome, {{ user.username }}!</h2>
+    <button (click)="signOut()">Sign Out</button>
+  </ng-template>
+</amplify-authenticator>

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-attributes/sign-up-with-attributes.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-attributes/sign-up-with-attributes.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { Amplify } from 'aws-amplify';
+import awsExports from '@environments/auth-with-all-attributes/src/aws-exports';
+
+@Component({
+  selector: 'sign-up-with-attributes',
+  templateUrl: 'sign-up-with-attributes.component.html',
+})
+export class SignUpWithAttributesComponent {
+  constructor() {
+    Amplify.configure(awsExports);
+  }
+}

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-authenticator/amplify-authenticator.component.ts
@@ -23,6 +23,7 @@ export class AmplifyAuthenticatorComponent implements OnInit, AfterContentInit {
   @Input() initialState: AuthenticatorMachineOptions['initialState'];
   @Input() loginMechanisms: AuthenticatorMachineOptions['loginMechanisms'];
   @Input() services: AuthenticatorMachineOptions['services'];
+  @Input() signUpAttributes: AuthenticatorMachineOptions['signUpAttributes'];
   @Input() variation: 'modal' | undefined;
 
   @ContentChildren(AmplifySlotDirective)
@@ -38,11 +39,12 @@ export class AmplifyAuthenticatorComponent implements OnInit, AfterContentInit {
   ) {}
 
   ngOnInit(): void {
-    const { initialState, loginMechanisms, services } = this;
+    const { initialState, loginMechanisms, services, signUpAttributes } = this;
     this.authenticator.startMachine({
       initialState,
       loginMechanisms,
       services,
+      signUpAttributes,
     });
 
     /**

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.html
@@ -1,5 +1,5 @@
 <div class="amplify-flex" style="flex-direction: column" data-amplify-fieldset>
-  <amplify-user-name-alias [name]="primaryAlias"></amplify-user-name-alias>
+  <amplify-user-name-alias [name]="loginMechanism"></amplify-user-name-alias>
   <amplify-form-field
     name="password"
     autocomplete="new-password"

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.html
@@ -11,7 +11,7 @@
     autocomplete="new-password"
   ></amplify-form-field>
 
-  <ng-container *ngFor="let secondaryAlias of secondaryAliases">
-    <amplify-form-field [name]="secondaryAlias"></amplify-form-field>
+  <ng-container *ngFor="let field of fieldNames">
+    <amplify-form-field [name]="field"></amplify-form-field>
   </ng-container>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.html
@@ -12,6 +12,9 @@
   ></amplify-form-field>
 
   <ng-container *ngFor="let field of fieldNames">
-    <amplify-form-field [name]="field"></amplify-form-field>
+    <amplify-form-field
+      [name]="field"
+      [labelHidden]="false"
+    ></amplify-form-field>
   </ng-container>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/amplify-sign-up/sign-up-form-fields/sign-up-form-fields.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthenticatorService } from '../../../../../services/authenticator.service';
-import { isEmpty } from 'lodash';
-import { getConfiguredAliases } from '@aws-amplify/ui';
+import {
+  authInputAttributes,
+  LoginMechanism,
+  SignUpAttribute,
+} from '@aws-amplify/ui';
 
 @Component({
   selector: 'amplify-sign-up-form-fields',
@@ -10,24 +13,31 @@ import { getConfiguredAliases } from '@aws-amplify/ui';
 export class AmplifySignUpFormFieldsComponent implements OnInit {
   public primaryAlias = '';
   public secondaryAliases: string[] = [];
+  public fieldNames: Array<LoginMechanism | SignUpAttribute>;
+  public loginMechanism: LoginMechanism;
 
   constructor(private authenticator: AuthenticatorService) {}
 
   ngOnInit(): void {
     const context = this.authenticator.context;
-    const { primaryAlias, secondaryAliases } = getConfiguredAliases(context);
 
-    /**
-     * If the login_mechanisms are configured to use ONLY username, we need
-     * to ask for some sort of secondary contact information in order to
-     * verify the user for Cognito. Currently matching this to how Vue is
-     * set up.
-     */
-    if (primaryAlias === 'username' && isEmpty(secondaryAliases)) {
-      secondaryAliases.push('email', 'phone_number');
-    }
+    const { loginMechanisms, signUpAttributes } = context.config;
 
-    this.primaryAlias = primaryAlias;
-    this.secondaryAliases = secondaryAliases;
+    this.fieldNames = Array.from(
+      new Set([...loginMechanisms, ...signUpAttributes])
+    );
+
+    this.fieldNames = this.fieldNames.filter((fieldName) => {
+      const hasDefaultField = !!authInputAttributes[fieldName];
+      if (!hasDefaultField) {
+        console.debug(
+          `Authenticator does not have a default implementation for ${fieldName}. Customize Authenticator.SignUp.FormFields to add your own.`
+        );
+      }
+      return hasDefaultField;
+    });
+
+    // Only 1 is supported, so `['email', 'phone_number']` will only show `email`
+    this.loginMechanism = this.fieldNames.shift() as LoginMechanism;
   }
 }

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.html
@@ -11,7 +11,7 @@
     [initialValue]="initialValue"
     [disabled]="disabled"
     [labelHidden]="labelHidden"
-    [autocomplete]="autocomplete"
+    [autocomplete]="inferAutocomplete()"
   ></amplify-phone-number-field>
 
   <amplify-password-field
@@ -23,7 +23,7 @@
     [initialValue]="initialValue"
     [disabled]="disabled"
     [labelHidden]="labelHidden"
-    [autocomplete]="autocomplete"
+    [autocomplete]="inferAutocomplete()"
   ></amplify-password-field>
 
   <amplify-text-field
@@ -36,7 +36,7 @@
     [initialValue]="initialValue"
     [disabled]="disabled"
     [labelHidden]="labelHidden"
-    [autocomplete]="autocomplete"
+    [autocomplete]="inferAutocomplete()"
   ></amplify-text-field>
 
   <amplify-error *ngIf="error">

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.html
@@ -1,4 +1,4 @@
-<div class="amplify-flex" style="flex-direction: column; gap: 0">
+<div class="amplify-flex amplify-field" style="flex-direction: column">
   <!-- Country code field -->
   <amplify-phone-number-field
     *ngIf="isPhoneField()"
@@ -10,6 +10,7 @@
     [required]="required"
     [initialValue]="initialValue"
     [disabled]="disabled"
+    [labelHidden]="labelHidden"
     [autocomplete]="autocomplete"
   ></amplify-phone-number-field>
 
@@ -21,6 +22,7 @@
     [required]="required"
     [initialValue]="initialValue"
     [disabled]="disabled"
+    [labelHidden]="labelHidden"
     [autocomplete]="autocomplete"
   ></amplify-password-field>
 
@@ -33,6 +35,7 @@
     [required]="required"
     [initialValue]="initialValue"
     [disabled]="disabled"
+    [labelHidden]="labelHidden"
     [autocomplete]="autocomplete"
   ></amplify-text-field>
 

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.ts
@@ -83,6 +83,10 @@ export class AmplifyFormFieldComponent implements OnInit {
     return this.type ?? this.attributeMap[this.name]?.type ?? 'text';
   }
 
+  inferAutocomplete(): string {
+    return this.autocomplete || this.attributeMap[this.name]?.placeholder;
+  }
+
   // TODO(enhancement): use enum to differentiate special field types
   isPasswordField(): boolean {
     return this.inferType() === 'password';

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.ts
@@ -22,7 +22,6 @@ import { AuthenticatorService } from '../../services/authenticator.service';
 })
 export class AmplifyFormFieldComponent implements OnInit {
   @Input() name: string;
-  // TODO: Separate entry for id
   @Input() type: string;
   @Input() required = true;
   @Input() placeholder = '';
@@ -30,6 +29,8 @@ export class AmplifyFormFieldComponent implements OnInit {
   @Input() initialValue = '';
   @Input() disabled = false;
   @Input() autocomplete = '';
+  @Input() labelHidden = true;
+
   public defaultCountryCode: string;
   public countryDialCodes = countryDialCodes;
   public textFieldId: string;

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-password-field/amplify-password-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-password-field/amplify-password-field.component.html
@@ -1,4 +1,4 @@
-<label class="amplify-label sr-only" [for]="fieldId">
+<label class="amplify-label" [class.sr-only]="labelHidden" [for]="fieldId">
   {{ label }}
 </label>
 <div class="amplify-flex amplify-field-group">

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-password-field/amplify-password-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-password-field/amplify-password-field.component.ts
@@ -15,6 +15,8 @@ export class AmplifyPasswordFieldComponent {
   @Input() name: string;
   @Input() placeholder = '';
   @Input() required = true;
+  @Input() labelHidden = false;
+
   public type: 'text' | 'password' = 'password';
 
   public showPassword = false;

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-text-field/amplify-text-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-text-field/amplify-text-field.component.html
@@ -1,4 +1,4 @@
-<label class="amplify-label sr-only" [for]="fieldId">
+<label class="amplify-label" [class.sr-only]="labelHidden" [for]="fieldId">
   {{ label }}
 </label>
 <input

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-text-field/amplify-text-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-text-field/amplify-text-field.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, HostBinding, Input } from '@angular/core';
 import { nanoid } from 'nanoid';
 
 @Component({
@@ -15,4 +15,7 @@ export class AmplifyTextFieldComponent {
   @Input() placeholder = '';
   @Input() required = true;
   @Input() type: string;
+  @Input() labelHidden = false;
+
+  @HostBinding('style.display') display = 'contents';
 }

--- a/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.html
@@ -1,3 +1,6 @@
+<label class="amplify-label" [class.sr-only]="labelHidden" [for]="textFieldId">
+  {{ label }}
+</label>
 <div
   class="amplify-flex amplify-phonenumberfield"
   amplify-field-group
@@ -5,7 +8,9 @@
 >
   <div class="amplify-field-group__outer-start">
     <div
-      class=" amplify-flex amplify-field amplify-selectfield amplify-countrycodeselect"
+      class="
+        amplify-flex amplify-field amplify-selectfield amplify-countrycodeselect
+      "
       style="flex-direction: column"
     >
       <amplify-form-select
@@ -18,9 +23,6 @@
     </div>
   </div>
 
-  <label class="sr-only amplify-label" [for]="textFieldId">
-    {{ label }}
-  </label>
   <input
     class="amplify-input"
     [id]="textFieldId"

--- a/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, HostBinding, Input } from '@angular/core';
 import { nanoid } from 'nanoid';
 import { countryDialCodes } from '@aws-amplify/ui';
 
@@ -18,5 +18,8 @@ export class PhoneNumberFieldComponent {
   @Input() placeholder = '';
   @Input() required = true;
   @Input() type: string;
+  @Input() labelHidden = false;
+
+  @HostBinding('style.display') display = 'contents';
   public countryDialCodes = countryDialCodes;
 }

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
@@ -32,11 +32,13 @@ export class AuthenticatorService implements OnDestroy {
     initialState,
     loginMechanisms,
     services,
+    signUpAttributes,
   }: AuthenticatorMachineOptions) {
     const machine = createAuthenticatorMachine({
       initialState,
       loginMechanisms,
       services,
+      signUpAttributes,
     });
 
     const authService = interpret(machine, {

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-attributes.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-attributes.feature
@@ -7,77 +7,77 @@ Feature: Sign Up with Attributes
   Background:
     Given I'm running the example "ui/components/authenticator/sign-up-with-attributes"
 
-  @angular @react @vue @todo-angular @todo-vue
+  @angular @react @vue @todo-vue
   Scenario: Login mechanism set to "username"
     Then I see "Username" as a "text" field
     And I see "Email" as an "email" field
     And I see "Phone Number" as a "tel" field
 
-  @todo-angular @react @todo-vue
+  @angular @react @todo-vue
   Scenario: Sign Up screen does not have Address
     Then I don't see "Address"
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen has Birthdate
     Then I see "Birthdate" as a "date" field
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen has Email
     Then I see "Email" as an "email" field
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen has Family Name
     Then I see "Family Name" as a "text" field
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen has Middle Name
     Then I see "Middle Name" as a "text" field
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen does not have Gender
     Then I don't see "Gender"
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen does not have Locale
     Then I don't see "Locale"
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen has Given Name
     Then I see "Given Name" as a "text" field
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen has Name
     Then I see "Name" as a "text" field
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen has Nickname
     Then I see "Nickname" as a "text" field
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen has Phone Number
     Then I see "Phone Number" as a "tel" field
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen has Preferred Username
     Then I see "Preferred Username" as a "text" field
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen does not have Picture
     Then I don't see "Picture"
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen has Profile
     Then I see "Profile" as a "url" field
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen does not have Updated At
     Then I don't see "Updated At"
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen has Website
     Then I see "Website" as a "url" field
 
-  @todo-angular @react @todo-vue  
+  @angular @react @todo-vue  
   Scenario: Sign Up screen does not have Zone Info
     Then I don't see "Zone Info"
 

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-phone.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-phone.feature
@@ -11,11 +11,11 @@ Feature: Sign Up with Phone
     Then I see "Phone Number" as an input field
     And I don't see "Username" as an input field
 
-  @angular @react @vue @todo-angular @todo-vue
+  @angular @react @vue @todo-vue
   Scenario: "Email" is included from `aws_cognito_verification_mechanisms`
     Then I see "Email" as an "email" field
 
-  @angular @react @vue @todo-angular @todo-vue
+  @angular @react @vue @todo-vue
   Scenario: Sign up with valid phone number & password
     When I select my country code with status "UNCONFIRMED"
     And I type my "phone number" with status "UNCONFIRMED"

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-username.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-username.feature
@@ -9,19 +9,19 @@ Feature: Sign Up with Username
   Scenario: Login mechanism set to "username"
     Then I see "Username" as an input field
 
-  @angular @react @vue @todo-angular @todo-vue
+  @angular @react @vue @todo-vue
   Scenario: "Preferred Username" is included from `aws_cognito_signup_attributes`
     Then I see "Preferred Username" as a "text" field
 
-  @angular @react @vue @todo-angular @todo-vue
+  @angular @react @vue @todo-vue
   Scenario: "Email" is included from `aws_cognito_verification_mechanisms`
     Then I see "Email" as an "email" field
   
-  @angular @react @vue @todo-angular @todo-vue
+  @angular @react @vue @todo-vue
   Scenario: "Phone Number" is not included
     Then I don't see "Phone Number"
   
-  @angular @react @vue @todo-angular @todo-vue
+  @angular @react @vue @todo-vue
   Scenario: Sign up a new username & password
     Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-username"
     When I type a new "username"

--- a/packages/ui/src/helpers/auth.ts
+++ b/packages/ui/src/helpers/auth.ts
@@ -16,30 +16,88 @@ import {
 } from '../types';
 
 export const authInputAttributes: AuthInputAttributes = {
-  username: {
-    label: 'Username',
-    type: 'text',
-    placeholder: 'Username',
-  },
-  email: {
-    label: 'Email',
-    type: 'email',
-    placeholder: 'Email',
-  },
-  phone_number: {
-    label: 'Phone Number',
-    type: 'tel',
-    placeholder: 'Phone',
+  birthdate: {
+    label: 'Birthdate',
+    placeholder: 'Birthdate',
+    type: 'date',
+    autocomplete: 'bday',
   },
   confirmation_code: {
     label: 'Confirmation Code',
     placeholder: 'Code',
     type: 'text',
+    autocomplete: 'one-time-code',
+  },
+  email: {
+    label: 'Email',
+    type: 'email',
+    placeholder: 'Email',
+    autocomplete: 'username',
+  },
+  family_name: {
+    label: 'Family Name',
+    placeholder: 'Family Name',
+    type: 'text',
+    autocomplete: 'family-name',
+  },
+  given_name: {
+    label: 'Given Name',
+    placeholder: 'Given Name',
+    type: 'text',
+    autocomplete: 'given-name',
+  },
+  middle_name: {
+    label: 'Middle Name',
+    placeholder: 'Middle Name',
+    type: 'text',
+    autocomplete: 'additional-name',
+  },
+  name: {
+    label: 'Name',
+    placeholder: 'Name',
+    type: 'text',
+    autocomplete: 'name',
+  },
+  nickname: {
+    label: 'Nickname',
+    placeholder: 'Nickname',
+    type: 'text',
+    autocomplete: 'tel',
   },
   password: {
     label: 'Password',
     placeholder: 'Password',
     type: 'password',
+    autocomplete: 'password',
+  },
+  phone_number: {
+    label: 'Phone Number',
+    placeholder: 'Phone',
+    type: 'tel',
+    autocomplete: 'tel',
+  },
+  preferred_username: {
+    label: 'Preferred Username',
+    placeholder: 'Preferred Username',
+    type: 'text',
+  },
+  profile: {
+    label: 'Profile',
+    placeholder: 'Profile',
+    type: 'url',
+    autocomplete: 'url',
+  },
+  website: {
+    label: 'Website',
+    placeholder: 'Website',
+    type: 'url',
+    autocomplete: 'url',
+  },
+  username: {
+    label: 'Username',
+    type: 'text',
+    placeholder: 'Username',
+    autocomplete: 'username',
   },
 };
 

--- a/packages/ui/src/types/authMachine.ts
+++ b/packages/ui/src/types/authMachine.ts
@@ -34,12 +34,10 @@ export interface SignInContext extends BaseFormContext {
 }
 
 // https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html
-export const SignUpAttributes = [
-  'address',
+export const signUpFieldsWithDefault = [
   'birthdate',
   'email',
   'family_name',
-  'gender',
   'given_name',
   'locale',
   'middle_name',
@@ -49,12 +47,25 @@ export const SignUpAttributes = [
   'picture',
   'preferred_username',
   'profile',
-  'updated_at',
   'website',
+] as const;
+
+export const signUpFieldsWithoutDefault = [
+  'address',
+  'gender',
+  'picture',
+  'updated_at',
   'zoneinfo',
 ] as const;
 
-export type SignUpAttribute = typeof SignUpAttributes[number];
+export type SignUpFieldsWithDefaults = typeof signUpFieldsWithDefault[number];
+
+export type SignUpFieldsWithoutDefaults =
+  typeof signUpFieldsWithoutDefault[number];
+
+export type SignUpAttribute =
+  | SignUpFieldsWithDefaults
+  | SignUpFieldsWithoutDefaults;
 
 export interface SignUpContext extends BaseFormContext {
   loginMechanisms: AuthContext['config']['loginMechanisms'];
@@ -134,14 +145,15 @@ export type LoginMechanism = typeof LoginMechanismArray[number];
 export type SocialProvider = 'amazon' | 'apple' | 'facebook' | 'google';
 
 // other non-alias inputs that Cognito would require
-export type AuthInputNames =
+export type AuthFieldsWithDefaults =
   | LoginMechanism
-  | SignUpAttribute
+  | SignUpFieldsWithDefaults
   | 'confirmation_code'
   | 'password';
 
-export type AuthInputAttributes = Partial<
-  Record<AuthInputNames, InputAttributes>
+export type AuthInputAttributes = Record<
+  AuthFieldsWithDefaults,
+  InputAttributes
 >;
 
 export type AuthEventData = Record<PropertyKey, any>; // TODO: this should be typed further

--- a/packages/ui/src/types/authMachine.ts
+++ b/packages/ui/src/types/authMachine.ts
@@ -140,9 +140,12 @@ export type AuthInputNames =
   | 'confirmation_code'
   | 'password';
 
-export type AuthInputAttributes = Partial<
-  Record<AuthInputNames, InputAttributes>
->;
+/**
+ * TODO: This can be much cleaner! Let's break AuthInputNames
+ * into those that have defaults and those that don't.
+ */
+export type AuthInputAttributes = Record<LoginMechanism, InputAttributes> &
+  Partial<Record<AuthInputNames, InputAttributes>>;
 
 export type AuthEventData = Record<PropertyKey, any>; // TODO: this should be typed further
 

--- a/packages/ui/src/types/authMachine.ts
+++ b/packages/ui/src/types/authMachine.ts
@@ -120,6 +120,7 @@ export interface InputAttributes {
   label: string;
   type: string;
   placeholder: string;
+  autocomplete?: string;
 }
 
 export const LoginMechanismArray = [
@@ -133,9 +134,15 @@ export type LoginMechanism = typeof LoginMechanismArray[number];
 export type SocialProvider = 'amazon' | 'apple' | 'facebook' | 'google';
 
 // other non-alias inputs that Cognito would require
-export type AuthInputNames = LoginMechanism | 'confirmation_code' | 'password';
+export type AuthInputNames =
+  | LoginMechanism
+  | SignUpAttribute
+  | 'confirmation_code'
+  | 'password';
 
-export type AuthInputAttributes = Record<AuthInputNames, InputAttributes>;
+export type AuthInputAttributes = Partial<
+  Record<AuthInputNames, InputAttributes>
+>;
 
 export type AuthEventData = Record<PropertyKey, any>; // TODO: this should be typed further
 

--- a/packages/ui/src/types/authMachine.ts
+++ b/packages/ui/src/types/authMachine.ts
@@ -140,12 +140,9 @@ export type AuthInputNames =
   | 'confirmation_code'
   | 'password';
 
-/**
- * TODO: This can be much cleaner! Let's break AuthInputNames
- * into those that have defaults and those that don't.
- */
-export type AuthInputAttributes = Record<LoginMechanism, InputAttributes> &
-  Partial<Record<AuthInputNames, InputAttributes>>;
+export type AuthInputAttributes = Partial<
+  Record<AuthInputNames, InputAttributes>
+>;
 
 export type AuthEventData = Record<PropertyKey, any>; // TODO: this should be typed further
 

--- a/packages/ui/src/types/authMachine.ts
+++ b/packages/ui/src/types/authMachine.ts
@@ -39,12 +39,10 @@ export const signUpFieldsWithDefault = [
   'email',
   'family_name',
   'given_name',
-  'locale',
   'middle_name',
   'name',
   'nickname',
   'phone_number',
-  'picture',
   'preferred_username',
   'profile',
   'website',
@@ -53,6 +51,7 @@ export const signUpFieldsWithDefault = [
 export const signUpFieldsWithoutDefault = [
   'address',
   'gender',
+  'locale',
   'picture',
   'updated_at',
   'zoneinfo',
@@ -144,7 +143,7 @@ export type LoginMechanism = typeof LoginMechanismArray[number];
 
 export type SocialProvider = 'amazon' | 'apple' | 'facebook' | 'google';
 
-// other non-alias inputs that Cognito would require
+// Auth fields that we provide default fields with
 export type AuthFieldsWithDefaults =
   | LoginMechanism
   | SignUpFieldsWithDefaults


### PR DESCRIPTION
*Issue #, if available:* #623, extending #650

*Description of changes:*

- [x] Remove `@todo-angular` placeholders
- [x] Add `labelHidden` prop to form fields so that we can display labels on sign up
- [x] Add `signUpAttributes` prop to `amplify-authenitcator`
- [x] Modify `amplify-sign-up-form-fields` component to render configured attributes

![image](https://user-images.githubusercontent.com/43682783/141196008-a0871cfb-9c77-46b2-8427-30f5a421a4aa.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
