### PR TITLE
Removing dangerouslySetInnerHTML

### DIFF
--- a/packages/react/src/components/AmplifyProvider/index.tsx
+++ b/packages/react/src/components/AmplifyProvider/index.tsx
@@ -31,10 +31,7 @@ export function AmplifyProvider({
         <div data-amplify-theme={name} data-amplify-color-mode={colorMode}>
           {children}
         </div>
-        <style
-          id={`amplify-theme-${name}`}
-          dangerouslySetInnerHTML={{ __html: cssText }}
-        />
+        <style id={`amplify-theme-${name}`}>{cssText}</style>
       </IdProvider>
     </AmplifyContext.Provider>
   );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Instead of using `dangerouslySetInnerHTML`, using a string child node for the theme CSS injection. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
