### PR TITLE
Update PasswordField to support showPasswordButton ref

### DIFF
--- a/.changeset/swift-moons-kneel.md
+++ b/.changeset/swift-moons-kneel.md
@@ -1,0 +1,6 @@
+---
+"docs": patch
+"@aws-amplify/ui-react": patch
+---
+
+Update PasswordField to support showPasswordButton ref

--- a/docs/src/pages/components/passwordfield/examples/refs.tsx
+++ b/docs/src/pages/components/passwordfield/examples/refs.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { PasswordField } from '@aws-amplify/ui-react';
+
+export const RefExample = () => {
+  const inputRef = React.useRef(null);
+  const showPasswordRef = React.useRef(null);
+
+  const onShowPasswordClick = React.useCallback(() => {
+    inputRef.current.focus();
+  }, []);
+
+  React.useEffect(() => {
+    if (showPasswordRef && showPasswordRef.current) {
+      console.count('useeffect');
+      showPasswordRef.current.addEventListener(
+        'click',
+        onShowPasswordClick,
+        false
+      );
+      return () => {
+        showPasswordRef.current.removeEventListener(
+          'click',
+          onShowPasswordClick,
+          false
+        );
+      };
+    }
+  }, [onShowPasswordClick]);
+
+  return (
+    <PasswordField
+      ref={inputRef}
+      showPasswordRef={showPasswordRef}
+      label="Password"
+    />
+  );
+};

