### PR TITLE
ForwardRef support - CountryCode and SliderField

### DIFF
--- a/.changeset/angry-suns-divide.md
+++ b/.changeset/angry-suns-divide.md
@@ -2,4 +2,4 @@
 "@aws-amplify/ui-react": patch
 ---
 
-ForwardRef support - CountryCode and SliderField
+ForwardRef support - CountryCode, SelectField, and SliderField

--- a/.changeset/angry-suns-divide.md
+++ b/.changeset/angry-suns-divide.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef support - CountryCode and SliderField

--- a/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
@@ -6,7 +6,7 @@ import { SelectField } from '../SelectField';
 import { ComponentClassNames } from '../shared/constants';
 import { CountryCodeSelectProps, PrimitiveWithForwardRef } from '../types';
 
-const CountryCodeSelectInner: PrimitiveWithForwardRef<
+const CountryCodeSelectPrimitive: PrimitiveWithForwardRef<
   CountryCodeSelectProps,
   'select'
 > = ({ className, ...props }, ref) => {
@@ -33,6 +33,6 @@ const CountryCodeSelectInner: PrimitiveWithForwardRef<
   );
 };
 
-export const CountryCodeSelect = React.forwardRef(CountryCodeSelectInner);
+export const CountryCodeSelect = React.forwardRef(CountryCodeSelectPrimitive);
 
 CountryCodeSelect.displayName = 'CountryCodeSelect';

--- a/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
@@ -1,16 +1,16 @@
-import { useMemo } from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import { countryDialCodes } from '@aws-amplify/ui';
 
 import { SelectField } from '../SelectField';
 import { ComponentClassNames } from '../shared/constants';
-import { CountryCodeSelectProps, Primitive } from '../types';
+import { CountryCodeSelectProps, PrimitiveWithForwardRef } from '../types';
 
