### PR TITLE
Add forwardRef support to Button & View

### DIFF
--- a/.changeset/dirty-keys-eat.md
+++ b/.changeset/dirty-keys-eat.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": minor
+---
+
+Add forwardRef support to Button & View

--- a/packages/react/src/primitives/Button/Button.tsx
+++ b/packages/react/src/primitives/Button/Button.tsx
@@ -1,37 +1,47 @@
 import classNames from 'classnames';
+import * as React from 'react';
+
 import { ComponentClassNames } from '../shared/constants';
-import { ButtonProps, Primitive } from '../types';
+import { ButtonProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-export const Button: Primitive<ButtonProps, 'button'> = ({
-  className,
-  children,
-  isFullWidth = false,
-  isDisabled,
-  isLoading,
-  loadingText = '',
-  size,
-  type = 'button',
-  variation,
-  ...rest
-}) => (
-  <View
-    as="button"
-    className={classNames(
-      ComponentClassNames.Button,
-      ComponentClassNames.FieldGroupControl,
-      className
-    )}
-    data-fullwidth={isFullWidth}
-    data-loading={isLoading}
-    data-size={size}
-    data-variation={variation}
-    isDisabled={isDisabled || isLoading}
-    type={type}
-    {...rest}
-  >
-    {isLoading && loadingText ? <span>{loadingText}</span> : children}
-  </View>
-);
+export const ButtonInner: PrimitiveWithForwardRef<ButtonProps, 'button'> = (
+  {
+    className,
+    children,
+    isFullWidth = false,
+    isDisabled,
+    isLoading,
+    loadingText = '',
+    size,
+    type = 'button',
+    variation,
+    ...rest
+  },
+  ref
+) => {
+  return (
+    <View
+      ref={ref}
+      as="button"
+      className={classNames(
+        ComponentClassNames.Button,
+        ComponentClassNames.FieldGroupControl,
+        className
+      )}
+      data-fullwidth={isFullWidth}
+      data-loading={isLoading}
+      data-size={size}
+      data-variation={variation}
+      isDisabled={isDisabled || isLoading}
+      type={type}
+      {...rest}
+    >
+      {isLoading && loadingText ? <span>{loadingText}</span> : children}
+    </View>
+  );
+};
+
+export const Button = React.forwardRef(ButtonInner);
 
 Button.displayName = 'Button';

--- a/packages/react/src/primitives/Button/Button.tsx
+++ b/packages/react/src/primitives/Button/Button.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared/constants';
 import { ButtonProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-export const ButtonInner: PrimitiveWithForwardRef<ButtonProps, 'button'> = (
+const ButtonInner: PrimitiveWithForwardRef<ButtonProps, 'button'> = (
   {
     className,
     children,

--- a/packages/react/src/primitives/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/primitives/Button/__tests__/Button.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -11,6 +12,17 @@ describe('Button test suite', () => {
 
     const button = await screen.findByRole('button');
     expect(button).toHaveClass(ComponentClassNames.Button, className);
+  });
+
+  it('should forward ref to button DOM element', async () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const buttonText = 'Hello there';
+
+    render(<Button ref={ref}>{buttonText}</Button>);
+
+    await screen.findByRole('button');
+    expect(ref.current.nodeName).toBe('BUTTON');
+    expect(ref.current.innerHTML).toBe(buttonText);
   });
 
   it('should set size and variation props correctly', async () => {

--- a/packages/react/src/primitives/View/View.tsx
+++ b/packages/react/src/primitives/View/View.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNonStyleProps, usePropStyles } from '../shared/styleUtils';
 import { ElementType, PrimitivePropsWithRef, ViewProps } from '../types';
 
-export const ViewInner = <Element extends ElementType = 'div'>(
+const ViewInner = <Element extends ElementType = 'div'>(
   {
     as = 'div',
     className,

--- a/packages/react/src/primitives/View/View.tsx
+++ b/packages/react/src/primitives/View/View.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
 import { useNonStyleProps, usePropStyles } from '../shared/styleUtils';
-import { ElementType, PrimitiveProps, ViewProps } from '../types';
+import { ElementType, PrimitivePropsWithRef, ViewProps } from '../types';
 
-export const View = <Element extends ElementType = 'div'>({
-  as = 'div',
-  className,
-  children,
-  role,
-  id,
-  testId,
-  ariaLabel,
-  isDisabled,
-  style,
-  ...rest
-}: PrimitiveProps<ViewProps, Element>) => {
+export const ViewInner = <Element extends ElementType = 'div'>(
+  {
+    as = 'div',
+    className,
+    children,
+    role,
+    id,
+    testId,
+    ariaLabel,
+    isDisabled,
+    style,
+    ...rest
+  }: PrimitivePropsWithRef<ViewProps, Element>,
+  ref?: React.ForwardedRef<HTMLElement>
+) => {
   const propStyles = usePropStyles(rest, style);
   const nonStyleProps = useNonStyleProps(rest);
 
@@ -26,9 +29,14 @@ export const View = <Element extends ElementType = 'div'>({
       disabled: isDisabled,
       id,
       role,
+      ref,
       style: propStyles,
       ...nonStyleProps,
     },
     children
   );
 };
+
+export const View = React.forwardRef(ViewInner);
+
+View.displayName = 'View';

--- a/packages/react/src/primitives/View/__tests__/View.test.tsx
+++ b/packages/react/src/primitives/View/__tests__/View.test.tsx
@@ -1,7 +1,10 @@
-import { View } from '../View';
-import { render, screen } from '@testing-library/react';
-import { ComponentPropsToStylePropsMap } from '../../types';
+import * as React from 'react';
+
 import { kebabCase } from 'lodash';
+import { render, screen } from '@testing-library/react';
+
+import { ComponentPropsToStylePropsMap } from '../../types';
+import { View } from '../View';
 
 describe('View: ', () => {
   const viewText = 'Hello from inside a view';
@@ -20,6 +23,17 @@ describe('View: ', () => {
     expect(view.dataset['testid']).toBe(viewTestId);
     expect(view.innerHTML).toBe(viewText);
     expect(view.nodeName).toBe('DIV');
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const text = 'Hello there';
+
+    render(<View ref={ref}>{text}</View>);
+
+    await screen.findByText(text);
+    expect(ref.current.nodeName).toBe('DIV');
+    expect(ref.current.innerHTML).toBe(text);
   });
 
   it('can render a <button> HTML element', async () => {

--- a/packages/react/src/primitives/types/view.ts
+++ b/packages/react/src/primitives/types/view.ts
@@ -7,6 +7,20 @@ type MergeProps<A, B> = A & Omit<B, keyof A>;
 
 export type ElementType = React.FC<any> | keyof JSX.IntrinsicElements;
 
+/**
+ * Convert string element type to DOMElement Type
+ * e.g. 'button' => HTMLButtonElement
+ */
+export type HTMLElementType<Element extends ElementType> =
+  Element extends keyof JSX.IntrinsicElements
+    ? JSX.IntrinsicElements[Element] extends React.DetailedHTMLProps<
+        unknown,
+        infer HTMLType
+      >
+      ? HTMLType
+      : never
+    : HTMLDivElement;
+
 export type ElementProps<Element extends ElementType> =
   Element extends keyof JSX.IntrinsicElements
     ? JSX.IntrinsicElements[Element]
@@ -18,14 +32,31 @@ export type PrimitiveProps<
   Props extends ViewProps,
   Element extends ElementType
 > = MergeProps<
-  Omit<Props, 'as'> & { as?: Element | Props['as'] },
-  ElementProps<Element>
+  Omit<Props, 'as'> & {
+    as?: Element | Props['as'];
+  },
+  Omit<ElementProps<Element>, 'ref'> // exclude `ref?: LegacyRef` included in DetailedHTMLProps
 >;
+
+export type PrimitivePropsWithRef<
+  Props extends ViewProps,
+  Element extends ElementType
+> = PrimitiveProps<Props, Element> & {
+  ref?: React.Ref<HTMLElementType<Element>>;
+};
 
 export type Primitive<
   Props extends ViewProps,
   Element extends ElementType
 > = React.FC<PrimitiveProps<Props, Element>>;
+
+export type PrimitiveWithForwardRef<
+  Props extends ViewProps,
+  Element extends ElementType
+> = React.ForwardRefRenderFunction<
+  HTMLElementType<Element>,
+  PrimitivePropsWithRef<Props, Element>
+>;
 
 export interface ViewProps
   extends BaseComponentProps,


### PR DESCRIPTION
*Description of changes:*
This PR adds React.forwardRef support to the Button and View primitives to start. I'm not including all the primitive components in this PR for ease of review. When approved, I will cut follow up PRs for the other primitives.

*Why this PR*
React offers the `ref` API as a way to access the underlying DOM element for a component. This PR forwards a ref attached on one of the Amplify UI primitives down to the underlying element. This allows customers to have an escape hatch to manage focus, animations, check if an element is in viewport, etc.

Example:

```tsx
const CustomerComponent = () =>{
  const ref = React.useRef<HTMLButtonElement>(null);
  
  // In response to some other app action, force focus on button:
  // ref.current.focus();
  
  return(
    <Button ref={ref>Hello</Button>
  )
}

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
