### PR TITLE
Fix forgot password placeholder

### DIFF
--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/reset-password/reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/reset-password/reset-password.component.html
@@ -15,6 +15,7 @@
         type="username"
         autocomplete="username"
         [placeholder]="labelText"
+        [label]="labelText"
       ></amplify-form-field>
       <button amplify-button variation="primary" fullWidth="true" type="submit">
         {{ sendCodeText }}

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/reset-password/reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/reset-password/reset-password.component.html
@@ -14,6 +14,7 @@
         name="username"
         type="username"
         autocomplete="username"
+        [placeholder]="labelText"
       ></amplify-form-field>
       <button amplify-button variation="primary" fullWidth="true" type="submit">
         {{ sendCodeText }}

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/reset-password/reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/reset-password/reset-password.component.ts
@@ -1,20 +1,27 @@
-import { Component, HostBinding, Input } from '@angular/core';
+import { Component, HostBinding, Input, OnInit } from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
-import { translate } from '@aws-amplify/ui';
+import { getAliasInfoFromContext, translate } from '@aws-amplify/ui';
 
 @Component({
   selector: 'amplify-reset-password',
   templateUrl: './reset-password.component.html',
 })
-export class ResetPasswordComponent {
+export class ResetPasswordComponent implements OnInit {
   @HostBinding('attr.data-amplify-authenticator-resetPassword') dataAttr = '';
   @Input() public headerText = translate('Reset your password');
 
   // translated texts
   public sendCodeText = translate('Send Code');
   public backToSignInText = translate('Back to Sign In');
+  public labelText = translate<string>('Username');
 
   constructor(public authenticator: AuthenticatorService) {}
+
+  ngOnInit(): void {
+    const { authState } = this.authenticator;
+    const { label } = getAliasInfoFromContext(authState.context);
+    this.labelText = `Enter your ${label.toLowerCase()}`;
+  }
 
   public get context() {
     const { updateForm, toSignIn, submitForm, error } = this.authenticator;

--- a/packages/e2e/features/ui/components/authenticator/reset-password.feature
+++ b/packages/e2e/features/ui/components/authenticator/reset-password.feature
@@ -18,3 +18,9 @@ Feature: Reset Password
     When I type my "username" with status "UNKNOWN"
     And I click the "Send code" button
     Then I see "Username/client id combination not found."
+
+  @angular @react @vue
+  Scenario: Reset Password with valid placeholder 
+    Then I see "Enter your username"
+    And I don't see "Enter your phone number"
+    And I don't see "Enter your email"

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -1,11 +1,14 @@
-import { translate } from '@aws-amplify/ui';
+import { getAliasInfoFromContext, translate } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
 import { Flex, Form, Heading, TextField } from '../../..';
 import { RemoteErrorMessage, TwoButtonSubmitFooter } from '../shared';
 
 export const ResetPassword = (): JSX.Element => {
-  const { isPending, submitForm, updateForm } = useAuthenticator();
+  const { isPending, submitForm, updateForm, _state } = useAuthenticator();
+
+  const { label } = getAliasInfoFromContext(_state.context);
+  const labelText = `Enter your ${label.toLowerCase()}`;
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     let { checked, name, type, value } = event.target;
@@ -33,7 +36,7 @@ export const ResetPassword = (): JSX.Element => {
           <TextField
             autoComplete="username"
             name="username"
-            placeholder={translate('Enter your username')}
+            placeholder={translate<string>(labelText)}
             label={translate('Enter your username')}
             labelHidden={true}
             required={true}

--- a/packages/ui/src/i18n/dictionaries/en.ts
+++ b/packages/ui/src/i18n/dictionaries/en.ts
@@ -16,6 +16,8 @@ export const enDict = {
   Email: 'Email',
   'Enter your code': 'Enter your code',
   'Enter your username': 'Enter your username',
+  'Enter your phone number': 'Enter your phone number',
+  'Enter your email': 'Enter your email',
   'Forgot your password? ': 'Forgot your password? ',
   'Hide password': 'Hide password',
   Loading: 'Loading',

--- a/packages/vue/src/components/reset-password.vue
+++ b/packages/vue/src/components/reset-password.vue
@@ -83,7 +83,7 @@ const onBackToSignInClicked = (): void => {
             style="flex-direction: column"
           >
             <base-label class="sr-only amplify-label" for="amplify-field-7dce">
-              Username
+              {{ labelText }}
             </base-label>
             <base-wrapper class="amplify-flex">
               <base-input

--- a/packages/vue/src/components/reset-password.vue
+++ b/packages/vue/src/components/reset-password.vue
@@ -1,102 +1,27 @@
-<template>
-  <slot v-bind="$attrs" name="resetPasswordSlotI">
-    <base-form
-      v-bind="$attrs"
-      data-amplify-authenticator-resetpassword
-      @input="onInput"
-      @submit.prevent="onResetPasswordSubmit"
-    >
-      <base-wrapper class="amplify-flex" style="flex-direction: column">
-        <slot name="header">
-          <base-heading class="amplify-heading" :level="3">
-            {{ resetPasswordHeading }}
-          </base-heading>
-        </slot>
-        <base-field-set
-          class="amplify-flex"
-          style="flex-direction: column"
-          :disabled="actorState.matches('resetPassword.pending')"
-        >
-          <base-wrapper
-            class="amplify-flex amplify-field amplify-textfield"
-            style="flex-direction: column"
-          >
-            <base-label class="sr-only amplify-label" for="amplify-field-7dce">
-              Username
-            </base-label>
-            <base-wrapper class="amplify-flex">
-              <base-input
-                class="amplify-input amplify-field-group__control"
-                id="amplify-field-7dce"
-                aria-invalid="false"
-                name="username"
-                :placeholder="enterUsernameText"
-                autocomplete="username"
-                required
-                type="username"
-              ></base-input>
-            </base-wrapper>
-          </base-wrapper>
-        </base-field-set>
-
-        <base-footer
-          class="amplify-flex"
-          style="flex-direction: column; align-items: unset"
-        >
-          <base-alert v-if="actorState?.context?.remoteError">
-            {{ actorState?.context?.remoteError }}
-          </base-alert>
-          <amplify-button
-            class="amplify-field-group__control"
-            data-fullwidth="false"
-            data-variation="primary"
-            type="submit"
-            style="font-weight: normal"
-            :disabled="actorState.matches('resetPassword.pending')"
-            >{{ resetPasswordText }}</amplify-button
-          >
-          <amplify-button
-            class="amplify-field-group__control"
-            data-fullwidth="false"
-            data-size="small"
-            data-variation="link"
-            style="font-weight: normal"
-            type="button"
-            @click.prevent="onBackToSignInClicked"
-          >
-            {{ backSignInText }}</amplify-button
-          >
-          <slot
-            name="footer"
-            :onBackToSignInClicked="onBackToSignInClicked"
-            :onResetPasswordSubmit="onResetPasswordSubmit"
-          >
-          </slot>
-        </base-footer>
-      </base-wrapper>
-    </base-form>
-  </slot>
-</template>
-
 <script setup lang="ts">
-import { computed, ComputedRef, useAttrs } from 'vue';
-import { getActorState, ResetPasswordState, translate } from '@aws-amplify/ui';
+import { computed, ComputedRef, useAttrs, toRefs } from 'vue';
+import {
+  getAliasInfoFromContext,
+  ResetPasswordState,
+  translate,
+} from '@aws-amplify/ui';
 
-import { useAuth } from '../composables/useAuth';
+import { useAuthenticator } from '../composables/useAuth';
 
 const attrs = useAttrs();
 const emit = defineEmits(['resetPasswordSubmit', 'backToSignInClicked']);
 
-const { state, send } = useAuth();
-const actorState: ComputedRef<ResetPasswordState> = computed(() =>
-  getActorState(state.value)
-) as ComputedRef<ResetPasswordState>;
+const { state, send } = useAuthenticator();
+const { error, isPending } = toRefs(useAuthenticator());
+
+const { label } = getAliasInfoFromContext(state.context);
+const labelText = `Enter your ${label.toLowerCase()}`;
 
 // Computed Properties
 const backSignInText = computed(() => translate('Back to Sign In'));
 const resetPasswordHeading = computed(() => translate('Reset your password'));
 const resetPasswordText = computed(() => translate('Send Code'));
-const enterUsernameText = computed(() => translate('Enter your username'));
+const enterUsernameText = computed(() => translate<string>(labelText));
 
 // Methods
 const onResetPasswordSubmit = (e: Event): void => {
@@ -133,3 +58,83 @@ const onBackToSignInClicked = (): void => {
   }
 };
 </script>
+
+<template>
+  <slot v-bind="$attrs" name="resetPasswordSlotI">
+    <base-form
+      v-bind="$attrs"
+      data-amplify-authenticator-resetpassword
+      @input="onInput"
+      @submit.prevent="onResetPasswordSubmit"
+    >
+      <base-wrapper class="amplify-flex" style="flex-direction: column">
+        <slot name="header">
+          <base-heading class="amplify-heading" :level="3">
+            {{ resetPasswordHeading }}
+          </base-heading>
+        </slot>
+        <base-field-set
+          class="amplify-flex"
+          style="flex-direction: column"
+          :disabled="isPending"
+        >
+          <base-wrapper
+            class="amplify-flex amplify-field amplify-textfield"
+            style="flex-direction: column"
+          >
+            <base-label class="sr-only amplify-label" for="amplify-field-7dce">
+              Username
+            </base-label>
+            <base-wrapper class="amplify-flex">
+              <base-input
+                class="amplify-input amplify-field-group__control"
+                id="amplify-field-7dce"
+                aria-invalid="false"
+                name="username"
+                :placeholder="enterUsernameText"
+                autocomplete="username"
+                required
+                type="username"
+              ></base-input>
+            </base-wrapper>
+          </base-wrapper>
+        </base-field-set>
+
+        <base-footer
+          class="amplify-flex"
+          style="flex-direction: column; align-items: unset"
+        >
+          <base-alert v-if="error">
+            {{ error }}
+          </base-alert>
+          <amplify-button
+            class="amplify-field-group__control"
+            data-fullwidth="false"
+            data-variation="primary"
+            type="submit"
+            style="font-weight: normal"
+            :disabled="isPending"
+            >{{ resetPasswordText }}</amplify-button
+          >
+          <amplify-button
+            class="amplify-field-group__control"
+            data-fullwidth="false"
+            data-size="small"
+            data-variation="link"
+            style="font-weight: normal"
+            type="button"
+            @click.prevent="onBackToSignInClicked"
+          >
+            {{ backSignInText }}</amplify-button
+          >
+          <slot
+            name="footer"
+            :onBackToSignInClicked="onBackToSignInClicked"
+            :onResetPasswordSubmit="onResetPasswordSubmit"
+          >
+          </slot>
+        </base-footer>
+      </base-wrapper>
+    </base-form>
+  </slot>
+</template>

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -1,5 +1,5 @@
 import { useActor } from '@xstate/vue';
-import { ref, reactive, Ref, watchEffect, onMounted, computed } from 'vue';
+import { ref, reactive, Ref, watchEffect } from 'vue';
 import { getServiceFacade } from '@aws-amplify/ui';
 import { facade } from './useUtils';
 import { InterpretService } from '@/components';

--- a/packages/vue/src/composables/useAuth.ts
+++ b/packages/vue/src/composables/useAuth.ts
@@ -1,5 +1,5 @@
 import { useActor } from '@xstate/vue';
-import { ref, reactive, Ref, watchEffect, onMounted } from 'vue';
+import { ref, reactive, Ref, watchEffect, onMounted, computed } from 'vue';
 import { getServiceFacade } from '@aws-amplify/ui';
 import { facade } from './useUtils';
 import { InterpretService } from '@/components';
@@ -15,20 +15,23 @@ export const useAuth = (serv?: InterpretService) => {
 };
 
 export const useAuthenticator = () => {
-  onMounted(() => {
-    watchEffect(() => {
-      if (!service.value) return;
-
-      const { state, send } = useAuth();
-
-      const facadeValues = getServiceFacade({ send, state: state.value });
-      for (const key of Object.keys(facade)) {
-        //@ts-ignore
-        useAuthenticatorValue[key] = facadeValues[key];
-      }
-      useAuthenticatorValue.send = send;
-      useAuthenticatorValue.state = state;
-    });
+  createValues();
+  watchEffect(() => {
+    createValues();
   });
   return useAuthenticatorValue;
 };
+
+function createValues() {
+  if (!service.value) return;
+
+  const { state, send } = useAuth();
+
+  const facadeValues = getServiceFacade({ send, state: state.value });
+  for (const key of Object.keys(facade)) {
+    //@ts-ignore
+    useAuthenticatorValue[key] = facadeValues[key];
+  }
+  useAuthenticatorValue.send = send;
+  useAuthenticatorValue.state = state;
+}


### PR DESCRIPTION
*Issue #, if available:*
#714 

*Description of changes:*
Updated placeholder label so it shows the correct `email/phone number/username` label on the reset password page. 

![image](https://user-images.githubusercontent.com/65630/142248349-ac30ab3b-25dc-4815-928b-9c95fff0bbcd.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
