### PR TITLE
docs: Use native Pagination primitive instead of `usePagination`

### DIFF
--- a/docs/src/pages/HomePrimitivePreview.tsx
+++ b/docs/src/pages/HomePrimitivePreview.tsx
@@ -29,6 +29,16 @@ export const HomePrimitivePreview = () => {
   const [exclusiveValue, setExclusiveValue] = React.useState('align-left');
   const { tokens } = useTheme();
 
+  const [currentPage, setCurrentPage] = React.useState(1);
+
+  const onPrevious = () => {
+    setCurrentPage(Math.max(1, currentPage - 1));
+  };
+
+  const onNext = () => {
+    setCurrentPage(Math.min(10, currentPage + 1));
+  };
+
   return (
     <Flex direction="column" flex="1">
       <Flex
@@ -44,12 +54,12 @@ export const HomePrimitivePreview = () => {
         </Badge>
 
         <Pagination
-          currentPage={1}
+          currentPage={currentPage}
           totalPages={10}
           siblingCount={1}
-          onChange={() => {}}
-          onPrevious={() => {}}
-          onNext={() => {}}
+          onChange={setCurrentPage}
+          onPrevious={onPrevious}
+          onNext={onNext}
         />
       </Flex>
       <Flex direction="row" padding={`0 0 0 ${tokens.space.medium}`}>

--- a/docs/src/pages/HomePrimitivePreview.tsx
+++ b/docs/src/pages/HomePrimitivePreview.tsx
@@ -18,7 +18,6 @@ import {
   Loader,
   Placeholder,
   Pagination,
-  usePagination,
   SwitchField,
   CheckboxField,
   Divider,
@@ -28,11 +27,6 @@ import {
 
 export const HomePrimitivePreview = () => {
   const [exclusiveValue, setExclusiveValue] = React.useState('align-left');
-  const pagination = usePagination({
-    currentPage: 1,
-    totalPages: 10,
-    siblingCount: 1,
-  });
   const { tokens } = useTheme();
 
   return (
@@ -49,7 +43,14 @@ export const HomePrimitivePreview = () => {
           New
         </Badge>
 
-        <Pagination {...pagination} />
+        <Pagination
+          currentPage={1}
+          totalPages={10}
+          siblingCount={1}
+          onChange={() => {}}
+          onPrevious={() => {}}
+          onNext={() => {}}
+        />
       </Flex>
       <Flex direction="row" padding={`0 0 0 ${tokens.space.medium}`}>
         <ToggleButtonGroup


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use native Pagination primitive instead of `usePagination`. Checked locally.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
