### PR TITLE
Add bottom-padding to sign-in and sign-up footer

### DIFF
--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.html
@@ -1,9 +1,7 @@
 <div data-amplify-authenticator [attr.data-variation]="variation">
   <div data-amplify-container>
-    <div data-amplify-header>
-      <amplify-slot name="header" [context]="context"></amplify-slot>
-    </div>
-    <div data-amplify-body>
+    <amplify-slot name="header" [context]="context"></amplify-slot>
+    <div data-amplify-router>
       <amplify-tabs
         (tabChange)="onTabChange()"
         *ngIf="route === 'signIn' || route === 'signUp'"
@@ -103,9 +101,7 @@
       </amplify-slot>
     </div>
 
-    <div data-amplify-footer>
-      <amplify-slot name="footer" [context]="context"></amplify-slot>
-    </div>
+    <amplify-slot name="footer" [context]="context"></amplify-slot>
   </div>
 </div>
 

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.html
@@ -27,15 +27,17 @@
   </form>
 
   <amplify-slot name="sign-in-footer" [context]="context">
-    <button
-      amplify-button
-      fontWeight="normal"
-      size="small"
-      variation="link"
-      fullWidth="true"
-      (click)="authenticator.toResetPassword()"
-    >
-      {{ forgotPasswordText }}
-    </button>
+    <div data-amplify-footer>
+      <button
+        amplify-button
+        fontWeight="normal"
+        size="small"
+        variation="link"
+        fullWidth="true"
+        (click)="authenticator.toResetPassword()"
+      >
+        {{ forgotPasswordText }}
+      </button>
+    </div>
   </amplify-slot>
 </div>

--- a/packages/react/src/components/Authenticator/Router/index.tsx
+++ b/packages/react/src/components/Authenticator/Router/index.tsx
@@ -49,7 +49,7 @@ export function Router({
         <View data-amplify-container="">
           <Header />
 
-          <View data-amplify-body="">
+          <View data-amplify-router="">
             {(() => {
               switch (route) {
                 case 'idle':

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -77,7 +77,6 @@ export function SignIn() {
           </Button>
         </Flex>
       </form>
-
       <Footer />
     </View>
   );
@@ -88,7 +87,7 @@ SignIn.Footer = () => {
   const { toResetPassword } = useAuthenticator();
 
   return (
-    <View textAlign="center">
+    <View data-amplify-footer="">
       <Button
         fontWeight="normal"
         onClick={toResetPassword}

--- a/packages/ui/src/theme/css/component/authenticator.scss
+++ b/packages/ui/src/theme/css/component/authenticator.scss
@@ -42,14 +42,10 @@
   }
 }
 
-[data-amplify-authenticator] [data-amplify-header],
-[data-amplify-authenticator] [data-amplify-footer] {
-  text-align: center;
-}
-
 // footers inside each screen should have some margin below it
 [data-amplify-authenticator] [data-amplify-router] [data-amplify-footer] {
   padding-bottom: var(--amplify-space-medium);
+  text-align: center;
 }
 
 [data-amplify-authenticator] [data-amplify-router] {

--- a/packages/ui/src/theme/css/component/authenticator.scss
+++ b/packages/ui/src/theme/css/component/authenticator.scss
@@ -42,14 +42,17 @@
   }
 }
 
-[data-amplify-authenticator] [data-amplify-container] > {
-  [data-amplify-header],
-  [data-amplify-footer] {
-    text-align: center;
-  }
+[data-amplify-authenticator] [data-amplify-header],
+[data-amplify-authenticator] [data-amplify-footer] {
+  text-align: center;
 }
 
-[data-amplify-authenticator] [data-amplify-container] > [data-amplify-body] {
+// footers inside each screen should have some margin below it
+[data-amplify-authenticator] [data-amplify-router] [data-amplify-footer] {
+  padding-bottom: var(--amplify-space-medium);
+}
+
+[data-amplify-authenticator] [data-amplify-router] {
   background-color: var(--amplify-colors-background-primary);
   box-shadow: var(--amplify-shadows-medium);
 }

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -203,10 +203,8 @@ watch(
     v-if="!state?.matches('authenticated')"
   >
     <div data-amplify-container>
-      <div data-amplify-header>
-        <slot name="header"> </slot>
-      </div>
-      <div data-amplify-body>
+      <slot name="header"> </slot>
+      <div data-amplify-router>
         <base-two-tabs
           v-if="actorState?.matches('signIn') || actorState?.matches('signUp')"
         >
@@ -444,9 +442,7 @@ watch(
           </template>
         </confirm-verify-user>
       </div>
-      <div data-amplify-footer>
-        <slot name="footer"></slot>
-      </div>
+      <slot name="footer"></slot>
     </div>
   </div>
 

--- a/packages/vue/src/components/primitives/base-footer.vue
+++ b/packages/vue/src/components/primitives/base-footer.vue
@@ -4,7 +4,7 @@
     name="footert"
     :slotData="mySlots.default && mySlots.default()"
   >
-    <footer v-bind="$attrs" data-amplify-footer=""><slot></slot></footer>
+    <footer v-bind="$attrs"><slot></slot></footer>
   </slot>
 </template>
 

--- a/packages/vue/src/components/sign-in.vue
+++ b/packages/vue/src/components/sign-in.vue
@@ -100,7 +100,13 @@ const onForgotPasswordClicked = (): void => {
 
             <user-name-alias :userNameAlias="true" />
             <base-wrapper
-              class=" amplify-flex amplify-field amplify-textfield amplify-passwordfield password-field"
+              class="
+                amplify-flex
+                amplify-field
+                amplify-textfield
+                amplify-passwordfield
+                password-field
+              "
               style="flex-direction: column"
             >
               <password-control
@@ -135,17 +141,19 @@ const onForgotPasswordClicked = (): void => {
 
     <base-footer>
       <slot name="footer">
-        <amplify-button
-          @click="onForgotPasswordClicked"
-          class="amplify-field-group__control"
-          data-fullwidth="true"
-          data-size="small"
-          data-variation="link"
-          style="font-weight: normal"
-          type="button"
-        >
-          {{ forgotYourPasswordLink }}
-        </amplify-button>
+        <div data-amplify-footer>
+          <amplify-button
+            @click="onForgotPasswordClicked"
+            class="amplify-field-group__control"
+            data-fullwidth="true"
+            data-size="small"
+            data-variation="link"
+            style="font-weight: normal"
+            type="button"
+          >
+            {{ forgotYourPasswordLink }}
+          </amplify-button>
+        </div>
       </slot>
     </base-footer>
   </slot>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adding default padding-bottom to `sign-in-footer`.

Also adjusted `data-amplify-*` structure slightly. Now the routed screen is labeled `data-amplify-router`. Each screen has `data-amplify-header` and `data-amplify-footer` that has default styles. 

Overriding those headers will also remove those styles.

## Vue


![Vue1](https://user-images.githubusercontent.com/43682783/142474950-d593b68e-424b-4c30-8453-299c7de21528.png)

![Vue2](https://user-images.githubusercontent.com/43682783/142474960-981c38fe-7f80-49c1-9a21-bd67e7d2ff59.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
