### PR TITLE
ForwardRef support - Flex and Grid

### DIFF
--- a/.changeset/heavy-bulldogs-sit.md
+++ b/.changeset/heavy-bulldogs-sit.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef support - Flex and Grid

--- a/packages/react/src/primitives/Flex/Flex.tsx
+++ b/packages/react/src/primitives/Flex/Flex.tsx
@@ -1,17 +1,23 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { FlexProps, Primitive } from '../types';
+import { FlexProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-export const Flex: Primitive<FlexProps, 'div'> = ({
-  className,
-  children,
-  ...rest
-}) => (
-  <View className={classNames(ComponentClassNames.Flex, className)} {...rest}>
+const FlexInner: PrimitiveWithForwardRef<FlexProps, 'div'> = (
+  { className, children, ...rest },
+  ref
+) => (
+  <View
+    className={classNames(ComponentClassNames.Flex, className)}
+    ref={ref}
+    {...rest}
+  >
     {children}
   </View>
 );
+
+export const Flex = React.forwardRef(FlexInner);
 
 Flex.displayName = 'Flex';

--- a/packages/react/src/primitives/Flex/__tests__/Flex.test.tsx
+++ b/packages/react/src/primitives/Flex/__tests__/Flex.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import * as React from 'react';
 import { kebabCase } from 'lodash';
+import { render, screen } from '@testing-library/react';
 
 import {
   ComponentPropsToStylePropsMap,
@@ -44,6 +45,14 @@ describe('Flex: ', () => {
     render(<Flex className="custom-flex">{flexText}</Flex>);
     const flex = await screen.findByText(flexText);
     expect(flex.classList.contains('custom-flex')).toBe(true);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Flex ref={ref}>{flexText}</Flex>);
+
+    await screen.findByText(flexText);
+    expect(ref.current.nodeName).toBe('DIV');
   });
 
   it('can render any arbitrary data-* attribute', async () => {

--- a/packages/react/src/primitives/Grid/Grid.tsx
+++ b/packages/react/src/primitives/Grid/Grid.tsx
@@ -1,17 +1,23 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { GridProps, Primitive } from '../types';
+import { GridProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-export const Grid: Primitive<GridProps, 'div'> = ({
-  className,
-  children,
-  ...rest
-}) => (
-  <View className={classNames(ComponentClassNames.Grid, className)} {...rest}>
+const GridInner: PrimitiveWithForwardRef<GridProps, 'div'> = (
+  { className, children, ...rest },
+  ref
+) => (
+  <View
+    className={classNames(ComponentClassNames.Grid, className)}
+    ref={ref}
+    {...rest}
+  >
     {children}
   </View>
 );
+
+export const Grid = React.forwardRef(GridInner);
 
 Grid.displayName = 'Grid';

--- a/packages/react/src/primitives/Grid/__tests__/Grid.test.tsx
+++ b/packages/react/src/primitives/Grid/__tests__/Grid.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { kebabCase } from 'lodash';
 
@@ -85,6 +86,13 @@ describe('Grid: ', () => {
     const grid = await screen.findByTestId(testId);
     expect(grid).toHaveClass('custom-grid');
     expect(grid).toHaveClass(ComponentClassNames.Grid);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Grid ref={ref} testId={testId}></Grid>);
+    await screen.findByTestId(testId);
+    expect(ref.current.nodeName).toBe('DIV');
   });
 
   it('can render any arbitrary data-* attribute', async () => {

--- a/packages/react/src/primitives/View/View.tsx
+++ b/packages/react/src/primitives/View/View.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { useNonStyleProps, usePropStyles } from '../shared/styleUtils';
-import { ElementType, PrimitivePropsWithRef, ViewProps } from '../types';
+import {
+  ElementType,
+  HTMLElementType,
+  PrimitivePropsWithRef,
+  ViewProps,
+} from '../types';
 
 const ViewInner = <Element extends ElementType = 'div'>(
   {
@@ -15,7 +20,7 @@ const ViewInner = <Element extends ElementType = 'div'>(
     style,
     ...rest
   }: PrimitivePropsWithRef<ViewProps, Element>,
-  ref?: React.ForwardedRef<HTMLElement>
+  ref?: React.ForwardedRef<HTMLElementType<Element>>
 ) => {
   const propStyles = usePropStyles(rest, style);
   const nonStyleProps = useNonStyleProps(rest);


### PR DESCRIPTION
*Issue:*
Closes https://github.com/aws-amplify/amplify-ui/issues/710

*Description of changes:*
This PR adds forward ref support for `Flex` and `Grid` primitives by wrapping them in `React.forwardRef`. I'm limiting the number of primitives changed per PR to make them easier to review.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null);
  
  // do something with ref, like measure where it is on screen:
  // ref.current.getBoundingClientRect()
  
  return (
    <Flex ref={ref} />
  );
};
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
