### PR TITLE
ForwardRef support - base primitives

### DIFF
--- a/.changeset/strong-spies-rush.md
+++ b/.changeset/strong-spies-rush.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef support - base primitives

--- a/packages/react/src/primitives/Divider/Divider.tsx
+++ b/packages/react/src/primitives/Divider/Divider.tsx
@@ -1,22 +1,24 @@
 import classNames from 'classnames';
+import * as React from 'react';
 
 import { ComponentClassNames } from '../shared';
-import { DividerProps, Primitive } from '../types';
+import { DividerProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-export const Divider: Primitive<DividerProps, 'hr'> = ({
-  className,
-  orientation = 'horizontal',
-  size,
-  ...rest
-}) => (
+const DividerInner: PrimitiveWithForwardRef<DividerProps, 'hr'> = (
+  { className, orientation = 'horizontal', size, ...rest },
+  ref
+) => (
   <View
     aria-orientation={orientation}
     as="hr"
     className={classNames(ComponentClassNames.Divider, className)}
     data-size={size}
+    ref={ref}
     {...rest}
   />
 );
+
+export const Divider = React.forwardRef(DividerInner);
 
 Divider.displayName = 'Divider';

--- a/packages/react/src/primitives/Divider/__tests__/Divider.test.tsx
+++ b/packages/react/src/primitives/Divider/__tests__/Divider.test.tsx
@@ -1,5 +1,7 @@
-import { Divider } from '../Divider';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
+
+import { Divider } from '../Divider';
 import { ComponentClassNames } from '../../shared';
 
 describe('Divider component', () => {
@@ -27,6 +29,14 @@ describe('Divider component', () => {
     const divider = (await screen.findByRole('separator')) as HTMLHRElement;
     expect(divider.className).toContain('my-divider');
     expect(divider.className).toContain(ComponentClassNames.Divider);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLHRElement>();
+    render(<Divider className="my-divider" ref={ref} />);
+
+    await screen.findByRole('separator');
+    expect(ref.current.nodeName).toBe('HR');
   });
 
   it('can render any arbitrary data-* attribute', async () => {

--- a/packages/react/src/primitives/Heading/Heading.tsx
+++ b/packages/react/src/primitives/Heading/Heading.tsx
@@ -1,7 +1,8 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { HeadingProps, Primitive } from '../types';
+import { HeadingProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
 type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
@@ -19,19 +20,20 @@ const headingLevels: HeadingLevels = {
   6: 'h6',
 };
 
-export const Heading: Primitive<HeadingProps, HeadingTag> = ({
-  className,
-  children,
-  level = 6,
-  ...rest
-}) => (
+const HeadingInner: PrimitiveWithForwardRef<HeadingProps, HeadingTag> = (
+  { className, children, level = 6, ...rest },
+  ref
+) => (
   <View
     as={headingLevels[level]}
     className={classNames(ComponentClassNames.Heading, className)}
+    ref={ref}
     {...rest}
   >
     {children}
   </View>
 );
+
+export const Heading = React.forwardRef(HeadingInner);
 
 Heading.displayName = 'Heading';

--- a/packages/react/src/primitives/Heading/__tests__/Heading.test.tsx
+++ b/packages/react/src/primitives/Heading/__tests__/Heading.test.tsx
@@ -1,8 +1,10 @@
+import * as React from 'react';
+import { kebabCase } from 'lodash';
 import { render, screen } from '@testing-library/react';
+
 import { Heading } from '../Heading';
 import { ComponentClassNames } from '../../shared';
 import { ComponentPropsToStylePropsMap } from '../../types';
-import { kebabCase } from 'lodash';
 
 describe('Heading: ', () => {
   it('renders an h6 tag by default', async () => {
@@ -67,6 +69,19 @@ describe('Heading: ', () => {
     const heading = await screen.findByTestId('headingId');
     expect(heading.classList.contains('custom-heading')).toBe(true);
     expect(heading.classList.contains(ComponentClassNames.Heading)).toBe(true);
+  });
+
+  it('can forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const headingText = 'Title';
+    render(
+      <Heading level={2} ref={ref}>
+        {headingText}
+      </Heading>
+    );
+    await screen.findByRole('heading');
+    expect(ref.current.nodeName).toBe('H2');
+    expect(ref.current.innerHTML).toBe(headingText);
   });
 
   it('can render any arbitrary data-* attribute', async () => {

--- a/packages/react/src/primitives/Icon/Icon.tsx
+++ b/packages/react/src/primitives/Icon/Icon.tsx
@@ -1,18 +1,22 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
-import { IconProps, Primitive } from '../types';
+import { IconProps, PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared';
 import { View } from '../View';
 
 const defaultViewBox = { minX: 0, minY: 0, width: 24, height: 24 };
 
-export const Icon: Primitive<IconProps, 'svg'> = ({
-  className,
-  fill = 'currentColor',
-  pathData,
-  viewBox = defaultViewBox,
-  ...rest
-}) => {
+const IconInner: PrimitiveWithForwardRef<IconProps, 'svg'> = (
+  {
+    className,
+    fill = 'currentColor',
+    pathData,
+    viewBox = defaultViewBox,
+    ...rest
+  },
+  ref
+) => {
   const minX = viewBox.minX ? viewBox.minX : defaultViewBox.minX;
   const minY = viewBox.minY ? viewBox.minY : defaultViewBox.minY;
   const width = viewBox.width ? viewBox.width : defaultViewBox.width;
@@ -22,6 +26,7 @@ export const Icon: Primitive<IconProps, 'svg'> = ({
     <View
       as="svg"
       className={classNames(ComponentClassNames.Icon, className)}
+      ref={ref}
       viewBox={`${minX} ${minY} ${width} ${height}`}
       {...rest}
     >
@@ -29,5 +34,7 @@ export const Icon: Primitive<IconProps, 'svg'> = ({
     </View>
   );
 };
+
+export const Icon = React.forwardRef(IconInner);
 
 Icon.displayName = 'Icon';

--- a/packages/react/src/primitives/Icon/__tests__/Icon.test.tsx
+++ b/packages/react/src/primitives/Icon/__tests__/Icon.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Icon } from '../Icon';
@@ -51,6 +52,22 @@ describe('Icon component', () => {
     expect(icon.classList.length).toBe(2);
     expect(icon.classList[0]).toContain(ComponentClassNames.Icon);
     expect(icon.classList[1]).toContain('my-icon-component');
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<SVGSVGElement>();
+
+    render(
+      <Icon
+        ref={ref}
+        testId={iconTestId}
+        pathData={pathData}
+        ariaLabel="Search"
+      />
+    );
+
+    await screen.findByTestId(iconTestId);
+    expect(ref.current.nodeName).toBe('svg');
   });
 
   it('can set viewBox attribute', async () => {

--- a/packages/react/src/primitives/Image/Image.tsx
+++ b/packages/react/src/primitives/Image/Image.tsx
@@ -1,15 +1,22 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared';
-import { ImageProps, Primitive } from '../types';
+import { ImageProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-export const Image: Primitive<ImageProps, 'img'> = ({ className, ...rest }) => (
+const ImageInner: PrimitiveWithForwardRef<ImageProps, 'img'> = (
+  { className, ...rest },
+  ref
+) => (
   <View
     as="img"
+    ref={ref}
     className={classNames(ComponentClassNames.Image, className)}
     {...rest}
   />
 );
+
+export const Image = React.forwardRef(ImageInner);
 
 Image.displayName = 'Image';

--- a/packages/react/src/primitives/Image/__tests__/Image.test.tsx
+++ b/packages/react/src/primitives/Image/__tests__/Image.test.tsx
@@ -1,8 +1,10 @@
-import { Image } from '../Image';
+import * as React from 'react';
+import { kebabCase } from 'lodash';
 import { fireEvent, render, screen } from '@testing-library/react';
+
+import { Image } from '../Image';
 import { ComponentClassNames } from '../../shared';
 import { ComponentPropsToStylePropsMap } from '../../types';
-import { kebabCase } from 'lodash';
 
 const altText = 'Cool cat';
 const src = 'http://localhost/cat.jpg';
@@ -112,5 +114,13 @@ describe('Image: ', () => {
         kebabCase(ComponentPropsToStylePropsMap.objectPosition)
       )
     ).toBe('top left');
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLImageElement>();
+
+    render(<Image alt={altText} src="nonexistent.jpg" ref={ref} />);
+    await screen.findByRole('img');
+    expect(ref.current.nodeName).toBe('IMG');
   });
 });

--- a/packages/react/src/primitives/Text/Text.tsx
+++ b/packages/react/src/primitives/Text/Text.tsx
@@ -1,26 +1,26 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { TextProps, Primitive } from '../types';
+import { TextProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-export const Text: Primitive<TextProps, 'p'> = ({
-  as = 'p',
-  className,
-  children,
-  isTruncated,
-  variation,
-  ...rest
-}) => (
+const TextInner: PrimitiveWithForwardRef<TextProps, 'p'> = (
+  { as = 'p', className, children, isTruncated, variation, ...rest },
+  ref
+) => (
   <View
     as={as}
     className={classNames(ComponentClassNames.Text, className)}
     data-truncate={isTruncated}
     data-variation={variation}
+    ref={ref}
     {...rest}
   >
     {children}
   </View>
 );
+
+export const Text = React.forwardRef(TextInner);
 
 Text.displayName = 'Text';

--- a/packages/react/src/primitives/Text/__test__/Text.test.tsx
+++ b/packages/react/src/primitives/Text/__test__/Text.test.tsx
@@ -1,8 +1,10 @@
-import { Text } from '../Text';
+import * as React from 'react';
+import { kebabCase } from 'lodash';
 import { render, screen } from '@testing-library/react';
+
+import { Text } from '../Text';
 import { ComponentClassNames } from '../../shared';
 import { ComponentPropsToStylePropsMap } from '../../types';
-import { kebabCase } from 'lodash';
 
 describe('Text: ', () => {
   const textText = 'This is a Text primitive';
@@ -14,6 +16,14 @@ describe('Text: ', () => {
     expect(text.innerHTML).toBe(textText);
     expect(text.nodeName).toBe('P');
     expect(text.className).toContain(ComponentClassNames.Text);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLParagraphElement>();
+    render(<Text ref={ref}>{textText}</Text>);
+
+    await screen.findByText(textText);
+    expect(ref.current.nodeName).toBe('P');
   });
 
   it('can render a classname for Text', async () => {

--- a/packages/react/src/primitives/View/View.tsx
+++ b/packages/react/src/primitives/View/View.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { useNonStyleProps, usePropStyles } from '../shared/styleUtils';
-import { ElementType, PrimitivePropsWithRef, ViewProps } from '../types';
+import {
+  ElementType,
+  HTMLElementType,
+  PrimitivePropsWithRef,
+  ViewProps,
+} from '../types';
 
 const ViewInner = <Element extends ElementType = 'div'>(
   {
@@ -15,7 +20,7 @@ const ViewInner = <Element extends ElementType = 'div'>(
     style,
     ...rest
   }: PrimitivePropsWithRef<ViewProps, Element>,
-  ref?: React.ForwardedRef<HTMLElement>
+  ref?: React.ForwardedRef<HTMLElementType<Element>>
 ) => {
   const propStyles = usePropStyles(rest, style);
   const nonStyleProps = useNonStyleProps(rest);


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for base primitives: `Divider`, `Heading`, `Icon`, `Image`,  `Text` by wrapping them in `React.forwardRef`. I'm limiting the number of primitives changed per PR to make them easier to review.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null);
  
  // do something with ref, like measure where it is on screen:
  // ref.current.getBoundingClientRect()
  
  return (
    <Image ref={ref} />
  );
};
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
