### PR TITLE
Remove AmplifyProvider custom components feature

### DIFF
--- a/.changeset/sharp-cherries-knock.md
+++ b/.changeset/sharp-cherries-knock.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": minor
+---
+
+Remove AmplifyProvider custom components feature

--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -22,7 +22,7 @@ function MyApp({ Component, pageProps }) {
         <title>Amplify UI</title>
         <link rel="icon" type="image/svg+xml" href={favicon} />
       </Head>
-      <AmplifyProvider components={{}} theme={theme} colorMode={colorMode}>
+      <AmplifyProvider theme={theme} colorMode={colorMode}>
         <Header
           platform={platform}
           colorMode={colorMode}

--- a/examples/next/pages/examples/listings/App.tsx
+++ b/examples/next/pages/examples/listings/App.tsx
@@ -18,7 +18,7 @@ import './styles.scss';
 export const App = ({ children }) => {
   const [colorMode, setColorMode] = useState<ColorMode>('system');
   return (
-    <AmplifyProvider components={{}} theme={theme} colorMode={colorMode}>
+    <AmplifyProvider theme={theme} colorMode={colorMode}>
       <header className="listing-app-header">
         <Logo />
 

--- a/packages/react/src/components/AmplifyProvider/AmplifyContext.tsx
+++ b/packages/react/src/components/AmplifyProvider/AmplifyContext.tsx
@@ -2,14 +2,10 @@ import * as React from 'react';
 
 import { defaultTheme, WebTheme } from '@aws-amplify/ui';
 
-import * as primitives from '../../primitives/components';
-
 interface AmplifyContextType {
-  components: Partial<typeof primitives>;
   theme: WebTheme;
 }
 
 export const AmplifyContext = React.createContext<AmplifyContextType>({
-  components: primitives,
   theme: defaultTheme,
 });

--- a/packages/react/src/components/AmplifyProvider/__tests__/AmplifyProvider.test.tsx
+++ b/packages/react/src/components/AmplifyProvider/__tests__/AmplifyProvider.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import { useAmplify } from '../../../hooks';
 
 import { AmplifyProvider } from '../index';
 import { Heading } from '../../../primitives';

--- a/packages/react/src/components/AmplifyProvider/__tests__/AmplifyProvider.test.tsx
+++ b/packages/react/src/components/AmplifyProvider/__tests__/AmplifyProvider.test.tsx
@@ -1,13 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { useAmplify } from '../../../hooks';
 
-import { AmplifyProvider } from '..';
+import { AmplifyProvider } from '../index';
+import { Heading } from '../../../primitives';
 
 const App = () => {
-  const {
-    components: { Heading },
-  } = useAmplify();
-
   return <Heading>Howdy</Heading>;
 };
 
@@ -33,22 +30,5 @@ describe('AmplifyProvider', () => {
     const wrapper = container.querySelector('[data-amplify-theme]');
     expect(wrapper).toBeInTheDocument();
     expect(wrapper).toHaveAttribute('data-amplify-theme', 'default-theme');
-  });
-
-  it('accepts custom primitives as components', async () => {
-    render(
-      <AmplifyProvider
-        components={{
-          Heading({ children }) {
-            return <h1>Custom {children}</h1>;
-          },
-        }}
-      >
-        <App />
-      </AmplifyProvider>
-    );
-
-    const heading = await screen.getByText('Custom Howdy');
-    expect(heading.nodeName).toBe('H1');
   });
 });

--- a/packages/react/src/components/AmplifyProvider/index.tsx
+++ b/packages/react/src/components/AmplifyProvider/index.tsx
@@ -1,24 +1,21 @@
-import { IdProvider } from '@radix-ui/react-id';
 import * as React from 'react';
+import { IdProvider } from '@radix-ui/react-id';
 
 import { createTheme, defaultTheme, Theme as UiTheme } from '@aws-amplify/ui';
 
 import { AmplifyContext } from './AmplifyContext';
-import * as primitives from '../../primitives/components';
 
 export type Theme = UiTheme;
 export type ColorMode = 'system' | 'light' | 'dark';
 
 interface AmplifyProviderProps {
   children: React.ReactNode;
-  components?: Partial<typeof primitives>;
-  theme?: Theme;
   colorMode?: ColorMode;
+  theme?: Theme;
 }
 
 export function AmplifyProvider({
   children,
-  components,
   colorMode,
   theme = defaultTheme,
 }: AmplifyProviderProps) {
@@ -27,7 +24,6 @@ export function AmplifyProvider({
   return (
     <AmplifyContext.Provider
       value={{
-        components,
         theme: webTheme,
       }}
     >

--- a/packages/react/src/hooks/useAmplify.ts
+++ b/packages/react/src/hooks/useAmplify.ts
@@ -3,23 +3,14 @@ import * as React from 'react';
 import { Theme } from '@aws-amplify/ui';
 
 import { AmplifyContext } from '../components/AmplifyProvider/AmplifyContext';
-import * as primitives from '../primitives/components';
 
 interface UseAmplifyOutput {
-  components: typeof primitives;
   theme: Theme;
 }
 
 export function useAmplify(): UseAmplifyOutput {
   const context = React.useContext(AmplifyContext);
-  const { components: customComponents, theme } = context;
-  const components = React.useMemo(
-    () => ({
-      ...primitives,
-      ...customComponents,
-    }),
-    [customComponents]
-  );
+  const { theme } = context;
 
-  return { components, theme };
+  return { theme };
 }


### PR DESCRIPTION
*Description of changes:*
This PR removes the `AmplifyProvider` custom components feature. The original intention of this feature was to allow customers to completely override any primitive used below the `AmplifyProvider`. However, it doesn't work correctly as currently implemented as we import primitives used in other composed primitives directly from relative paths. Additionally, there is little evidence of a customer need for this feature that cannot be met primarily by overriding the provided CSS variables. This PR removes the feature for GA launch, but we may return to revisit this feature in the future depending on customer feedback.

Further background:
https://github.com/aws-amplify/amplify-ui/pull/582
(original git blame commits were overwritten)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
