### PR TITLE
adding text color and border radius to badges

### DIFF
--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -12,6 +12,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-alert-error-background-color: var(--amplify-colors-background-error);
         --amplify-components-alert-warning-background-color: var(--amplify-colors-background-warning);
         --amplify-components-alert-success-background-color: var(--amplify-colors-background-success);
+        --amplify-components-badge-color: var(--amplify-colors-font-primary);
         --amplify-components-badge-line-height: 1;
         --amplify-components-badge-font-weight: var(--amplify-font-weights-semibold);
         --amplify-components-badge-font-size: var(--amplify-font-sizes-small);
@@ -19,10 +20,14 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-badge-padding-vertical: var(--amplify-space-xs);
         --amplify-components-badge-padding-horizontal: var(--amplify-space-small);
         --amplify-components-badge-background-color: var(--amplify-colors-background-tertiary);
-        --amplify-components-badge-border-radius: 9999px;
+        --amplify-components-badge-border-radius: var(--amplify-radii-xl);
+        --amplify-components-badge-info-color: var(--amplify-colors-font-info);
         --amplify-components-badge-info-background-color: var(--amplify-colors-background-info);
+        --amplify-components-badge-warning-color: var(--amplify-colors-font-warning);
         --amplify-components-badge-warning-background-color: var(--amplify-colors-background-warning);
+        --amplify-components-badge-success-color: var(--amplify-colors-font-success);
         --amplify-components-badge-success-background-color: var(--amplify-colors-background-success);
+        --amplify-components-badge-error-color: var(--amplify-colors-font-error);
         --amplify-components-badge-error-background-color: var(--amplify-colors-background-error);
         --amplify-components-badge-small-font-size: var(--amplify-font-sizes-xs);
         --amplify-components-badge-small-padding-vertical: var(--amplify-space-xxs);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -62,6 +62,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-alert-error-background-color: var(--amplify-colors-background-error);
         --amplify-components-alert-warning-background-color: var(--amplify-colors-background-warning);
         --amplify-components-alert-success-background-color: var(--amplify-colors-background-success);
+        --amplify-components-badge-color: var(--amplify-colors-font-primary);
         --amplify-components-badge-line-height: 1;
         --amplify-components-badge-font-weight: var(--amplify-font-weights-semibold);
         --amplify-components-badge-font-size: var(--amplify-font-sizes-small);
@@ -69,10 +70,14 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-badge-padding-vertical: var(--amplify-space-xs);
         --amplify-components-badge-padding-horizontal: var(--amplify-space-small);
         --amplify-components-badge-background-color: var(--amplify-colors-background-tertiary);
-        --amplify-components-badge-border-radius: 9999px;
+        --amplify-components-badge-border-radius: var(--amplify-radii-xl);
+        --amplify-components-badge-info-color: var(--amplify-colors-font-info);
         --amplify-components-badge-info-background-color: var(--amplify-colors-background-info);
+        --amplify-components-badge-warning-color: var(--amplify-colors-font-warning);
         --amplify-components-badge-warning-background-color: var(--amplify-colors-background-warning);
+        --amplify-components-badge-success-color: var(--amplify-colors-font-success);
         --amplify-components-badge-success-background-color: var(--amplify-colors-background-success);
+        --amplify-components-badge-error-color: var(--amplify-colors-font-error);
         --amplify-components-badge-error-background-color: var(--amplify-colors-background-error);
         --amplify-components-badge-small-font-size: var(--amplify-font-sizes-xs);
         --amplify-components-badge-small-padding-vertical: var(--amplify-space-xxs);

--- a/packages/ui/src/theme/css/component/badge.scss
+++ b/packages/ui/src/theme/css/component/badge.scss
@@ -1,4 +1,5 @@
 .amplify-badge {
+  color: var(--amplify-components-badge-color);
   background-color: var(--amplify-components-badge-background-color);
   border-radius: var(--amplify-components-badge-border-radius);
   display: inline-flex;
@@ -10,18 +11,22 @@
   line-height: var(--amplify-components-badge-line-height);
 
   &[data-variation='info'] {
+    color: var(--amplify-components-badge-info-color);
     background-color: var(--amplify-components-badge-info-background-color);
   }
 
   &[data-variation='error'] {
+    color: var(--amplify-components-badge-error-color);
     background-color: var(--amplify-components-badge-error-background-color);
   }
 
   &[data-variation='warning'] {
+    color: var(--amplify-components-badge-warning-color);
     background-color: var(--amplify-components-badge-warning-background-color);
   }
 
   &[data-variation='success'] {
+    color: var(--amplify-components-badge-success-color);
     background-color: var(--amplify-components-badge-success-background-color);
   }
 

--- a/packages/ui/src/theme/tokens/components/badge.js
+++ b/packages/ui/src/theme/tokens/components/badge.js
@@ -1,5 +1,6 @@
 module.exports = {
   // Default styles
+  color: { value: '{colors.font.primary.value}' },
   lineHeight: { value: 1 },
   fontWeight: { value: '{fontWeights.semibold.value}' },
   fontSize: { value: '{fontSizes.small.value}' },
@@ -8,22 +9,26 @@ module.exports = {
   paddingHorizontal: { value: '{space.small.value}' },
   backgroundColor: { value: '{colors.background.tertiary.value}' },
   // An arbitrarily large value to ensure that the left and right sides of the badge are perfectly rounded for any size variation
-  borderRadius: { value: '9999px' },
+  borderRadius: { value: '{radii.xl.value}' },
 
   // Variations
   info: {
+    color: { value: '{colors.font.info.value}' },
     backgroundColor: { value: '{colors.background.info.value}' },
   },
 
   warning: {
+    color: { value: '{colors.font.warning.value}' },
     backgroundColor: { value: '{colors.background.warning.value}' },
   },
 
   success: {
+    color: { value: '{colors.font.success.value}' },
     backgroundColor: { value: '{colors.background.success.value}' },
   },
 
   error: {
+    color: { value: '{colors.font.error.value}' },
     backgroundColor: { value: '{colors.background.error.value}' },
   },
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Added font color tokens for badges
* Used a reference to radii token for badge border radius so it is theme-able at a broader level

<img width="882" alt="CleanShot 2021-11-16 at 15 31 12@2x" src="https://user-images.githubusercontent.com/321279/142082790-87cc28a3-7b52-4325-a61b-9971fa0151d0.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
