### PR TITLE
refactor: removing labelled by children in favor of label prop

### DIFF
--- a/.changeset/bump-versions.md
+++ b/.changeset/bump-versions.md
@@ -23,11 +23,10 @@
             <CheckboxField
               errorMessage={validationErrors.acknowledgement}
               hasError={!!validationErrors.acknowledgement}
+              label="I agree with the Terms & Conditions"
               name="acknowledgement"
               value="yes"
-            >
-              I agree with the Terms & Conditions
-            </CheckboxField>
+            />
           </>
         );
       },

--- a/docs/src/components/CheckboxFieldPropControls.tsx
+++ b/docs/src/components/CheckboxFieldPropControls.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import {
   CheckboxField,
@@ -17,6 +17,9 @@ export interface CheckboxFieldPropControlsProps extends CheckboxFieldProps {
     value: React.SetStateAction<CheckboxFieldProps['isDisabled']>
   ) => void;
   setLabel: (value: React.SetStateAction<CheckboxFieldProps['label']>) => void;
+  setLabelHidden: (
+    value: React.SetStateAction<CheckboxFieldProps['labelHidden']>
+  ) => void;
   setSize: (value: React.SetStateAction<CheckboxFieldProps['size']>) => void;
 }
 
@@ -29,6 +32,8 @@ export const CheckboxFieldPropControls: CheckboxFieldPropControlsInterface = ({
   setIsDisabled,
   label,
   setLabel,
+  labelHidden,
+  setLabelHidden,
   size,
   setSize,
 }) => {
@@ -40,7 +45,7 @@ export const CheckboxFieldPropControls: CheckboxFieldPropControlsInterface = ({
           name="label"
           label="label"
           labelHidden
-          value={label}
+          value={label as string}
           onChange={(e) =>
             setLabel(e.target.value as CheckboxFieldProps['label'])
           }
@@ -67,9 +72,15 @@ export const CheckboxFieldPropControls: CheckboxFieldPropControlsInterface = ({
         value="true"
         checked={isDisabled}
         onChange={(e) => setIsDisabled(e.target.checked)}
-      >
-        isDisabled
-      </CheckboxField>
+        label="isDisabled"
+      />
+      <CheckboxField
+        name="label-hidden"
+        value="true"
+        checked={labelHidden}
+        onChange={(e) => setLabelHidden(e.target.checked)}
+        label="labelHidden"
+      />
     </DemoBox>
   );
 };

--- a/docs/src/components/ExpanderPropControls.tsx
+++ b/docs/src/components/ExpanderPropControls.tsx
@@ -39,9 +39,8 @@ export const ExpanderPropControls: React.FC<ExpanderPropControlsProps> = ({
           checked={isCollapsible}
           value="yes"
           onChange={(event) => setIsCollapsible(event.target.checked)}
-        >
-          isCollapsible
-        </CheckboxField>
+          label="isCollapsible"
+        />
       ) : null}
     </DemoBox>
   );

--- a/docs/src/components/SliderFieldPropControls.tsx
+++ b/docs/src/components/SliderFieldPropControls.tsx
@@ -149,25 +149,22 @@ export const SliderFieldPropControls: React.FC<SliderFieldPropControlsProps> =
           value="yes"
           checked={isDisabled}
           onChange={(event) => setIsDisabled(event.target.checked)}
-        >
-          isDisabled
-        </CheckboxField>
+          label="isDisabled"
+        />
         <CheckboxField
           name="value-hidden"
           value="yes"
           checked={isValueHidden}
           onChange={(event) => setIsValueHidden(event.target.checked)}
-        >
-          isValueHidden
-        </CheckboxField>
+          label="isValueHidden"
+        />
         <CheckboxField
           name="label-hidden"
           value="yes"
           checked={labelHidden}
           onChange={(event) => setLabelHidden(event.target.checked)}
-        >
-          labelHidden
-        </CheckboxField>
+          label="labelHidden"
+        />
       </DemoBox>
     );
   };

--- a/docs/src/components/StepperFieldPropControls.tsx
+++ b/docs/src/components/StepperFieldPropControls.tsx
@@ -83,8 +83,7 @@ export const StepperFieldPropControls: React.FC<StepperFieldPropControlsProps> =
         value="yes"
         checked={labelHidden}
         onChange={(event) => setLabelHidden(event.target.checked)}
