### PR TITLE
ForwardRef support - textarea, checkbox, radio

### DIFF
--- a/.changeset/polite-bags-wonder.md
+++ b/.changeset/polite-bags-wonder.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef support - textarea, checkbox, radio

--- a/packages/react/src/primitives/Checkbox/Checkbox.tsx
+++ b/packages/react/src/primitives/Checkbox/Checkbox.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { useCheckbox } from './useCheckbox';
@@ -7,24 +8,27 @@ import { Input } from '../Input';
 import { Text } from '../Text';
 import { VisuallyHidden } from '../VisuallyHidden';
 import { CheckboxProps } from '../types/checkbox';
-import { Primitive } from '../types/view';
+import { PrimitiveWithForwardRef } from '../types/view';
 import { splitPrimitiveProps } from '../shared/styleUtils';
 import { ComponentClassNames } from '../shared/constants';
 import { useTestId } from '../utils/testUtils';
 
-export const Checkbox: Primitive<CheckboxProps, 'input'> = ({
-  checked,
-  className,
-  defaultChecked,
-  hasError,
-  isDisabled,
-  label,
-  labelHidden,
-  onChange: onChangeProp,
-  size,
-  testId,
-  ..._rest
-}) => {
+const CheckboxInner: PrimitiveWithForwardRef<CheckboxProps, 'input'> = (
+  {
+    checked,
+    className,
+    defaultChecked,
+    hasError,
+    isDisabled,
+    label,
+    labelHidden,
+    onChange: onChangeProp,
+    size,
+    testId,
+    ..._rest
+  },
+  ref
+) => {
   const { baseStyleProps, flexContainerStyleProps, rest } =
     splitPrimitiveProps(_rest);
 
@@ -58,6 +62,7 @@ export const Checkbox: Primitive<CheckboxProps, 'input'> = ({
           onBlur={onBlur}
           onChange={onChange}
           onFocus={onFocus}
+          ref={ref}
           type="checkbox"
           {...rest}
         />
@@ -93,5 +98,7 @@ export const Checkbox: Primitive<CheckboxProps, 'input'> = ({
     </Flex>
   );
 };
+
+export const Checkbox = React.forwardRef(CheckboxInner);
 
 Checkbox.displayName = 'Checkbox';

--- a/packages/react/src/primitives/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/react/src/primitives/Checkbox/__tests__/Checkbox.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -37,6 +38,14 @@ describe('Checkbox test suite', () => {
 
     const checkbox = await screen.findByTestId(basicProps.testId);
     expect(checkbox).toHaveClass(customClassName);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(<Checkbox ref={ref} {...basicProps} />);
+
+    await screen.findByTestId(basicProps.testId);
+    expect(ref.current.nodeName).toBe('INPUT');
   });
 
   it('should render all flex style props', async () => {

--- a/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
+++ b/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
@@ -1,41 +1,48 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { Checkbox } from '../Checkbox';
 import { FieldErrorMessage } from '../Field';
 import { Flex } from '../Flex';
-import { CheckboxFieldProps, Primitive } from '../types';
+import { CheckboxFieldProps, PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared';
 import { useTestId } from '../utils/testUtils';
 
-export const CheckboxField: Primitive<CheckboxFieldProps, 'input'> = ({
-  className,
-  errorMessage,
-  hasError = false,
-  labelHidden = false,
-  testId,
-  size,
-  ...rest
-}) => {
-  const checkboxTestId = useTestId(testId, ComponentClassNames.Checkbox);
-  return (
-    <Flex
-      className={classNames(
-        ComponentClassNames.Field,
-        ComponentClassNames.CheckboxField,
-        className
-      )}
-      data-size={size}
-      testId={testId}
-    >
-      <Checkbox
-        hasError={hasError}
-        labelHidden={labelHidden}
-        testId={checkboxTestId}
-        {...rest}
-      />
-      <FieldErrorMessage hasError={hasError} errorMessage={errorMessage} />
-    </Flex>
-  );
-};
+const CheckboxFieldInner: PrimitiveWithForwardRef<CheckboxFieldProps, 'input'> =
+  (
+    {
+      className,
+      errorMessage,
+      hasError = false,
+      labelHidden = false,
+      testId,
+      size,
+      ...rest
+    },
+    ref
+  ) => {
+    const checkboxTestId = useTestId(testId, ComponentClassNames.Checkbox);
+    return (
+      <Flex
+        className={classNames(
+          ComponentClassNames.Field,
+          ComponentClassNames.CheckboxField,
+          className
+        )}
+        data-size={size}
+        testId={testId}
+      >
+        <Checkbox
+          hasError={hasError}
+          labelHidden={labelHidden}
+          testId={checkboxTestId}
+          ref={ref}
+          {...rest}
+        />
+        <FieldErrorMessage hasError={hasError} errorMessage={errorMessage} />
+      </Flex>
+    );
+  };
+export const CheckboxField = React.forwardRef(CheckboxFieldInner);
 
 CheckboxField.displayName = 'CheckboxField';

--- a/packages/react/src/primitives/CheckboxField/__tests__/CheckboxField.test.tsx
+++ b/packages/react/src/primitives/CheckboxField/__tests__/CheckboxField.test.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -18,7 +18,7 @@ describe('CheckboxField test suite', () => {
     return <CheckboxField {...props} />;
   };
   const ControlledCheckboxField = () => {
-    const [checked, setChecked] = useState(false);
+    const [checked, setChecked] = React.useState(false);
     return (
       <CheckboxField
         checked={checked}
@@ -37,6 +37,14 @@ describe('CheckboxField test suite', () => {
       ComponentClassNames.CheckboxField,
       className
     );
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(<CheckboxField {...basicProps} ref={ref} />);
+
+    await screen.findByTestId(basicProps.testId);
+    expect(ref.current.nodeName).toBe('INPUT');
   });
 
   describe('Checkbox functionality', () => {

--- a/packages/react/src/primitives/Radio/Radio.tsx
+++ b/packages/react/src/primitives/Radio/Radio.tsx
@@ -1,21 +1,17 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { Flex } from '../Flex';
 import { Input } from '../Input';
 import { useRadioGroupContext } from '../RadioGroupField/context';
 import { Text } from '../Text';
-import { RadioProps, Primitive } from '../types';
+import { RadioProps, PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared';
 
-export const Radio: Primitive<RadioProps, 'input'> = ({
-  children,
-  className,
-  id,
-  isDisabled,
-  testId,
-  value,
-  ...rest
-}) => {
+export const RadioInner: PrimitiveWithForwardRef<RadioProps, 'input'> = (
+  { children, className, id, isDisabled, testId, value, ...rest },
+  ref
+) => {
   const {
     currentValue,
     defaultValue,
@@ -57,6 +53,7 @@ export const Radio: Primitive<RadioProps, 'input'> = ({
         isReadOnly={isReadOnly}
         isRequired={isRequired}
         onChange={onChange}
+        ref={ref}
         type="radio"
         name={name}
         value={value}
@@ -81,5 +78,7 @@ export const Radio: Primitive<RadioProps, 'input'> = ({
     </Flex>
   );
 };
+
+export const Radio = React.forwardRef(RadioInner);
 
 Radio.displayName = 'Radio';

--- a/packages/react/src/primitives/Radio/__tests__/Radio.test.tsx
+++ b/packages/react/src/primitives/Radio/__tests__/Radio.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Radio } from '../Radio';
@@ -25,6 +26,18 @@ describe('RadioField test suite', () => {
     const radioLabel = await screen.findByText('test');
     expect(radioLabel).toContainHTML('test');
     expect(radioLabel).toHaveClass(ComponentClassNames.RadioLabel);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(
+      <Radio id="test" value="test" ref={ref}>
+        test
+      </Radio>
+    );
+
+    await screen.findByRole('radio');
+    expect(ref.current.nodeName).toBe('INPUT');
   });
 
   it('should be disabled if isDisabled passed', async () => {

--- a/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
+++ b/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
@@ -1,37 +1,43 @@
+import * as React from 'react';
 import classNames from 'classnames';
-import { useMemo } from 'react';
 
 import { RadioGroupContext, RadioGroupContextType } from './context';
 import { FieldErrorMessage, FieldDescription } from '../Field';
 import { Flex } from '../Flex';
 import { Label } from '../Label';
-import { RadioGroupFieldProps, Primitive } from '../types';
+import { RadioGroupFieldProps, PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared/constants';
 import { useStableId } from '../shared/utils';
 
 // Note: RadioGroupField doesn't extend the JSX.IntrinsicElements<'input'> types (instead extending 'typeof Flex')
 // because all rest props are passed to Flex container
-export const RadioGroupField: Primitive<RadioGroupFieldProps, typeof Flex> = ({
-  children,
-  className,
-  defaultValue,
-  descriptiveText,
-  errorMessage,
-  hasError = false,
-  id,
-  isDisabled,
-  isRequired,
-  isReadOnly,
-  label,
-  labelHidden = false,
-  onChange,
-  name,
-  size,
-  value,
-  ...rest
-}) => {
+const RadioGroupFieldInner: PrimitiveWithForwardRef<
+  RadioGroupFieldProps,
+  typeof Flex
+> = (
+  {
+    children,
+    className,
+    defaultValue,
+    descriptiveText,
+    errorMessage,
+    hasError = false,
+    id,
+    isDisabled,
+    isRequired,
+    isReadOnly,
+    label,
+    labelHidden = false,
+    onChange,
+    name,
+    size,
+    value,
+    ...rest
+  },
+  ref
+) => {
   const fieldId = useStableId(id);
-  const radioGroupContextValue: RadioGroupContextType = useMemo(
+  const radioGroupContextValue: RadioGroupContextType = React.useMemo(
     () => ({
       currentValue: value,
       defaultValue,
@@ -64,6 +70,7 @@ export const RadioGroupField: Primitive<RadioGroupFieldProps, typeof Flex> = ({
         className
       )}
       data-size={size}
+      ref={ref}
       {...rest}
     >
       <Label id={fieldId} visuallyHidden={labelHidden}>
@@ -86,5 +93,7 @@ export const RadioGroupField: Primitive<RadioGroupFieldProps, typeof Flex> = ({
     </Flex>
   );
 };
+
+export const RadioGroupField = React.forwardRef(RadioGroupFieldInner);
 
 RadioGroupField.displayName = 'RadioGroupField';

--- a/packages/react/src/primitives/RadioGroupField/__tests__/RadioGroupField.test.tsx
+++ b/packages/react/src/primitives/RadioGroupField/__tests__/RadioGroupField.test.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -36,7 +36,7 @@ describe('RadioFieldGroup test suite', () => {
   };
 
   const ControlledRadioFieldGroup = () => {
-    const [value, setValue] = useState('html');
+    const [value, setValue] = React.useState('html');
     return (
       <RadioGroupField
         {...basicProps}
@@ -60,6 +60,14 @@ describe('RadioFieldGroup test suite', () => {
       ComponentClassNames.RadioGroupField,
       className
     );
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<RadioGroupField {...basicProps} ref={ref}></RadioGroupField>);
+
+    await screen.findByTestId('test');
+    expect(ref.current.nodeName).toBe('DIV');
   });
 
   it('should render all flex style props', async () => {

--- a/packages/react/src/primitives/TextArea/TextArea.tsx
+++ b/packages/react/src/primitives/TextArea/TextArea.tsx
@@ -1,20 +1,23 @@
-import classNames from 'classnames';
 import * as React from 'react';
+import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared';
-import { Primitive } from '../types/view';
+import { PrimitiveWithForwardRef } from '../types/view';
 import { TextAreaProps } from '../types/textArea';
 import { View } from '../View';
 
-export const TextArea: Primitive<TextAreaProps, 'textarea'> = ({
-  className,
-  isReadOnly,
-  isRequired,
-  size,
-  hasError = false,
-  variation,
-  ...rest
-}) => (
+const TextAreaInner: PrimitiveWithForwardRef<TextAreaProps, 'textarea'> = (
+  {
+    className,
+    isReadOnly,
+    isRequired,
+    size,
+    hasError = false,
+    variation,
+    ...rest
+  },
+  ref
+) => (
   <View
     aria-invalid={hasError}
     as="textarea"
@@ -26,9 +29,12 @@ export const TextArea: Primitive<TextAreaProps, 'textarea'> = ({
     data-size={size}
     data-variation={variation}
     readOnly={isReadOnly}
+    ref={ref}
     required={isRequired}
     {...rest}
   />
 );
+
+export const TextArea = React.forwardRef(TextAreaInner);
 
 TextArea.displayName = 'TextArea';

--- a/packages/react/src/primitives/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/react/src/primitives/TextArea/__tests__/TextArea.test.tsx
@@ -43,17 +43,17 @@ describe('TextArea component', () => {
     render(<TextArea size="small" hasError isDisabled isReadOnly isRequired />);
 
     const textarea = await screen.findByRole('textbox');
-    expect(textarea).toHaveAttribute('disabled');
-    expect(textarea).toHaveAttribute('readonly');
-    expect(textarea).toHaveAttribute('required');
+    expect(textarea).toHaveAttribute('disabled', '');
+    expect(textarea).toHaveAttribute('readonly', '');
+    expect(textarea).toHaveAttribute('required', '');
   });
 
   it('should set size and variation data attributes', async () => {
     render(<TextArea size="small" variation="quiet" />);
 
     const textarea = await screen.findByRole('textbox');
-    expect(textarea.dataset['size']).toBe('small');
-    expect(textarea.dataset['variation']).toBe('quiet');
+    expect(textarea).toHaveAttribute('data-size', 'small');
+    expect(textarea).toHaveAttribute('data-variation', 'quiet');
   });
 
   it('can set defaultValue (uncontrolled)', async () => {
@@ -62,7 +62,7 @@ describe('TextArea component', () => {
     const textarea = (await screen.findByRole(
       'textbox'
     )) as HTMLTextAreaElement;
-    expect(textarea.value).toBe('test');
+    expect(textarea).toHaveValue('test');
   });
 
   it('can set value (controlled component)', async () => {
@@ -72,7 +72,7 @@ describe('TextArea component', () => {
     const textarea = (await screen.findByRole(
       'textbox'
     )) as HTMLTextAreaElement;
-    expect(textarea.value).toBe('test');
+    expect(textarea).toHaveValue('test');
   });
 
   it('show add aria-invalid attribute to textarea when hasError', async () => {
@@ -80,7 +80,7 @@ describe('TextArea component', () => {
     const textarea = (await screen.findByRole(
       'textbox'
     )) as HTMLTextAreaElement;
-    expect(textarea).toHaveAttribute('aria-invalid');
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
   });
 
   it('should fire event handlers', async () => {

--- a/packages/react/src/primitives/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/react/src/primitives/TextArea/__tests__/TextArea.test.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TextArea } from '../TextArea';
+import { ComponentClassNames } from '../../shared';
+
+describe('TextArea component', () => {
+  it('should render custom classname for TextArea', async () => {
+    render(<TextArea className="custom-class" />);
+
+    const textarea = (await screen.findByRole(
+      'textbox'
+    )) as HTMLTextAreaElement;
+    expect(textarea).toHaveClass('custom-class');
+    expect(textarea).toHaveClass(ComponentClassNames.Textarea);
+  });
+
+  it('should render expected classname, id TextArea field', async () => {
+    render(
+      <TextArea
+        id="testField"
+        testId="testId"
+        className="my-textarea"
+        defaultValue="Hello there"
+      />
+    );
+
+    const textarea = await screen.findByRole('textbox');
+    expect(textarea).toHaveClass('my-textarea');
+    expect(textarea.id).toBe('testField');
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+
+    render(<TextArea ref={ref} />);
+    await screen.findByRole('textbox');
+    expect(ref.current.nodeName).toBe('TEXTAREA');
+  });
+
+  it('should render the state attributes', async () => {
+    render(<TextArea size="small" hasError isDisabled isReadOnly isRequired />);
+
+    const textarea = await screen.findByRole('textbox');
+    expect(textarea).toHaveAttribute('disabled');
+    expect(textarea).toHaveAttribute('readonly');
+    expect(textarea).toHaveAttribute('required');
+  });
+
+  it('should set size and variation data attributes', async () => {
+    render(<TextArea size="small" variation="quiet" />);
+
+    const textarea = await screen.findByRole('textbox');
+    expect(textarea.dataset['size']).toBe('small');
+    expect(textarea.dataset['variation']).toBe('quiet');
+  });
+
+  it('can set defaultValue (uncontrolled)', async () => {
+    render(<TextArea defaultValue="test" />);
+
+    const textarea = (await screen.findByRole(
+      'textbox'
+    )) as HTMLTextAreaElement;
+    expect(textarea.value).toBe('test');
+  });
+
+  it('can set value (controlled component)', async () => {
+    // onChange added to silence console error
+    render(<TextArea value="test" onChange={() => {}} />);
+
+    const textarea = (await screen.findByRole(
+      'textbox'
+    )) as HTMLTextAreaElement;
+    expect(textarea.value).toBe('test');
+  });
+
+  it('show add aria-invalid attribute to textarea when hasError', async () => {
+    render(<TextArea id="testField" hasError={true} />);
+    const textarea = (await screen.findByRole(
+      'textbox'
+    )) as HTMLTextAreaElement;
+    expect(textarea).toHaveAttribute('aria-invalid');
+  });
+
+  it('should fire event handlers', async () => {
+    const onChange = jest.fn();
+    const onInput = jest.fn();
+    const onPaste = jest.fn();
+    render(
+      <TextArea onChange={onChange} onInput={onInput} onPaste={onPaste} />
+    );
+    const textarea = (await screen.findByRole(
+      'textbox'
+    )) as HTMLTextAreaElement;
+    userEvent.type(textarea, 'hello');
+    userEvent.paste(textarea, 'there');
+    expect(onChange).toHaveBeenCalled();
+    expect(onInput).toHaveBeenCalled();
+    expect(onPaste).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for the `TextArea`, `Checkbox`, `CheckboxField`, `Radio` and `RadioGroupField` primitives (ones that directly render View) by wrapping them in `React.forwardRef`. I'm limiting the number of primitives changed per PR to make them easier to review.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null);
  
  // Below returns INPUT because the ref is forwarded down to DOM element
  // (CheckboxField => Checkbox => View => <input>)
  // ref.current.nodeName 
  
  return (
    <CheckboxField ref={ref} />
  );
};
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
