### PR TITLE
ForwardRef support - Simple Inputs

### DIFF
--- a/.changeset/rich-experts-allow.md
+++ b/.changeset/rich-experts-allow.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Forward ref inputs

--- a/packages/react/src/primitives/FieldGroupIcon/FieldGroupIcon.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/FieldGroupIcon.tsx
@@ -1,19 +1,27 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { FieldGroupIconProps, Primitive } from '../types';
+import { FieldGroupIconProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-export const FieldGroupIcon: Primitive<FieldGroupIconProps, 'button'> = ({
-  className,
-  children,
-  isVisible = true,
-  excludeFromTabOrder = false,
-  ...rest
-}) => {
+const FieldGroupIconInner: PrimitiveWithForwardRef<
+  FieldGroupIconProps,
+  'button' | 'div'
+> = (
+  {
+    className,
+    children,
+    isVisible = true,
+    excludeFromTabOrder = false,
+    ...rest
+  },
+  ref
+) => {
   return isVisible ? (
     <View
       className={classNames(ComponentClassNames.FieldGroupIcon, className)}
+      ref={ref}
       tabIndex={excludeFromTabOrder ? -1 : undefined}
       {...rest}
     >
@@ -21,5 +29,7 @@ export const FieldGroupIcon: Primitive<FieldGroupIconProps, 'button'> = ({
     </View>
   ) : null;
 };
+
+export const FieldGroupIcon = React.forwardRef(FieldGroupIconInner);
 
 FieldGroupIcon.displayName = 'FieldGroupIcon';

--- a/packages/react/src/primitives/FieldGroupIcon/__tests__/FieldGroupIcon.test.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/__tests__/FieldGroupIcon.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+
+import * as React from 'react';
+
+import { FieldGroupIcon } from '../FieldGroupIcon';
+import { Text } from '../../Text';
+import { Button } from '../../Button';
+
+import { ComponentClassNames } from '../../shared';
+
+describe('FieldGroupIcon component', () => {
+  const testId = 'fieldGroupTestId';
+  it('should render default and custom classname for FieldGroupIcon', async () => {
+    render(<FieldGroupIcon className="custom-class" testId={testId} />);
+
+    const fieldGroup = await screen.findByTestId(testId);
+
+    expect(fieldGroup).toHaveClass('custom-class');
+    expect(fieldGroup).toHaveClass(ComponentClassNames.FieldGroupIcon);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <FieldGroupIcon ref={ref} className="custom-class" testId={testId} />
+    );
+    await screen.findByTestId(testId);
+    expect(ref.current.nodeName).toBe('DIV');
+  });
+});

--- a/packages/react/src/primitives/Input/Input.tsx
+++ b/packages/react/src/primitives/Input/Input.tsx
@@ -1,35 +1,39 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared';
-import { InputProps, Primitive } from '../types';
+import { InputProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-export const Input: Primitive<InputProps, 'input'> = ({
-  autoComplete,
-  checked,
-  className,
-  defaultChecked,
-  defaultValue,
-  id,
-  isDisabled,
-  isReadOnly,
-  isRequired,
-  size,
-  type = 'text',
-  hasError = false,
-  value,
-  variation,
-  onBlur,
-  onChange,
-  onCopy,
-  onCut,
-  onFocus,
-  onInput,
-  onPaste,
-  onSelect,
-  onWheel,
-  ...rest
-}) => (
+const InputInner: PrimitiveWithForwardRef<InputProps, 'input'> = (
+  {
+    autoComplete,
+    checked,
+    className,
+    defaultChecked,
+    defaultValue,
+    id,
+    isDisabled,
+    isReadOnly,
+    isRequired,
+    size,
+    type = 'text',
+    hasError = false,
+    value,
+    variation,
+    onBlur,
+    onChange,
+    onCopy,
+    onCut,
+    onFocus,
+    onInput,
+    onPaste,
+    onSelect,
+    onWheel,
+    ...rest
+  },
+  ref
+) => (
   <View
     aria-invalid={hasError}
     as="input"
@@ -56,11 +60,14 @@ export const Input: Primitive<InputProps, 'input'> = ({
     onSelect={onSelect}
     onWheel={onWheel}
     readOnly={isReadOnly}
+    ref={ref}
     required={isRequired}
     type={type}
     value={value}
     {...rest}
   />
 );
+
+export const Input = React.forwardRef(InputInner);
 
 Input.displayName = 'Input';

--- a/packages/react/src/primitives/Input/__tests__/Input.test.tsx
+++ b/packages/react/src/primitives/Input/__tests__/Input.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -12,6 +13,7 @@ describe('Input component', () => {
     expect(input).toHaveClass('custom-class');
     expect(input).toHaveClass(ComponentClassNames.Input);
   });
+
   it('should render expected classname, id Input field', async () => {
     render(
       <Input
@@ -25,6 +27,14 @@ describe('Input component', () => {
     const input = await screen.findByRole('textbox');
     expect(input).toHaveClass('my-input');
     expect(input.id).toBe('testField');
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLInputElement>();
+
+    render(<Input ref={ref} />);
+    await screen.findByRole('textbox');
+    expect(ref.current.nodeName).toBe('INPUT');
   });
 
   it('should render the state attributes', async () => {

--- a/packages/react/src/primitives/Label/Label.tsx
+++ b/packages/react/src/primitives/Label/Label.tsx
@@ -1,26 +1,28 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { LabelProps, Primitive } from '../types';
+import { LabelProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-export const Label: Primitive<LabelProps, 'label'> = ({
-  children,
-  className,
-  visuallyHidden,
-  ...rest
-}) => {
+const LabelInner: PrimitiveWithForwardRef<LabelProps, 'label'> = (
+  { children, className, visuallyHidden, ...rest },
+  ref
+) => {
   return (
     <View
       as="label"
       className={classNames(ComponentClassNames.Label, className, {
         'sr-only': visuallyHidden,
       })}
+      ref={ref}
       {...rest}
     >
       {children}
     </View>
   );
 };
+
+export const Label = React.forwardRef(LabelInner);
 
 Label.displayName = 'Label';

--- a/packages/react/src/primitives/Label/__tests__/Label.test.tsx
+++ b/packages/react/src/primitives/Label/__tests__/Label.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Label } from '../Label';
@@ -13,5 +14,13 @@ describe('Label component', () => {
     const label = (await screen.findByText('My label')) as HTMLLabelElement;
     expect(label).toHaveClass('my-test-label');
     expect(label.htmlFor).toBe('my-label');
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLLabelElement>();
+
+    render(<Label ref={ref}>My label</Label>);
+    await screen.findByText('My label');
+    expect(ref.current.nodeName).toBe('LABEL');
   });
 });

--- a/packages/react/src/primitives/Select/Select.tsx
+++ b/packages/react/src/primitives/Select/Select.tsx
@@ -1,28 +1,32 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { Flex } from '../Flex';
 import { View } from '../View';
 import { IconExpandMore } from '../Icon';
 import { SelectProps } from '../types/select';
-import { Primitive } from '../types';
+import { PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared';
 
-export const Select: Primitive<SelectProps, 'select'> = ({
-  autoComplete,
-  className,
-  size,
-  variation,
-  value,
-  defaultValue,
-  hasError,
-  icon = <IconExpandMore size="large" />,
-  iconColor,
-  children,
-  placeholder,
-  isDisabled,
-  isRequired,
-  ...rest
-}) => {
+const SelectInner: PrimitiveWithForwardRef<SelectProps, 'select'> = (
+  {
+    autoComplete,
+    className,
+    size,
+    variation,
+    value,
+    defaultValue,
+    hasError,
+    icon = <IconExpandMore size="large" />,
+    iconColor,
+    children,
+    placeholder,
+    isDisabled,
+    isRequired,
+    ...rest
+  },
+  ref
+) => {
   const DEFAULT_PLACEHOLDER_VALUE = '';
   // value === undefined is to make sure that component is used in uncontrolled way so that setting defaultValue is valid
   const shouldSetDefaultPlaceholderValue =
@@ -48,6 +52,7 @@ export const Select: Primitive<SelectProps, 'select'> = ({
           ComponentClassNames.FieldGroupControl,
           className
         )}
+        ref={ref}
         {...rest}
       >
         {placeholder && <option value="">{placeholder}</option>}
@@ -64,5 +69,7 @@ export const Select: Primitive<SelectProps, 'select'> = ({
     </View>
   );
 };
+
+export const Select = React.forwardRef(SelectInner);
 
 Select.displayName = 'Select';

--- a/packages/react/src/primitives/Select/__tests__/Select.test.tsx
+++ b/packages/react/src/primitives/Select/__tests__/Select.test.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -13,7 +13,7 @@ describe('Select primitive test suite', () => {
   const variation = 'quiet';
   const placeholder = 'Please select your option';
   const SelectControlled = () => {
-    const [value, setValue] = useState('');
+    const [value, setValue] = React.useState('');
 
     return (
       <Select
@@ -56,6 +56,14 @@ describe('Select primitive test suite', () => {
     expect(select).toHaveClass(ComponentClassNames.Select);
     expect(select).not.toBeDisabled();
     expect(select).not.toBeRequired();
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLSelectElement>();
+    render(<Select ref={ref} testId={testId}></Select>);
+
+    await screen.findByTestId(testId);
+    expect(ref.current.nodeName).toBe('SELECT');
   });
 
   it('should be able to pass through isDisabled and isRequired props', async () => {

--- a/packages/react/src/primitives/View/View.tsx
+++ b/packages/react/src/primitives/View/View.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { useNonStyleProps, usePropStyles } from '../shared/styleUtils';
-import { ElementType, PrimitivePropsWithRef, ViewProps } from '../types';
+import {
+  ElementType,
+  HTMLElementType,
+  PrimitivePropsWithRef,
+  ViewProps,
+} from '../types';
 
 const ViewInner = <Element extends ElementType = 'div'>(
   {
@@ -15,7 +20,7 @@ const ViewInner = <Element extends ElementType = 'div'>(
     style,
     ...rest
   }: PrimitivePropsWithRef<ViewProps, Element>,
-  ref?: React.ForwardedRef<HTMLElement>
+  ref?: React.ForwardedRef<HTMLElementType<Element>>
 ) => {
   const propStyles = usePropStyles(rest, style);
   const nonStyleProps = useNonStyleProps(rest);


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for the simple input related primitives (ones that directly render View) by wrapping them in `React.forwardRef`. I'm limiting the number of primitives changed per PR to make them easier to review.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null);
  
  // do something with ref, like measure where it is on screen:
  // ref.current.focus()
  
  return (
    <Input ref={ref} />
  );
};
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.