### PR TITLE
Fix redirect from signIn to confirmSignUp

### DIFF
--- a/.changeset/itchy-cougars-hug.md
+++ b/.changeset/itchy-cougars-hug.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+Fix redirect from signIn to confirmSignUp

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -170,3 +170,12 @@ Then('the {string} field is invalid', (name: string) => {
     .then(($el) => $el.get(0).checkValidity())
     .should('be.false');
 });
+
+When('I type a valid confirmation code', () => {
+  // This should be intercepted & mocked
+  cy.findByLabelText('Confirmation Code').type('validcode');
+});
+
+When('I type an invalid confirmation code', () => {
+  cy.findByLabelText('Confirmation Code').type('invalidcode');
+});

--- a/packages/e2e/cypress/integration/ui/components/authenticator/confirm-sign-up/confirm-sign-up.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/confirm-sign-up/confirm-sign-up.steps.ts
@@ -1,14 +1,5 @@
 import { Then, When } from 'cypress-cucumber-preprocessor/steps';
 
-When('I type a valid confirmation code', () => {
-  // This should be intercepted & mocked
-  cy.findByLabelText('Confirmation Code').type('validcode');
-});
-
-When('I type an invalid confirmation code', () => {
-  cy.findByLabelText('Confirmation Code').type('invalidcode');
-});
-
 Then('I see an error alert', () => {
   cy.findByRole('alert').should('exist');
 });

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
@@ -19,10 +19,22 @@ Feature: Sign In with Email
 
   @angular @react @vue
   Scenario: Sign in with unconfirmed credentials
+
+  If you sign in with an unconfirmed account, Authenticator will redirect you to `confirmSignUp` route.
+
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-email"
     When I type my "email" with status "UNCONFIRMED"
     And I type my password
     And I click the "Sign in" button
     Then I see "Confirmation Code"
+    And I type a valid confirmation code
+    And I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmSignUp" } }' with fixture "confirm-sign-up-with-email"
+    # Mocking these two calls is much easier than intercepting 6+ network calls with tokens that are validated & expire within the hour
+    And I mock 'Amplify.Auth.signIn' with fixture "Auth.signIn-verified-email"
+    And I mock 'Amplify.Auth.currentAuthenticatedUser' with fixture "Auth.currentAuthenticatedUser-verified-email"
+    And I click the "Confirm" button
+    Then I see "Sign out"
+
 
   @angular @react @vue
   Scenario: Sign in with confirmed credentials

--- a/packages/ui/src/machines/authenticator/actions.ts
+++ b/packages/ui/src/machines/authenticator/actions.ts
@@ -66,7 +66,8 @@ export const setConfirmSignUpIntent = assign({
 export const setCredentials = assign({
   authAttributes: (context: SignInContext | SignUpContext, _) => {
     const [primaryAlias] = context.loginMechanisms;
-    const username = context.formValues[primaryAlias];
+    const username =
+      context.formValues[primaryAlias] ?? context.formValues['username'];
     const password = context.formValues?.password;
 
     return { username, password };


### PR DESCRIPTION
*Issue #, if available:* Fixes #818

*Description of changes:* Transition from `signIn` to `confirmSignUp` wasn't working correctly because `setCredentials` assumes `formValues[primaryAlias]` contains the username. This is not true for `signIn` because `signIn` always has its `primaryAlias` input `name` set to `username`. 

This PR handles `signIn` case and adds a test for it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
