### PR TITLE
Remove @beta references to @aws-amplify/cli

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Add Amplify CLI
-        run: yarn global add @aws-amplify/cli@beta
+        run: yarn global add @aws-amplify/cli
 
       - name: Pull down AWS environments
         run: yarn environments pull

--- a/docs/src/pages/components/authenticator/index.page.mdx
+++ b/docs/src/pages/components/authenticator/index.page.mdx
@@ -52,20 +52,21 @@ Once an end-user has created an account & signed in, the underlying component is
 The Authenticator works seamlessly with the [Amplify CLI](https://docs.amplify.aws/cli/start/install/)
 to **automatically** work with your backend.
 
-First, update `@aws-amplify/cli@beta` with [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/):
+First, update `@aws-amplify/cli` with [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)
+if you're using a version before `6.4.0`:
 
 <Tabs>
 <TabItem title="npm">
 
 ```shell
-npm install -g @aws-amplify/cli@beta
+npm install -g @aws-amplify/cli@latest
 ```
 
 </TabItem>
 <TabItem title="yarn">
 
 ```shell
-yarn add @aws-amplify/cli@beta
+yarn global add @aws-amplify/cli@latest
 ```
 
 </TabItem>

--- a/environments/README.md
+++ b/environments/README.md
@@ -2,6 +2,10 @@
 
 This folder contains a list of pre-built Amplify backends for use with manual & automated testing.
 
+## Zero Configuration
+
+These environments rely on `@aws-amplify/cli@latest` (v6.4.0+) to work.
+
 ## Using an Existing Backend Environment
 
 For manual and end-to-end testing, example applications will use a particular backend environment by pulling the `aws-exports.js` file from the `environments/{BACKEND_ENVIRONMENT}/src` directory. To use an existing backend environment, please use the following instructions.


### PR DESCRIPTION
*Issue #, if available:* Closes #646

*Description of changes:*

- [x] No longer test against `@beta`
- [x] Instruct usage of `@latest` (vs. just having it installed)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
