### PR TITLE
Remove POC Form primitive

### DIFF
--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -26,7 +26,6 @@ describe('@aws-amplify/ui-react', () => {
           "FieldGroupIcon",
           "FieldGroupIconButton",
           "Flex",
-          "Form",
           "Grid",
           "Heading",
           "Icon",

--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -9,7 +9,7 @@ import {
 import { useAuthenticator } from '..';
 import { Flex, Heading } from '../../..';
 import { ConfirmationCodeInput, ConfirmSignInFooter } from '../shared';
-import { isInputTarget } from '../../../helpers/utils';
+import { isInputEventTarget } from '../../../helpers/utils';
 
 export const ConfirmSignIn = (): JSX.Element => {
   const { _state, error, submitForm, updateForm } = useAuthenticator();
@@ -31,7 +31,7 @@ export const ConfirmSignIn = (): JSX.Element => {
       );
   }
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputTarget(event.target)) {
+    if (isInputEventTarget(event.target)) {
       let { checked, name, type, value } = event.target;
       if (type === 'checkbox' && !checked) value = undefined;
 

--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -9,7 +9,7 @@ import {
 import { useAuthenticator } from '..';
 import { Flex, Heading } from '../../..';
 import { ConfirmationCodeInput, ConfirmSignInFooter } from '../shared';
-import { isInputEventTarget } from '../../../helpers/utils';
+import { isInputOrSelectElement, isInputElement } from '../../../helpers/utils';
 
 export const ConfirmSignIn = (): JSX.Element => {
   const { _state, error, submitForm, updateForm } = useAuthenticator();
@@ -31,9 +31,15 @@ export const ConfirmSignIn = (): JSX.Element => {
       );
   }
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputEventTarget(event.target)) {
-      let { checked, name, type, value } = event.target;
-      if (type === 'checkbox' && !checked) value = undefined;
+    if (isInputOrSelectElement(event.target)) {
+      let { name, type, value } = event.target;
+      if (
+        isInputElement(event.target) &&
+        type === 'checkbox' &&
+        !event.target.checked
+      ) {
+        value = undefined;
+      }
 
       updateForm({ name, value });
     }

--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -7,8 +7,9 @@ import {
 } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
-import { Flex, Form, Heading } from '../../..';
+import { Flex, Heading } from '../../..';
 import { ConfirmationCodeInput, ConfirmSignInFooter } from '../shared';
+import { isInputTarget } from '../../../helpers/utils';
 
 export const ConfirmSignIn = (): JSX.Element => {
   const { _state, error, submitForm, updateForm } = useAuthenticator();
@@ -29,12 +30,13 @@ export const ConfirmSignIn = (): JSX.Element => {
         `Unexpected challengeName encountered in ConfirmSignIn: ${challengeName}`
       );
   }
+  const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
+    if (isInputTarget(event.target)) {
+      let { checked, name, type, value } = event.target;
+      if (type === 'checkbox' && !checked) value = undefined;
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let { checked, name, type, value } = event.target;
-    if (type === 'checkbox' && !checked) value = undefined;
-
-    updateForm({ name, value });
+      updateForm({ name, value });
+    }
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -43,7 +45,8 @@ export const ConfirmSignIn = (): JSX.Element => {
   };
 
   return (
-    <Form
+    <form
+      data-amplify-form=""
       data-amplify-authenticator-confirmsignin=""
       method="post"
       onChange={handleChange}
@@ -58,6 +61,6 @@ export const ConfirmSignIn = (): JSX.Element => {
 
         <ConfirmSignInFooter />
       </Flex>
-    </Form>
+    </form>
   );
 };

--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -2,7 +2,7 @@ import { translate } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '../..';
 import { Button, Flex, Heading } from '../../..';
-import { isInputEventTarget } from '../../../helpers/utils';
+import { isInputOrSelectElement, isInputElement } from '../../../helpers/utils';
 
 import {
   ConfirmationCodeInput,
@@ -14,9 +14,15 @@ export function ConfirmSignUp() {
   const { isPending, resendCode, submitForm, updateForm } = useAuthenticator();
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputEventTarget(event.target)) {
-      let { checked, name, type, value } = event.target;
-      if (type === 'checkbox' && !checked) value = undefined;
+    if (isInputOrSelectElement(event.target)) {
+      let { name, type, value } = event.target;
+      if (
+        isInputElement(event.target) &&
+        type === 'checkbox' &&
+        !event.target.checked
+      ) {
+        value = undefined;
+      }
 
       updateForm({ name, value });
     }

--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -1,7 +1,9 @@
 import { translate } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '../..';
-import { Button, Flex, Form, Heading } from '../../..';
+import { Button, Flex, Heading } from '../../..';
+import { isInputTarget } from '../../../helpers/utils';
+
 import {
   ConfirmationCodeInput,
   ConfirmationCodeInputProps,
@@ -11,11 +13,13 @@ import {
 export function ConfirmSignUp() {
   const { isPending, resendCode, submitForm, updateForm } = useAuthenticator();
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let { checked, name, type, value } = event.target;
-    if (type === 'checkbox' && !checked) value = undefined;
+  const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
+    if (isInputTarget(event.target)) {
+      let { checked, name, type, value } = event.target;
+      if (type === 'checkbox' && !checked) value = undefined;
 
-    updateForm({ name, value });
+      updateForm({ name, value });
+    }
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -30,7 +34,8 @@ export function ConfirmSignUp() {
 
   return (
     // TODO Automatically add these namespaces again from `useAmplify`
-    <Form
+    <form
+      data-amplify-form=""
       data-amplify-authenticator-confirmsignup=""
       method="post"
       onChange={handleChange}
@@ -60,6 +65,6 @@ export function ConfirmSignUp() {
           </Button>
         </Flex>
       </Flex>
-    </Form>
+    </form>
   );
 }

--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -2,7 +2,7 @@ import { translate } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '../..';
 import { Button, Flex, Heading } from '../../..';
-import { isInputTarget } from '../../../helpers/utils';
+import { isInputEventTarget } from '../../../helpers/utils';
 
 import {
   ConfirmationCodeInput,
@@ -14,7 +14,7 @@ export function ConfirmSignUp() {
   const { isPending, resendCode, submitForm, updateForm } = useAuthenticator();
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputTarget(event.target)) {
+    if (isInputEventTarget(event.target)) {
       let { checked, name, type, value } = event.target;
       if (type === 'checkbox' && !checked) value = undefined;
 

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -2,7 +2,7 @@ import { getActorContext, SignInContext, translate } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
 import { Button, Flex, Heading, PasswordField, Text } from '../../..';
-import { isInputEventTarget } from '../../../helpers/utils';
+import { isInputOrSelectElement, isInputElement } from '../../../helpers/utils';
 
 export const ForceNewPassword = (): JSX.Element => {
   const { _state, error, isPending, toSignIn, submitForm, updateForm } =
@@ -10,9 +10,15 @@ export const ForceNewPassword = (): JSX.Element => {
   const { validationError } = getActorContext(_state) as SignInContext;
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputEventTarget(event.target)) {
-      let { checked, name, type, value } = event.target;
-      if (type === 'checkbox' && !checked) value = undefined;
+    if (isInputOrSelectElement(event.target)) {
+      let { name, type, value } = event.target;
+      if (
+        isInputElement(event.target) &&
+        type === 'checkbox' &&
+        !event.target.checked
+      ) {
+        value = undefined;
+      }
 
       updateForm({ name, value });
     }

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -2,7 +2,7 @@ import { getActorContext, SignInContext, translate } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
 import { Button, Flex, Heading, PasswordField, Text } from '../../..';
-import { isInputTarget } from '../../../helpers/utils';
+import { isInputEventTarget } from '../../../helpers/utils';
 
 export const ForceNewPassword = (): JSX.Element => {
   const { _state, error, isPending, toSignIn, submitForm, updateForm } =
@@ -10,7 +10,7 @@ export const ForceNewPassword = (): JSX.Element => {
   const { validationError } = getActorContext(_state) as SignInContext;
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputTarget(event.target)) {
+    if (isInputEventTarget(event.target)) {
       let { checked, name, type, value } = event.target;
       if (type === 'checkbox' && !checked) value = undefined;
 

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -1,18 +1,21 @@
 import { getActorContext, SignInContext, translate } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
-import { Button, Flex, Form, Heading, PasswordField, Text } from '../../..';
+import { Button, Flex, Heading, PasswordField, Text } from '../../..';
+import { isInputTarget } from '../../../helpers/utils';
 
 export const ForceNewPassword = (): JSX.Element => {
   const { _state, error, isPending, toSignIn, submitForm, updateForm } =
     useAuthenticator();
   const { validationError } = getActorContext(_state) as SignInContext;
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let { checked, name, type, value } = event.target;
-    if (type === 'checkbox' && !checked) value = undefined;
+  const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
+    if (isInputTarget(event.target)) {
+      let { checked, name, type, value } = event.target;
+      if (type === 'checkbox' && !checked) value = undefined;
 
-    updateForm({ name, value });
+      updateForm({ name, value });
+    }
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -21,7 +24,8 @@ export const ForceNewPassword = (): JSX.Element => {
   };
 
   return (
-    <Form
+    <form
+      data-amplify-form=""
       data-amplify-authenticator-forcenewpassword=""
       method="post"
       onChange={handleChange}
@@ -83,6 +87,6 @@ export const ForceNewPassword = (): JSX.Element => {
           {translate('Back to Sign In')}
         </Button>
       </Flex>
-    </Form>
+    </form>
   );
 };

--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -11,7 +11,7 @@ import {
   RemoteErrorMessage,
   TwoButtonSubmitFooter,
 } from '../shared';
-import { isInputEventTarget } from '../../../helpers/utils';
+import { isInputOrSelectElement, isInputElement } from '../../../helpers/utils';
 
 export const ConfirmResetPassword = (): JSX.Element => {
   const { _state, submitForm, updateForm } = useAuthenticator();
@@ -22,9 +22,15 @@ export const ConfirmResetPassword = (): JSX.Element => {
   const confirmPasswordLabel = translate('Confirm Password');
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputEventTarget(event.target)) {
-      let { checked, name, type, value } = event.target;
-      if (type === 'checkbox' && !checked) value = undefined;
+    if (isInputOrSelectElement(event.target)) {
+      let { name, type, value } = event.target;
+      if (
+        isInputElement(event.target) &&
+        type === 'checkbox' &&
+        !event.target.checked
+      ) {
+        value = undefined;
+      }
 
       updateForm({ name, value });
     }

--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -11,7 +11,7 @@ import {
   RemoteErrorMessage,
   TwoButtonSubmitFooter,
 } from '../shared';
-import { isInputTarget } from '../../../helpers/utils';
+import { isInputEventTarget } from '../../../helpers/utils';
 
 export const ConfirmResetPassword = (): JSX.Element => {
   const { _state, submitForm, updateForm } = useAuthenticator();
@@ -22,7 +22,7 @@ export const ConfirmResetPassword = (): JSX.Element => {
   const confirmPasswordLabel = translate('Confirm Password');
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputTarget(event.target)) {
+    if (isInputEventTarget(event.target)) {
       let { checked, name, type, value } = event.target;
       if (type === 'checkbox' && !checked) value = undefined;
 

--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -5,12 +5,13 @@ import {
 } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
-import { Flex, Form, Heading, PasswordField, Text } from '../../..';
+import { Flex, Heading, PasswordField, Text } from '../../..';
 import {
   ConfirmationCodeInput,
   RemoteErrorMessage,
   TwoButtonSubmitFooter,
 } from '../shared';
+import { isInputTarget } from '../../../helpers/utils';
 
 export const ConfirmResetPassword = (): JSX.Element => {
   const { _state, submitForm, updateForm } = useAuthenticator();
@@ -20,11 +21,13 @@ export const ConfirmResetPassword = (): JSX.Element => {
   const passwordText = translate('New password');
   const confirmPasswordLabel = translate('Confirm Password');
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let { checked, name, type, value } = event.target;
-    if (type === 'checkbox' && !checked) value = undefined;
+  const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
+    if (isInputTarget(event.target)) {
+      let { checked, name, type, value } = event.target;
+      if (type === 'checkbox' && !checked) value = undefined;
 
-    updateForm({ name, value });
+      updateForm({ name, value });
+    }
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -33,7 +36,8 @@ export const ConfirmResetPassword = (): JSX.Element => {
   };
 
   return (
-    <Form
+    <form
+      data-amplify-form=""
       data-amplify-authenticator-confirmresetpassword=""
       method="post"
       onSubmit={handleSubmit}
@@ -77,6 +81,6 @@ export const ConfirmResetPassword = (): JSX.Element => {
           cancelButtonText={translate('Resend Code')}
         />
       </Flex>
-    </Form>
+    </form>
   );
 };

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -1,17 +1,20 @@
 import { translate } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
-import { Flex, Form, Heading, TextField } from '../../..';
+import { Flex, Heading, TextField } from '../../..';
 import { RemoteErrorMessage, TwoButtonSubmitFooter } from '../shared';
+import { isInputTarget } from '../../../helpers/utils';
 
 export const ResetPassword = (): JSX.Element => {
   const { isPending, submitForm, updateForm } = useAuthenticator();
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let { checked, name, type, value } = event.target;
-    if (type === 'checkbox' && !checked) value = undefined;
+  const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
+    if (isInputTarget(event.target)) {
+      let { checked, name, type, value } = event.target;
+      if (type === 'checkbox' && !checked) value = undefined;
 
-    updateForm({ name, value });
+      updateForm({ name, value });
+    }
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -20,7 +23,8 @@ export const ResetPassword = (): JSX.Element => {
   };
 
   return (
-    <Form
+    <form
+      data-amplify-form=""
       data-amplify-authenticator-resetpassword=""
       method="post"
       onChange={handleChange}
@@ -54,6 +58,6 @@ export const ResetPassword = (): JSX.Element => {
           }
         />
       </Flex>
-    </Form>
+    </form>
   );
 };

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -3,15 +3,21 @@ import { translate } from '@aws-amplify/ui';
 import { useAuthenticator } from '..';
 import { Flex, Heading, TextField } from '../../..';
 import { RemoteErrorMessage, TwoButtonSubmitFooter } from '../shared';
-import { isInputEventTarget } from '../../../helpers/utils';
+import { isInputOrSelectElement, isInputElement } from '../../../helpers/utils';
 
 export const ResetPassword = (): JSX.Element => {
   const { isPending, submitForm, updateForm } = useAuthenticator();
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputEventTarget(event.target)) {
-      let { checked, name, type, value } = event.target;
-      if (type === 'checkbox' && !checked) value = undefined;
+    if (isInputOrSelectElement(event.target)) {
+      let { name, type, value } = event.target;
+      if (
+        isInputElement(event.target) &&
+        type === 'checkbox' &&
+        !event.target.checked
+      ) {
+        value = undefined;
+      }
 
       updateForm({ name, value });
     }

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -3,13 +3,13 @@ import { translate } from '@aws-amplify/ui';
 import { useAuthenticator } from '..';
 import { Flex, Heading, TextField } from '../../..';
 import { RemoteErrorMessage, TwoButtonSubmitFooter } from '../shared';
-import { isInputTarget } from '../../../helpers/utils';
+import { isInputEventTarget } from '../../../helpers/utils';
 
 export const ResetPassword = (): JSX.Element => {
   const { isPending, submitForm, updateForm } = useAuthenticator();
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputTarget(event.target)) {
+    if (isInputEventTarget(event.target)) {
       let { checked, name, type, value } = event.target;
       if (type === 'checkbox' && !checked) value = undefined;
 

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -5,7 +5,9 @@ import QRCode from 'qrcode';
 import { useEffect, useState } from 'react';
 
 import { useAuthenticator } from '..';
-import { Flex, Form, Heading, Image } from '../../..';
+import { Flex, Heading, Image } from '../../..';
+import { isInputTarget } from '../../../helpers/utils';
+
 import {
   ConfirmationCodeInput,
   ConfirmSignInFooter,
@@ -44,11 +46,13 @@ export const SetupTOTP = (): JSX.Element => {
     generateQRCode(user);
   }, [user]);
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let { checked, name, type, value } = event.target;
-    if (type === 'checkbox' && !checked) value = undefined;
+  const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
+    if (isInputTarget(event.target)) {
+      let { checked, name, type, value } = event.target;
+      if (type === 'checkbox' && !checked) value = undefined;
 
-    updateForm({ name, value });
+      updateForm({ name, value });
+    }
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -57,7 +61,8 @@ export const SetupTOTP = (): JSX.Element => {
   };
 
   return (
-    <Form
+    <form
+      data-amplify-form=""
       data-amplify-authenticator-setup-totp=""
       method="post"
       onChange={handleChange}
@@ -85,6 +90,6 @@ export const SetupTOTP = (): JSX.Element => {
 
         <ConfirmSignInFooter />
       </Flex>
-    </Form>
+    </form>
   );
 };

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 
 import { useAuthenticator } from '..';
 import { Flex, Heading, Image } from '../../..';
-import { isInputTarget } from '../../../helpers/utils';
+import { isInputEventTarget } from '../../../helpers/utils';
 
 import {
   ConfirmationCodeInput,
@@ -47,7 +47,7 @@ export const SetupTOTP = (): JSX.Element => {
   }, [user]);
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputTarget(event.target)) {
+    if (isInputEventTarget(event.target)) {
       let { checked, name, type, value } = event.target;
       if (type === 'checkbox' && !checked) value = undefined;
 

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 
 import { useAuthenticator } from '..';
 import { Flex, Heading, Image } from '../../..';
-import { isInputEventTarget } from '../../../helpers/utils';
+import { isInputOrSelectElement, isInputElement } from '../../../helpers/utils';
 
 import {
   ConfirmationCodeInput,
@@ -47,9 +47,15 @@ export const SetupTOTP = (): JSX.Element => {
   }, [user]);
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputEventTarget(event.target)) {
-      let { checked, name, type, value } = event.target;
-      if (type === 'checkbox' && !checked) value = undefined;
+    if (isInputOrSelectElement(event.target)) {
+      let { name, type, value } = event.target;
+      if (
+        isInputElement(event.target) &&
+        type === 'checkbox' &&
+        !event.target.checked
+      ) {
+        value = undefined;
+      }
 
       updateForm({ name, value });
     }

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -4,7 +4,7 @@ import { useAuthenticator } from '..';
 import { Button, Flex, PasswordField, View } from '../../..';
 import { FederatedSignIn } from '../FederatedSignIn';
 import { RemoteErrorMessage, UserNameAlias } from '../shared';
-import { isInputTarget } from '../../../helpers/utils';
+import { isInputEventTarget } from '../../../helpers/utils';
 
 export function SignIn() {
   const {
@@ -17,7 +17,7 @@ export function SignIn() {
   } = useAuthenticator();
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputTarget(event.target)) {
+    if (isInputEventTarget(event.target)) {
       let { checked, name, type, value } = event.target;
       if (type === 'checkbox' && !checked) value = undefined;
 

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -4,7 +4,7 @@ import { useAuthenticator } from '..';
 import { Button, Flex, PasswordField, View } from '../../..';
 import { FederatedSignIn } from '../FederatedSignIn';
 import { RemoteErrorMessage, UserNameAlias } from '../shared';
-import { isInputEventTarget } from '../../../helpers/utils';
+import { isInputElement, isInputOrSelectElement } from '../../../helpers/utils';
 
 export function SignIn() {
   const {
@@ -17,9 +17,15 @@ export function SignIn() {
   } = useAuthenticator();
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputEventTarget(event.target)) {
-      let { checked, name, type, value } = event.target;
-      if (type === 'checkbox' && !checked) value = undefined;
+    if (isInputOrSelectElement(event.target)) {
+      let { name, type, value } = event.target;
+      if (
+        isInputElement(event.target) &&
+        type === 'checkbox' &&
+        !event.target.checked
+      ) {
+        value = undefined;
+      }
 
       updateForm({ name, value });
     }

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -1,9 +1,10 @@
 import { translate } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
-import { Button, Flex, Form, Heading, PasswordField, View } from '../../..';
+import { Button, Flex, PasswordField, View } from '../../..';
 import { FederatedSignIn } from '../FederatedSignIn';
 import { RemoteErrorMessage, UserNameAlias } from '../shared';
+import { isInputTarget } from '../../../helpers/utils';
 
 export function SignIn() {
   const {
@@ -15,11 +16,13 @@ export function SignIn() {
     updateForm,
   } = useAuthenticator();
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let { checked, name, type, value } = event.target;
-    if (type === 'checkbox' && !checked) value = undefined;
+  const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
+    if (isInputTarget(event.target)) {
+      let { checked, name, type, value } = event.target;
+      if (type === 'checkbox' && !checked) value = undefined;
 
-    updateForm({ name, value });
+      updateForm({ name, value });
+    }
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -31,7 +34,8 @@ export function SignIn() {
     <View>
       <Header />
 
-      <Form
+      <form
+        data-amplify-form=""
         data-amplify-authenticator-signin=""
         method="post"
         onSubmit={handleSubmit}
@@ -66,7 +70,7 @@ export function SignIn() {
             {translate('Sign in')}
           </Button>
         </Flex>
-      </Form>
+      </form>
 
       <Footer />
     </View>

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -5,7 +5,7 @@ import { Button, Flex, View } from '../../..';
 import { FederatedSignIn } from '../FederatedSignIn';
 import { RemoteErrorMessage } from '../shared';
 import { FormFields } from './FormFields';
-import { isInputEventTarget } from '../../../helpers/utils';
+import { isInputOrSelectElement, isInputElement } from '../../../helpers/utils';
 
 export function SignUp() {
   const { components, hasValidationErrors, isPending, submitForm, updateForm } =
@@ -22,9 +22,15 @@ export function SignUp() {
   console.log({ components });
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputEventTarget(event.target)) {
-      let { checked, name, type, value } = event.target;
-      if (type === 'checkbox' && !checked) value = undefined;
+    if (isInputOrSelectElement(event.target)) {
+      let { name, type, value } = event.target;
+      if (
+        isInputElement(event.target) &&
+        type === 'checkbox' &&
+        !event.target.checked
+      ) {
+        value = undefined;
+      }
 
       updateForm({ name, value });
     }

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -1,10 +1,11 @@
 import { translate } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
-import { Button, Flex, Form, View } from '../../..';
+import { Button, Flex, View } from '../../..';
 import { FederatedSignIn } from '../FederatedSignIn';
 import { RemoteErrorMessage } from '../shared';
 import { FormFields } from './FormFields';
+import { isInputTarget } from '../../../helpers/utils';
 
 export function SignUp() {
   const { components, hasValidationErrors, isPending, submitForm, updateForm } =
@@ -20,11 +21,13 @@ export function SignUp() {
 
   console.log({ components });
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let { checked, name, type, value } = event.target;
-    if (type === 'checkbox' && !checked) value = undefined;
+  const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
+    if (isInputTarget(event.target)) {
+      let { checked, name, type, value } = event.target;
+      if (type === 'checkbox' && !checked) value = undefined;
 
-    updateForm({ name, value });
+      updateForm({ name, value });
+    }
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -36,7 +39,8 @@ export function SignUp() {
     <View>
       <Header />
 
-      <Form
+      <form
+        data-amplify-form=""
         data-amplify-authenticator-signup=""
         method="post"
         onChange={handleChange}
@@ -63,7 +67,7 @@ export function SignUp() {
             {translate('Create Account')}
           </Button>
         </Flex>
-      </Form>
+      </form>
 
       <Footer />
     </View>

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -5,7 +5,7 @@ import { Button, Flex, View } from '../../..';
 import { FederatedSignIn } from '../FederatedSignIn';
 import { RemoteErrorMessage } from '../shared';
 import { FormFields } from './FormFields';
-import { isInputTarget } from '../../../helpers/utils';
+import { isInputEventTarget } from '../../../helpers/utils';
 
 export function SignUp() {
   const { components, hasValidationErrors, isPending, submitForm, updateForm } =
@@ -22,7 +22,7 @@ export function SignUp() {
   console.log({ components });
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputTarget(event.target)) {
+    if (isInputEventTarget(event.target)) {
       let { checked, name, type, value } = event.target;
       if (type === 'checkbox' && !checked) value = undefined;
 

--- a/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
@@ -7,13 +7,13 @@ import {
   RemoteErrorMessage,
   TwoButtonSubmitFooter,
 } from '../shared';
-import { isInputTarget } from '../../../helpers/utils';
+import { isInputEventTarget } from '../../../helpers/utils';
 
 export const ConfirmVerifyUser = (): JSX.Element => {
   const { submitForm, updateForm } = useAuthenticator();
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputTarget(event.target)) {
+    if (isInputEventTarget(event.target)) {
       let { checked, name, type, value } = event.target;
       if (type === 'checkbox' && !checked) value = undefined;
 

--- a/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
@@ -7,15 +7,21 @@ import {
   RemoteErrorMessage,
   TwoButtonSubmitFooter,
 } from '../shared';
-import { isInputEventTarget } from '../../../helpers/utils';
+import { isInputOrSelectElement, isInputElement } from '../../../helpers/utils';
 
 export const ConfirmVerifyUser = (): JSX.Element => {
   const { submitForm, updateForm } = useAuthenticator();
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputEventTarget(event.target)) {
-      let { checked, name, type, value } = event.target;
-      if (type === 'checkbox' && !checked) value = undefined;
+    if (isInputOrSelectElement(event.target)) {
+      let { name, type, value } = event.target;
+      if (
+        isInputElement(event.target) &&
+        type === 'checkbox' &&
+        !event.target.checked
+      ) {
+        value = undefined;
+      }
 
       updateForm({ name, value });
     }

--- a/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
@@ -1,21 +1,24 @@
 import { translate } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
-import { Flex, Form, Heading } from '../../..';
+import { Flex, Heading } from '../../..';
 import {
   ConfirmationCodeInput,
   RemoteErrorMessage,
   TwoButtonSubmitFooter,
 } from '../shared';
+import { isInputTarget } from '../../../helpers/utils';
 
 export const ConfirmVerifyUser = (): JSX.Element => {
   const { submitForm, updateForm } = useAuthenticator();
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let { checked, name, type, value } = event.target;
-    if (type === 'checkbox' && !checked) value = undefined;
+  const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
+    if (isInputTarget(event.target)) {
+      let { checked, name, type, value } = event.target;
+      if (type === 'checkbox' && !checked) value = undefined;
 
-    updateForm({ name, value });
+      updateForm({ name, value });
+    }
   };
 
   const handleSubmit = (event: React.ChangeEvent<HTMLFormElement>) => {
@@ -24,7 +27,8 @@ export const ConfirmVerifyUser = (): JSX.Element => {
   };
 
   return (
-    <Form
+    <form
+      data-amplify-form=""
       data-amplify-authenticator-confirmverifyuser=""
       method="post"
       onChange={handleChange}
@@ -46,6 +50,6 @@ export const ConfirmVerifyUser = (): JSX.Element => {
           cancelButtonSendType="SKIP"
         />
       </Flex>
-    </Form>
+    </form>
   );
 };

--- a/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
@@ -11,7 +11,7 @@ import {
 import { useAuthenticator } from '..';
 import { Flex, Heading, Radio, RadioGroupField } from '../../..';
 import { RemoteErrorMessage, TwoButtonSubmitFooter } from '../shared';
-import { isInputTarget } from '../../../helpers/utils';
+import { isInputEventTarget } from '../../../helpers/utils';
 
 const censorContactInformation = (
   type: ContactMethod,
@@ -72,7 +72,7 @@ export const VerifyUser = (): JSX.Element => {
   );
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputTarget(event.target)) {
+    if (isInputEventTarget(event.target)) {
       let { checked, name, type, value } = event.target;
       if (type === 'checkbox' && !checked) value = undefined;
 

--- a/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
@@ -9,8 +9,9 @@ import {
 } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
-import { Flex, Form, Heading, Radio, RadioGroupField } from '../../..';
+import { Flex, Heading, Radio, RadioGroupField } from '../../..';
 import { RemoteErrorMessage, TwoButtonSubmitFooter } from '../shared';
+import { isInputTarget } from '../../../helpers/utils';
 
 const censorContactInformation = (
   type: ContactMethod,
@@ -70,11 +71,13 @@ export const VerifyUser = (): JSX.Element => {
     </RadioGroupField>
   );
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let { checked, name, type, value } = event.target;
-    if (type === 'checkbox' && !checked) value = undefined;
+  const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
+    if (isInputTarget(event.target)) {
+      let { checked, name, type, value } = event.target;
+      if (type === 'checkbox' && !checked) value = undefined;
 
-    updateForm({ name, value });
+      updateForm({ name, value });
+    }
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -83,7 +86,8 @@ export const VerifyUser = (): JSX.Element => {
   };
 
   return (
-    <Form
+    <form
+      data-amplify-form=""
       data-amplify-authenticator-verifyuser=""
       method="post"
       onChange={handleChange}
@@ -104,6 +108,6 @@ export const VerifyUser = (): JSX.Element => {
           submitButtonText={footerSubmitText}
         />
       </Flex>
-    </Form>
+    </form>
   );
 };

--- a/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
@@ -11,7 +11,7 @@ import {
 import { useAuthenticator } from '..';
 import { Flex, Heading, Radio, RadioGroupField } from '../../..';
 import { RemoteErrorMessage, TwoButtonSubmitFooter } from '../shared';
-import { isInputEventTarget } from '../../../helpers/utils';
+import { isInputOrSelectElement, isInputElement } from '../../../helpers/utils';
 
 const censorContactInformation = (
   type: ContactMethod,
@@ -72,9 +72,15 @@ export const VerifyUser = (): JSX.Element => {
   );
 
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
-    if (isInputEventTarget(event.target)) {
-      let { checked, name, type, value } = event.target;
-      if (type === 'checkbox' && !checked) value = undefined;
+    if (isInputOrSelectElement(event.target)) {
+      let { name, type, value } = event.target;
+      if (
+        isInputElement(event.target) &&
+        type === 'checkbox' &&
+        !event.target.checked
+      ) {
+        value = undefined;
+      }
 
       updateForm({ name, value });
     }

--- a/packages/react/src/helpers/utils.ts
+++ b/packages/react/src/helpers/utils.ts
@@ -1,7 +1,14 @@
 export const isDevelopment = () => process.env.NODE_ENV !== 'production';
 
-export const isInputEventTarget = (
+export const isInputOrSelectElement = (
   target: unknown
-): target is HTMLInputElement => {
+): target is HTMLInputElement | HTMLSelectElement => {
+  return (
+    (target as HTMLInputElement)?.nodeName === 'INPUT' ||
+    (target as HTMLSelectElement)?.nodeName === 'SELECT'
+  );
+};
+
+export const isInputElement = (target: unknown): target is HTMLInputElement => {
   return (target as HTMLInputElement)?.nodeName === 'INPUT';
 };

--- a/packages/react/src/helpers/utils.ts
+++ b/packages/react/src/helpers/utils.ts
@@ -1,5 +1,7 @@
 export const isDevelopment = () => process.env.NODE_ENV !== 'production';
 
-export const isInputTarget = (target: unknown): target is HTMLInputElement => {
+export const isInputEventTarget = (
+  target: unknown
+): target is HTMLInputElement => {
   return (target as HTMLInputElement)?.nodeName === 'INPUT';
 };

--- a/packages/react/src/helpers/utils.ts
+++ b/packages/react/src/helpers/utils.ts
@@ -3,12 +3,15 @@ export const isDevelopment = () => process.env.NODE_ENV !== 'production';
 export const isInputOrSelectElement = (
   target: unknown
 ): target is HTMLInputElement | HTMLSelectElement => {
-  return (
-    (target as HTMLInputElement)?.nodeName === 'INPUT' ||
-    (target as HTMLSelectElement)?.nodeName === 'SELECT'
-  );
+  return isInputElement(target) || isSelectElement(target);
 };
 
 export const isInputElement = (target: unknown): target is HTMLInputElement => {
-  return (target as HTMLInputElement)?.nodeName === 'INPUT';
+  return (target as HTMLElement)?.nodeName === 'INPUT';
+};
+
+export const isSelectElement = (
+  target: unknown
+): target is HTMLInputElement => {
+  return (target as HTMLElement)?.nodeName === 'SELECT';
 };

--- a/packages/react/src/helpers/utils.ts
+++ b/packages/react/src/helpers/utils.ts
@@ -1,1 +1,5 @@
 export const isDevelopment = () => process.env.NODE_ENV !== 'production';
+
+export const isInputTarget = (target: unknown): target is HTMLInputElement => {
+  return (target as HTMLInputElement)?.nodeName === 'INPUT';
+};

--- a/packages/react/src/primitives/index.tsx
+++ b/packages/react/src/primitives/index.tsx
@@ -3,7 +3,3 @@ export * from './hooks';
 
 export * from './shared';
 export * from './types';
-
-export function Form(props) {
-  return <form data-amplify-form="" {...props} />;
-}


### PR DESCRIPTION
*Description of changes:*
Removes the `Form` primitive and replaces it with `form` in all the places it was used in Authenticator.

![2021-11-17 13 22 57](https://user-images.githubusercontent.com/6165315/142276702-6ea85ea3-6bb4-443b-bdcd-9d96e7b0d2b1.gif)


TODO:

- [x] Test locally in next-example apps for style regressions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
