### PR TITLE
Fixing icon issues with docs build and react build

### DIFF
--- a/docs/src/pages/components/togglebutton/examples.tsx
+++ b/docs/src/pages/components/togglebutton/examples.tsx
@@ -6,7 +6,7 @@ import {
   IconFormatAlignLeft,
   IconFormatAlignRight,
   IconFormatBold,
-  IconFormatColorFill,
+  IconFormatColorReset,
   IconFormatItalic,
   IconFormatUnderlined,
   ToggleButton,
@@ -49,7 +49,7 @@ export const MultipleSelectionDemo = () => {
           <IconFormatUnderlined />
         </ToggleButton>
         <ToggleButton value="color-fill">
-          <IconFormatColorFill />
+          <IconFormatColorReset />
         </ToggleButton>
       </ToggleButtonGroup>
     </Example>

--- a/docs/src/pages/index.page.tsx
+++ b/docs/src/pages/index.page.tsx
@@ -8,7 +8,7 @@ import {
   Heading,
   View,
   Text,
-  IconCopy,
+  IconContentCopy,
   Flex,
   Image,
 } from '@aws-amplify/ui-react';
@@ -105,7 +105,7 @@ const HomePage = ({ colorMode }) => {
               className="install-code"
               innerEndComponent={
                 <Button variation="link">
-                  <IconCopy /> Copy
+                  <IconContentCopy /> Copy
                 </Button>
               }
               value={`npm i @aws-amplify/ui-${framework}`}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "yarn run build:icons && yarn run build:ts && yarn run build:catalog",
+    "build": "yarn run build:ts && yarn run build:catalog",
     "build:ts": "tsup --minify --keep-names",
     "build:catalog": "ts-node scripts/generatePrimitivesCatalog.ts",
     "dev": "tsup --watch src",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* No longer running build:icons as part of react build since it will override prettier's changes
* Fixing broken icons in docs, should unblock #732


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
