### PR TITLE
primitives: update exports and add displayname

### DIFF
--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -1895,7 +1895,6 @@ describe('@aws-amplify/ui-react', () => {
           "useDataStoreCollection",
           "useDataStoreItem",
           "usePagination",
-          "useSearchField",
           "useTheme",
           "withAuthenticator",
         ]

--- a/packages/react/src/primitives/Alert/Alert.tsx
+++ b/packages/react/src/primitives/Alert/Alert.tsx
@@ -74,3 +74,5 @@ export const Alert: Primitive<AlertProps, typeof Flex> = ({
     )
   );
 };
+
+Alert.displayName = 'Alert';

--- a/packages/react/src/primitives/Alert/AlertIcon.tsx
+++ b/packages/react/src/primitives/Alert/AlertIcon.tsx
@@ -25,3 +25,5 @@ export const AlertIcon: React.FC<AlertIconProps> = ({
       return null;
   }
 };
+
+AlertIcon.displayName = 'AlertIcon';

--- a/packages/react/src/primitives/Alert/index.ts
+++ b/packages/react/src/primitives/Alert/index.ts
@@ -1,1 +1,1 @@
-export * from './Alert';
+export { Alert } from './Alert';

--- a/packages/react/src/primitives/Badge/Badge.tsx
+++ b/packages/react/src/primitives/Badge/Badge.tsx
@@ -21,3 +21,5 @@ export const Badge: Primitive<BadgeProps, 'span'> = ({
     {children}
   </View>
 );
+
+Badge.displayName = 'Badge';

--- a/packages/react/src/primitives/Badge/index.ts
+++ b/packages/react/src/primitives/Badge/index.ts
@@ -1,1 +1,1 @@
-export * from './Badge';
+export { Badge } from './Badge';

--- a/packages/react/src/primitives/Button/Button.tsx
+++ b/packages/react/src/primitives/Button/Button.tsx
@@ -33,3 +33,5 @@ export const Button: Primitive<ButtonProps, 'button'> = ({
     {isLoading && loadingText ? <span>{loadingText}</span> : children}
   </View>
 );
+
+Button.displayName = 'Button';

--- a/packages/react/src/primitives/Button/index.ts
+++ b/packages/react/src/primitives/Button/index.ts
@@ -1,1 +1,1 @@
-export * from './Button';
+export { Button } from './Button';

--- a/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
@@ -26,3 +26,5 @@ export const ButtonGroup: Primitive<ButtonGroupProps, typeof Flex> = ({
     })}
   </Flex>
 );
+
+ButtonGroup.displayName = 'ButtonGroup';

--- a/packages/react/src/primitives/ButtonGroup/index.ts
+++ b/packages/react/src/primitives/ButtonGroup/index.ts
@@ -1,1 +1,1 @@
-export * from './ButtonGroup';
+export { ButtonGroup } from './ButtonGroup';

