### PR TITLE
chore(angular): make authenticator service variable public

### DIFF
--- a/examples/angular/src/pages/ui/components/authenticator/custom-slots/custom-slots.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/custom-slots/custom-slots.component.ts
@@ -9,7 +9,7 @@ import awsExports from '@environments/auth-with-federated/src/aws-exports';
   templateUrl: 'custom-slots.component.html',
 })
 export class CustomSlotsComponent {
-  constructor(private authenticator: AuthenticatorService) {
+  constructor(public authenticator: AuthenticatorService) {
     Amplify.configure(awsExports);
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Currently, `private authenticator: AuthenticatorService` is marked as `private` in `custom-slots` example. This should be marked as public because they are being used in the templates. Technically the samples still worked because transpiled JS doesn't actually have private variables (yet), but it's a good practice.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
