### PR TITLE
docs: removing usePagination usage

### DIFF
--- a/docs/src/pages/components/pagination/react.mdx
+++ b/docs/src/pages/components/pagination/react.mdx
@@ -28,18 +28,6 @@ import '@aws-amplify/ui-react/styles.css';
 
 <PaginationDemo isDemo={false} />
 
-Or create with the built-in usePagination hook.
-
-```jsx
-import { Pagination, usePagination } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
-
-const pagination = usePagination({ currentPage: 1, totalPages: 10, siblingCount: 1 })
-<Pagination {...pagination} />;
-```
-
-<PaginationDemo isDemo={false} />
-
 ## CSS styling
 
 ### Global styling


### PR DESCRIPTION
*Description of changes:*

Remove `usePagination` usage on docs but keep it exported for now per discussion today. Need more discussion on whether we should make it available externally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
