### PR TITLE
chore: adding flex and margin style props

### DIFF
--- a/packages/react/src/components/AmplifyProvider/AmplifyContext.tsx
+++ b/packages/react/src/components/AmplifyProvider/AmplifyContext.tsx
@@ -1,13 +1,13 @@
-import { createContext, ReactNode } from 'react';
+import * as React from 'react';
 
 import { defaultTheme, WebTheme } from '@aws-amplify/ui';
 
 interface AmplifyContextType {
-  components: Record<string, ReactNode>;
+  components: Record<string, any>;
   theme: WebTheme;
 }
 
-export const AmplifyContext = createContext<AmplifyContextType>({
+export const AmplifyContext = React.createContext<AmplifyContextType>({
   components: undefined,
   theme: defaultTheme,
 });

--- a/packages/react/src/hooks/useAmplify.ts
+++ b/packages/react/src/hooks/useAmplify.ts
@@ -1,9 +1,16 @@
 import * as React from 'react';
 
+import { Theme } from '@aws-amplify/ui';
+
 import { AmplifyContext } from '../components/AmplifyProvider/AmplifyContext';
 import * as primitives from '../primitives';
 
-export function useAmplify() {
+interface UseAmplifyOutput {
+  components: Record<string, React.ReactNode>;
+  theme: Theme;
+}
+
+export function useAmplify(): UseAmplifyOutput {
   const context = React.useContext(AmplifyContext);
   const { components: customComponents, theme } = context;
   const components = React.useMemo(

--- a/packages/react/src/hooks/useAmplify.ts
+++ b/packages/react/src/hooks/useAmplify.ts
@@ -6,7 +6,7 @@ import { AmplifyContext } from '../components/AmplifyProvider/AmplifyContext';
 import * as primitives from '../primitives';
 
 interface UseAmplifyOutput {
-  components: Record<string, React.ReactNode>;
+  components: Record<string, any>;
   theme: Theme;
 }
 

--- a/packages/react/src/primitives/shared/styleUtils.ts
+++ b/packages/react/src/primitives/shared/styleUtils.ts
@@ -215,6 +215,7 @@ const BaseStylePropsMap: Required<{ [key in keyof BaseStyleProps]: true }> = {
   left: true,
   letterSpacing: true,
   lineHeight: true,
+  margin: true,
   maxHeight: true,
   maxWidth: true,
   minHeight: true,

--- a/packages/react/src/primitives/types/style.ts
+++ b/packages/react/src/primitives/types/style.ts
@@ -38,44 +38,38 @@ export type ResponsiveStyle<PropertyType> =
   | ResponsiveObject<StyleProp<PropertyType>>;
 
 export interface BaseStyleProps extends FlexItemStyleProps, GridItemStyleProps {
-  alignSelf?: ResponsiveStyle<Property.AlignSelf>;
+  alignSelf?: ResponsiveStyle<StyleToken<Property.AlignSelf>>;
   backgroundColor?: ResponsiveStyle<StyleToken<Property.BackgroundColor>>;
-  border?: ResponsiveStyle<Property.Border>;
+  border?: ResponsiveStyle<StyleToken<Property.Border>>;
   borderRadius?: ResponsiveStyle<StyleToken<Property.BorderRadius>>;
-  bottom?: ResponsiveStyle<Property.Bottom>;
+  bottom?: ResponsiveStyle<StyleToken<Property.Bottom>>;
   boxShadow?: ResponsiveStyle<StyleToken<Property.BoxShadow>>;
   color?: ResponsiveStyle<StyleToken<Property.Color>>;
-  display?: ResponsiveStyle<Property.Display>;
+  display?: ResponsiveStyle<StyleToken<Property.Display>>;
   fontFamily?: ResponsiveStyle<StyleToken<Property.FontFamily>>;
   fontSize?: ResponsiveStyle<StyleToken<Property.FontSize>>;
-  fontStyle?: ResponsiveStyle<Property.FontStyle>;
+  fontStyle?: ResponsiveStyle<StyleToken<Property.FontStyle>>;
   fontWeight?: ResponsiveStyle<StyleToken<Property.FontWeight>>;
   height?: ResponsiveStyle<StyleToken<Property.Height>>;
   left?: ResponsiveStyle<StyleToken<Property.Left>>;
-  letterSpacing?: ResponsiveStyle<Property.LetterSpacing>;
-  lineHeight?: ResponsiveStyle<Property.LineHeight>;
-  margin?: ResponsiveStyle<Property.Margin>;
-  maxHeight?: ResponsiveStyle<Property.MaxHeight>;
-  maxWidth?: ResponsiveStyle<Property.MaxWidth>;
-  minHeight?: ResponsiveStyle<Property.MinHeight>;
-  minWidth?: ResponsiveStyle<Property.MinWidth>;
-  opacity?: ResponsiveStyle<Property.Opacity>;
+  letterSpacing?: ResponsiveStyle<StyleToken<Property.LetterSpacing>>;
   lineHeight?: ResponsiveStyle<StyleToken<Property.LineHeight>>;
+  margin?: ResponsiveStyle<StyleToken<Property.Margin>>;
   maxHeight?: ResponsiveStyle<StyleToken<Property.MaxHeight>>;
   maxWidth?: ResponsiveStyle<StyleToken<Property.MaxWidth>>;
   minHeight?: ResponsiveStyle<StyleToken<Property.MinHeight>>;
   minWidth?: ResponsiveStyle<StyleToken<Property.MinWidth>>;
   opacity?: ResponsiveStyle<StyleToken<Property.Opacity>>;
-  overflow?: ResponsiveStyle<Property.Overflow>;
+  overflow?: ResponsiveStyle<StyleToken<Property.Overflow>>;
   padding?: ResponsiveStyle<StyleToken<Property.Padding>>;
-  position?: ResponsiveStyle<Property.Position>;
+  position?: ResponsiveStyle<StyleToken<Property.Position>>;
   right?: ResponsiveStyle<StyleToken<Property.Right>>;
-  textAlign?: ResponsiveStyle<Property.TextAlign>;
-  textDecoration?: ResponsiveStyle<Property.TextDecoration>;
-  textTransform?: ResponsiveStyle<Property.TextTransform>;
+  textAlign?: ResponsiveStyle<StyleToken<Property.TextAlign>>;
+  textDecoration?: ResponsiveStyle<StyleToken<Property.TextDecoration>>;
+  textTransform?: ResponsiveStyle<StyleToken<Property.TextTransform>>;
   top?: ResponsiveStyle<StyleToken<Property.Top>>;
   transform?: ResponsiveStyle<StyleToken<Property.Transform>>;
-  transformOrigin?: ResponsiveStyle<Property.TransformOrigin>;
+  transformOrigin?: ResponsiveStyle<StyleToken<Property.TransformOrigin>>;
   width?: ResponsiveStyle<StyleToken<Property.Width>>;
 }
 

--- a/packages/react/src/primitives/types/style.ts
+++ b/packages/react/src/primitives/types/style.ts
@@ -47,6 +47,7 @@ export interface BaseStyleProps extends FlexItemStyleProps, GridItemStyleProps {
   left?: ResponsiveStyle<Property.Left>;
   letterSpacing?: ResponsiveStyle<Property.LetterSpacing>;
   lineHeight?: ResponsiveStyle<Property.LineHeight>;
+  margin?: ResponsiveStyle<Property.Margin>;
   maxHeight?: ResponsiveStyle<Property.MaxHeight>;
   maxWidth?: ResponsiveStyle<Property.MaxWidth>;
   minHeight?: ResponsiveStyle<Property.MinHeight>;
@@ -104,9 +105,11 @@ export interface AllStyleProps
     GridContainerStyleProps,
     TextAreaStyleProps {}
 
-export type ComponentPropToStyleProp = {
-  [key in keyof AllStyleProps]: keyof React.CSSProperties;
-};
+export type ComponentPropToStyleProp = Required<
+  {
+    [key in keyof AllStyleProps]: keyof React.CSSProperties;
+  }
+>;
 
 /**
  * Maps from component style props to React `style` props
@@ -135,6 +138,7 @@ export const ComponentPropsToStylePropsMap: ComponentPropToStyleProp = {
   columnStart: 'gridColumnStart',
   direction: 'flexDirection',
   display: 'display',
+  flex: 'flex',
   fontFamily: 'fontFamily',
   fontSize: 'fontSize',
   fontStyle: 'fontStyle',
@@ -146,6 +150,7 @@ export const ComponentPropsToStylePropsMap: ComponentPropToStyleProp = {
   left: 'left',
   letterSpacing: 'letterSpacing',
   lineHeight: 'lineHeight',
+  margin: 'margin',
   maxHeight: 'maxHeight',
   maxWidth: 'maxWidth',
   minHeight: 'minHeight',


### PR DESCRIPTION
*Description of changes:*

1. Adding flex and margin style props
2. Making all props required in `ComponentPropToStyleProp` so that any missing style props in `ComponentPropsToStylePropsMap` will be caught.
3. Adding interface to type `useAmplify` hook explicitly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
