### PR TITLE
Add useControllable and useThemeBreakpoint hooks

### DIFF
--- a/packages/react/src/helpers/index.ts
+++ b/packages/react/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/packages/react/src/helpers/utils.ts
+++ b/packages/react/src/helpers/utils.ts
@@ -1,0 +1,1 @@
+export const isDevelopment = () => process.env.NODE_ENV !== 'production';

--- a/packages/react/src/hooks/__tests__/useControllable.test.tsx
+++ b/packages/react/src/hooks/__tests__/useControllable.test.tsx
@@ -1,0 +1,169 @@
+// Taken from https://www.npmjs.com/package/@awsui/components-react
+import React, { useImperativeHandle } from 'react';
+import { render, act } from '@testing-library/react';
+
+import { useControllable } from '../useControllable';
+
+interface Props {
+  value: string | undefined;
+  defaultValue: string;
+  onChange?: () => void;
+}
+
+interface Ref {
+  setHookValue: (newValue: React.SetStateAction<string | undefined>) => void;
+}
+
+const Component = React.forwardRef(
+  ({ value, defaultValue, onChange }: Props, ref: React.Ref<Ref>) => {
+    const [hookValue, setHookValue] = useControllable(
+      value,
+      onChange,
+      defaultValue,
+      {
+        componentName: 'MyComponent',
+        controlledProp: 'value',
+        changeHandler: 'onChange',
+      }
+    );
+
+    useImperativeHandle(ref, () => ({
+      setHookValue,
+    }));
+
+    return <span>{hookValue}</span>;
+  }
+);
+
+let consoleWarnSpy: jest.SpyInstance;
+afterEach(() => {
+  consoleWarnSpy?.mockRestore();
+});
+
+describe('useControllable', () => {
+  test('only prints a warning if the property switches from controlled to uncontrolled', () => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const onChange = () => void 0;
+    const { container, rerender } = render(
+      <Component
+        value="a value"
+        defaultValue="the default value"
+        onChange={onChange}
+      />
+    );
+    expect(console.warn).not.toHaveBeenCalled();
+
+    rerender(
+      <Component
+        value={undefined}
+        defaultValue="the default value"
+        onChange={onChange}
+      />
+    );
+    expect(container).toHaveTextContent('');
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      "MyComponent: A component tried to change controlled 'value' property to be uncontrolled. " +
+        'This is not supported. Properties should not switch from controlled to uncontrolled (or vice versa). ' +
+        'Decide between using a controlled or uncontrolled mode for the lifetime of the component. ' +
+        'More info: https://fb.me/react-controlled-components'
+    );
+  });
+
+  test('only prints a warning if the property switches from uncontrolled to controlled', () => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const { container, rerender } = render(
+      <Component value={undefined} defaultValue="the default value" />
+    );
+    expect(console.warn).not.toHaveBeenCalled();
+
+    rerender(<Component value="a value" defaultValue="the default value" />);
+    expect(container).toHaveTextContent('the default value');
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      "MyComponent: A component tried to change uncontrolled 'value' property to be controlled. " +
+        'This is not supported. Properties should not switch from uncontrolled to controlled (or vice versa). ' +
+        'Decide between using a controlled or uncontrolled mode for the lifetime of the component. ' +
+        'More info: https://fb.me/react-controlled-components'
+    );
+  });
+
+  test('prints a warning if the onChange handler is missing', () => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    render(<Component value="any value" defaultValue="the default value" />);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      'MyComponent: You provided a `value` prop without an `onChange` handler. This will render a non-interactive component.'
+    );
+  });
+
+  test('tracks the defaultValue if and only if the component is uncontrolled and unchanged', () => {
+    const ref = React.createRef<Ref>();
+
+    const { container, rerender } = render(
+      <Component value={undefined} defaultValue="the default value" ref={ref} />
+    );
+    expect(container).toHaveTextContent('the default value');
+
+    rerender(
+      <Component
+        value={undefined}
+        defaultValue="a different default value"
+        ref={ref}
+      />
+    );
+    expect(container).toHaveTextContent('a different default value');
+
+    act(() => ref.current!.setHookValue('a value set inside the component'));
+    expect(container).toHaveTextContent('a value set inside the component');
+
+    rerender(
+      <Component
+        value={undefined}
+        defaultValue="another different default value"
+      />
+    );
+    expect(container).toHaveTextContent('a value set inside the component');
+  });
+
+  test('if property is provided, the component is controlled', () => {
+    const ref = React.createRef<Ref>();
+
+    const { container, rerender } = render(
+      <Component value="value one" defaultValue="the default value" ref={ref} />
+    );
+    expect(container).toHaveTextContent('value one');
+
+    rerender(
+      <Component value="value two" defaultValue="the default value" ref={ref} />
+    );
+    expect(container).toHaveTextContent('value two');
+
+    act(() =>
+      ref.current!.setHookValue('a value set from inside the component')
+    );
+    expect(container).toHaveTextContent('value two');
+  });
+
+  test('if property is not provided, the component is uncontrolled', () => {
+    const ref = React.createRef<Ref>();
+    const { container } = render(
+      <Component value={undefined} defaultValue="the default value" ref={ref} />
+    );
+    expect(container).toHaveTextContent('the default value');
+
+    act(() => ref.current!.setHookValue('another value'));
+    expect(container).toHaveTextContent('another value');
+
+    act(() =>
+      ref.current!.setHookValue((oldState) => oldState + ' but modified')
+    );
+    expect(container).toHaveTextContent('another value but modified');
+
+    act(() => ref.current!.setHookValue(undefined!));
+    expect(container).toHaveTextContent('');
+  });
+});

