### PR TITLE
Remove internal FieldGroup from public export

### DIFF
--- a/.changeset/young-cheetahs-perform.md
+++ b/.changeset/young-cheetahs-perform.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Remove internal fieldgroup export

--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -25,7 +25,6 @@ describe('@aws-amplify/ui-react', () => {
           "ErrorText",
           "Expander",
           "ExpanderItem",
-          "FieldGroup",
           "FieldGroupIcon",
           "FieldGroupIconButton",
           "Fieldset",

--- a/packages/react/src/primitives/components.ts
+++ b/packages/react/src/primitives/components.ts
@@ -7,7 +7,6 @@ export { CheckboxField } from './CheckboxField';
 export { Collection } from './Collection';
 export { Divider } from './Divider';
 export { Expander, ExpanderItem } from './Expander';
-export { FieldGroup } from './FieldGroup';
 export { FieldGroupIcon, FieldGroupIconButton } from './FieldGroupIcon';
 export { Flex } from './Flex';
 export { Grid } from './Grid';


### PR DESCRIPTION
*Description of changes:*
This PR removes the `FieldGroup` internal component from the external API surface area. It wasn't intended to be exposed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
