### PR TITLE
ForwardRef support for FieldClearButton & FieldGroupIconButton

### DIFF
--- a/.changeset/tall-cups-obey.md
+++ b/.changeset/tall-cups-obey.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef support for FieldClearButton and FieldGroupIconButton.

--- a/packages/react/src/primitives/Field/FieldClearButton.tsx
+++ b/packages/react/src/primitives/Field/FieldClearButton.tsx
@@ -1,16 +1,21 @@
-import { FieldClearButtonProps, Primitive } from '../types';
+import * as React from 'react';
+
+import { FieldClearButtonProps, PrimitiveWithForwardRef } from '../types';
 import { FieldGroupIconButton } from '../FieldGroupIcon';
 import { IconClose } from '../Icon';
 import { SharedText } from '../shared/i18n';
 
 const ariaLabelText = SharedText.Fields.ariaLabel.clearField;
 
-export const FieldClearButton: Primitive<FieldClearButtonProps, 'button'> = (
-  props
-) => (
-  <FieldGroupIconButton ariaLabel={ariaLabelText} {...props}>
+const FieldClearButtonPrimitive: PrimitiveWithForwardRef<
+  FieldClearButtonProps,
+  'button'
+> = (props, ref) => (
+  <FieldGroupIconButton ariaLabel={ariaLabelText} {...props} ref={ref}>
     <IconClose size={props.size} />
   </FieldGroupIconButton>
 );
+
+export const FieldClearButton = React.forwardRef(FieldClearButtonPrimitive);
 
 FieldClearButton.displayName = 'FieldClearButton';

--- a/packages/react/src/primitives/Field/FieldClearButton.tsx
+++ b/packages/react/src/primitives/Field/FieldClearButton.tsx
@@ -11,7 +11,7 @@ const FieldClearButtonPrimitive: PrimitiveWithForwardRef<
   FieldClearButtonProps,
   'button'
 > = (props, ref) => (
-  <FieldGroupIconButton ariaLabel={ariaLabelText} {...props} ref={ref}>
+  <FieldGroupIconButton ariaLabel={ariaLabelText} ref={ref} {...props}>
     <IconClose size={props.size} />
   </FieldGroupIconButton>
 );

--- a/packages/react/src/primitives/Field/__tests__/FieldClearButton.test.tsx
+++ b/packages/react/src/primitives/Field/__tests__/FieldClearButton.test.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { FieldClearButton } from '../FieldClearButton';
+
+describe('FieldClearButton component', () => {
+  const testId = 'fieldGroupTestId';
+  it('should render default and custom classname for FieldClearButton', async () => {
+    render(<FieldClearButton className="custom-class" testId={testId} />);
+
+    const fieldClearbutton = await screen.findByTestId(testId);
+
+    expect(fieldClearbutton).toHaveClass('custom-class');
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(
+      <FieldClearButton ref={ref} className="custom-class" testId={testId} />
+    );
+    await screen.findByTestId(testId);
+    expect(ref.current.nodeName).toBe('BUTTON');
+  });
+});

--- a/packages/react/src/primitives/FieldGroupIcon/FieldGroupIconButton.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/FieldGroupIconButton.tsx
@@ -4,20 +4,24 @@ import classNames from 'classnames';
 import { Button } from '../Button';
 import { ComponentClassNames } from '../shared/constants';
 import { FieldGroupIcon } from './FieldGroupIcon';
-import { FieldGroupIconButtonProps } from '../types';
+import { FieldGroupIconButtonProps, PrimitiveWithForwardRef } from '../types';
 
-export const FieldGroupIconButton: React.FC<FieldGroupIconButtonProps> = ({
-  children,
-  className,
-  ...rest
-}) => (
+export const FieldGroupIconButtonPrimitive: PrimitiveWithForwardRef<
+  FieldGroupIconButtonProps,
+  'button'
+> = ({ children, className, ...rest }, ref) => (
   <FieldGroupIcon
     as={Button}
     className={classNames(ComponentClassNames.FieldGroupIconButton, className)}
+    ref={ref}
     {...rest}
   >
     {children}
   </FieldGroupIcon>
+);
+
+export const FieldGroupIconButton = React.forwardRef(
+  FieldGroupIconButtonPrimitive
 );
 
 FieldGroupIconButton.displayName = 'FieldGroupIconButton';

--- a/packages/react/src/primitives/FieldGroupIcon/__tests__/FieldGroupIcon.test.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/__tests__/FieldGroupIcon.test.tsx
@@ -1,12 +1,9 @@
 import { render, screen } from '@testing-library/react';
-
 import * as React from 'react';
 
 import { FieldGroupIcon } from '../FieldGroupIcon';
-import { Text } from '../../Text';
-import { Button } from '../../Button';
 
-import { ComponentClassNames } from '../../shared';
+import { ComponentClassNames } from '../../shared/constants';
 
 describe('FieldGroupIcon component', () => {
   const testId = 'fieldGroupTestId';

--- a/packages/react/src/primitives/FieldGroupIcon/__tests__/FieldGroupIconButton.test.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/__tests__/FieldGroupIconButton.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+
+import { FieldGroupIconButton } from '../FieldGroupIconButton';
+import { ComponentClassNames } from '../../shared/constants';
+
+describe('FieldGroupIconButton: ', () => {
+  it('should render default and custom classname', async () => {
+    const className = 'custom-class';
+    render(<FieldGroupIconButton className={className} />);
+
+    const fieldGroupIconButton = await screen.findByRole('button');
+    expect(fieldGroupIconButton).toHaveClass(
+      ComponentClassNames.FieldGroupIconButton,
+      className
+    );
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const testId = 'field-group-icon-button';
+    const ref = React.createRef<HTMLButtonElement>();
+    render(<FieldGroupIconButton ref={ref} testId={testId} />);
+    await screen.findAllByTestId(testId);
+    expect(ref.current.nodeName).toBe('BUTTON');
+  });
+});


### PR DESCRIPTION
*Description of changes:*

Adding forward ref support for `FieldClearButton` & `FieldGroupIconButton`.  

 @reesscot finished most all of the work here. Credits to him

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
