### PR TITLE
React documentation prefers Authenticator over withAuthenticator

### DIFF
--- a/docs/src/pages/components/authenticator/LabelsAndTextDemo.tsx
+++ b/docs/src/pages/components/authenticator/LabelsAndTextDemo.tsx
@@ -73,7 +73,7 @@ function Screen({ Component }: ScreenProps) {
 export function LabelsAndTextDemo({ Component }: ScreenProps) {
   return (
     <Authenticator.Provider>
-      <View data-amplify-authenticator="" data-variaton="modal">
+      <View data-amplify-authenticator="">
         <View data-amplify-container="">
           <View data-amplify-body>
             <Screen Component={Component} />

--- a/docs/src/pages/components/authenticator/index.page.mdx
+++ b/docs/src/pages/components/authenticator/index.page.mdx
@@ -29,11 +29,6 @@ to your application with minimal boilerplate.
 
 <Example>
   <Authenticator />
-
-  <p className="text-sm text-center mt-6 text-gray-500 italic">
-    <strong>Note</strong>: This example isn't fully functional until configured
-    with an Amplify backend.
-  </p>
 </Example>
 
 ## Quick Start
@@ -93,10 +88,6 @@ You can explicitly redirect to `signUp` or `resetPassword` as your `initialState
     </Fragment>
     <Example>
       <Authenticator initialState="signIn" />
-      <p className="text-sm text-center mt-6 text-gray-500 italic">
-        <strong>Note</strong>: This example isn't fully functional until
-        configured with an Amplify backend.
-      </p>
     </Example>
   </TabItem>
   <TabItem title="Sign Up">
@@ -105,10 +96,6 @@ You can explicitly redirect to `signUp` or `resetPassword` as your `initialState
     </Fragment>
     <Example>
       <Authenticator initialState="signUp" />
-      <p className="text-sm text-center mt-6 text-gray-500 italic">
-        <strong>Note</strong>: This example isn't fully functional until
-        configured with an Amplify backend.
-      </p>
     </Example>
   </TabItem>
   <TabItem title="Reset Password">
@@ -117,10 +104,6 @@ You can explicitly redirect to `signUp` or `resetPassword` as your `initialState
     </Fragment>
     <Example>
       <Authenticator initialState="resetPassword" />
-      <p className="text-sm text-center mt-6 text-gray-500 italic">
-        <strong>Note</strong>: This example isn't fully functional until
-        configured with an Amplify backend.
-      </p>
     </Example>
   </TabItem>
 </Tabs>
@@ -148,10 +131,6 @@ You can provide an alternative `username` such as `email` or `phone_number`.
     </Fragment>
     <Example>
       <Authenticator />
-      <p className="text-sm text-center mt-6 text-gray-500 italic">
-        <strong>Note</strong>: This example isn't fully functional until
-        configured with an Amplify backend.
-      </p>
     </Example>
   </TabItem>
   <TabItem title="Email">
@@ -160,10 +139,6 @@ You can provide an alternative `username` such as `email` or `phone_number`.
     </Fragment>
     <Example>
       <Authenticator loginMechanisms={['email']} />
-      <p className="text-sm text-center mt-6 text-gray-500 italic">
-        <strong>Note</strong>: This example isn't fully functional until
-        configured with an Amplify backend.
-      </p>
     </Example>
   </TabItem>
   <TabItem title="Phone Number">
@@ -174,10 +149,6 @@ You can provide an alternative `username` such as `email` or `phone_number`.
     </Fragment>
     <Example>
       <Authenticator loginMechanisms={['phone_number']} />
-      <p className="text-sm text-center mt-6 text-gray-500 italic">
-        <strong>Note</strong>: This example isn't fully functional until
-        configured with an Amplify backend.
-      </p>
     </Example>
   </TabItem>
 </Tabs>
@@ -258,10 +229,6 @@ For your [configured social providers](https://docs.amplify.aws/lib/auth/social/
 
 <Example>
   <Authenticator socialProviders={['amazon', 'apple', 'facebook', 'google']} />
-  <p className="text-sm text-center mt-6 text-gray-500 italic">
-    <strong>Note</strong>: This example isn't fully functional until configured
-    with an Amplify backend.
-  </p>
 </Example>
 
 ### `variation`
@@ -623,10 +590,6 @@ The example below uses a `<style>` tag to change the default colors to a dark th
     }
   `}</style>
   <Authenticator />
-  <p className="text-sm text-center mt-6 text-gray-500 italic">
-    <strong>Note</strong>: This example isn't fully functional until configured
-    with an Amplify backend.
-  </p>
 </Example>
 
 ### Additional CSS Styling
@@ -648,8 +611,4 @@ For example, if you'd like to hide the sign up tab, you can override the `amplif
     }
   `}</style>
   <Authenticator className="customization-hide-sign-up" />
-  <p className="text-sm text-center mt-6 text-gray-500 italic">
-    <strong>Note</strong>: This example isn't fully functional until configured
-    with an Amplify backend.
-  </p>
 </Example>

--- a/docs/src/pages/components/authenticator/index.page.mdx
+++ b/docs/src/pages/components/authenticator/index.page.mdx
@@ -497,10 +497,10 @@ Using the same techniques as [Internationalization (I18n)](#internationalization
 
 ### Sign Up Fields
 
-The following example customizes the Sign Up screen with:
+The following example customizes the Sign Up screen by:
 
-- Re-using the default form fields
-- Appending a custom "Terms & Conditions" checkbox with custom validation
+- Re-using the default Sign Up form fields
+- Appending a custom "Terms & Conditions" checkbox with a `validateCustomSignUp` service
 
 <Fragment>
   {({ platform }) => import(`./sign-up-fields.${platform}.mdx`)}

--- a/docs/src/pages/components/authenticator/initialState.resetPassword.react.mdx
+++ b/docs/src/pages/components/authenticator/initialState.resetPassword.react.mdx
@@ -1,3 +1,3 @@
-```js{2} file=../../../../../examples/next/pages/ui/components/authenticator/reset-password/index.page.tsx#L13-
+```js{3} file=../../../../../examples/next/pages/ui/components/authenticator/reset-password/index.page.tsx#L9-
 
 ```

--- a/docs/src/pages/components/authenticator/initialState.signIn.react.mdx
+++ b/docs/src/pages/components/authenticator/initialState.signIn.react.mdx
@@ -1,3 +1,3 @@
-```js{2} file=../../../../../examples/next/pages/ui/components/authenticator/sign-in-with-username/index.page.tsx#L13-
+```js{3} file=../../../../../examples/next/pages/ui/components/authenticator/sign-in-with-username/index.page.tsx#L9-
 
 ```

--- a/docs/src/pages/components/authenticator/initialState.signUp.react.mdx
+++ b/docs/src/pages/components/authenticator/initialState.signUp.react.mdx
@@ -1,3 +1,3 @@
-```js{2} file=../../../../../examples/next/pages/ui/components/authenticator/sign-up-with-username/index.page.tsx#L13-
+```js{3} file=../../../../../examples/next/pages/ui/components/authenticator/sign-up-with-username/index.page.tsx#L9-
 
 ```

--- a/docs/src/pages/components/authenticator/loginMechanisms.email.react.mdx
+++ b/docs/src/pages/components/authenticator/loginMechanisms.email.react.mdx
@@ -1,5 +1,14 @@
-```js{2}
-export default withAuthenticator(App, {
-  loginMechanisms: ['email']
-});
+```js{3}
+export default function App() {
+  return (
+    <Authenticator loginMechanisms={['email']}>
+      {({ signOut, user }) => (
+        <main>
+          <h1>Hello {user.username}</h1>
+          <button onClick={signOut}>Sign out</button>
+        </main>
+      )}
+    </Authenticator>
+  );
+}
 ```

--- a/docs/src/pages/components/authenticator/loginMechanisms.phone_number.react.mdx
+++ b/docs/src/pages/components/authenticator/loginMechanisms.phone_number.react.mdx
@@ -1,5 +1,14 @@
-```js{2}
-export default withAuthenticator(App, {
-  loginMechanisms: ['phone_number']
-});
+```js{3}
+export default function App() {
+  return (
+    <Authenticator loginMechanisms={['phone_number']}>
+      {({ signOut, user }) => (
+        <main>
+          <h1>Hello {user.username}</h1>
+          <button onClick={signOut}>Sign out</button>
+        </main>
+      )}
+    </Authenticator>
+  );
+}
 ```

--- a/docs/src/pages/components/authenticator/loginMechanisms.username.react.mdx
+++ b/docs/src/pages/components/authenticator/loginMechanisms.username.react.mdx
@@ -1,5 +1,14 @@
-```js{2}
-export default withAuthenticator(App, {
-  loginMechanisms: ['username']
-});
+```js{3}
+export default function App() {
+  return (
+    <Authenticator loginMechanisms={['username']}>
+      {({ signOut, user }) => (
+        <main>
+          <h1>Hello {user.username}</h1>
+          <button onClick={signOut}>Sign out</button>
+        </main>
+      )}
+    </Authenticator>
+  );
+}
 ```

--- a/docs/src/pages/components/authenticator/sign-up-fields.react.mdx
+++ b/docs/src/pages/components/authenticator/sign-up-fields.react.mdx
@@ -1,3 +1,3 @@
-```tsx{4-6,21} file=../../../../../examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx#L13-
+```tsx{7-9,24} file=../../../../../examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx#L13-
 
 ```

--- a/docs/src/pages/components/authenticator/sign-up-fields.react.mdx
+++ b/docs/src/pages/components/authenticator/sign-up-fields.react.mdx
@@ -1,3 +1,3 @@
-```tsx{3-11,28-48,51-57} file=../../../../../examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
+```tsx{4-6,21} file=../../../../../examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx#L13-
 
 ```

--- a/docs/src/pages/components/authenticator/signUpAttributes.all.react.mdx
+++ b/docs/src/pages/components/authenticator/signUpAttributes.all.react.mdx
@@ -1,23 +1,32 @@
-```js{2}
-export default withAuthenticator(App, {
-  signUpAttributes: [
-    'address',
-    'birthdate',
-    'email',
-    'family_name',
-    'gender',
-    'given_name',
-    'locale',
-    'middle_name',
-    'name',
-    'nickname',
-    'phone_number',
-    'picture',
-    'preferred_username',
-    'profile',
-    'updated_at',
-    'website',
-    'zoneinfo',
-  ]
-})
+```js{3-21}
+export default function App() {
+  return (
+    <Authenticator signUpAttributes={[
+      'address',
+      'birthdate',
+      'email',
+      'family_name',
+      'gender',
+      'given_name',
+      'locale',
+      'middle_name',
+      'name',
+      'nickname',
+      'phone_number',
+      'picture',
+      'preferred_username',
+      'profile',
+      'updated_at',
+      'website',
+      'zoneinfo',
+    ]}>
+      {({ signOut, user }) => (
+        <main>
+          <h1>Hello {user.username}</h1>
+          <button onClick={signOut}>Sign out</button>
+        </main>
+      )}
+    </Authenticator>
+  );
+}
 ```

--- a/docs/src/pages/components/authenticator/signUpAttributes.default.react.mdx
+++ b/docs/src/pages/components/authenticator/signUpAttributes.default.react.mdx
@@ -1,5 +1,14 @@
-```js{2}
-export default withAuthenticator(App, {
-  signUpAttributes: []
-});
+```js{3}
+export default function App() {
+  return (
+    <Authenticator signUpAttributes={[]}>
+      {({ signOut, user }) => (
+        <main>
+          <h1>Hello {user.username}</h1>
+          <button onClick={signOut}>Sign out</button>
+        </main>
+      )}
+    </Authenticator>
+  );
+}
 ```

--- a/docs/src/pages/components/authenticator/socialProviders.react.mdx
+++ b/docs/src/pages/components/authenticator/socialProviders.react.mdx
@@ -1,5 +1,14 @@
-```js{2}
-export default withAuthenticator(App, {
-  socialProviders: ['amazon', 'apple', 'facebook', 'google']
-});
+```js{3}
+export default function App() {
+  return (
+    <Authenticator socialProviders={['amazon', 'apple', 'facebook', 'google']}>
+      {({ signOut, user }) => (
+        <main>
+          <h1>Hello {user.username}</h1>
+          <button onClick={signOut}>Sign out</button>
+        </main>
+      )}
+    </Authenticator>
+  );
+}
 ```

--- a/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
@@ -13,6 +13,9 @@ Amplify.configure(awsExports);
 export default function App() {
   return (
     <Authenticator
+      // Default to Sign Up screen
+      initialState="signUp"
+      // Customize `Authenticator.SignUp.FormFields`
       components={{
         SignUp: {
           FormFields() {

--- a/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
@@ -1,26 +1,19 @@
 import { Amplify } from 'aws-amplify';
 
 import {
-  // Access the default `Authenticator.SignUp.FormFields` for re-use
   Authenticator,
-  // Amplify UI Primitives to simplify the custom fields
   CheckboxField,
-  // React hook to get access to validation errors
   useAuthenticator,
 } from '@aws-amplify/ui-react';
-import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
 import awsExports from '@environments/auth-with-email-and-custom-attributes/src/aws-exports';
 Amplify.configure(awsExports);
 
-export default function App({ signOut }) {
+export default function App() {
   return (
     <Authenticator
-      // Default to Sign Up screen
-      initialState="signUp"
       components={{
-        // Customize `Authenticator.SignUp.FormFields`
         SignUp: {
           FormFields() {
             const { validationErrors } = useAuthenticator();
@@ -53,7 +46,12 @@ export default function App({ signOut }) {
         },
       }}
     >
-      {({ signOut }) => <button onClick={signOut}>Sign out</button>}
+      {({ signOut, user }) => (
+        <main>
+          <h1>Hello {user.username}</h1>
+          <button onClick={signOut}>Sign out</button>
+        </main>
+      )}
     </Authenticator>
   );
 }

--- a/examples/next/pages/ui/components/authenticator/reset-password/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/reset-password/index.page.tsx
@@ -1,15 +1,20 @@
 import { Amplify } from 'aws-amplify';
 
-import { withAuthenticator } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
 import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';
 Amplify.configure(awsExports);
 
-function App({ signOut }) {
-  return <button onClick={signOut}>Sign out</button>;
+export default function App() {
+  return (
+    <Authenticator initialState="resetPassword">
+      {({ signOut, user }) => (
+        <main>
+          <h1>Hello {user.username}</h1>
+          <button onClick={signOut}>Sign out</button>
+        </main>
+      )}
+    </Authenticator>
+  );
 }
-
-export default withAuthenticator(App, {
-  initialState: 'resetPassword',
-});

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-username/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-username/index.page.tsx
@@ -10,10 +10,10 @@ export default function App() {
   return (
     <Authenticator>
       {({ signOut, user }) => (
-        <>
+        <main>
           <h1>Hello {user.username}</h1>
           <button onClick={signOut}>Sign out</button>
-        </>
+        </main>
       )}
     </Authenticator>
   );

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-username/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-username/index.page.tsx
@@ -1,15 +1,20 @@
 import { Amplify } from 'aws-amplify';
 
-import { withAuthenticator } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
 import awsExports from '@environments/auth-with-username/src/aws-exports';
 Amplify.configure(awsExports);
 
-function App({ signOut }) {
-  return <button onClick={signOut}>Sign out</button>;
+export default function App() {
+  return (
+    <Authenticator initialState="signUp">
+      {({ signOut, user }) => (
+        <main>
+          <h1>Hello {user.username}</h1>
+          <button onClick={signOut}>Sign out</button>
+        </main>
+      )}
+    </Authenticator>
+  );
 }
-
-export default withAuthenticator(App, {
-  initialState: 'signUp',
-});


### PR DESCRIPTION
*Issue #, if available:* Closes #640

> Using the past <AmplifyAuthenticator/> is more component composition friendly compared to the new HOC withAuthenticator. I guess the new UI is not backward compatible as I have tried to simply replace <AmplifyAuthenticator/> with the new <Authenticator/>, but it doesn't work.

This will also make way for use cases like https://codesandbox.io/s/change-your-layout-rh4z9?file=/src/App.js with `useAuthenticator`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