--- a/packages/react/src/primitives/Card/Card.tsx
+++ b/packages/react/src/primitives/Card/Card.tsx
@@ -13,3 +13,5 @@ export const Card: Primitive<CardProps, 'div'> = ({
     {children}
   </View>
 );
+
+Card.displayName = 'Card';

--- a/packages/react/src/primitives/Card/index.ts
+++ b/packages/react/src/primitives/Card/index.ts
@@ -1,1 +1,1 @@
-export * from "./Card";
+export { Card } from './Card';

--- a/packages/react/src/primitives/Checkbox/Checkbox.tsx
+++ b/packages/react/src/primitives/Checkbox/Checkbox.tsx
@@ -94,3 +94,5 @@ export const Checkbox: Primitive<CheckboxProps, 'input'> = ({
     </Flex>
   );
 };
+
+Checkbox.displayName = 'Checkbox';

--- a/packages/react/src/primitives/Checkbox/index.ts
+++ b/packages/react/src/primitives/Checkbox/index.ts
@@ -1,1 +1,1 @@
-export * from './Checkbox';
+export { Checkbox } from './Checkbox';

--- a/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
+++ b/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
@@ -69,3 +69,5 @@ export const CheckboxField: Primitive<CheckboxFieldProps, 'input'> = ({
     </Flex>
   );
 };
+
+CheckboxField.displayName = 'CheckboxField';

--- a/packages/react/src/primitives/CheckboxField/index.ts
+++ b/packages/react/src/primitives/CheckboxField/index.ts
@@ -1,1 +1,1 @@
-export * from './CheckboxField';
+export { CheckboxField } from './CheckboxField';

--- a/packages/react/src/primitives/Collection/Collection.tsx
+++ b/packages/react/src/primitives/Collection/Collection.tsx
@@ -113,3 +113,5 @@ export const Collection = <Item,>({
     </Flex>
   );
 };
+
+Collection.displayName = 'Collection';

--- a/packages/react/src/primitives/Collection/index.ts
+++ b/packages/react/src/primitives/Collection/index.ts
@@ -1,1 +1,1 @@
-export * from './Collection';
+export { Collection } from './Collection';

--- a/packages/react/src/primitives/Divider/Divider.tsx
+++ b/packages/react/src/primitives/Divider/Divider.tsx
@@ -18,3 +18,5 @@ export const Divider: Primitive<DividerProps, 'hr'> = ({
     {...rest}
   />
 );
+
+Divider.displayName = 'Divider';

--- a/packages/react/src/primitives/Divider/index.ts
+++ b/packages/react/src/primitives/Divider/index.ts
@@ -1,1 +1,1 @@
-export * from './Divider';
+export { Divider } from './Divider';

--- a/packages/react/src/primitives/Field/FieldClearButton.tsx
+++ b/packages/react/src/primitives/Field/FieldClearButton.tsx
@@ -12,3 +12,5 @@ export const FieldClearButton: Primitive<FieldClearButtonProps, 'button'> = (
     <IconClose size={props.size} />
   </FieldGroupIconButton>
 );
+
+FieldClearButton.displayName = 'FieldClearButton';

--- a/packages/react/src/primitives/Field/FieldDescription.tsx
+++ b/packages/react/src/primitives/Field/FieldDescription.tsx
@@ -14,3 +14,5 @@ export const FieldDescription: React.FC<FieldDescriptionProps> = ({
     </Text>
   ) : null;
 };
+
+FieldDescription.displayName = 'FieldDescription';

--- a/packages/react/src/primitives/Field/FieldErrorMessage.tsx
+++ b/packages/react/src/primitives/Field/FieldErrorMessage.tsx
@@ -14,3 +14,5 @@ export const FieldErrorMessage: React.FC<FieldErrorMessageProps> = ({
     </Text>
   ) : null;
 };
+
+FieldErrorMessage.displayName = 'FieldErrorMessage';

--- a/packages/react/src/primitives/Field/index.ts
+++ b/packages/react/src/primitives/Field/index.ts
@@ -1,3 +1,3 @@
-export * from './FieldClearButton';
-export * from './FieldDescription';
-export * from './FieldErrorMessage';
+export { FieldClearButton } from './FieldClearButton';
+export { FieldDescription } from './FieldDescription';
+export { FieldErrorMessage } from './FieldErrorMessage';

--- a/packages/react/src/primitives/FieldGroup/FieldGroup.tsx
+++ b/packages/react/src/primitives/FieldGroup/FieldGroup.tsx
@@ -66,3 +66,5 @@ export const FieldGroup: Primitive<FieldGroupOptions, typeof Flex> = ({
     </Flex>
   );
 };
+
+FieldGroup.displayName = 'FieldGroup';

--- a/packages/react/src/primitives/FieldGroup/index.ts
+++ b/packages/react/src/primitives/FieldGroup/index.ts
@@ -1,1 +1,1 @@
-export * from './FieldGroup';
+export { FieldGroup } from './FieldGroup';

--- a/packages/react/src/primitives/FieldGroupIcon/FieldGroupIcon.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/FieldGroupIcon.tsx
@@ -21,3 +21,5 @@ export const FieldGroupIcon: Primitive<FieldGroupIconProps, 'button'> = ({
     </View>
   ) : null;
 };
+
+FieldGroupIcon.displayName = 'FieldGroupIcon';

--- a/packages/react/src/primitives/FieldGroupIcon/FieldGroupIconButton.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/FieldGroupIconButton.tsx
@@ -19,3 +19,5 @@ export const FieldGroupIconButton: React.FC<FieldGroupIconButtonProps> = ({
     {children}
   </FieldGroupIcon>
 );
+
+FieldGroupIconButton.displayName = 'FieldGroupIconButton';

--- a/packages/react/src/primitives/FieldGroupIcon/index.ts
+++ b/packages/react/src/primitives/FieldGroupIcon/index.ts
@@ -1,2 +1,2 @@
-export * from './FieldGroupIcon';
-export * from './FieldGroupIconButton';
+export { FieldGroupIcon } from './FieldGroupIcon';
+export { FieldGroupIconButton } from './FieldGroupIconButton';

--- a/packages/react/src/primitives/Flex/Flex.tsx
+++ b/packages/react/src/primitives/Flex/Flex.tsx
@@ -13,3 +13,5 @@ export const Flex: Primitive<FlexProps, 'div'> = ({
     {children}
   </View>
 );
+
+Flex.displayName = 'Flex';

--- a/packages/react/src/primitives/Flex/index.ts
+++ b/packages/react/src/primitives/Flex/index.ts
@@ -1,1 +1,1 @@
-export * from './Flex';
+export { Flex } from './Flex';

--- a/packages/react/src/primitives/Grid/Grid.tsx
+++ b/packages/react/src/primitives/Grid/Grid.tsx
@@ -13,3 +13,5 @@ export const Grid: Primitive<GridProps, 'div'> = ({
     {children}
   </View>
 );
+
+Grid.displayName = 'Grid';

--- a/packages/react/src/primitives/Grid/index.ts
+++ b/packages/react/src/primitives/Grid/index.ts
@@ -1,1 +1,1 @@
-export * from './Grid';
+export { Grid } from './Grid';

--- a/packages/react/src/primitives/Heading/Heading.tsx
+++ b/packages/react/src/primitives/Heading/Heading.tsx
@@ -33,3 +33,5 @@ export const Heading: Primitive<HeadingProps, HeadingTag> = ({
     {children}
   </View>
 );
+
+Heading.displayName = 'Heading';

--- a/packages/react/src/primitives/Heading/index.ts
+++ b/packages/react/src/primitives/Heading/index.ts
@@ -1,1 +1,1 @@
-export * from './Heading';
+export { Heading } from './Heading';

--- a/packages/react/src/primitives/Icon/Icon.tsx
+++ b/packages/react/src/primitives/Icon/Icon.tsx
@@ -29,3 +29,5 @@ export const Icon: Primitive<IconProps, 'svg'> = ({
     </View>
   );
 };
+
+Icon.displayName = 'Icon';

--- a/packages/react/src/primitives/Icon/index.ts
+++ b/packages/react/src/primitives/Icon/index.ts
@@ -1,2 +1,2 @@
-export * from './Icon';
+export { Icon } from './Icon';
 export * from './icons';

--- a/packages/react/src/primitives/Image/Image.tsx
+++ b/packages/react/src/primitives/Image/Image.tsx
@@ -11,3 +11,5 @@ export const Image: Primitive<ImageProps, 'img'> = ({ className, ...rest }) => (
     {...rest}
   />
 );
+
+Image.displayName = 'Image';

--- a/packages/react/src/primitives/Image/index.ts
+++ b/packages/react/src/primitives/Image/index.ts
@@ -1,1 +1,1 @@
-export * from './Image';
+export { Image } from './Image';

--- a/packages/react/src/primitives/Input/Input.tsx
+++ b/packages/react/src/primitives/Input/Input.tsx
@@ -62,3 +62,5 @@ export const Input: Primitive<InputProps, 'input'> = ({
     {...rest}
   />
 );
+
+Input.displayName = 'Input';

--- a/packages/react/src/primitives/Input/index.ts
+++ b/packages/react/src/primitives/Input/index.ts
@@ -1,1 +1,1 @@
-export * from './Input';
+export { Input } from './Input';

--- a/packages/react/src/primitives/Label/Label.tsx
+++ b/packages/react/src/primitives/Label/Label.tsx
@@ -22,3 +22,5 @@ export const Label: Primitive<LabelProps, 'label'> = ({
     </View>
   );
 };
+
+Label.displayName = 'Label';

--- a/packages/react/src/primitives/Label/index.ts
+++ b/packages/react/src/primitives/Label/index.ts
@@ -1,1 +1,1 @@
-export * from './Label';
+export { Label } from './Label';

--- a/packages/react/src/primitives/Link/Link.tsx
+++ b/packages/react/src/primitives/Link/Link.tsx
@@ -23,3 +23,5 @@ export const Link: Primitive<LinkProps, 'a'> = ({
     </View>
   );
 };
+
+Link.displayName = 'Link';

--- a/packages/react/src/primitives/Link/index.ts
+++ b/packages/react/src/primitives/Link/index.ts
@@ -1,1 +1,1 @@
-export * from './Link';
+export { Link } from './Link';

--- a/packages/react/src/primitives/Loader/Loader.tsx
+++ b/packages/react/src/primitives/Loader/Loader.tsx
@@ -74,3 +74,5 @@ export const Loader: Primitive<LoaderProps, 'svg'> = ({
     </View>
   );
 };
+
+Loader.displayName = 'Loader';

--- a/packages/react/src/primitives/Menu/Menu.tsx
+++ b/packages/react/src/primitives/Menu/Menu.tsx
@@ -53,3 +53,5 @@ export const Menu: Primitive<MenuProps, 'div'> = ({
     </DropdownMenuContent>
   </DropdownMenu>
 );
+
+Menu.displayName = 'Menu';

--- a/packages/react/src/primitives/Menu/MenuButton.tsx
+++ b/packages/react/src/primitives/Menu/MenuButton.tsx
@@ -50,3 +50,5 @@ export const MenuButton = React.forwardRef<
     );
   }
 );
+
+MenuButton.displayName = 'MenuButton';

--- a/packages/react/src/primitives/Menu/MenuItem.tsx
+++ b/packages/react/src/primitives/Menu/MenuItem.tsx
@@ -24,3 +24,5 @@ export const MenuItem = React.forwardRef<HTMLDivElement, MenuItemProps>(
     );
   }
 );
+
+MenuItem.displayName = 'MenuItem';

--- a/packages/react/src/primitives/Pagination/Pagination.tsx
+++ b/packages/react/src/primitives/Pagination/Pagination.tsx
@@ -37,3 +37,5 @@ export const Pagination: Primitive<PaginationProps, 'nav'> = ({
     </View>
   );
 };
+
+Pagination.displayName = 'Pagination';

--- a/packages/react/src/primitives/Pagination/PaginationItem.tsx
+++ b/packages/react/src/primitives/Pagination/PaginationItem.tsx
@@ -107,3 +107,5 @@ export const PaginationItem: React.FC<PaginationItemProps> = ({
   }
   return <View as="li" />;
 };
+
+PaginationItem.displayName = 'PaginationItem';

--- a/packages/react/src/primitives/Pagination/index.ts
+++ b/packages/react/src/primitives/Pagination/index.ts
@@ -1,2 +1,2 @@
-export * from './Pagination';
-export * from './usePagination';
+export { Pagination } from './Pagination';
+export { usePagination } from './usePagination';

--- a/packages/react/src/primitives/PasswordField/PasswordField.tsx
+++ b/packages/react/src/primitives/PasswordField/PasswordField.tsx
@@ -45,3 +45,5 @@ export const PasswordField: Primitive<PasswordFieldProps, 'input'> = ({
     />
   );
 };
+
+PasswordField.displayName = 'PasswordField';

--- a/packages/react/src/primitives/PasswordField/ShowPasswordButton.tsx
+++ b/packages/react/src/primitives/PasswordField/ShowPasswordButton.tsx
@@ -32,3 +32,5 @@ export const ShowPasswordButton: React.FC<ShowPasswordButtonProps> = ({
     </Button>
   );
 };
+
+ShowPasswordButton.displayName = 'ShowPasswordButton';

--- a/packages/react/src/primitives/PasswordField/index.ts
+++ b/packages/react/src/primitives/PasswordField/index.ts
@@ -1,1 +1,1 @@
-export * from './PasswordField';
+export { PasswordField } from './PasswordField';

--- a/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
@@ -31,3 +31,5 @@ export const CountryCodeSelect: Primitive<CountryCodeSelectProps, 'select'> = ({
     </SelectField>
   );
 };
+
+CountryCodeSelect.displayName = 'CountryCodeSelect';

--- a/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
@@ -49,3 +49,5 @@ export const PhoneNumberField: Primitive<PhoneNumberFieldProps, 'input'> = ({
     />
   );
 };
+
+PhoneNumberField.displayName = 'PhoneNumberField';

--- a/packages/react/src/primitives/PhoneNumberField/index.ts
+++ b/packages/react/src/primitives/PhoneNumberField/index.ts
@@ -1,1 +1,1 @@
-export * from './PhoneNumberField';
+export { PhoneNumberField } from './PhoneNumberField';

--- a/packages/react/src/primitives/Placeholder/Placeholder.tsx
+++ b/packages/react/src/primitives/Placeholder/Placeholder.tsx
@@ -23,3 +23,5 @@ export const Placeholder: Primitive<PlaceholderProps, 'div'> = ({
     />
   );
 };
+
+Placeholder.displayName = 'Placeholder';

--- a/packages/react/src/primitives/Placeholder/index.ts
+++ b/packages/react/src/primitives/Placeholder/index.ts
@@ -1,1 +1,1 @@
-export * from './Placeholder';
+export { Placeholder } from './Placeholder';

--- a/packages/react/src/primitives/Radio/Radio.tsx
+++ b/packages/react/src/primitives/Radio/Radio.tsx
@@ -81,3 +81,5 @@ export const Radio: Primitive<RadioProps, 'input'> = ({
     </Flex>
   );
 };
+
+Radio.displayName = 'Radio';

--- a/packages/react/src/primitives/Radio/index.ts
+++ b/packages/react/src/primitives/Radio/index.ts
@@ -1,1 +1,1 @@
-export * from './Radio';
+export { Radio } from './Radio';

--- a/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
+++ b/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
@@ -86,3 +86,5 @@ export const RadioGroupField: Primitive<RadioGroupFieldProps, typeof Flex> = ({
     </Flex>
   );
 };
+
+RadioGroupField.displayName = 'RadioGroupField';

--- a/packages/react/src/primitives/RadioGroupField/index.ts
+++ b/packages/react/src/primitives/RadioGroupField/index.ts
@@ -1,1 +1,1 @@
-export * from './RadioGroupField';
+export { RadioGroupField } from './RadioGroupField';

--- a/packages/react/src/primitives/Rating/Rating.tsx
+++ b/packages/react/src/primitives/Rating/Rating.tsx
@@ -68,3 +68,5 @@ export const Rating: Primitive<RatingProps, typeof Flex> = ({
     </Flex>
   );
 };
+
+Rating.displayName = 'Rating';

--- a/packages/react/src/primitives/Rating/RatingIcon.tsx
+++ b/packages/react/src/primitives/Rating/RatingIcon.tsx
@@ -24,3 +24,5 @@ export const RatingIcon: React.FC<RatingIconProps> = ({
     </View>
   );
 };
+
+RatingIcon.displayName = 'RatingIcon';

--- a/packages/react/src/primitives/Rating/RatingMixedIcon.tsx
+++ b/packages/react/src/primitives/Rating/RatingMixedIcon.tsx
@@ -51,3 +51,5 @@ export const RatingMixedIcon: React.FC<RatingMixedIconProps> = ({
     </View>
   );
 };
+
+RatingMixedIcon.displayName = 'RatingMixedIcon';

--- a/packages/react/src/primitives/Rating/index.ts
+++ b/packages/react/src/primitives/Rating/index.ts
@@ -1,1 +1,1 @@
-export * from './Rating';
+export { Rating } from './Rating';

--- a/packages/react/src/primitives/ScrollView/ScrollView.tsx
+++ b/packages/react/src/primitives/ScrollView/ScrollView.tsx
@@ -18,3 +18,5 @@ export const ScrollView: Primitive<ScrollViewProps, 'div'> = ({
     {children}
   </View>
 );
+
+ScrollView.displayName = 'ScrollView';

--- a/packages/react/src/primitives/ScrollView/index.ts
+++ b/packages/react/src/primitives/ScrollView/index.ts
@@ -1,1 +1,1 @@
-export * from './ScrollView';
+export { ScrollView } from './ScrollView';

--- a/packages/react/src/primitives/SearchField/SearchField.tsx
+++ b/packages/react/src/primitives/SearchField/SearchField.tsx
@@ -113,3 +113,5 @@ export const SearchField: Primitive<SearchFieldProps, 'input'> = ({
     />
   );
 };
+
+SearchField.displayName = 'SearchField';

--- a/packages/react/src/primitives/SearchField/SearchFieldButton.tsx
+++ b/packages/react/src/primitives/SearchField/SearchFieldButton.tsx
@@ -20,3 +20,5 @@ export const SearchFieldButton: Primitive<SearchFieldButtonProps, 'button'> = (
     </FieldGroupIconButton>
   );
 };
+
+SearchFieldButton.displayName = 'SearchFieldButton';

--- a/packages/react/src/primitives/SearchField/index.ts
+++ b/packages/react/src/primitives/SearchField/index.ts
@@ -1,1 +1,1 @@
-export * from './SearchField';
+export { SearchField } from './SearchField';

--- a/packages/react/src/primitives/Select/Select.tsx
+++ b/packages/react/src/primitives/Select/Select.tsx
@@ -64,3 +64,5 @@ export const Select: Primitive<SelectProps, 'select'> = ({
     </View>
   );
 };
+
+Select.displayName = 'Select';

--- a/packages/react/src/primitives/Select/index.ts
+++ b/packages/react/src/primitives/Select/index.ts
@@ -1,1 +1,1 @@
-export * from './Select';
+export { Select } from './Select';

--- a/packages/react/src/primitives/SelectField/SelectField.tsx
+++ b/packages/react/src/primitives/SelectField/SelectField.tsx
@@ -86,3 +86,5 @@ export const SelectField: Primitive<SelectFieldProps, 'select'> = (props) => {
     </Flex>
   );
 };
+
+SelectField.displayName = 'SelectField';

--- a/packages/react/src/primitives/SelectField/index.ts
+++ b/packages/react/src/primitives/SelectField/index.ts
@@ -1,1 +1,1 @@
-export * from './SelectField';
+export { SelectField } from './SelectField';

--- a/packages/react/src/primitives/SliderField/SliderField.tsx
+++ b/packages/react/src/primitives/SliderField/SliderField.tsx
@@ -133,3 +133,5 @@ export const SliderField: Primitive<SliderFieldProps, typeof Root> = ({
     </Flex>
   );
 };
+
+SliderField.displayName = 'SliderField';

--- a/packages/react/src/primitives/StepperField/StepperField.tsx
+++ b/packages/react/src/primitives/StepperField/StepperField.tsx
@@ -129,3 +129,5 @@ export const StepperField: Primitive<StepperFieldProps, 'input'> = (props) => {
     </Flex>
   );
 };
+
+StepperField.displayName = 'StepperField';

--- a/packages/react/src/primitives/SwitchField/SwitchField.tsx
+++ b/packages/react/src/primitives/SwitchField/SwitchField.tsx
@@ -91,3 +91,5 @@ export const SwitchField: Primitive<SwitchFieldProps, typeof Flex> = ({
     </Flex>
   );
 };
+
+SwitchField.displayName = 'SwitchField';

--- a/packages/react/src/primitives/SwitchField/index.ts
+++ b/packages/react/src/primitives/SwitchField/index.ts
@@ -1,1 +1,1 @@
-export * from './SwitchField';
+export { SwitchField } from './SwitchField';

--- a/packages/react/src/primitives/Tabs/Tabs.tsx
+++ b/packages/react/src/primitives/Tabs/Tabs.tsx
@@ -10,6 +10,7 @@ import { Flex } from '../Flex';
 import { ComponentClassNames } from '../shared/constants';
 import classNames from 'classnames';
 import { convertStylePropsToStyleObj, prefixer } from '../shared/styleUtils';
+import { Primitive } from '../types';
 
 const isTabsType = (child: any): child is React.Component<TabItemProps> => {
   return (
@@ -19,11 +20,8 @@ const isTabsType = (child: any): child is React.Component<TabItemProps> => {
     child.props.children != null
   );
 };
-export interface Tabs {
-  (props: TabsProps): React.ReactComponentElement<any>;
-}
 
-export const Tabs: Tabs = ({
+export const Tabs: Primitive<TabsProps, typeof Flex> = ({
   alignContent,
   alignItems,
   ariaLabel,
@@ -39,7 +37,7 @@ export const Tabs: Tabs = ({
   justifyContent,
   wrap,
   ...rest
-}) => {
+}: TabsProps) => {
   const tabs = React.Children.map(children, (child) => {
     if (!isTabsType(child)) {
       console.warn(
@@ -99,3 +97,6 @@ export const Tabs: Tabs = ({
 };
 
 export const TabItem: React.FC<TabItemProps> = () => <></>;
+
+Tabs.displayName = 'Tabs';
+TabItem.displayName = 'TabItem';

--- a/packages/react/src/primitives/Tabs/index.ts
+++ b/packages/react/src/primitives/Tabs/index.ts
@@ -1,1 +1,1 @@
-export * from './Tabs';
+export { Tabs, TabItem } from './Tabs';

--- a/packages/react/src/primitives/Text/Text.tsx
+++ b/packages/react/src/primitives/Text/Text.tsx
@@ -22,3 +22,5 @@ export const Text: Primitive<TextProps, 'p'> = ({
     {children}
   </View>
 );
+
+Text.displayName = 'Text';

--- a/packages/react/src/primitives/Text/index.ts
+++ b/packages/react/src/primitives/Text/index.ts
@@ -1,1 +1,1 @@
-export * from './Text';
+export { Text } from './Text';

--- a/packages/react/src/primitives/TextArea/TextArea.tsx
+++ b/packages/react/src/primitives/TextArea/TextArea.tsx
@@ -30,3 +30,5 @@ export const TextArea: Primitive<TextAreaProps, 'textarea'> = ({
     {...rest}
   />
 );
+
+TextArea.displayName = 'TextArea';

--- a/packages/react/src/primitives/TextArea/index.ts
+++ b/packages/react/src/primitives/TextArea/index.ts
@@ -1,1 +1,1 @@
-export * from './TextArea';
+export { TextArea } from './TextArea';

--- a/packages/react/src/primitives/TextField/TextField.tsx
+++ b/packages/react/src/primitives/TextField/TextField.tsx
@@ -109,3 +109,5 @@ export const TextField = <Multiline extends boolean>(
     </Flex>
   );
 };
+
+TextField.displayName = 'TextField';

--- a/packages/react/src/primitives/ToggleButton/ToggleButton.tsx
+++ b/packages/react/src/primitives/ToggleButton/ToggleButton.tsx
@@ -40,3 +40,5 @@ export const ToggleButton: Primitive<ToggleButtonProps, typeof Button> = ({
     </Button>
   );
 };
+
+ToggleButton.displayName = 'ToggleButton';

--- a/packages/react/src/primitives/ToggleButton/index.ts
+++ b/packages/react/src/primitives/ToggleButton/index.ts
@@ -1,1 +1,1 @@
-export * from './ToggleButton';
+export { ToggleButton } from './ToggleButton';

--- a/packages/react/src/primitives/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react/src/primitives/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -43,3 +43,5 @@ export const ToggleButtonGroup: Primitive<ToggleButtonGroupProps, typeof Flex> =
       </Flex>
     );
   };
+
+ToggleButtonGroup.displayName = 'ToggleButtonGroup';

--- a/packages/react/src/primitives/ToggleButtonGroup/index.ts
+++ b/packages/react/src/primitives/ToggleButtonGroup/index.ts
@@ -1,1 +1,1 @@
-export * from './ToggleButtonGroup';
+export { ToggleButtonGroup } from './ToggleButtonGroup';

--- a/packages/react/src/primitives/View/index.ts
+++ b/packages/react/src/primitives/View/index.ts
@@ -1,1 +1,1 @@
-export * from './View';
+export { View } from './View';

--- a/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
@@ -18,3 +18,5 @@ export const VisuallyHidden: Primitive<VisuallyHiddenProps, 'span'> = ({
     {children}
   </View>
 );
+
+VisuallyHidden.displayName = 'VisuallyHidden';

--- a/packages/react/src/primitives/VisuallyHidden/index.ts
+++ b/packages/react/src/primitives/VisuallyHidden/index.ts
@@ -1,1 +1,1 @@
-export * from './VisuallyHidden';
+export { VisuallyHidden } from './VisuallyHidden';


### PR DESCRIPTION
*Description of changes:*
This PR updates the following:
* exports and adds a `displayName` for all Primitives. See: [React docs](https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools)
* converts all `export * from './primitive'` exports to named exports to prevent accidentally shipping internal APIs

This work is needed for the React.forwardRef support work, but I wanted to split it out into a separate PR to make it easier to review.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
