### PR TITLE
fix: center text in federated signin buttons

### DIFF
--- a/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignInButtons/FederatedSignInButton.tsx
+++ b/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignInButtons/FederatedSignInButton.tsx
@@ -1,7 +1,7 @@
 import { FederatedIdentityProviders, SocialProvider } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '../..';
-import { Button, Flex, Icon, Text } from '../../../..';
+import { Button, Icon, Text } from '../../../..';
 
 export interface FederatedSignInButtonProps {
   icon?: SocialProvider;
@@ -112,15 +112,10 @@ export const FederatedSignInButton = (
       onClick={handleClick}
       className="federated-sign-in-button"
       fontWeight="normal"
+      gap="1rem"
     >
-      <Flex
-        direction="row"
-        justifyContent="center"
-        className="federated-sign-in-button-row"
-      >
-        {iconComponent}
-        <Text alignSelf="center">{text}</Text>
-      </Flex>
+      {iconComponent}
+      <Text as="span">{text}</Text>
     </Button>
   );
 };


### PR DESCRIPTION
*Issue #, if available:*

Fixing text does not center in federated signin buttons

![Screen Shot 2021-11-10 at 12 39 50 PM](https://user-images.githubusercontent.com/40295569/141191535-2b301bac-b7a6-4cf9-b681-1f6dd9997e6a.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
