### PR TITLE
ForwardRef for PhoneNumberField

### DIFF
--- a/.changeset/violet-bees-draw.md
+++ b/.changeset/violet-bees-draw.md
@@ -1,0 +1,6 @@
+---
+"docs": patch
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef for PhoneNumberField

--- a/docs/src/pages/components/phonenumberfield/examples/refs.tsx
+++ b/docs/src/pages/components/phonenumberfield/examples/refs.tsx
@@ -1,0 +1,26 @@
+import { PhoneNumberField, Flex, Text } from '@aws-amplify/ui-react';
+import * as React from 'react';
+
+export const RefExample = () => {
+  const inputRef = React.useRef(null);
+  const countryCodeRef = React.useRef(null);
+
+  const [inputValue, setInputValue] = React.useState('');
+
+  const onBlur = () => {
+    countryCodeRef.current.focus();
+    setInputValue(inputRef.current.value);
+  };
+  return (
+    <Flex direction="column">
+      <PhoneNumberField
+        ref={inputRef}
+        countryCodeRef={countryCodeRef}
+        label="Phone number"
+        defaultCountryCode="+1"
+        onBlur={onBlur}
+      />
+      <code>`inputRef` value: {inputValue}</code>
+    </Flex>
+  );
+};

--- a/docs/src/pages/components/phonenumberfield/react.mdx
+++ b/docs/src/pages/components/phonenumberfield/react.mdx
@@ -13,8 +13,9 @@ import {
   StatesExample,
   StyledRequiredExample,
 } from './examples';
-import { Example } from '@/components/Example';
+import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
+import { RefExample } from './examples/refs';
 
 The `PhoneNumberField` form primitive can be used allow users to input a phone number.
 
@@ -253,6 +254,23 @@ Use the `hasError` and `errorMessage` fields to mark a `PhoneNumberField` as hav
 
 <Example>
   <ErrorExample />
+</Example>
+
+### Forward refs
+
+[Ref](https://reactjs.org/docs/forwarding-refs.html) props are available on the PhoneNumberField for more advanced use cases such as focus management. The standard `ref` prop will forward to the underlying `input` element, and the `countryCodeRef` prop forwards to the country code `select` element.
+
+The following is a contrived example demonstrating use of the `ref` and `countryCodeRef` props:
+
+<Example>
+  <RefExample />
+<ExampleCode>
+
+```tsx file=./examples/refs.tsx
+
+```
+
+</ExampleCode>
 </Example>
 
 ## CSS Styling

--- a/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
@@ -1,26 +1,34 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { CountryCodeSelect } from './CountryCodeSelect';
 import { TextField } from '../TextField';
 import { ComponentClassNames } from '../shared/constants';
 import { SharedText } from '../shared/i18n';
-import { PhoneNumberFieldProps, Primitive } from '../types';
+import { PhoneNumberFieldProps, PrimitiveWithForwardRef } from '../types';
 
-export const PhoneNumberField: Primitive<PhoneNumberFieldProps, 'input'> = ({
-  autoComplete = 'tel-national',
-  className,
-  countryCodeName,
-  countryCodeLabel = SharedText.CountryCodeSelect.ariaLabel,
-  defaultCountryCode,
-  hasError,
-  isDisabled,
-  onCountryCodeChange,
-  onInput,
-  size,
-  type,
-  variation,
-  ...rest
-}) => {
+const PhoneNumberFieldPrimitive: PrimitiveWithForwardRef<
+  PhoneNumberFieldProps,
+  'input'
+> = (
+  {
+    autoComplete = 'tel-national',
+    className,
+    countryCodeName,
+    countryCodeLabel = SharedText.CountryCodeSelect.ariaLabel,
+    defaultCountryCode,
+    hasError,
+    isDisabled,
+    onCountryCodeChange,
+    onInput,
+    size,
+    type,
+    variation,
+    countryCodeRef,
+    ...rest
+  },
+  ref
+) => {
   return (
     <TextField
       outerStartComponent={
@@ -32,6 +40,7 @@ export const PhoneNumberField: Primitive<PhoneNumberFieldProps, 'input'> = ({
           label={countryCodeLabel}
           name={countryCodeName}
           onChange={onCountryCodeChange}
+          ref={countryCodeRef}
           size={size}
           variation={variation}
         />
@@ -42,6 +51,7 @@ export const PhoneNumberField: Primitive<PhoneNumberFieldProps, 'input'> = ({
       isDisabled={isDisabled}
       isMultiline={false}
       onInput={onInput}
+      ref={ref}
       size={size}
       type="tel"
       variation={variation}
@@ -49,5 +59,7 @@ export const PhoneNumberField: Primitive<PhoneNumberFieldProps, 'input'> = ({
     />
   );
 };
+
+export const PhoneNumberField = React.forwardRef(PhoneNumberFieldPrimitive);
 
 PhoneNumberField.displayName = 'PhoneNumberField';

--- a/packages/react/src/primitives/PhoneNumberField/__tests__/PhoneNumberField.test.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/__tests__/PhoneNumberField.test.tsx
@@ -1,8 +1,8 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { PhoneNumberField } from '../PhoneNumberField';
-import { PhoneNumberFieldProps, PrimitiveProps } from '../../types';
 import { ComponentClassNames } from '../../shared/constants';
 
 describe('PhoneNumberField primitive', () => {
@@ -10,7 +10,7 @@ describe('PhoneNumberField primitive', () => {
     defaultCountryCode = '+1',
     label = 'Phone Number',
     ...rest
-  }: Partial<PrimitiveProps<PhoneNumberFieldProps, 'input'>>) => {
+  }: Partial<typeof PhoneNumberField['defaultProps']>) => {
     render(
       <PhoneNumberField
         defaultCountryCode={defaultCountryCode}
@@ -28,6 +28,16 @@ describe('PhoneNumberField primitive', () => {
       }),
     };
   };
+
+  it('should forward ref and countryCodeRef to DOM elements', async () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const countryCodeRef = React.createRef<HTMLSelectElement>();
+    await setup({ ref, countryCodeRef });
+
+    await screen.findByRole('textbox');
+    expect(ref.current.nodeName).toBe('INPUT');
+    expect(countryCodeRef.current.nodeName).toBe('SELECT');
+  });
 
   it('should render a country code selector with an accessible role', async () => {
     const { $countryCodeSelector } = await setup({});

--- a/packages/react/src/primitives/types/phoneNumberField.ts
+++ b/packages/react/src/primitives/types/phoneNumberField.ts
@@ -9,6 +9,10 @@ export interface PhoneNumberFieldProps extends TextInputFieldProps {
   defaultCountryCode: string;
   onCountryCodeChange?: React.ChangeEventHandler<HTMLSelectElement>;
   type?: 'tel';
+  /**
+   * Forwarded ref for access to Country Code select DOM element
+   */
+  countryCodeRef?: React.Ref<HTMLSelectElement>;
 }
 
 export interface CountryCodeSelectProps extends SelectFieldProps {


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for the `PhoneNumberField` primitive by wrapping it in `React.forwardRef`. In this case we're supporting both the standard `ref` for access to the `input` field, and `countryCodeRef` for access to the `select` field.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null);
  const countryCodeRef = React.useRef(null);

  
  // Below returns INPUT because the ref is forwarded down to DOM element (PhoneNumberField => TextField => Input => <input>)
  // ref.current.nodeName

  // Below returns SELECT because the ref is forwarded down to DOM element (PhoneNumberField => SelectField => Input => <input>)
  // ref.current.nodeName
  
  return (
    <PhoneNumberField label="name" ref={ref} countryCodeRef={countryCodeRef}/>
  );
};
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
