### PR TITLE
Change display policy for Placeholder component

### DIFF
--- a/packages/ui/src/theme/css/component/placeholder.scss
+++ b/packages/ui/src/theme/css/component/placeholder.scss
@@ -6,6 +6,7 @@
   border-radius: var(--amplify-components-placeholder-border-radius);
   height: var(--amplify-components-placeholder-default-height);
   width: 100%;
+  display: block;
 
   &[data-size='small'] {
     height: var(--amplify-components-placeholder-small-height);


### PR DESCRIPTION
*Description of changes:*
Height and width styles are ignored because the component has a default `inline` behavior. This PR add a `display: block` CSS property to the Placeholder primitive styles.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
