### PR TITLE
fix(angular): fix typos on `form-fields` and `custom-sign-up-fields` example

### DIFF
--- a/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.html
@@ -4,13 +4,6 @@
     amplifySlot="sign-up-form-fields"
     let-validationErrors="validationErrors"
   >
-    <!--  Prepend `preferred_username` custom attribute  -->
-    <amplify-text-field
-      label="Preferred Username"
-      name="preferred_username"
-      placeholder="Preferred Username"
-    ></amplify-text-field>
-
     <!-- Re-use default `Authenticator.SignUp.FormFields` -->
     <amplify-sign-up-form-fields></amplify-sign-up-form-fields>
 

--- a/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import Amplify from 'aws-amplify';
-import awsExports from '@environments/auth-with-email/src/aws-exports';
+import awsExports from '@environments/auth-with-email-and-custom-attributes/src/aws-exports';
 
 @Component({
   selector: 'custom-sign-up-fields',

--- a/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/amplify-form-field/amplify-form-field.component.ts
@@ -84,7 +84,7 @@ export class AmplifyFormFieldComponent implements OnInit {
   }
 
   inferAutocomplete(): string {
-    return this.autocomplete || this.attributeMap[this.name]?.placeholder;
+    return this.autocomplete || this.attributeMap[this.name]?.autocomplete;
   }
 
   // TODO(enhancement): use enum to differentiate special field types


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- [x] typo on `inferAutocomplete`
- [x] typo on `sign-up-form-fields` environment
- [x] remove `preferred_username` field as it's already consumed from zero config

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
