### PR TITLE
Update yarn installation instructions

### DIFF
--- a/docs/src/pages/getting-started/installation/dependencies.react.mdx
+++ b/docs/src/pages/getting-started/installation/dependencies.react.mdx
@@ -13,7 +13,7 @@ npm install aws-amplify @aws-amplify/ui-react@next
 <TabItem title="yarn">
 
 ```shell
-yarn add @aws-amplify/ui-react@next
+yarn add aws-amplify @aws-amplify/ui-react@next
 ```
 
 </TabItem>


### PR DESCRIPTION
*Issue*
Closes https://github.com/aws-amplify/amplify-ui/issues/667

*Description of changes:*
This PR fixes an omission on the getting started page where the required `aws-amplify` dependency was missing from the yarn instructions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
