### PR TITLE
Fixing table page

### DIFF
--- a/docs/src/components/TablePropControls.tsx
+++ b/docs/src/components/TablePropControls.tsx
@@ -46,10 +46,9 @@ export const TablePropControls: TablePropControlsInterface = ({
       name="highlightonhover"
       value="false"
       checked={highlightOnHover}
+      label="highlightOnHover"
       onChange={(e) => setHighlightOnHover(e.target.checked)}
-    >
-      highlightOnHover
-    </CheckboxField>
+    />
     <FieldLabeler id="size">
       <SelectField
         id="size"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Table docs page is fixed now:

<img width="1440" alt="CleanShot 2021-11-17 at 10 51 13@2x" src="https://user-images.githubusercontent.com/321279/142263806-388341dc-31a8-4293-84c5-71f9dd0e076b.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
