### PR TITLE
Vue: Fix docs for vue

### DIFF
--- a/docs/src/pages/components/chatbot/index.page.mdx
+++ b/docs/src/pages/components/chatbot/index.page.mdx
@@ -6,12 +6,7 @@ description: A simple way to add a conversational UI into your app is to use our
 import { Fragment } from '@/components/Fragment';
 import { Alert } from '@aws-amplify/ui-react';
 
-<Alert variation="info" heading="Web Component">
-This component has not yet been converted to a native implementation.
-
-If you’re migrating from version 1 of the `@aws-amplify/ui-[framework]`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
-
-</Alert>
+<Fragment>{({ platform }) => import(`./warning.${platform}.mdx`)}</Fragment>
 
 ## Usage
 

--- a/docs/src/pages/components/chatbot/usage.vue.mdx
+++ b/docs/src/pages/components/chatbot/usage.vue.mdx
@@ -1,6 +1,63 @@
-_App.vue_
+import { Tabs, TabItem } from '@aws-amplify/ui-react';
 
 To use the chatbot, make sure to install the `@aws-amplify/ui-components` package.
+
+**main.js**
+
+<Tabs>
+<TabItem title="Vue 3">
+
+```js
+import { createApp } from 'vue';
+import App from './App.vue';
+import {
+  applyPolyfills,
+  defineCustomElements,
+} from '@aws-amplify/ui-components/loader';
+
+import Amplify from 'aws-amplify';
+import awsconfig from './aws-exports';
+Amplify.configure(awsconfig);
+
+applyPolyfills().then(() => {
+  defineCustomElements(window);
+});
+
+const app = createApp(App);
+app.config.isCustomElement = (tag) => tag.startsWith('amplify-');
+app.mount('#app');
+```
+
+</TabItem>
+<TabItem title="Vue 2">
+
+```js
+import Vue from 'vue';
+import App from './App.vue';
+import {
+  applyPolyfills,
+  defineCustomElements,
+} from '@aws-amplify/ui-components/loader';
+
+import Amplify from 'aws-amplify';
+import awsconfig from './aws-exports';
+
+Amplify.configure(awsconfig);
+
+applyPolyfills().then(() => {
+  defineCustomElements(window);
+});
+
+Vue.config.ignoredElements = [/amplify-\w*/];
+
+new Vue({
+  render: (h) => h(App),
+}).$mount('#app');
+```
+
+  </TabItem>
+</Tabs>
+**App.vue**
 
 ```html
 <template>

--- a/docs/src/pages/components/chatbot/warning.angular.mdx
+++ b/docs/src/pages/components/chatbot/warning.angular.mdx
@@ -3,6 +3,6 @@ import { Alert } from '@aws-amplify/ui-react';
 <Alert variation="info" heading="Web Component">
 This component has not yet been converted to a native implementation.
 
-If you’re migrating from version 1 of the `@aws-amplify/ui-[framework]`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
+If you’re migrating from version 1 of the `@aws-amplify/ui-angular`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
 
 </Alert>

--- a/docs/src/pages/components/chatbot/warning.angular.mdx
+++ b/docs/src/pages/components/chatbot/warning.angular.mdx
@@ -1,0 +1,8 @@
+import { Alert } from '@aws-amplify/ui-react';
+
+<Alert variation="info" heading="Web Component">
+This component has not yet been converted to a native implementation.
+
+If you’re migrating from version 1 of the `@aws-amplify/ui-[framework]`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
+
+</Alert>

--- a/docs/src/pages/components/chatbot/warning.react.mdx
+++ b/docs/src/pages/components/chatbot/warning.react.mdx
@@ -3,6 +3,6 @@ import { Alert } from '@aws-amplify/ui-react';
 <Alert variation="info" heading="Web Component">
 This component has not yet been converted to a native implementation.
 
-If you’re migrating from version 1 of the `@aws-amplify/ui-[framework]`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
+If you’re migrating from version 1 of the `@aws-amplify/ui-react`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
 
 </Alert>

--- a/docs/src/pages/components/chatbot/warning.react.mdx
+++ b/docs/src/pages/components/chatbot/warning.react.mdx
@@ -1,0 +1,8 @@
+import { Alert } from '@aws-amplify/ui-react';
+
+<Alert variation="info" heading="Web Component">
+This component has not yet been converted to a native implementation.
+
+If you’re migrating from version 1 of the `@aws-amplify/ui-[framework]`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
+
+</Alert>

--- a/docs/src/pages/components/chatbot/warning.vue.mdx
+++ b/docs/src/pages/components/chatbot/warning.vue.mdx
@@ -1,0 +1,8 @@
+import { Alert } from '@aws-amplify/ui-react';
+
+<Alert variation="info" heading="Web Component">
+  This component has not yet been converted to a native implementation.
+
+To use this component on Vue, you must install the `@aws-amplify/ui-components` package into your project.
+
+</Alert>

--- a/docs/src/pages/components/storage/index.page.mdx
+++ b/docs/src/pages/components/storage/index.page.mdx
@@ -6,12 +6,7 @@ description: A simple way to interact with our storage solutions.
 import { Fragment } from '@/components/Fragment';
 import { Alert } from '@aws-amplify/ui-react';
 
-<Alert variation="info" heading="Web Component">
-This component has not yet been converted to a native implementation.
-
-If you’re migrating from version 1 of the `@aws-amplify/ui-[framework]`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
-
-</Alert>
+<Fragment>{({ platform }) => import(`./warning.${platform}.mdx`)}</Fragment>
 
 ## S3 Album
 

--- a/docs/src/pages/components/storage/warning.angular.mdx
+++ b/docs/src/pages/components/storage/warning.angular.mdx
@@ -3,6 +3,6 @@ import { Alert } from '@aws-amplify/ui-react';
 <Alert variation="info" heading="Web Component">
 This component has not yet been converted to a native implementation.
 
-If you’re migrating from version 1 of the `@aws-amplify/ui-[framework]`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
+If you’re migrating from version 1 of the `@aws-amplify/ui-angular`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
 
 </Alert>

--- a/docs/src/pages/components/storage/warning.angular.mdx
+++ b/docs/src/pages/components/storage/warning.angular.mdx
@@ -1,0 +1,8 @@
+import { Alert } from '@aws-amplify/ui-react';
+
+<Alert variation="info" heading="Web Component">
+This component has not yet been converted to a native implementation.
+
+If you’re migrating from version 1 of the `@aws-amplify/ui-[framework]`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
+
+</Alert>

--- a/docs/src/pages/components/storage/warning.react.mdx
+++ b/docs/src/pages/components/storage/warning.react.mdx
@@ -3,6 +3,6 @@ import { Alert } from '@aws-amplify/ui-react';
 <Alert variation="info" heading="Web Component">
 This component has not yet been converted to a native implementation.
 
-If you’re migrating from version 1 of the `@aws-amplify/ui-[framework]`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
+If you’re migrating from version 1 of the `@aws-amplify/ui-react`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
 
 </Alert>

--- a/docs/src/pages/components/storage/warning.react.mdx
+++ b/docs/src/pages/components/storage/warning.react.mdx
@@ -1,0 +1,8 @@
+import { Alert } from '@aws-amplify/ui-react';
+
+<Alert variation="info" heading="Web Component">
+This component has not yet been converted to a native implementation.
+
+If you’re migrating from version 1 of the `@aws-amplify/ui-[framework]`, please see [Usage](#usage) below to see the updated import with `/legacy` path.
+
+</Alert>

--- a/docs/src/pages/components/storage/warning.vue.mdx
+++ b/docs/src/pages/components/storage/warning.vue.mdx
@@ -1,0 +1,8 @@
+import { Alert } from '@aws-amplify/ui-react';
+
+<Alert variation="info" heading="Web Component">
+  This component has not yet been converted to a native implementation.
+
+To use this component on Vue, you must install the `@aws-amplify/ui-components` package into your project.
+
+</Alert>

--- a/docs/src/pages/getting-started/installation/dependencies.vue.mdx
+++ b/docs/src/pages/getting-started/installation/dependencies.vue.mdx
@@ -14,7 +14,7 @@ npm install aws-amplify @aws-amplify/ui-vue
 <TabItem title="yarn">
 
 ```shell
-yarn add @aws-amplify/ui-vue
+yarn add aws-amplify @aws-amplify/ui-vue
 ```
 
 </TabItem>


### PR DESCRIPTION
*Issue #, if available:*
#815 

*Description of changes:*

- [x] Chatbot documentation is missing some of the usage install information, ~~as well as the use cases~~
- [x] Banner on Chatbot and Storage for Vue show to use /legacy as the import. That does not exist on Vue
- [x] Typo on getting started guide for vue for yarn is missing aws-amplify

Vue Banner

![image](https://user-images.githubusercontent.com/65630/142924594-77036218-948b-45de-8ad7-172082fff066.png)

Angular/React Banner
![image](https://user-images.githubusercontent.com/65630/142924633-28bba1f4-41ac-46e9-a852-85ca3f9c7d44.png)





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
