### PR TITLE
Adding developer preview banner for primitive pages

### DIFF
--- a/docs/src/components/Layout/index.tsx
+++ b/docs/src/components/Layout/index.tsx
@@ -1,9 +1,43 @@
 import * as React from 'react';
 import debounce from 'lodash/debounce';
-import { Alert, Heading, Text, useTheme } from '@aws-amplify/ui-react';
+import {
+  Alert,
+  Heading,
+  Button,
+  Text,
+  IconFeedback,
+  useTheme,
+} from '@aws-amplify/ui-react';
 import { SecondaryNav } from './SecondaryNav';
 import { TableOfContents } from '../TableOfContents';
 import { Footer } from './Footer';
+
+const PrimitiveAlert = () => {
+  const { tokens } = useTheme();
+  return (
+    <Alert
+      variation="info"
+      heading="Developer preview"
+      margin={`${tokens.space.small} 0 0 0`}
+    >
+      <Text>
+        Amplify UI primitive components like this one are in developer preview
+        and only available in React for now.
+      </Text>
+      <Button
+        as="a"
+        size="small"
+        gap={tokens.space.xs}
+        margin={`${tokens.space.xs} 0 0 0`}
+        isExternal
+        href="https://github.com/aws-amplify/amplify-ui/discussions/198"
+      >
+        <IconFeedback />
+        Add feedback here
+      </Button>
+    </Alert>
+  );
+};
 
 export default function Page({
   children,
@@ -12,7 +46,12 @@ export default function Page({
   children: any;
   frontmatter?: any;
 }) {
-  const { title, description, hideToc = false } = frontmatter;
+  const {
+    title,
+    description,
+    hideToc = false,
+    isPrimitive = false,
+  } = frontmatter;
   const { tokens } = useTheme();
   const [headings, setHeadings] = React.useState([]);
 
@@ -53,6 +92,7 @@ export default function Page({
             >
               {description}
             </Text>
+            {isPrimitive ? <PrimitiveAlert /> : null}
           </section>
 
           {children}

--- a/docs/src/data/links.ts
+++ b/docs/src/data/links.ts
@@ -116,7 +116,7 @@ export const layoutComponents = [
   { href: '/components/flex', label: 'Flex', body: `` },
   { href: '/components/grid', label: 'Grid', body: `` },
   { href: '/components/table', label: 'Table', body: `` },
-  { href: '/components/expander', label: 'Table', body: `` },
+  { href: '/components/expander', label: 'Expander', body: `` },
 ].sort(sortByLabel);
 
 export const navigationComponents: ComponentNavItem[] = [

--- a/docs/src/data/links.ts
+++ b/docs/src/data/links.ts
@@ -38,6 +38,11 @@ export const baseComponents: ComponentNavItem[] = [
     label: 'Divider',
     body: ``,
   },
+  {
+    href: '/components/scrollview',
+    label: 'Scrollview',
+    body: ``,
+  },
 ].sort(sortByLabel);
 
 export const connectedComponents = [
@@ -89,6 +94,7 @@ export const feedbackComponents: ComponentNavItem[] = [
 export const inputComponents = [
   { href: '/components/textfield', label: 'Text Field', body: `` },
   { href: '/components/selectfield', label: 'Select Field', body: `` },
+  { href: '/components/sliderfield', label: 'Stepper Field', body: `` },
   { href: '/components/stepperfield', label: 'Stepper Field', body: `` },
   { href: '/components/searchfield', label: 'Search Field', body: `` },
   { href: '/components/passwordfield', label: 'Password Field', body: `` },
@@ -110,6 +116,7 @@ export const layoutComponents = [
   { href: '/components/flex', label: 'Flex', body: `` },
   { href: '/components/grid', label: 'Grid', body: `` },
   { href: '/components/table', label: 'Table', body: `` },
+  { href: '/components/expander', label: 'Table', body: `` },
 ].sort(sortByLabel);
 
 export const navigationComponents: ComponentNavItem[] = [

--- a/docs/src/data/links.ts
+++ b/docs/src/data/links.ts
@@ -94,7 +94,7 @@ export const feedbackComponents: ComponentNavItem[] = [
 export const inputComponents = [
   { href: '/components/textfield', label: 'Text Field', body: `` },
   { href: '/components/selectfield', label: 'Select Field', body: `` },
-  { href: '/components/sliderfield', label: 'Stepper Field', body: `` },
+  { href: '/components/sliderfield', label: 'Slider Field', body: `` },
   { href: '/components/stepperfield', label: 'Stepper Field', body: `` },
   { href: '/components/searchfield', label: 'Search Field', body: `` },
   { href: '/components/passwordfield', label: 'Password Field', body: `` },

--- a/docs/src/pages/components/alert/index.page.mdx
+++ b/docs/src/pages/components/alert/index.page.mdx
@@ -1,6 +1,7 @@
 ---
 title: Alert
 description: An Alert displays a brief, important message in a way that attracts the user's attention without interrupting the user's task. Alerts are typically intended to be read out dynamically by a screen reader.
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/badge/index.page.mdx
+++ b/docs/src/pages/components/badge/index.page.mdx
@@ -1,6 +1,7 @@
 ---
 title: Badge
 description: A Badge is a small visual element to denote a status or message about an item. A small, color-coded visual element that contains letters or numbers, that you can use to label, categorize, or organize items.
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/button/index.page.mdx
+++ b/docs/src/pages/components/button/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Button
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/card/index.page.mdx
+++ b/docs/src/pages/components/card/index.page.mdx
@@ -1,6 +1,7 @@
 ---
 title: Card
 description: The Card component can be used to group related pieces of content.
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/checkboxfield/index.page.mdx
+++ b/docs/src/pages/components/checkboxfield/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: CheckboxField
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/collection/index.page.mdx
+++ b/docs/src/pages/components/collection/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Collection
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/divider/index.page.mdx
+++ b/docs/src/pages/components/divider/index.page.mdx
@@ -1,6 +1,7 @@
 ---
 title: Divider
 description: A Divider creates separations in content. Dividers can help organize content and establish visual rhythm.
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/expander/index.page.mdx
+++ b/docs/src/pages/components/expander/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Expander
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/flex/index.page.mdx
+++ b/docs/src/pages/components/flex/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Flex
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/grid/index.page.mdx
+++ b/docs/src/pages/components/grid/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Grid
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/heading/index.page.mdx
+++ b/docs/src/pages/components/heading/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Heading
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/icon/index.page.mdx
+++ b/docs/src/pages/components/icon/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Icon
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/image/index.page.mdx
+++ b/docs/src/pages/components/image/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Image
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/link/index.page.mdx
+++ b/docs/src/pages/components/link/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Link
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/loader/index.page.mdx
+++ b/docs/src/pages/components/loader/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Loader
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/menu/index.page.mdx
+++ b/docs/src/pages/components/menu/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Menu
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/pagination/index.page.mdx
+++ b/docs/src/pages/components/pagination/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Pagination
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/passwordfield/index.page.mdx
+++ b/docs/src/pages/components/passwordfield/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: PasswordField
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/phonenumberfield/index.page.mdx
+++ b/docs/src/pages/components/phonenumberfield/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: PhoneNumberField
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/placeholder/index.page.mdx
+++ b/docs/src/pages/components/placeholder/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Placeholder
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/radiogroupfield/index.page.mdx
+++ b/docs/src/pages/components/radiogroupfield/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: RadioGroupField
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/rating/index.page.mdx
+++ b/docs/src/pages/components/rating/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Rating
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/scrollview/index.page.mdx
+++ b/docs/src/pages/components/scrollview/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: ScrollView
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/searchfield/index.page.mdx
+++ b/docs/src/pages/components/searchfield/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: SearchField
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/selectfield/index.page.mdx
+++ b/docs/src/pages/components/selectfield/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: SelectField
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/sliderfield/index.page.mdx
+++ b/docs/src/pages/components/sliderfield/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: SliderField
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/stepperfield/index.page.mdx
+++ b/docs/src/pages/components/stepperfield/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: StepperField
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/switchfield/index.page.mdx
+++ b/docs/src/pages/components/switchfield/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: SwitchField
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/table/index.page.mdx
+++ b/docs/src/pages/components/table/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Table
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/tabs/index.page.mdx
+++ b/docs/src/pages/components/tabs/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tabs
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/text/index.page.mdx
+++ b/docs/src/pages/components/text/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Text
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/textfield/index.page.mdx
+++ b/docs/src/pages/components/textfield/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: TextField
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/togglebutton/index.page.mdx
+++ b/docs/src/pages/components/togglebutton/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: ToggleButton
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/view/index.page.mdx
+++ b/docs/src/pages/components/view/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: View
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';

--- a/docs/src/pages/components/visuallyhidden/index.page.mdx
+++ b/docs/src/pages/components/visuallyhidden/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: VisuallyHidden
+isPrimitive: true
 ---
 
 import { Fragment } from '@/components/Fragment';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adding a developer preview banner on primitive pages. Note: with the #741 the alert will look nicer

<img width="1440" alt="CleanShot 2021-11-17 at 10 31 51@2x" src="https://user-images.githubusercontent.com/321279/142261177-972f3878-cbb8-4285-919a-48abb8807c86.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