-      >
-        labelHidden
-      </CheckboxField>
+        label="labelHidden"
+      />
     </DemoBox>
   );

--- a/docs/src/components/ToggleButtonPropControls.tsx
+++ b/docs/src/components/ToggleButtonPropControls.tsx
@@ -60,9 +60,8 @@ export const ToggleButtonPropControls: ToggleButtonPropControlsInterface = ({
         value="yes"
         checked={isDisabled}
         onChange={(event) => setIsDisabled(event.target.checked)}
-      >
-        isDisabled
-      </CheckboxField>
+        label="isDisabled"
+      />
     </DemoBox>
   );
 };

--- a/docs/src/components/useCheckboxFieldProps.tsx
+++ b/docs/src/components/useCheckboxFieldProps.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import * as React from 'react';
 
 import { CheckboxFieldProps } from '@aws-amplify/ui-react';
 
@@ -9,22 +9,25 @@ interface UseCheckboxFieldProps {
 }
 
 export const useCheckboxFieldProps: UseCheckboxFieldProps = (initialValues) => {
-  const [checked, setChecked] = useState<CheckboxFieldProps['checked']>(
+  const [checked, setChecked] = React.useState<CheckboxFieldProps['checked']>(
     initialValues.checked
   );
-  const [isDisabled, setIsDisabled] = useState<
+  const [isDisabled, setIsDisabled] = React.useState<
     CheckboxFieldProps['isDisabled']
   >(initialValues.isDisabled);
-  const [label, setLabel] = useState<CheckboxFieldProps['label']>(
+  const [label, setLabel] = React.useState<CheckboxFieldProps['label']>(
     initialValues.label
   );
-  const [name, setName] = useState<CheckboxFieldProps['name']>(
+  const [labelHidden, setLabelHidden] = React.useState<
+    CheckboxFieldProps['labelHidden']
+  >(initialValues.labelHidden);
+  const [name, setName] = React.useState<CheckboxFieldProps['name']>(
     initialValues.size
   );
-  const [size, setSize] = useState<CheckboxFieldProps['size']>(
+  const [size, setSize] = React.useState<CheckboxFieldProps['size']>(
     initialValues.size
   );
-  const [value, setValue] = useState<CheckboxFieldProps['value']>(
+  const [value, setValue] = React.useState<CheckboxFieldProps['value']>(
     initialValues.size
   );
 
@@ -36,6 +39,8 @@ export const useCheckboxFieldProps: UseCheckboxFieldProps = (initialValues) => {
     setIsDisabled,
     label,
     setLabel,
+    labelHidden,
+    setLabelHidden,
     name,
     setName,
     size,

--- a/docs/src/pages/components/authenticator/index.page.mdx
+++ b/docs/src/pages/components/authenticator/index.page.mdx
@@ -414,9 +414,8 @@ The following example customizes the Sign Up screen with:
                 hasError={!!validationErrors.acknowledgement}
                 name="acknowledgement"
                 value="yes"
-              >
-                I agree with the Terms & Conditions
-              </CheckboxField>
+                label="I agree with the Terms & Conditions"
+              />
             </>
           );
         },

--- a/docs/src/pages/components/checkboxfield/demo.tsx
+++ b/docs/src/pages/components/checkboxfield/demo.tsx
@@ -1,15 +1,11 @@
-import React, { useState } from 'react';
-
 import { CheckboxField, Flex } from '@aws-amplify/ui-react';
 
 import { CheckboxFieldPropControls } from '@/components/CheckboxFieldPropControls';
 import { useCheckboxFieldProps } from '@/components/useCheckboxFieldProps';
 
-export const Demo: React.FC = () => {
-  const label = 'Subscribe';
+export const Demo = () => {
   const props = useCheckboxFieldProps({
-    label,
-    children: label,
+    label: 'Subscribe',
     name: 'subscribe',
     value: 'yes',
   });
@@ -21,9 +17,9 @@ export const Demo: React.FC = () => {
         value={props.value}
         isDisabled={props.isDisabled}
         size={props.size}
-      >
-        {props.label}
-      </CheckboxField>
+        label={props.label}
+        labelHidden={props.labelHidden}
+      />
     </Flex>
   );
 };

--- a/docs/src/pages/components/checkboxfield/examples/controlledExample.tsx
+++ b/docs/src/pages/components/checkboxfield/examples/controlledExample.tsx
@@ -1,17 +1,16 @@
-import React, { useState } from 'react';
+import * as React from 'react';
 
 import { CheckboxField } from '@aws-amplify/ui-react';
 
-export const ControlledCheckbox: React.FC = () => {
-  const [checked, setChecked] = useState(false);
+export const ControlledCheckbox = () => {
+  const [checked, setChecked] = React.useState(false);
   return (
     <CheckboxField
       name="subscribe-controlled"
       value="yes"
       checked={checked}
       onChange={(e) => setChecked(e.target.checked)}
-    >
-      Subscribe
-    </CheckboxField>
+      label="Subscribe"
+    />
   );
 };

--- a/docs/src/pages/components/checkboxfield/examples/valueExample.tsx
+++ b/docs/src/pages/components/checkboxfield/examples/valueExample.tsx
@@ -1,0 +1,15 @@
+import { CheckboxField, Button } from '@aws-amplify/ui-react';
+import * as React from 'react';
+
+export const ValueExample = () => {
+  const onSubmit = (event) => {
+    event.preventDefault();
+    alert(event.target.subscribe.value);
+  };
+  return (
+    <form onSubmit={onSubmit}>
+      <CheckboxField label="Subscribe" name="subscribe" value="yes" />
+      <Button type="submit">Submit</Button>
+    </form>
+  );
+};

--- a/docs/src/pages/components/checkboxfield/react.mdx
+++ b/docs/src/pages/components/checkboxfield/react.mdx
@@ -1,8 +1,10 @@
 import { CheckboxField } from '@aws-amplify/ui-react';
 
-import { ControlledCheckbox } from './examples';
+import { ControlledCheckbox } from './examples/controlledExample';
+import { ValueExample } from './examples/valueExample';
 import { Demo } from './demo';
 import { Example } from '@/components/Example';
+import { Fragment } from '@/components/Fragment';
 
 CheckboxField is used to mark an individual item as selected, or to select multiple items from a list of individual items.
 
@@ -14,46 +16,22 @@ CheckboxField is used to mark an individual item as selected, or to select multi
 
 ## Usage
 
-Import the CheckboxField primitive and styles.
+Import the CheckboxField primitive.
 
 ```jsx
 import { CheckboxField } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
 
-<CheckboxField name="subscribe" value="yes">
-  Subscribe
-</CheckboxField>;
+<CheckboxField label="Subscribe" name="subscribe" value="yes" />;
 ```
 
 <Example>
-  <CheckboxField name="subscribe" value="yes">
-    {'Subscribe'}
-  </CheckboxField>
+  <CheckboxField label="Subscribe" name="subscribe" value="yes" />
 </Example>
 
 ### Controlled component
 
-```jsx
-import { useState } from 'react';
-import { CheckboxField } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
+```tsx file=./examples/controlledExample.tsx
 
-const ControlledCheckbox = () => {
-  const [checked, setChecked] = useState(false);
-
-  return (
-    <CheckboxField
-      name="subscribe-controlled"
-      value="yes"
-      checked={checked}
-      onChange={(e) => setChecked(e.target.checked)}
-    >
-      Subscribe
-    </CheckboxField>
-  );
-};
-
-<ControlledCheckbox />;
 ```
 
 <Example>
@@ -66,46 +44,29 @@ Use the `size` prop to change the SelectField size. Available options are `small
 
 ```jsx
 import { CheckboxField } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
 
-<CheckboxField name="subscribe" value="yes" size="small">
-  Subscribe
-</CheckboxField>
-<CheckboxField name="subscribe" value="yes">
-  Subscribe
-</CheckboxField>
-<CheckboxField name="subscribe" value="yes" size="large">
-  Subscribe
-</CheckboxField>
+<CheckboxField label="Subscribe" name="subscribe" value="yes" size="small" />
+<CheckboxField label="Subscribe" name="subscribe" value="yes" />
+<CheckboxField label="Subscribe" name="subscribe" value="yes" size="large" />
 ```
 
 <Example>
-  <CheckboxField name="subscribe" value="yes" size="small">
-    {'Subscribe'}
-  </CheckboxField>
-  <CheckboxField name="subscribe" value="yes">
-    {'Subscribe'}
-  </CheckboxField>
-  <CheckboxField name="subscribe" value="yes" size="large">
-    {'Subscribe'}
-  </CheckboxField>
+  <CheckboxField label="Subscribe" name="subscribe" value="yes" size="small" />
+  <CheckboxField label="Subscribe" name="subscribe" value="yes" />
+  <CheckboxField label="Subscribe" name="subscribe" value="yes" size="large" />
 </Example>
 
 ### Value
 
 The value associated with the checkbox name in form data, used when submitting an HTML form. If a checkbox is unchecked when its form is submitted, its value will not be submitted. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefvalue).
 
-```jsx
-import { CheckboxField, Button } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
+```tsx file=./examples/valueExample.tsx
 
-<form>
-  <CheckboxField name="subscribe" value="yes">
-    Subscribe
-  </CheckboxField>
-  <Button type="submit">Submit</Button>
-</form>;
 ```
+
+<Example>
+  <ValueExample />
+</Example>
 
 In this example, we've got a name of `subscribe`, and a value of `yes`. When the form is submitted, the data name/value pair will be `subscribe=yes`.
 
@@ -117,23 +78,20 @@ A disabled checkbox will be not be focusable not mutable. A checked checkbox cou
 
 ```jsx
 import { CheckboxField } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
 
-<CheckboxField name="subscribe" value="yes" isDisabled={true}>
-  Subscribe
-</CheckboxField>
-<CheckboxField name="subscribe" value="yes" defaultChecked={true} isDisabled={true}>
-  Subscribe
-</CheckboxField>;
+<CheckboxField label="Subscribe" name="subscribe" value="yes" isDisabled={true} />
+<CheckboxField label="Subscribe" name="subscribe" value="yes" defaultChecked={true} isDisabled={true} />
 ```
 
 <Example>
-  <CheckboxField name="subscribe" value="yes" isDisabled>
-    {'Subscribe'}
-  </CheckboxField>
-  <CheckboxField name="subscribe" value="yes" defaultChecked isDisabled>
-    {'Subscribe'}
-  </CheckboxField>
+  <CheckboxField label="Subscribe" name="subscribe" value="yes" isDisabled />
+  <CheckboxField
+    label="Subscribe"
+    name="subscribe"
+    value="yes"
+    defaultChecked
+    isDisabled
+  />
 </Example>
 
 ### Validation error
@@ -142,22 +100,44 @@ Use the `hasError` and `errorMessage` props to mark a CheckboxField as having an
 
 ```jsx
 import { CheckboxField } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
 
-<CheckboxField name="subscribe" value="yes">
-  Subscribe
-</CheckboxField>;
+<CheckboxField label="Subscribe" name="subscribe" value="yes" />;
 ```
 
 <Example>
   <CheckboxField
+    label="Subscribe"
     name="subscribe"
     value="yes"
     hasError={true}
     errorMessage="This is a required field"
-  >
-    {'Subscribe'}
-  </CheckboxField>
+  />
+</Example>
+
+### Accessibility / Label behavior
+
+<Fragment>{() => import('./../shared/formFieldAccessibility.mdx')}</Fragment>
+
+```jsx
+import { CheckboxField } from '@aws-amplify/ui-react';
+
+<CheckboxField label="Subscribe" name="subscribe" value="yes" />;
+<CheckboxField
+  label="Subscribe"
+  name="subscribe"
+  value="yes"
+  labelHidden={true}
+/>;
+```
+
+<Example>
+  <CheckboxField label="Subscribe" name="subscribe" value="yes" />
+  <CheckboxField
+    label="Subscribe"
+    name="subscribe"
+    value="yes"
+    labelHidden={true}
+  />
 </Example>
 
 ## CSS Styling
@@ -180,12 +160,18 @@ To override styling on all Checkbox icons, you can set the Amplify CSS variables
 ```
 
 <Example>
-  <CheckboxField name="subscribe" value="yes" className="global-css-variable">
-    {'Subscribe'}
-  </CheckboxField>
-  <CheckboxField name="subscribe" value="yes" className="global-class">
-    {'Subscribe'}
-  </CheckboxField>
+  <CheckboxField
+    label="Subscribe"
+    name="subscribe"
+    value="yes"
+    className="global-css-variable"
+  />
+  <CheckboxField
+    label="Subscribe"
+    name="subscribe"
+    value="yes"
+    className="global-class"
+  />
 </Example>
 
 To replace Checkbox icon styling, unset it:
@@ -213,18 +199,23 @@ _Using a class selector:_
 
 ```jsx
 import { CheckboxField } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
 import './styles.css';
 
-<CheckboxField name="subscribe" value="yes" className="custom-checkbox">
-  Subscribe
-</CheckboxField>;
+<CheckboxField
+  label="Subscribe"
+  name="subscribe"
+  value="yes"
+  className="custom-checkbox"
+/>;
 ```
 
 <Example>
-  <CheckboxField name="subscribe" value="yes" className="custom-checkbox">
-    {'Subscribe'}
-  </CheckboxField>
+  <CheckboxField
+    label="Subscribe"
+    name="subscribe"
+    value="yes"
+    className="custom-checkbox"
+  />
 </Example>
 
 _Using data attributes:_
@@ -239,33 +230,28 @@ _Using data attributes:_
 
 ```jsx
 import { CheckboxField } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
 import './styles.css';
 
-<CheckboxField name="subscribe" value="yes">
-  Subscribe
-</CheckboxField>;
+<CheckboxField label="Subscribe" name="subscribe" value="yes" />;
 ```
 
 <Example>
-  <CheckboxField name="subscribe" value="yes" className="custom-data-attribute">
-    {'Subscribe'}
-  </CheckboxField>
+  <CheckboxField
+    label="Subscribe"
+    name="subscribe"
+    value="yes"
+    className="custom-data-attribute"
+  />
 </Example>
 
 _Using style props:_
 
 ```jsx
 import { CheckboxField } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
 
-<CheckboxField name="subscribe" value="yes" gap="1rem">
-  Subscribe
-</CheckboxField>;
+<CheckboxField label="Subscribe" name="subscribe" value="yes" gap="1rem" />;
 ```
 
 <Example>
-  <CheckboxField name="subscribe" value="yes" gap="1rem">
-    {'Subscribe'}
-  </CheckboxField>
+  <CheckboxField label="Subscribe" name="subscribe" value="yes" gap="1rem" />
 </Example>

--- a/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
@@ -38,9 +38,8 @@ export default withAuthenticator(App, {
               hasError={!!validationErrors.acknowledgement}
               name="acknowledgement"
               value="yes"
-            >
-              I agree with the Terms & Conditions
-            </CheckboxField>
+              label="I agree with the Terms & Conditions"
+            />
           </>
         );
       },

--- a/packages/react/src/primitives/Checkbox/Checkbox.tsx
+++ b/packages/react/src/primitives/Checkbox/Checkbox.tsx
@@ -14,12 +14,12 @@ import { useTestId } from '../utils/testUtils';
 
 export const Checkbox: Primitive<CheckboxProps, 'input'> = ({
   checked,
-  children,
   className,
   defaultChecked,
   hasError,
-  id,
   isDisabled,
+  label,
+  labelHidden,
   onChange: onChangeProp,
   size,
   testId,
@@ -54,7 +54,6 @@ export const Checkbox: Primitive<CheckboxProps, 'input'> = ({
           checked={checked}
           className={ComponentClassNames.CheckboxInput}
           defaultChecked={defaultChecked}
-          id={id}
           isDisabled={isDisabled}
           onBlur={onBlur}
           onChange={onChange}
@@ -81,14 +80,14 @@ export const Checkbox: Primitive<CheckboxProps, 'input'> = ({
           size={size}
         />
       </Flex>
-      {children && (
+      {label && !labelHidden && (
         <Text
           as="span"
           className={ComponentClassNames.CheckboxLabel}
           data-disabled={isDisabled}
-          data-testid={labelTestId}
+          testId={labelTestId}
         >
-          {children}
+          {label}
         </Text>
       )}
     </Flex>

--- a/packages/react/src/primitives/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/react/src/primitives/Checkbox/__tests__/Checkbox.test.tsx
@@ -12,15 +12,14 @@ import {
 
 describe('Checkbox test suite', () => {
   const basicProps = {
-    children: 'Subscribe',
+    label: 'Subscribe',
     name: 'testName',
     value: 'testValue',
     testId: 'testId',
   };
 
   const getCheckbox = (props: PrimitiveProps<CheckboxProps, 'input'>) => {
-    const { children, ...rest } = props;
-    return <Checkbox {...rest}>{children}</Checkbox>;
+    return <Checkbox {...props} />;
   };
 
   it('should render basic props correctly', async () => {

--- a/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
+++ b/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
@@ -8,27 +8,12 @@ import { ComponentClassNames } from '../shared';
 import { useTestId } from '../utils/testUtils';
 
 export const CheckboxField: Primitive<CheckboxFieldProps, 'input'> = ({
-  alignContent,
-  alignItems,
-  checked,
-  children,
   className,
-  defaultChecked,
-  direction,
   errorMessage,
-  gap,
   hasError = false,
-  id,
-  isDisabled,
-  isReadOnly,
-  isRequired,
-  justifyContent,
-  name,
-  onChange,
+  labelHidden = false,
   testId,
   size,
-  value,
-  wrap,
   ...rest
 }) => {
   const checkboxTestId = useTestId(testId, ComponentClassNames.Checkbox);
@@ -43,28 +28,11 @@ export const CheckboxField: Primitive<CheckboxFieldProps, 'input'> = ({
       testId={testId}
     >
       <Checkbox
-        alignContent={alignContent}
-        alignItems={alignItems}
-        checked={checked}
-        defaultChecked={defaultChecked}
-        direction={direction}
-        gap={gap}
         hasError={hasError}
-        id={id}
-        isDisabled={isDisabled}
-        isReadOnly={isReadOnly}
-        isRequired={isRequired}
-        justifyContent={justifyContent}
-        name={name}
-        onChange={onChange}
+        labelHidden={labelHidden}
         testId={checkboxTestId}
-        size={size}
-        value={value}
-        wrap={wrap}
         {...rest}
-      >
-        {children}
-      </Checkbox>
+      />
       <FieldErrorMessage hasError={hasError} errorMessage={errorMessage} />
     </Flex>
   );

--- a/packages/react/src/primitives/CheckboxField/__tests__/CheckboxField.test.tsx
+++ b/packages/react/src/primitives/CheckboxField/__tests__/CheckboxField.test.tsx
@@ -8,15 +8,14 @@ import { ComponentClassNames } from '../../shared';
 
 describe('CheckboxField test suite', () => {
   const basicProps = {
-    children: 'Subscribe',
+    label: 'Subscribe',
     name: 'testName',
     value: 'testValue',
     testId: 'testId',
   };
 
   const getCheckboxField = (props: CheckboxFieldProps) => {
-    const { children, ...rest } = props;
-    return <CheckboxField {...rest}>{children}</CheckboxField>;
+    return <CheckboxField {...props} />;
   };
   const ControlledCheckboxField = () => {
     const [checked, setChecked] = useState(false);
@@ -25,9 +24,7 @@ describe('CheckboxField test suite', () => {
         checked={checked}
         onChange={(e) => setChecked(e.target.checked)}
         {...basicProps}
-      >
-        Subscribe
-      </CheckboxField>
+      />
     );
   };
   it('should render default and custom classname', async () => {

--- a/packages/react/src/primitives/types/checkbox.ts
+++ b/packages/react/src/primitives/types/checkbox.ts
@@ -6,7 +6,14 @@ export interface CheckboxProps extends FlexProps, InputProps {
   /**
    * The label text
    */
-  children: FieldProps['label'];
+  label: FieldProps['label'];
+
+  /**
+   * Visually hide label (not recommended in most cases)
+   * @default false
+   */
+  labelHidden?: boolean;
+
   /**
    * The name of the input field in a checkbox (Useful for form submission).
    */

--- a/packages/react/src/primitives/types/checkboxField.ts
+++ b/packages/react/src/primitives/types/checkboxField.ts
@@ -1,6 +1,4 @@
 import { CheckboxProps } from './checkbox';
 import { FieldProps } from './field';
 
-export interface CheckboxFieldProps
-  extends CheckboxProps,
-    Omit<FieldProps, 'label'> {}
+export interface CheckboxFieldProps extends CheckboxProps, FieldProps {}


### PR DESCRIPTION
*Issue #, if available:*

The `CheckboxField` is accepting `children` as label which is inconsistent with other field primitives

*Description of changes:*

Removing labelled by `children` support in favor of passing a `label` prop



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
