### PR TITLE
feat(ui): spawn all actors on init and cache them

### DIFF
--- a/packages/react/src/components/Authenticator/Router/index.tsx
+++ b/packages/react/src/components/Authenticator/Router/index.tsx
@@ -52,6 +52,7 @@ export function Router({
           <View data-amplify-body="">
             {(() => {
               switch (route) {
+                case 'spawnActors':
                 case 'idle':
                   return null;
                 case 'confirmSignUp':

--- a/packages/ui/src/helpers/auth.ts
+++ b/packages/ui/src/helpers/auth.ts
@@ -119,7 +119,7 @@ export const getAliasInfoFromContext = (
   alias?: LoginMechanism
 ) => {
   const loginMechanisms = context.config?.loginMechanisms;
-  const error = context.actorRef?.context?.validationError['username'];
+  const error = context.activeActor?.context?.validationError['username'];
 
   if (LoginMechanismArray.includes(alias)) {
     return {
@@ -165,7 +165,7 @@ export const getConfiguredAliases = (context: AuthContext) => {
  * to render: e.g. `getActorState(state).matches('confirmSignUp.edit').
  */
 export const getActorState = (state: AuthMachineState): AuthActorState => {
-  return state.context.actorRef?.getSnapshot();
+  return state.context.activeActor?.getSnapshot();
 };
 
 /**

--- a/packages/ui/src/helpers/auth.ts
+++ b/packages/ui/src/helpers/auth.ts
@@ -248,6 +248,8 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
         return 'verifyUser';
       case actorState?.matches('confirmVerifyUser'):
         return 'confirmVerifyUser';
+      case actorState.matches('idle'):
+        return 'idle';
       default:
         console.debug(
           'Cannot infer `route` from Authenticator state:',

--- a/packages/ui/src/machines/authenticator/actors/resetPassword.ts
+++ b/packages/ui/src/machines/authenticator/actors/resetPassword.ts
@@ -1,5 +1,5 @@
 import { Auth } from 'aws-amplify';
-import { createMachine, sendUpdate } from 'xstate';
+import { assign, createMachine, sendUpdate } from 'xstate';
 
 import { AuthEvent, ResetPasswordContext } from '../../../types';
 import { runValidators } from '../../../validators';
@@ -22,8 +22,17 @@ export const resetPasswordActor = createMachine<
 >(
   {
     id: 'resetPasswordActor',
-    initial: 'init',
+    initial: 'idle',
+    context: {} as any,
     states: {
+      idle: {
+        on: {
+          INIT: {
+            actions: 'setContext',
+            target: 'init',
+          },
+        },
+      },
       init: {
         always: [
           { target: 'confirmResetPassword', cond: 'shouldAutoConfirmReset' },
@@ -156,6 +165,9 @@ export const resetPasswordActor = createMachine<
       setFieldErrors,
       setRemoteError,
       setUsername,
+      setContext: assign((context, event) => ({
+        ...event.data,
+      })),
     },
     guards: {
       shouldAutoConfirmReset: (context, event): boolean => {

--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -1,7 +1,7 @@
 import { Auth } from 'aws-amplify';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
-import { createMachine, sendUpdate } from 'xstate';
+import { createMachine, sendUpdate, assign } from 'xstate';
 
 import { AuthChallengeNames, AuthEvent, SignInContext } from '../../../types';
 import { runValidators } from '../../../validators';
@@ -27,9 +27,18 @@ import { defaultServices } from '../defaultServices';
 
 export const signInActor = createMachine<SignInContext, AuthEvent>(
   {
-    initial: 'init',
+    initial: 'idle',
     id: 'signInActor',
+    context: {} as any,
     states: {
+      idle: {
+        on: {
+          INIT: {
+            actions: 'setContext',
+            target: 'init',
+          },
+        },
+      },
       init: {
         always: [{ target: 'signIn' }],
       },
@@ -355,6 +364,9 @@ export const signInActor = createMachine<SignInContext, AuthEvent>(
       setUnverifiedAttributes,
       setUser,
       setUsernameAuthAttributes,
+      setContext: assign((context, event) => ({
+        ...event.data,
+      })),
     },
     guards: {
       shouldConfirmSignIn: (_, event): boolean => {

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -35,7 +35,7 @@ export function createAuthenticatorMachine({
           signUpAttributes,
           socialProviders,
         },
-        actorRef: undefined,
+        activeActor: undefined,
       },
       states: {
         // See: https://xstate.js.org/docs/guides/communication.html#invoking-promises
@@ -124,7 +124,7 @@ export function createAuthenticatorMachine({
     },
     {
       actions: {
-        forwardToActor: forwardTo((context) => context.actorRef),
+        forwardToActor: forwardTo((context) => context.activeActor),
         setUser: assign({
           user: (_, event) => event.data.user || event.data,
         }),
@@ -192,20 +192,20 @@ export function createAuthenticatorMachine({
           },
         }),
         useSignInActor: assign({
-          actorRef: (context, event) => {
+          activeActor: (context, event) => {
             return context.actors.signInActor;
           },
         }),
         useSignUpActor: assign({
-          actorRef: (context) => context.actors.signUpActor,
+          activeActor: (context) => context.actors.signUpActor,
         }),
         useResetPasswordActor: assign({
-          actorRef: (context) => {
+          activeActor: (context) => {
             return context.actors.resetPasswordActor;
           },
         }),
         useSignOutActor: assign({
-          actorRef: (context) => context.actors.signOutActor,
+          activeActor: (context) => context.actors.signOutActor,
         }),
         initSignInActor: send((context, event) => {
           const data = {

--- a/packages/ui/src/machines/authenticator/signUp.ts
+++ b/packages/ui/src/machines/authenticator/signUp.ts
@@ -1,7 +1,7 @@
 import { Auth } from 'aws-amplify';
 import get from 'lodash/get';
 import pickBy from 'lodash/pickBy';
-import { createMachine, sendUpdate } from 'xstate';
+import { assign, createMachine, sendUpdate } from 'xstate';
 
 import { AuthEvent, SignUpContext } from '../../types';
 import { runValidators } from '../../validators';
@@ -25,8 +25,17 @@ export function createSignUpMachine({ services }: SignUpMachineOptions) {
   return createMachine<SignUpContext, AuthEvent>(
     {
       id: 'signUpActor',
-      initial: 'init',
+      initial: 'idle',
+      context: {} as any,
       states: {
+        idle: {
+          on: {
+            INIT: {
+              actions: 'setContext',
+              target: 'init',
+            },
+          },
+        },
         init: {
           always: [
             { target: 'confirmSignUp', cond: 'shouldInitConfirmSignUp' },
@@ -224,6 +233,9 @@ export function createSignUpMachine({ services }: SignUpMachineOptions) {
         setFieldErrors,
         setRemoteError,
         setUser,
+        setContext: assign((context, event) => ({
+          ...event.data,
+        })),
       },
       services: {
         async signIn(context, event) {

--- a/packages/ui/src/types/authMachine.ts
+++ b/packages/ui/src/types/authMachine.ts
@@ -1,11 +1,19 @@
 import { CognitoUser } from 'amazon-cognito-identity-js';
-import { Interpreter, State } from 'xstate';
+import { Actor, ActorRefFrom, Interpreter, State, StateMachine } from 'xstate';
 import { ValidationError } from './validator';
 
 export type AuthFormData = Record<string, string>;
 
 export interface AuthContext {
   actorRef?: any;
+  actors?: {
+    signInActor: ActorRefFrom<StateMachine<SignInContext, any, AuthEvent>>;
+    signUpActor: ActorRefFrom<StateMachine<SignUpContext, any, AuthEvent>>;
+    resetPasswordActor: ActorRefFrom<
+      StateMachine<ResetPasswordContext, any, AuthEvent>
+    >;
+    signOutActor: ActorRefFrom<StateMachine<SignOutContext, any, AuthEvent>>;
+  }; // TODO: type this
   config?: {
     loginMechanisms?: LoginMechanism[];
     signUpAttributes?: SignUpAttribute[];
@@ -116,6 +124,7 @@ export type AuthEventTypes =
   | 'SIGN_UP'
   | 'SKIP'
   | 'SUBMIT'
+  | 'INIT'
   | InvokeActorEventTypes;
 
 export enum AuthChallengeNames {

--- a/packages/ui/src/types/authMachine.ts
+++ b/packages/ui/src/types/authMachine.ts
@@ -5,7 +5,7 @@ import { ValidationError } from './validator';
 export type AuthFormData = Record<string, string>;
 
 export interface AuthContext {
-  actorRef?: any;
+  activeActor?: any;
   actors?: {
     signInActor: ActorRefFrom<StateMachine<SignInContext, any, AuthEvent>>;
     signUpActor: ActorRefFrom<StateMachine<SignUpContext, any, AuthEvent>>;


### PR DESCRIPTION
*Issue #, if available:* Fixes #764

*Description of changes:* Do not merge, this is a non-trivial change.

- [x] Spawn all actors on init
- [ ] Look into lazily spawning actors as needed
- [ ] Parents should spawn each actor with all contexts that are known at the first init (e.g. `loginMechanisms`, `signUpAttributes`)
- [x] When parent activates an actor, it passes additional context from another actor (`intent`, `authAttribute`)
- [ ] With caching, we have to be careful actors aren't stuck in a "DONE" state. (e.g. `forgotPassword` can be called multiple times). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
