### PR TITLE
Docs: Update navigation so query params are passed over

### DIFF
--- a/docs/src/components/Layout/Header.tsx
+++ b/docs/src/components/Layout/Header.tsx
@@ -20,19 +20,19 @@ import { Logo } from '@/components/Logo';
 import { FrameworkChooser } from './FrameworkChooser';
 
 const NavLink = ({ href, children, isExternal = false }) => {
-  const router = useRouter();
-  const isCurrent = router.pathname.startsWith(href);
+  const { pathname, query } = useRouter();
+  const isCurrent = pathname.startsWith(href);
   const className = `docs-nav-link ${isCurrent ? 'current' : ''}`;
 
   if (isExternal) {
     return (
-      <Link isExternal className={className}>
+      <Link isExternal href={href} className={className}>
         {children}
       </Link>
     );
   }
   return (
-    <NextLink href={href}>
+    <NextLink href={{ pathname: href, query }}>
       <a className={className}>{children}</a>
     </NextLink>
   );
@@ -75,12 +75,12 @@ export const Header = ({ platform, colorMode, setColorMode }) => {
           <Button className="docs-header-menu-button" size="small">
             <IconMenu />
           </Button>
-          <NextLink href="/">
+          <NavLink href="/">
             <a className="docs-logo-link">
               <VisuallyHidden>Amplify UI Home</VisuallyHidden>
               <Logo />
             </a>
-          </NextLink>
+          </NavLink>
 
           <Flex as="nav" className="docs-nav" alignItems="center" gap="0">
             <NavLink href="/getting-started/installation">

--- a/docs/src/components/Layout/Header.tsx
+++ b/docs/src/components/Layout/Header.tsx
@@ -21,7 +21,7 @@ import { FrameworkChooser } from './FrameworkChooser';
 
 const NavLink = ({ href, children, isExternal = false }) => {
   const { pathname, query } = useRouter();
-  const isCurrent = pathname.startsWith(href);
+  const isCurrent = pathname.startsWith(href) && href !== '/';
   const className = `docs-nav-link ${isCurrent ? 'current' : ''}`;
 
   if (isExternal) {

--- a/docs/src/components/Layout/SecondaryNav.tsx
+++ b/docs/src/components/Layout/SecondaryNav.tsx
@@ -22,11 +22,11 @@ const NavLinks = ({ items }: { items: ComponentNavItem[] }) => (
 );
 
 const NavLink = ({ href, children }) => {
-  const { pathname } = useRouter();
+  const { pathname, query } = useRouter();
   const isCurrent = pathname === href;
 
   return (
-    <Link href={href}>
+    <Link href={{ pathname: href, query }}>
       <a className={`docs-secondary-nav-link ${isCurrent ? 'current' : ''}`}>
         {children}
       </a>

--- a/docs/src/pages/components/ComponentsGrid.tsx
+++ b/docs/src/pages/components/ComponentsGrid.tsx
@@ -10,12 +10,14 @@ import {
   navigationComponents,
   utilityComponents,
 } from '@/data/links';
+import { useRouter } from 'next/router';
 
 const ComponentGrid = ({ components }) => {
+  const { query } = useRouter();
   return (
     <Grid templateColumns="1fr 1fr" gap="var(--amplify-space-large)">
       {components.map(({ href, label, body }) => (
-        <Link href={href} key={href}>
+        <Link href={{ pathname: href, query }} key={href}>
           <Card className="docs-component-card" variation="elevated">
             <Heading level={4}>{label}</Heading>
             <div className="docs-component-card-contents">{body}</div>


### PR DESCRIPTION
*Description of changes:*

When navigating the docs site if you change to `Vue` or `Angular` the site forgets these selections when moving around the site.

My fix will always pass the current platform query params to every `NavLink`.

- [x] Update `NavLink` to accept query
- [x] Fix bug when clicking external link that wasn't opening.



https://user-images.githubusercontent.com/65630/142316030-66397f57-4441-44b1-996e-16f594686ba8.mp4





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