--- a/docs/src/pages/components/passwordfield/examples/refs.tsx
+++ b/docs/src/pages/components/passwordfield/examples/refs.tsx
@@ -3,22 +3,22 @@ import { PasswordField } from '@aws-amplify/ui-react';
 
 export const RefExample = () => {
   const inputRef = React.useRef(null);
-  const showPasswordRef = React.useRef(null);
+  const showPasswordButtonRef = React.useRef(null);
 
   const onShowPasswordClick = React.useCallback(() => {
     inputRef.current.focus();
   }, []);
 
   React.useEffect(() => {
-    if (showPasswordRef && showPasswordRef.current) {
+    if (showPasswordButtonRef && showPasswordButtonRef.current) {
       console.count('useeffect');
-      showPasswordRef.current.addEventListener(
+      showPasswordButtonRef.current.addEventListener(
         'click',
         onShowPasswordClick,
         false
       );
       return () => {
-        showPasswordRef.current.removeEventListener(
+        showPasswordButtonRef.current.removeEventListener(
           'click',
           onShowPasswordClick,
           false
@@ -29,9 +29,9 @@ export const RefExample = () => {
 
   return (
     <PasswordField
-      ref={inputRef}
-      showPasswordRef={showPasswordRef}
       label="Password"
+      ref={inputRef}
+      showPasswordButtonRef={showPasswordButtonRef}
     />
   );
 };

--- a/docs/src/pages/components/passwordfield/react.mdx
+++ b/docs/src/pages/components/passwordfield/react.mdx
@@ -272,9 +272,9 @@ Use the `hasError` and `errorMessage` fields to mark a PasswordField as having a
 
 ### Forward refs
 
-[Ref](https://reactjs.org/docs/forwarding-refs.html) props are available for more advanced use cases such as focus management. The standard `ref` prop will forward to the underlying `input` element, and the `showPasswordRef` prop forwards to the show password `button` element.
+[Ref](https://reactjs.org/docs/forwarding-refs.html) props are available for more advanced use cases such as focus management. The standard `ref` prop will forward to the underlying `input` element, and the `showPasswordButtonRef` prop forwards to the show password `button` element.
 
-The following is an example demonstrating use of the `ref` and `showPasswordRef` props:
+The following is an example demonstrating use of the `ref` and `showPasswordButtonRef` props:
 
 <Example>
   <RefExample />

--- a/docs/src/pages/components/passwordfield/react.mdx
+++ b/docs/src/pages/components/passwordfield/react.mdx
@@ -14,8 +14,9 @@ import {
   RequiredPasswordFieldExample,
   SignUpFormExample,
 } from './examples';
-import { Example } from '@/components/Example';
+import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
+import { RefExample } from './examples/refs';
 
 The PasswordField primitive allows users to input passwords. It also features full password manager support and an optional show/hide password button for user convenience.
 
@@ -267,6 +268,23 @@ Use the `hasError` and `errorMessage` fields to mark a PasswordField as having a
       errorMessage="Password should not be 1234! 😱"
     />
   </Flex>
+</Example>
+
+### Forward refs
+
+[Ref](https://reactjs.org/docs/forwarding-refs.html) props are available for more advanced use cases such as focus management. The standard `ref` prop will forward to the underlying `input` element, and the `showPasswordRef` prop forwards to the show password `button` element.
+
+The following is an example demonstrating use of the `ref` and `showPasswordRef` props:
+
+<Example>
+  <RefExample />
+<ExampleCode>
+
+```tsx file=./examples/refs.tsx
+
+```
+
+</ExampleCode>
 </Example>
 
 ## CSS Styling

--- a/packages/react/src/primitives/PasswordField/PasswordField.tsx
+++ b/packages/react/src/primitives/PasswordField/PasswordField.tsx
@@ -19,7 +19,7 @@ const PasswordFieldPrimitive: PrimitiveWithForwardRef<
     label,
     className,
     hideShowPassword = false,
-    showPasswordRef,
+    showPasswordButtonRef,
     size,
     ...rest
   },
@@ -44,7 +44,7 @@ const PasswordFieldPrimitive: PrimitiveWithForwardRef<
           <ShowPasswordButton
             fieldType={type}
             onClick={showPasswordOnClick}
-            ref={showPasswordRef}
+            ref={showPasswordButtonRef}
             size={size}
           />
         )

--- a/packages/react/src/primitives/PasswordField/PasswordField.tsx
+++ b/packages/react/src/primitives/PasswordField/PasswordField.tsx
@@ -19,6 +19,7 @@ const PasswordFieldPrimitive: PrimitiveWithForwardRef<
     label,
     className,
     hideShowPassword = false,
+    showPasswordRef,
     size,
     ...rest
   },
@@ -43,6 +44,7 @@ const PasswordFieldPrimitive: PrimitiveWithForwardRef<
           <ShowPasswordButton
             fieldType={type}
             onClick={showPasswordOnClick}
+            ref={showPasswordRef}
             size={size}
           />
         )

--- a/packages/react/src/primitives/PasswordField/ShowPasswordButton.tsx
+++ b/packages/react/src/primitives/PasswordField/ShowPasswordButton.tsx
@@ -14,7 +14,6 @@ const ShowPasswordButtonPrimitive: PrimitiveWithForwardRef<
 > = ({ fieldType, size, ...rest }, ref) => {
   return (
     <Button
-      {...rest}
       ariaLabel={
         fieldType === 'password'
           ? ariaLabelText.showPassword
@@ -23,6 +22,7 @@ const ShowPasswordButtonPrimitive: PrimitiveWithForwardRef<
       className={ComponentClassNames.FieldShowPassword}
       ref={ref}
       size={size}
+      {...rest}
     >
       {fieldType === 'password' ? (
         <IconVisibility size={size} />

--- a/packages/react/src/primitives/PasswordField/ShowPasswordButton.tsx
+++ b/packages/react/src/primitives/PasswordField/ShowPasswordButton.tsx
@@ -1,28 +1,28 @@
 import * as React from 'react';
 
-import { ShowPasswordButtonProps } from '../types';
 import { Button } from '../Button';
 import { ComponentClassNames } from '../shared/constants';
 import { IconVisibility, IconVisibilityOff } from '../Icon';
 import { SharedText } from '../shared/i18n';
+import { PrimitiveWithForwardRef, ShowPasswordButtonProps } from '../types';
 
 const ariaLabelText = SharedText.ShowPasswordButton.ariaLabel;
 
-export const ShowPasswordButton: React.FC<ShowPasswordButtonProps> = ({
-  fieldType,
-  size,
-  onClick,
-}) => {
+const ShowPasswordButtonPrimitive: PrimitiveWithForwardRef<
+  ShowPasswordButtonProps,
+  typeof Button
+> = ({ fieldType, size, ...rest }, ref) => {
   return (
     <Button
-      className={ComponentClassNames.FieldShowPassword}
-      onClick={onClick}
-      size={size}
+      {...rest}
       ariaLabel={
         fieldType === 'password'
           ? ariaLabelText.showPassword
           : ariaLabelText.hidePassword
       }
+      className={ComponentClassNames.FieldShowPassword}
+      ref={ref}
+      size={size}
     >
       {fieldType === 'password' ? (
         <IconVisibility size={size} />
@@ -32,5 +32,7 @@ export const ShowPasswordButton: React.FC<ShowPasswordButtonProps> = ({
     </Button>
   );
 };
+
+export const ShowPasswordButton = React.forwardRef(ShowPasswordButtonPrimitive);
 
 ShowPasswordButton.displayName = 'ShowPasswordButton';

--- a/packages/react/src/primitives/PasswordField/__tests__/PasswordField.test.tsx
+++ b/packages/react/src/primitives/PasswordField/__tests__/PasswordField.test.tsx
@@ -26,12 +26,21 @@ describe('PasswordField component', () => {
     expect(passwordFieldWrapper).toHaveClass(ComponentClassNames.PasswordField);
   });
 
-  it('should forward ref to DOM element', async () => {
+  it('should forward refs to DOM elements', async () => {
     const ref = React.createRef<HTMLInputElement>();
-    render(<PasswordField testId={testId} label="Password" ref={ref} />);
+    const showPasswordRef = React.createRef<HTMLButtonElement>();
+    render(
+      <PasswordField
+        testId={testId}
+        label="Password"
+        ref={ref}
+        showPasswordRef={showPasswordRef}
+      />
+    );
 
     await screen.findByTestId(testId);
     expect(ref.current.nodeName).toBe('INPUT');
+    expect(showPasswordRef.current.nodeName).toBe('BUTTON');
   });
 
   it('should be password input type', async () => {

--- a/packages/react/src/primitives/PasswordField/__tests__/PasswordField.test.tsx
+++ b/packages/react/src/primitives/PasswordField/__tests__/PasswordField.test.tsx
@@ -28,19 +28,19 @@ describe('PasswordField component', () => {
 
   it('should forward refs to DOM elements', async () => {
     const ref = React.createRef<HTMLInputElement>();
-    const showPasswordRef = React.createRef<HTMLButtonElement>();
+    const showPasswordButtonRef = React.createRef<HTMLButtonElement>();
     render(
       <PasswordField
         testId={testId}
         label="Password"
         ref={ref}
-        showPasswordRef={showPasswordRef}
+        showPasswordButtonRef={showPasswordButtonRef}
       />
     );
 
     await screen.findByTestId(testId);
     expect(ref.current.nodeName).toBe('INPUT');
-    expect(showPasswordRef.current.nodeName).toBe('BUTTON');
+    expect(showPasswordButtonRef.current.nodeName).toBe('BUTTON');
   });
 
   it('should be password input type', async () => {

--- a/packages/react/src/primitives/PasswordField/__tests__/ShowPasswordButton.test.tsx
+++ b/packages/react/src/primitives/PasswordField/__tests__/ShowPasswordButton.test.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { ComponentClassNames } from '../../shared';
+import { ShowPasswordButton } from '../ShowPasswordButton';
+
+import { SharedText } from '../../shared/i18n';
+const ariaLabelText = SharedText.ShowPasswordButton.ariaLabel;
+
+describe('ShowPasswordButton component', () => {
+  const testId = 'testId';
+
+  it('should render default classname for ShowPasswordButton', async () => {
+    render(<ShowPasswordButton fieldType="password" />);
+
+    const button = await screen.findByRole('button');
+
+    expect(button).toHaveClass(ComponentClassNames.FieldShowPassword);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(<ShowPasswordButton fieldType="password" ref={ref} />);
+
+    await screen.findByRole('button');
+
+    expect(ref.current.nodeName).toBe('BUTTON');
+  });
+
+  it('should set correct ariaLabel for fieldType password', async () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(<ShowPasswordButton fieldType="password" ref={ref} />);
+
+    await screen.findByLabelText(ariaLabelText.showPassword);
+
+    expect(ref.current.nodeName).toBe('BUTTON');
+  });
+
+  it('should set correct ariaLabel for fieldType text', async () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(
+      <ShowPasswordButton
+        fieldType="text"
+        className="custom-class"
+        ref={ref}
+        testId={testId}
+      />
+    );
+
+    await screen.findByLabelText(ariaLabelText.hidePassword);
+
+    expect(ref.current.nodeName).toBe('BUTTON');
+  });
+});

--- a/packages/react/src/primitives/types/passwordField.ts
+++ b/packages/react/src/primitives/types/passwordField.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ButtonProps } from './button';
 import { TextInputFieldProps } from './textField';
 
@@ -13,11 +14,12 @@ export interface PasswordFieldProps extends TextInputFieldProps {
    * @default "current-password"
    */
   autoComplete?: 'new-password' | 'current-password' | string;
+
+  showPasswordRef?: React.Ref<HTMLButtonElement>;
 }
 
 export type PasswordFieldType = 'password' | 'text';
 
-export interface ShowPasswordButtonProps
-  extends Pick<ButtonProps, 'onClick' | 'size'> {
+export interface ShowPasswordButtonProps extends ButtonProps {
   fieldType: PasswordFieldType;
 }

--- a/packages/react/src/primitives/types/passwordField.ts
+++ b/packages/react/src/primitives/types/passwordField.ts
@@ -15,7 +15,10 @@ export interface PasswordFieldProps extends TextInputFieldProps {
    */
   autoComplete?: 'new-password' | 'current-password' | string;
 
-  showPasswordRef?: React.Ref<HTMLButtonElement>;
+  /**
+   * Forwarded ref for access to show password button DOM element
+   */
+  showPasswordButtonRef?: React.Ref<HTMLButtonElement>;
 }
 
 export type PasswordFieldType = 'password' | 'text';


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for the `ShowPasswordButton` in the `PasswordField` primitive by offering a `showPasswordRef` prop.

```jsx
export const RefExample = () => {
  const inputRef = React.useRef(null);
  const showPasswordRef = React.useRef(null);

  const onShowPasswordClick = React.useCallback(() => {
    inputRef.current.focus();
  }, []);

  React.useEffect(() => {
    if (showPasswordRef && showPasswordRef.current) {
      console.count('useeffect');
      showPasswordRef.current.addEventListener(
        'click',
        onShowPasswordClick,
        false
      );
      return () => {
        showPasswordRef.current.removeEventListener(
          'click',
          onShowPasswordClick,
          false
        );
      };
    }
  }, [onShowPasswordClick]);

  return (
    <PasswordField
      ref={inputRef}
      showPasswordRef={showPasswordRef}
      label="Password"
    />
  );
};
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
