### PR TITLE
Angular / Vue , socialProviders, signUpAttributes documentation fix

### DIFF
--- a/docs/src/components/Layout/FrameworkChooser.tsx
+++ b/docs/src/components/Layout/FrameworkChooser.tsx
@@ -23,6 +23,7 @@ export const FrameworkChooser = ({ platform }) => {
       size="small"
       style={{ margin: '0 auto' }}
       onChange={(value: string) => {
+        if (!value) return;
         chooseFramework(value);
       }}
     >

--- a/docs/src/pages/components/authenticator/signUpAttributes.all.angular.mdx
+++ b/docs/src/pages/components/authenticator/signUpAttributes.all.angular.mdx
@@ -1,0 +1,21 @@
+```html{1}
+  <amplify-authenticator [signUpAttributes]="[
+    'address',
+    'birthdate',
+    'email',
+    'family_name',
+    'gender',
+    'given_name',
+    'locale',
+    'middle_name',
+    'name',
+    'nickname',
+    'phone_number',
+    'picture',
+    'preferred_username',
+    'profile',
+    'updated_at',
+    'website',
+    'zoneinfo', ]"
+    ></amplify-authenticator>
+```

--- a/docs/src/pages/components/authenticator/signUpAttributes.all.vue.mdx
+++ b/docs/src/pages/components/authenticator/signUpAttributes.all.vue.mdx
@@ -1,0 +1,23 @@
+```html{2}
+<template>
+  <authenticator :sign-up-attributes="[
+    'address',
+    'birthdate',
+    'email',
+    'family_name',
+    'gender',
+    'given_name',
+    'locale',
+    'middle_name',
+    'name',
+    'nickname',
+    'phone_number',
+    'picture',
+    'preferred_username',
+    'profile',
+    'updated_at',
+    'website',
+    'zoneinfo', ]"
+    />
+</template>
+```

--- a/docs/src/pages/components/authenticator/signUpAttributes.default.angular.mdx
+++ b/docs/src/pages/components/authenticator/signUpAttributes.default.angular.mdx
@@ -1,0 +1,3 @@
+```html{1}
+<amplify-authenticator [signUpAttributes]="[]"></amplify-authenticator>
+```

--- a/docs/src/pages/components/authenticator/signUpAttributes.default.vue.mdx
+++ b/docs/src/pages/components/authenticator/signUpAttributes.default.vue.mdx
@@ -1,0 +1,5 @@
+```html{2}
+<template>
+  <authenticator :sign-up-attributes="[]"/>
+</template>
+```

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
@@ -8,7 +8,11 @@ import {
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { AuthenticatorMachineOptions, translate } from '@aws-amplify/ui';
+import {
+  AuthenticatorMachineOptions,
+  SocialProvider,
+  translate,
+} from '@aws-amplify/ui';
 import { AmplifySlotDirective } from '../../../../utilities/amplify-slot/amplify-slot.directive';
 import { CustomComponentsService } from '../../../../services/custom-components.service';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
@@ -24,6 +28,7 @@ export class AuthenticatorComponent implements OnInit, AfterContentInit {
   @Input() loginMechanisms: AuthenticatorMachineOptions['loginMechanisms'];
   @Input() services: AuthenticatorMachineOptions['services'];
   @Input() signUpAttributes: AuthenticatorMachineOptions['signUpAttributes'];
+  @Input() socialProviders: SocialProvider[];
   @Input() variation: 'modal' | undefined;
 
   @ContentChildren(AmplifySlotDirective)
@@ -39,12 +44,19 @@ export class AuthenticatorComponent implements OnInit, AfterContentInit {
   ) {}
 
   ngOnInit(): void {
-    const { initialState, loginMechanisms, services, signUpAttributes } = this;
+    const {
+      initialState,
+      loginMechanisms,
+      services,
+      signUpAttributes,
+      socialProviders,
+    } = this;
     this.authenticator.startMachine({
       initialState,
       loginMechanisms,
       services,
       signUpAttributes,
+      socialProviders,
     });
 
     /**

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
@@ -33,12 +33,14 @@ export class AuthenticatorService implements OnDestroy {
     loginMechanisms,
     services,
     signUpAttributes,
+    socialProviders,
   }: AuthenticatorMachineOptions) {
     const machine = createAuthenticatorMachine({
       initialState,
       loginMechanisms,
       services,
       signUpAttributes,
+      socialProviders,
     });
 
     const authService = interpret(machine, {

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -9,6 +9,7 @@ import {
   createAuthenticatorMachine,
   translate,
   CognitoUserAmplify,
+  SocialProvider,
 } from '@aws-amplify/ui';
 
 import SignIn from './sign-in.vue';
@@ -24,19 +25,26 @@ import ConfirmVerifyUser from './confirm-verify-user.vue';
 
 const attrs = useAttrs();
 
-const { initialState, loginMechanisms, variation, services, signUpAttributes } =
-  withDefaults(
-    defineProps<{
-      initialState?: AuthenticatorMachineOptions['initialState'];
-      loginMechanisms?: AuthenticatorMachineOptions['loginMechanisms'];
-      services?: AuthenticatorMachineOptions['services'];
-      signUpAttributes?: AuthenticatorMachineOptions['signUpAttributes'];
-      variation?: 'modal';
-    }>(),
-    {
-      variation: undefined,
-    }
-  );
+const {
+  initialState,
+  loginMechanisms,
+  variation,
+  services,
+  signUpAttributes,
+  socialProviders,
+} = withDefaults(
+  defineProps<{
+    initialState?: AuthenticatorMachineOptions['initialState'];
+    loginMechanisms?: AuthenticatorMachineOptions['loginMechanisms'];
+    services?: AuthenticatorMachineOptions['services'];
+    signUpAttributes?: AuthenticatorMachineOptions['signUpAttributes'];
+    variation?: 'modal';
+    socialProviders?: SocialProvider[];
+  }>(),
+  {
+    variation: undefined,
+  }
+);
 
 const emit = defineEmits([
   'signInSubmit',
@@ -55,6 +63,7 @@ const machine = createAuthenticatorMachine({
   loginMechanisms,
   services,
   signUpAttributes,
+  socialProviders,
 });
 
 const service = useInterpret(machine, {


### PR DESCRIPTION
*Issue #, if available:*

Fixed the following issues
 

- [x] Added `socialProviders` to Angular and Vue
- [x] Added documentation for `signUpAttributes` for Angular and Vue
- [x] Fixed issue on documentation site where clicking framework button twice caused a `null` framework to display


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
