### PR TITLE
Pass props from withAuthenticator to Component

### DIFF
--- a/.changeset/olive-glasses-bake.md
+++ b/.changeset/olive-glasses-bake.md
@@ -1,6 +1,4 @@
 ---
-"next-example": patch
-"e2e": patch
 "@aws-amplify/ui-react": patch
 ---
 

--- a/.changeset/olive-glasses-bake.md
+++ b/.changeset/olive-glasses-bake.md
@@ -1,0 +1,7 @@
+---
+"next-example": patch
+"e2e": patch
+"@aws-amplify/ui-react": patch
+---
+
+Pass props from withAuthenticator to Component

--- a/examples/next/pages/ui/components/authenticator/withAuthenticator/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/withAuthenticator/index.page.tsx
@@ -6,7 +6,11 @@ import '@aws-amplify/ui-react/styles.css';
 import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';
 Amplify.configure(awsExports);
 
-function App({ signOut, user }) {
+function App({ isPassedToWithAuthenticator, signOut, user }) {
+  if (!isPassedToWithAuthenticator) {
+    throw new Error(`isPassedToWithAuthenticator was not provided`);
+  }
+
   return (
     <>
       <h1>Hello {user.username}</h1>
@@ -16,3 +20,11 @@ function App({ signOut, user }) {
 }
 
 export default withAuthenticator(App);
+
+export async function getStaticProps() {
+  return {
+    props: {
+      isPassedToWithAuthenticator: true,
+    },
+  };
+}

--- a/packages/e2e/features/ui/components/authenticator/withAuthenticator.feature
+++ b/packages/e2e/features/ui/components/authenticator/withAuthenticator.feature
@@ -1,0 +1,17 @@
+Feature: withAuthenticator
+
+  Higher-Order Component wrapps App with an Authenticator
+
+  Background:
+    Given I'm running the example "/ui/components/authenticator/withAuthenticator"
+
+  @react
+  Scenario: Application is wrapped with Authenticator
+    Then I see "Sign in"
+
+  @react
+  Scenario: Application renders when signed in
+    When I type my "username" with status "CONFIRMED"
+    And I type my password
+    And I click the "Sign in" button
+    Then I see "Sign out"

--- a/packages/react/src/components/Authenticator/withAuthenticator.tsx
+++ b/packages/react/src/components/Authenticator/withAuthenticator.tsx
@@ -10,10 +10,10 @@ export function withAuthenticator(
 ) {
   const { variation = 'modal' } = options;
 
-  return function WrappedWithAuthenticator() {
+  return function WrappedWithAuthenticator(props) {
     return (
       <Authenticator variation={variation} {...options}>
-        {(props) => <Component {...props} />}
+        {(authenticator) => <Component {...props} {...authenticator} />}
       </Authenticator>
     );
   };


### PR DESCRIPTION
*Issue #, if available:* Closes #837

*Description of changes:*

`withAuthenticator` didn't pass along props, but this PR passes it & validates it with a new `.feature` test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
