### PR TITLE
Reduced bundle size by changing imports of lodash

### DIFF
--- a/packages/ui/src/helpers/auth.ts
+++ b/packages/ui/src/helpers/auth.ts
@@ -1,4 +1,4 @@
-import { includes } from 'lodash';
+import includes from 'lodash/includes';
 import { Sender } from 'xstate';
 
 import { AuthContext } from '..';

--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -1,5 +1,6 @@
 import { Auth } from 'aws-amplify';
-import { get, isEmpty } from 'lodash';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 import { createMachine, sendUpdate } from 'xstate';
 
 import { AuthChallengeNames, AuthEvent, SignInContext } from '../../../types';

--- a/packages/ui/src/machines/authenticator/signUp.ts
+++ b/packages/ui/src/machines/authenticator/signUp.ts
@@ -1,5 +1,6 @@
 import { Auth } from 'aws-amplify';
-import { get, pickBy } from 'lodash';
+import get from 'lodash/get';
+import pickBy from 'lodash/pickBy';
 import { createMachine, sendUpdate } from 'xstate';
 
 import { AuthEvent, SignUpContext } from '../../types';


### PR DESCRIPTION
*Issue #, if available:*
#599

*Description of changes:*
I noticed the imports of lodash in the `@aws-amplify/ui` package was inconsistent. I updated it so all the lodash imports looked the same. This also helped reduce the bundle size in the Vue packages by 50kb.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