-export const CountryCodeSelect: Primitive<CountryCodeSelectProps, 'select'> = ({
-  className,
-  ...props
-}) => {
-  const countryCodeOptions = useMemo(
+const CountryCodeSelectInner: PrimitiveWithForwardRef<
+  CountryCodeSelectProps,
+  'select'
+> = ({ className, ...props }, ref) => {
+  const countryCodeOptions = React.useMemo(
     () =>
       countryDialCodes.map((dialCode) => (
         <option key={dialCode} value={dialCode}>
@@ -25,11 +25,14 @@ export const CountryCodeSelect: Primitive<CountryCodeSelectProps, 'select'> = ({
       autoComplete="tel-country-code"
       className={classNames(ComponentClassNames.CountryCodeSelect, className)}
       labelHidden={true}
+      ref={ref}
       {...props}
     >
       {countryCodeOptions}
     </SelectField>
   );
 };
+
+export const CountryCodeSelect = React.forwardRef(CountryCodeSelectInner);
 
 CountryCodeSelect.displayName = 'CountryCodeSelect';

--- a/packages/react/src/primitives/PhoneNumberField/__tests__/CountryCodeSelect.test.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/__tests__/CountryCodeSelect.test.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { getByAltText, render, screen } from '@testing-library/react';
 import { countryDialCodes } from '@aws-amplify/ui';
 
@@ -10,7 +12,7 @@ describe('CountryCodeSelect', () => {
     defaultValue = '+1',
     label = 'Country Code',
     ...rest
-  }: Partial<CountryCodeSelectProps>) => {
+  }: Partial<typeof CountryCodeSelect['defaultProps']>) => {
     render(
       <CountryCodeSelect label={label} defaultValue={defaultValue} {...rest} />
     );
@@ -261,6 +263,15 @@ describe('CountryCodeSelect', () => {
     expect($countryCodeSelect).toHaveClass(
       ComponentClassNames.CountryCodeSelect
     );
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLSelectElement>();
+    const testId = 'CountryCodeSelectTestId';
+    await setup({ testId, ref });
+
+    await screen.findByTestId(testId);
+    expect(ref.current.nodeName).toBe('SELECT');
   });
 
   it('should have a hidden label by default', async () => {

--- a/packages/react/src/primitives/SelectField/SelectField.tsx
+++ b/packages/react/src/primitives/SelectField/SelectField.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
@@ -6,9 +7,12 @@ import { FieldErrorMessage, FieldDescription } from '../Field';
 import { Flex } from '../Flex';
 import { Select } from '../Select';
 import { Label } from '../Label';
-import { SelectFieldProps, Primitive } from '../types';
+import { SelectFieldProps, PrimitiveWithForwardRef } from '../types';
 
-export const SelectField: Primitive<SelectFieldProps, 'select'> = (props) => {
+const SelectFieldPrimitive: PrimitiveWithForwardRef<
+  SelectFieldProps,
+  'select'
+> = (props, ref) => {
   const {
     alignContent,
     alignItems,
@@ -75,6 +79,7 @@ export const SelectField: Primitive<SelectFieldProps, 'select'> = (props) => {
         isRequired={isRequired}
         onChange={onChange}
         placeholder={placeholder}
+        ref={ref}
         size={size}
         variation={variation}
         value={value}
@@ -86,5 +91,7 @@ export const SelectField: Primitive<SelectFieldProps, 'select'> = (props) => {
     </Flex>
   );
 };
+
+export const SelectField = React.forwardRef(SelectFieldPrimitive);
 
 SelectField.displayName = 'SelectField';

--- a/packages/react/src/primitives/SelectField/__tests__/SelectField.test.tsx
+++ b/packages/react/src/primitives/SelectField/__tests__/SelectField.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -103,6 +104,20 @@ describe('SelectField test suite', () => {
 
       const select = await screen.findByRole(role);
       expect(select).toHaveAttribute('id', id);
+    });
+
+    it('should forward ref to DOM element', async () => {
+      const ref = React.createRef<HTMLSelectElement>();
+      render(
+        <SelectField id={id} label={label} ref={ref}>
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+        </SelectField>
+      );
+
+      await screen.findByRole(role);
+      expect(ref.current.nodeName).toBe('SELECT');
     });
 
     it('should render labeled select field when id is provided', async () => {

--- a/packages/react/src/primitives/SliderField/SliderField.tsx
+++ b/packages/react/src/primitives/SliderField/SliderField.tsx
@@ -8,7 +8,7 @@ import { Flex } from '../Flex';
 import { Label } from '../Label';
 import { View } from '../View';
 import { SliderFieldProps } from '../types/sliderField';
-import { Primitive } from '../types/view';
+import { PrimitiveWithForwardRef } from '../types/view';
 import { ComponentClassNames } from '../shared/constants';
 import { splitPrimitiveProps } from '../shared/styleUtils';
 import { isFunction, useStableId } from '../shared/utils';
@@ -18,30 +18,37 @@ export const SLIDER_ROOT_TEST_ID = 'slider-root';
 export const SLIDER_TRACK_TEST_ID = 'slider-track';
 export const SLIDER_RANGE_TEST_ID = 'slider-range';
 
-export const SliderField: Primitive<SliderFieldProps, typeof Root> = ({
-  ariaValuetext,
-  className,
-  defaultValue,
-  descriptiveText,
-  emptyTrackColor,
-  errorMessage,
-  filledTrackColor,
-  hasError = false,
-  id,
-  isDisabled,
-  isValueHidden = false,
-  label,
-  labelHidden = false,
-  onChange,
-  orientation = 'horizontal',
-  outerEndComponent,
-  outerStartComponent,
-  testId,
-  thumbColor,
-  trackSize,
-  value,
-  ..._rest
-}) => {
+const SliderFieldPrimitive: PrimitiveWithForwardRef<
+  SliderFieldProps,
+  typeof Root
+> = (
+  {
+    ariaValuetext,
+    className,
+    defaultValue,
+    descriptiveText,
+    emptyTrackColor,
+    errorMessage,
+    filledTrackColor,
+    hasError = false,
+    id,
+    isDisabled,
+    isValueHidden = false,
+    label,
+    labelHidden = false,
+    onChange,
+    orientation = 'horizontal',
+    outerEndComponent,
+    outerStartComponent,
+    testId,
+    thumbColor,
+    trackSize,
+    dir,
+    value,
+    ..._rest
+  },
+  ref
+) => {
   const fieldId = useStableId(id);
 
   const { flexContainerStyleProps, rest } = splitPrimitiveProps(_rest);
@@ -101,10 +108,11 @@ export const SliderField: Primitive<SliderFieldProps, typeof Root> = ({
           className={classNames(ComponentClassNames.SliderFieldRoot, className)}
           data-testid={SLIDER_ROOT_TEST_ID}
           disabled={isDisabled}
-          orientation={orientation}
           defaultValue={defaultValues}
-          value={values}
           onValueChange={onValueChange}
+          orientation={orientation}
+          ref={ref}
+          value={values}
           {...rest}
         >
           <Track
@@ -133,5 +141,7 @@ export const SliderField: Primitive<SliderFieldProps, typeof Root> = ({
     </Flex>
   );
 };
+
+export const SliderField = React.forwardRef(SliderFieldPrimitive);
 
 SliderField.displayName = 'SliderField';

--- a/packages/react/src/primitives/SliderField/__tests__/SliderField.test.tsx
+++ b/packages/react/src/primitives/SliderField/__tests__/SliderField.test.tsx
@@ -53,6 +53,22 @@ describe('SliderField: ', () => {
       );
     });
 
+    it('should forward ref to DOM element', async () => {
+      const ref = React.createRef<HTMLSpanElement>();
+      const testId = 'sliderTestId';
+      render(
+        <SliderField
+          defaultValue={0}
+          label="slider"
+          ref={ref}
+          testId={testId}
+        />
+      );
+
+      await screen.findByTestId(testId);
+      expect(ref.current.nodeName).toBe('SPAN');
+    });
+
     it('should have `sr-only` class when labelHidden is true', async () => {
       render(
         <SliderField defaultValue={0} label="slider" labelHidden={true} />

--- a/packages/react/src/primitives/types/view.ts
+++ b/packages/react/src/primitives/types/view.ts
@@ -13,13 +13,19 @@ export type ElementType = React.FC<any> | keyof JSX.IntrinsicElements;
  */
 export type HTMLElementType<Element extends ElementType> =
   Element extends keyof JSX.IntrinsicElements
-    ? JSX.IntrinsicElements[Element] extends React.DetailedHTMLProps<
-        unknown,
-        infer HTMLType
-      >
-      ? HTMLType
-      : never
-    : HTMLDivElement;
+    ? React.ElementRef<Element>
+    : HTMLElementTypeFromExoticComponentRef<Element>;
+
+/**
+ * Allows us to extract ElementType from `typeof Root` used in SliderField
+ * e.g. React.ForwardRefExoticComponent<SliderProps & React.RefAttributes<HTMLSpanElement>> => HTMLSpanElement
+ */
+type HTMLElementTypeFromExoticComponentRef<Element extends ElementType> =
+  Element extends React.ForwardRefExoticComponent<
+    React.RefAttributes<infer DOMHTMLElement>
+  >
+    ? DOMHTMLElement
+    : HTMLElement; // Fallback to HTMLElement if nothing else matches
 
 export type ElementProps<Element extends ElementType> =
   Element extends keyof JSX.IntrinsicElements


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for the `CountryCodeSelect`, `SelectField`, and `SliderField` primitives by wrapping them in `React.forwardRef`.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null);
  
  // Below returns SPAN because the ref is forwarded down to DOM element (SliderField => Root => <span>)
  // ref.current.nodeName 
  
  return (
    <SliderField ref={ref} />
  );
};
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