--- a/packages/react/src/hooks/__tests__/useControllable.test.tsx
+++ b/packages/react/src/hooks/__tests__/useControllable.test.tsx
@@ -16,16 +16,16 @@ interface Ref {
 
 const Component = React.forwardRef(
   ({ value, defaultValue, onChange }: Props, ref: React.Ref<Ref>) => {
-    const [hookValue, setHookValue] = useControllable(
-      value,
-      onChange,
+    const [hookValue, setHookValue] = useControllable({
+      controlledValue: value,
+      handler: onChange,
       defaultValue,
-      {
+      propertyDescription: {
         componentName: 'MyComponent',
         controlledProp: 'value',
         changeHandler: 'onChange',
-      }
-    );
+      },
+    });
 
     useImperativeHandle(ref, () => ({
       setHookValue,

--- a/packages/react/src/hooks/index.tsx
+++ b/packages/react/src/hooks/index.tsx
@@ -9,4 +9,3 @@ export {
 } from './useDataStore';
 
 export { useTheme } from './useTheme';
-export { useThemeBreakpoint } from './useThemeBreakpoint';

--- a/packages/react/src/hooks/index.tsx
+++ b/packages/react/src/hooks/index.tsx
@@ -9,3 +9,4 @@ export {
 } from './useDataStore';
 
 export { useTheme } from './useTheme';
+export { useThemeBreakpoint } from './useThemeBreakpoint';

--- a/packages/react/src/hooks/useControllable.ts
+++ b/packages/react/src/hooks/useControllable.ts
@@ -1,3 +1,4 @@
+// Taken from https://www.npmjs.com/package/@awsui/components-react
 import * as React from 'react';
 
 interface PropertyDescription {

--- a/packages/react/src/hooks/useControllable.ts
+++ b/packages/react/src/hooks/useControllable.ts
@@ -1,9 +1,22 @@
 // Taken from https://www.npmjs.com/package/@awsui/components-react
 import * as React from 'react';
 
+import { isDevelopment } from '../helpers';
+
 interface PropertyDescription {
+  /**
+   * Name of the component.
+   */
   componentName: string;
+
+  /**
+   * Name of the prop to this component that is being controlled
+   */
   controlledProp: string;
+
+  /**
+   * Name of the handler that would be called when the controlled prop is changed.
+   */
   changeHandler: string;
 }
 
@@ -40,8 +53,6 @@ interface PropertyDescription {
  *  />
  * ```
  *
- * @internal
- *
  * @param controlledValue value for the controlled mode
  * @param handler update handler for controlled mode
  * @param defaultValue initial value for uncontrolled mode
@@ -56,7 +67,7 @@ export function useControllable<ValueType>(
   // The decision whether a component is controlled or uncontrolled is made on its first render and cannot be changed afterwards.
   const isControlled = React.useState(controlledValue !== undefined)[0];
 
-  if (isDevelopment) {
+  if (isDevelopment()) {
     // Print a warning if the component switches between controlled and uncontrolled mode.
 
     React.useEffect(() => {
@@ -103,8 +114,6 @@ export function useControllable<ValueType>(
     return [currentUncontrolledValue, setUncontrolledValue] as const;
   }
 }
-
-const isDevelopment = process.env.NODE_ENV !== 'production';
 
 function defaultCallback() {
   return void 0;

--- a/packages/react/src/hooks/useControllable.ts
+++ b/packages/react/src/hooks/useControllable.ts
@@ -1,0 +1,110 @@
+import * as React from 'react';
+
+interface PropertyDescription {
+  componentName: string;
+  controlledProp: string;
+  changeHandler: string;
+}
+
+/**
+ * This hook allows you to make a component that can be used both in controlled mode and uncontrolled mode.
+ * Pass in your component's props, and then implement your component as if it was only controlled.
+ * When calling onChange callbacks (or the equivalent for your property), you need to call both the callback returned by this function
+ * as well as the callback provided in your component's props.
+ *
+ * A component determines its mode (either controlled or uncontrolled) on the first render and keeps it for its lifetime. The mode cannot
+ * be switched later.
+ *
+ *
+ * Example usage:
+ * ```jsx
+ * const [checked, setChecked] = useControllable(
+ *     props,
+ *     props.defaultEnabled ?? false,
+ *     {
+ *        componentName: 'MyCheckboxComponent',
+ *        controlledProp: 'enabled',
+ *        changeHandler: 'onCheckedStatusChange'
+ *     }
+ * )
+ *
+ * return
+ *  <input
+ *   type="checkbox"
+ *   checked={checked}
+ *   onChange={event => {
+ *    setChecked(event.target.checked);
+ *    props.onCheckedStatusChange(event.target.checked);
+ *   }}
+ *  />
+ * ```
+ *
+ * @internal
+ *
+ * @param controlledValue value for the controlled mode
+ * @param handler update handler for controlled mode
+ * @param defaultValue initial value for uncontrolled mode
+ * @param description property metadata
+ */
+export function useControllable<ValueType>(
+  controlledValue: ValueType,
+  handler: ((...args: any[]) => unknown) | undefined,
+  defaultValue: ValueType,
+  { componentName, changeHandler, controlledProp }: PropertyDescription
+) {
+  // The decision whether a component is controlled or uncontrolled is made on its first render and cannot be changed afterwards.
+  const isControlled = React.useState(controlledValue !== undefined)[0];
+
+  if (isDevelopment) {
+    // Print a warning if the component switches between controlled and uncontrolled mode.
+
+    React.useEffect(() => {
+      if (isControlled && handler === undefined) {
+        console.warn(
+          `${componentName}: You provided a \`${controlledProp}\` prop without an \`${changeHandler}\` handler. This will render a non-interactive component.`
+        );
+      }
+    }, [handler, isControlled, componentName, changeHandler, controlledProp]);
+
+    React.useEffect(() => {
+      const isControlledNow = controlledValue !== undefined;
+      if (isControlled !== isControlledNow) {
+        const initialMode = isControlled ? 'controlled' : 'uncontrolled';
+        const modeNow = isControlledNow ? 'controlled' : 'uncontrolled';
+        console.warn(
+          `${componentName}: A component tried to change ${initialMode} '${controlledProp}' property to be ${modeNow}. ` +
+            `This is not supported. Properties should not switch from ${initialMode} to ${modeNow} (or vice versa). ` +
+            `Decide between using a controlled or uncontrolled mode for the lifetime of the component. ` +
+            `More info: https://fb.me/react-controlled-components`
+        );
+      }
+    }, [isControlled, controlledProp, componentName, controlledValue]);
+  }
+
+  // This is the value that is used if the component is uncontrolled.
+  const [valueState, setValue] = React.useState(defaultValue);
+  const [valueHasBeenSet, setValueHasBeenSet] = React.useState(false);
+
+  // We track changes to the defaultValue
+  const currentUncontrolledValue = valueHasBeenSet ? valueState : defaultValue;
+
+  const setUncontrolledValue = React.useCallback(
+    (newValue: React.SetStateAction<ValueType>) => {
+      setValue(newValue);
+      setValueHasBeenSet(true);
+    },
+    [setValue, setValueHasBeenSet]
+  );
+
+  if (isControlled) {
+    return [controlledValue, defaultCallback] as const;
+  } else {
+    return [currentUncontrolledValue, setUncontrolledValue] as const;
+  }
+}
+
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+function defaultCallback() {
+  return void 0;
+}

--- a/packages/react/src/hooks/useControllable.ts
+++ b/packages/react/src/hooks/useControllable.ts
@@ -20,6 +20,28 @@ interface PropertyDescription {
   changeHandler: string;
 }
 
+export interface UseControllableProps<ValueType> {
+  /**
+   * Value for the controlled mode
+   */
+  controlledValue: ValueType;
+
+  /**
+   * Update handler for controlled mode
+   */
+  handler: ((...args: any[]) => unknown) | undefined;
+
+  /**
+   * Initial value for uncontrolled mode
+   */
+  defaultValue: ValueType;
+
+  /**
+   * Property metadata
+   */
+  propertyDescription: PropertyDescription;
+}
+
 /**
  * This hook allows you to make a component that can be used both in controlled mode and uncontrolled mode.
  * Pass in your component's props, and then implement your component as if it was only controlled.
@@ -52,18 +74,13 @@ interface PropertyDescription {
  *   }}
  *  />
  * ```
- *
- * @param controlledValue value for the controlled mode
- * @param handler update handler for controlled mode
- * @param defaultValue initial value for uncontrolled mode
- * @param description property metadata
  */
-export function useControllable<ValueType>(
-  controlledValue: ValueType,
-  handler: ((...args: any[]) => unknown) | undefined,
-  defaultValue: ValueType,
-  { componentName, changeHandler, controlledProp }: PropertyDescription
-) {
+export function useControllable<ValueType>({
+  controlledValue,
+  handler,
+  defaultValue,
+  propertyDescription: { componentName, changeHandler, controlledProp },
+}: UseControllableProps<ValueType>) {
   // The decision whether a component is controlled or uncontrolled is made on its first render and cannot be changed afterwards.
   const isControlled = React.useState(controlledValue !== undefined)[0];
 

--- a/packages/react/src/hooks/useThemeBreakpoint.ts
+++ b/packages/react/src/hooks/useThemeBreakpoint.ts
@@ -1,0 +1,25 @@
+import { useTheme } from './useTheme';
+import { useBreakpoint } from '../primitives/shared/responsive/useBreakpoint';
+import { Breakpoint } from '../primitives/types/responsive';
+
+/**
+ * Hook to get the current breakpoint of the provided theme.
+ * @returns {Breakpoint}
+ */
+export const useThemeBreakpoint = (): Breakpoint => {
+  const {
+    breakpoints: {
+      values: breakpoints,
+      unit: breakpointUnit,
+      defaultBreakpoint,
+    },
+  } = useTheme();
+
+  const breakpoint = useBreakpoint({
+    breakpoints,
+    breakpointUnit,
+    defaultBreakpoint: defaultBreakpoint as Breakpoint,
+  });
+
+  return breakpoint;
+};


### PR DESCRIPTION
1. Add `useControllable` internal hook to implement primitives (or other components) in an optionally controlled fashion. Currently we are already using this behavior in some of our components (eg. `Checkbox`) without appropriately warning the users about the improper usage. With this hook the duplication of the pattern would be avoided with better DX.

2. Add `useThemeBreakpoint` hook to get the current breakpoint value of the configured theme without writing down all the boilerplate for the same.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
