### PR TITLE
ForwardRef support Utils and simple Feedback

### DIFF
--- a/packages/react/src/primitives/Loader/Loader.tsx
+++ b/packages/react/src/primitives/Loader/Loader.tsx
@@ -1,8 +1,9 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { View } from '../View';
 import { LoaderProps } from '../types/loader';
-import { Primitive } from '../types/view';
+import { PrimitiveWithForwardRef } from '../types/view';
 import { ComponentClassNames } from '../shared/constants';
 
 export const LINEAR_EMPTY = 'linear-empty';
@@ -10,14 +11,10 @@ export const LINEAR_FILLED = 'linear-filled';
 export const CIRCULAR_EMPTY = 'circular-empty';
 export const CIRCULAR_FILLED = 'circular-filled';
 
-export const Loader: Primitive<LoaderProps, 'svg'> = ({
-  className,
-  filledColor,
-  emptyColor,
-  size,
-  variation,
-  ...rest
-}) => {
+const LoaderInner: PrimitiveWithForwardRef<LoaderProps, 'svg'> = (
+  { className, filledColor, emptyColor, size, variation, ...rest },
+  ref
+) => {
   const linearLoader = (
     <g>
       <line
@@ -67,6 +64,7 @@ export const Loader: Primitive<LoaderProps, 'svg'> = ({
       className={classNames(ComponentClassNames.Loader, className)}
       data-size={size}
       data-variation={variation}
+      ref={ref}
       role="img"
       {...rest}
     >
@@ -74,5 +72,7 @@ export const Loader: Primitive<LoaderProps, 'svg'> = ({
     </View>
   );
 };
+
+export const Loader = React.forwardRef(LoaderInner);
 
 Loader.displayName = 'Loader';

--- a/packages/react/src/primitives/Loader/__tests__/Loader.test.tsx
+++ b/packages/react/src/primitives/Loader/__tests__/Loader.test.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { render, screen } from '@testing-library/react';
 
 import {
@@ -15,6 +17,14 @@ describe('Loader: ', () => {
     render(<Loader className={className} />);
     const loader = await screen.findByRole('img');
     expect(loader).toHaveClass(ComponentClassNames.Loader, className);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<SVGSVGElement>();
+    render(<Loader ref={ref} />);
+
+    await screen.findByRole('img');
+    expect(ref.current.nodeName).toBe('svg');
   });
 
   it('should set size attribute', async () => {

--- a/packages/react/src/primitives/Placeholder/Placeholder.tsx
+++ b/packages/react/src/primitives/Placeholder/Placeholder.tsx
@@ -1,16 +1,14 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared';
-import { PlaceholderProps, Primitive } from '../types';
+import { PlaceholderProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-export const Placeholder: Primitive<PlaceholderProps, 'div'> = ({
-  className,
-  children,
-  isLoaded,
-  size,
-  ...rest
-}) => {
+const PlaceholderInner: PrimitiveWithForwardRef<PlaceholderProps, 'div'> = (
+  { className, children, isLoaded, size, ...rest },
+  ref
+) => {
   if (isLoaded) {
     return <>{children}</>;
   }
@@ -19,9 +17,12 @@ export const Placeholder: Primitive<PlaceholderProps, 'div'> = ({
     <View
       className={classNames(ComponentClassNames.Placeholder, className)}
       data-size={size}
+      ref={ref}
       {...rest}
     />
   );
 };
+
+export const Placeholder = React.forwardRef(PlaceholderInner);
 
 Placeholder.displayName = 'Placeholder';

--- a/packages/react/src/primitives/Placeholder/__tests__/Placeholder.test.tsx
+++ b/packages/react/src/primitives/Placeholder/__tests__/Placeholder.test.tsx
@@ -1,4 +1,6 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
+
 import { Placeholder } from '../Placeholder';
 import { Text } from '../../Text';
 import { ComponentClassNames } from '../../shared';
@@ -12,6 +14,14 @@ describe('Placeholder: ', () => {
       placeholder.classList.contains(ComponentClassNames.Placeholder)
     ).toBe(true);
     expect(placeholder.dataset['size']).toBeUndefined();
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Placeholder ref={ref} testId="placeholderId" />);
+
+    await screen.findByTestId('placeholderId');
+    expect(ref.current.nodeName).toBe('DIV');
   });
 
   it('renders based on isLoaded prop', async () => {

--- a/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
@@ -1,22 +1,24 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { Primitive, VisuallyHiddenProps } from '../types';
+import { PrimitiveWithForwardRef, VisuallyHiddenProps } from '../types';
 import { View } from '../View';
 
-export const VisuallyHidden: Primitive<VisuallyHiddenProps, 'span'> = ({
-  as = 'span',
-  children,
-  className,
-  ...rest
-}) => (
+const VisuallyHiddenInner: PrimitiveWithForwardRef<
+  VisuallyHiddenProps,
+  'span'
+> = ({ as = 'span', children, className, ...rest }, ref) => (
   <View
     as={as}
     className={classNames(ComponentClassNames.VisuallyHidden, className)}
+    ref={ref}
     {...rest}
   >
     {children}
   </View>
 );
+
+export const VisuallyHidden = React.forwardRef(VisuallyHiddenInner);
 
 VisuallyHidden.displayName = 'VisuallyHidden';

--- a/packages/react/src/primitives/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
+++ b/packages/react/src/primitives/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
@@ -1,14 +1,24 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { VisuallyHidden } from '../VisuallyHidden';
 import { ComponentClassNames } from '../../shared/constants';
 
+const hiddenContent = 'A hidden text';
+
 describe('VisuallyHidden test suite', () => {
   it('should render classname correctly', async () => {
-    const hiddenContent = 'A hidden text';
     render(<VisuallyHidden>{hiddenContent}</VisuallyHidden>);
 
     const visuallyHidden = await screen.findByText(hiddenContent);
     expect(visuallyHidden).toHaveClass(ComponentClassNames.VisuallyHidden);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLSpanElement>();
+    render(<VisuallyHidden ref={ref}>{hiddenContent}</VisuallyHidden>);
+
+    await screen.findByText(hiddenContent);
+    expect(ref.current.nodeName).toBe('SPAN');
   });
 });


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for Util and simpler Feedback primitives (ones that directly render View) by wrapping them in `React.forwardRef`. I'm limiting the number of primitives changed per PR to make them easier to review.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null);
  
  // do something with ref
  // console.log(ref.current.nodeName); // logs "svg"
  
  return (
    <Loader ref={ref} />
  );
};
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
