### PR TITLE
ForwardRef support for Alert, ButtonGroup, Expander & ExpanderItem

### DIFF
--- a/.changeset/six-tigers-wink.md
+++ b/.changeset/six-tigers-wink.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+ForwardRef support for Alert, ButtonGroup, Expander & ExpanderItem

--- a/packages/react/src/primitives/Alert/Alert.tsx
+++ b/packages/react/src/primitives/Alert/Alert.tsx
@@ -9,10 +9,10 @@ import { Button } from '../Button';
 import { AlertIcon } from './AlertIcon';
 import { IconClose } from '../Icon';
 import { isFunction } from '../shared/utils';
-import { splitPrimitiveProps } from '../shared/styleUtils';
 
 const AlertPrimitive: PrimitiveWithForwardRef<AlertProps, typeof Flex> = (
   {
+    buttonRef,
     children,
     className,
     hasIcon = true,
@@ -20,13 +20,10 @@ const AlertPrimitive: PrimitiveWithForwardRef<AlertProps, typeof Flex> = (
     isDismissible = false,
     onDismiss,
     variation,
-    ..._rest
+    ...rest
   },
   ref
 ) => {
-  const { baseStyleProps, flexContainerStyleProps, rest } =
-    splitPrimitiveProps(_rest);
-
   const [dismissed, setDismissed] = React.useState<boolean>(false);
 
   const dismissAlert = React.useCallback(() => {
@@ -43,8 +40,6 @@ const AlertPrimitive: PrimitiveWithForwardRef<AlertProps, typeof Flex> = (
         className={classNames(ComponentClassNames.Alert, className)}
         data-variation={variation}
         ref={ref}
-        {...baseStyleProps}
-        {...flexContainerStyleProps}
         {...rest}
       >
         {hasIcon && <AlertIcon variation={variation} />}
@@ -59,6 +54,7 @@ const AlertPrimitive: PrimitiveWithForwardRef<AlertProps, typeof Flex> = (
             variation="link"
             className={ComponentClassNames.AlertDismiss}
             onClick={dismissAlert}
+            ref={buttonRef}
           >
             <IconClose />
           </Button>

--- a/packages/react/src/primitives/Alert/Alert.tsx
+++ b/packages/react/src/primitives/Alert/Alert.tsx
@@ -11,65 +11,62 @@ import { IconClose } from '../Icon';
 import { isFunction } from '../shared/utils';
 import { splitPrimitiveProps } from '../shared/styleUtils';
 
-export const AlertPrimitive: PrimitiveWithForwardRef<AlertProps, typeof Flex> =
-  (
-    {
-      children,
-      className,
-      hasIcon = true,
-      heading,
-      isDismissible = false,
-      onDismiss,
-      variation,
-      ..._rest
-    },
-    ref
-  ) => {
-    const { baseStyleProps, flexContainerStyleProps, rest } =
-      splitPrimitiveProps(_rest);
+const AlertPrimitive: PrimitiveWithForwardRef<AlertProps, typeof Flex> = (
+  {
+    children,
+    className,
+    hasIcon = true,
+    heading,
+    isDismissible = false,
+    onDismiss,
+    variation,
+    ..._rest
+  },
+  ref
+) => {
+  const { baseStyleProps, flexContainerStyleProps, rest } =
+    splitPrimitiveProps(_rest);
 
-    const [dismissed, setDismissed] = React.useState<boolean>(false);
+  const [dismissed, setDismissed] = React.useState<boolean>(false);
 
-    const dismissAlert = React.useCallback(() => {
-      setDismissed(!dismissed);
+  const dismissAlert = React.useCallback(() => {
+    setDismissed(!dismissed);
 
-      if (isFunction(onDismiss)) {
-        onDismiss();
-      }
-    }, [setDismissed, onDismiss]);
+    if (isFunction(onDismiss)) {
+      onDismiss();
+    }
+  }, [setDismissed, onDismiss]);
 
-    return (
-      !dismissed && (
-        <Flex
-          className={classNames(ComponentClassNames.Alert, className)}
-          data-variation={variation}
-          ref={ref}
-          {...baseStyleProps}
-          {...flexContainerStyleProps}
-          {...rest}
-        >
-          {hasIcon && <AlertIcon variation={variation} />}
-          <View role="alert" flex="1">
-            {heading && (
-              <View className={ComponentClassNames.AlertHeading}>
-                {heading}
-              </View>
-            )}
-            <View className={ComponentClassNames.AlertBody}>{children}</View>
-          </View>
-          {isDismissible && (
-            <Button
-              variation="link"
-              className={ComponentClassNames.AlertDismiss}
-              onClick={dismissAlert}
-            >
-              <IconClose />
-            </Button>
+  return (
+    !dismissed && (
+      <Flex
+        className={classNames(ComponentClassNames.Alert, className)}
+        data-variation={variation}
+        ref={ref}
+        {...baseStyleProps}
+        {...flexContainerStyleProps}
+        {...rest}
+      >
+        {hasIcon && <AlertIcon variation={variation} />}
+        <View role="alert" flex="1">
+          {heading && (
+            <View className={ComponentClassNames.AlertHeading}>{heading}</View>
           )}
-        </Flex>
-      )
-    );
-  };
+          <View className={ComponentClassNames.AlertBody}>{children}</View>
+        </View>
+        {isDismissible && (
+          <Button
+            variation="link"
+            className={ComponentClassNames.AlertDismiss}
+            onClick={dismissAlert}
+          >
+            <IconClose />
+          </Button>
+        )}
+      </Flex>
+    )
+  );
+};
 
 export const Alert = React.forwardRef(AlertPrimitive);
 

--- a/packages/react/src/primitives/Alert/Alert.tsx
+++ b/packages/react/src/primitives/Alert/Alert.tsx
@@ -2,73 +2,75 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { AlertProps, Primitive } from '../types';
+import { AlertProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 import { Flex } from '../Flex';
-import { Text } from '../Text';
 import { Button } from '../Button';
 import { AlertIcon } from './AlertIcon';
 import { IconClose } from '../Icon';
 import { isFunction } from '../shared/utils';
+import { splitPrimitiveProps } from '../shared/styleUtils';
 
-export const Alert: Primitive<AlertProps, typeof Flex> = ({
-  alignContent,
-  alignItems = 'center',
-  children,
-  className,
-  direction,
-  gap,
-  hasIcon = true,
-  heading,
-  isDismissible = false,
-  justifyContent = 'space-between',
-  onDismiss,
-  variation,
-  wrap,
-  ...rest
-}) => {
-  const [dismissed, setDismissed] = React.useState<boolean>(false);
+export const AlertPrimitive: PrimitiveWithForwardRef<AlertProps, typeof Flex> =
+  (
+    {
+      children,
+      className,
+      hasIcon = true,
+      heading,
+      isDismissible = false,
+      onDismiss,
+      variation,
+      ..._rest
+    },
+    ref
+  ) => {
+    const { baseStyleProps, flexContainerStyleProps, rest } =
+      splitPrimitiveProps(_rest);
 
-  const dismissAlert = React.useCallback(() => {
-    setDismissed(!dismissed);
+    const [dismissed, setDismissed] = React.useState<boolean>(false);
 
-    if (isFunction(onDismiss)) {
-      onDismiss();
-    }
-  }, [setDismissed, onDismiss]);
+    const dismissAlert = React.useCallback(() => {
+      setDismissed(!dismissed);
 
-  return (
-    !dismissed && (
-      <Flex
-        alignContent={alignContent}
-        alignItems={alignItems}
-        className={classNames(ComponentClassNames.Alert, className)}
-        data-variation={variation}
-        direction={direction}
-        gap={gap}
-        justifyContent={justifyContent}
-        wrap={wrap}
-        {...rest}
-      >
-        {hasIcon && <AlertIcon variation={variation} />}
-        <View role="alert" flex="1">
-          {heading && (
-            <View className={ComponentClassNames.AlertHeading}>{heading}</View>
+      if (isFunction(onDismiss)) {
+        onDismiss();
+      }
+    }, [setDismissed, onDismiss]);
+
+    return (
+      !dismissed && (
+        <Flex
+          className={classNames(ComponentClassNames.Alert, className)}
+          data-variation={variation}
+          ref={ref}
+          {...baseStyleProps}
+          {...flexContainerStyleProps}
+          {...rest}
+        >
+          {hasIcon && <AlertIcon variation={variation} />}
+          <View role="alert" flex="1">
+            {heading && (
+              <View className={ComponentClassNames.AlertHeading}>
+                {heading}
+              </View>
+            )}
+            <View className={ComponentClassNames.AlertBody}>{children}</View>
+          </View>
+          {isDismissible && (
+            <Button
+              variation="link"
+              className={ComponentClassNames.AlertDismiss}
+              onClick={dismissAlert}
+            >
+              <IconClose />
+            </Button>
           )}
-          <View className={ComponentClassNames.AlertBody}>{children}</View>
-        </View>
-        {isDismissible && (
-          <Button
-            variation="link"
-            className={ComponentClassNames.AlertDismiss}
-            onClick={dismissAlert}
-          >
-            <IconClose />
-          </Button>
-        )}
-      </Flex>
-    )
-  );
-};
+        </Flex>
+      )
+    );
+  };
+
+export const Alert = React.forwardRef(AlertPrimitive);
 
 Alert.displayName = 'Alert';

--- a/packages/react/src/primitives/Alert/__tests__/Alert.test.tsx
+++ b/packages/react/src/primitives/Alert/__tests__/Alert.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+
 import { Alert } from '../Alert';
-import { ComponentClassNames } from '../../shared';
+import { ComponentClassNames } from '../../shared/constants';
 import { ComponentPropsToStylePropsMap } from '../../types';
 import kebabCase from 'lodash/kebabCase';
 
@@ -131,5 +133,14 @@ describe('Alert: ', () => {
     render(<Alert data-demo="true" testId="dataTest"></Alert>);
     const alert = await screen.findByTestId('dataTest');
     expect(alert.dataset['demo']).toBe('true');
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const testId = 'alert';
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Alert ref={ref} testId={testId} />);
+
+    await screen.findAllByTestId(testId);
+    expect(ref.current.nodeName).toBe('DIV');
   });
 });

--- a/packages/react/src/primitives/Alert/__tests__/Alert.test.tsx
+++ b/packages/react/src/primitives/Alert/__tests__/Alert.test.tsx
@@ -135,12 +135,22 @@ describe('Alert: ', () => {
     expect(alert.dataset['demo']).toBe('true');
   });
 
-  it('should forward ref to DOM element', async () => {
-    const testId = 'alert';
-    const ref = React.createRef<HTMLDivElement>();
-    render(<Alert ref={ref} testId={testId} />);
+  describe.only('Forward ref: ', () => {
+    it('should forward ref to container DOM element', async () => {
+      const testId = 'alert';
+      const ref = React.createRef<HTMLDivElement>();
+      render(<Alert ref={ref} testId={testId} />);
 
-    await screen.findAllByTestId(testId);
-    expect(ref.current.nodeName).toBe('DIV');
+      await screen.findByTestId(testId);
+      expect(ref.current.nodeName).toBe('DIV');
+    });
+
+    it('should forward ref to dismiss button DOM element', async () => {
+      const ref = React.createRef<HTMLButtonElement>();
+      render(<Alert buttonRef={ref} isDismissible />);
+
+      await screen.findByRole('button');
+      expect(ref.current.nodeName).toBe('BUTTON');
+    });
   });
 });

--- a/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
@@ -2,20 +2,24 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { Flex } from '../Flex';
-import { ButtonProps, ButtonGroupProps, Primitive } from '../types';
+import {
+  ButtonProps,
+  ButtonGroupProps,
+  PrimitiveWithForwardRef,
+} from '../types';
 import { ComponentClassNames } from '../shared/constants';
 
-export const ButtonGroup: Primitive<ButtonGroupProps, typeof Flex> = ({
-  className,
-  children,
-  role = 'group',
-  size,
-  variation,
-  ...rest
-}) => (
+const ButtonGroupPrimitive: PrimitiveWithForwardRef<
+  ButtonGroupProps,
+  typeof Flex
+> = (
+  { className, children, role = 'group', size, variation, ...rest },
+  ref
+) => (
   <Flex
     className={classNames(ComponentClassNames.ButtonGroup, className)}
     role={role}
+    ref={ref}
     {...rest}
   >
     {React.Children.map(children, (child) => {
@@ -26,5 +30,7 @@ export const ButtonGroup: Primitive<ButtonGroupProps, typeof Flex> = ({
     })}
   </Flex>
 );
+
+export const ButtonGroup = React.forwardRef(ButtonGroupPrimitive);
 
 ButtonGroup.displayName = 'ButtonGroup';

--- a/packages/react/src/primitives/ButtonGroup/__tests__/ButtonGroup.test.tsx
+++ b/packages/react/src/primitives/ButtonGroup/__tests__/ButtonGroup.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
+import * as React from 'react';
 
 import { Button } from '../../Button';
 import { ButtonGroup } from '../ButtonGroup';
-import { ButtonGroupProps } from '../../types';
+import { ButtonGroupProps, PrimitivePropsWithRef } from '../../types';
 import { ComponentClassNames } from '../../shared/constants';
 import {
   testFlexProps,
@@ -10,7 +11,9 @@ import {
 } from '../../Flex/__tests__/Flex.test';
 
 describe('ButtonGroup: ', () => {
-  const getButtonGroup = (props: Partial<ButtonGroupProps>) => {
+  const getButtonGroup = (
+    props: Partial<PrimitivePropsWithRef<ButtonGroupProps, 'div'>>
+  ) => {
     return (
       <ButtonGroup {...props}>
         <Button>Button 1</Button>
@@ -51,5 +54,13 @@ describe('ButtonGroup: ', () => {
     expect(buttons[0]).toHaveAttribute('data-variation', variation);
     expect(buttons[1]).toHaveAttribute('data-variation', variation);
     expect(buttons[2]).toHaveAttribute('data-variation', variation);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(getButtonGroup({ ref }));
+
+    await screen.findAllByRole('group');
+    expect(ref.current.nodeName).toBe('DIV');
   });
 });

--- a/packages/react/src/primitives/Expander/Expander.tsx
+++ b/packages/react/src/primitives/Expander/Expander.tsx
@@ -33,9 +33,9 @@ const ExpanderPrimitive: PrimitiveWithForwardRef<ExpanderProps, typeof Root> = (
         data-testid={testId}
         defaultValue={defaultValue as string[]}
         onValueChange={onChange}
+        ref={ref}
         type={type}
         value={value as string[]}
-        ref={ref}
         {...rest}
       >
         {children}
@@ -47,9 +47,9 @@ const ExpanderPrimitive: PrimitiveWithForwardRef<ExpanderProps, typeof Root> = (
         data-testid={testId}
         defaultValue={defaultValue as string}
         onValueChange={onChange}
+        ref={ref}
         type={type}
         value={value as string}
-        ref={ref}
         {...rest}
       >
         {children}

--- a/packages/react/src/primitives/Expander/Expander.tsx
+++ b/packages/react/src/primitives/Expander/Expander.tsx
@@ -1,24 +1,28 @@
 import classNames from 'classnames';
 import { Root } from '@radix-ui/react-accordion';
+import * as React from 'react';
 
-import { Primitive } from '../types/view';
+import { PrimitiveWithForwardRef } from '../types/view';
 import { ExpanderProps } from '../types/expander';
 import { ComponentClassNames } from '../shared/constants';
 import { splitPrimitiveProps } from '../shared/styleUtils';
 
-export const Expander: Primitive<ExpanderProps, typeof Root> = ({
-  children,
-  className,
-  defaultValue,
-  isCollapsible,
-  onChange,
-  // It is not in use but remove it from rest to avoid type errors
-  onValueChange,
-  testId,
-  type = 'single',
-  value,
-  ..._rest
-}) => {
+const ExpanderPrimitive: PrimitiveWithForwardRef<ExpanderProps, typeof Root> = (
+  {
+    children,
+    className,
+    defaultValue,
+    isCollapsible,
+    onChange,
+    // It is not in use but remove it from rest to avoid type errors
+    onValueChange,
+    testId,
+    type = 'single',
+    value,
+    ..._rest
+  },
+  ref
+) => {
   // Throw away baseStyleProps and flexContainerStyleProps since they won't work on Root element
   const { rest } = splitPrimitiveProps(_rest);
 
@@ -31,6 +35,7 @@ export const Expander: Primitive<ExpanderProps, typeof Root> = ({
         onValueChange={onChange}
         type={type}
         value={value as string[]}
+        ref={ref}
         {...rest}
       >
         {children}
@@ -44,6 +49,7 @@ export const Expander: Primitive<ExpanderProps, typeof Root> = ({
         onValueChange={onChange}
         type={type}
         value={value as string}
+        ref={ref}
         {...rest}
       >
         {children}
@@ -52,5 +58,7 @@ export const Expander: Primitive<ExpanderProps, typeof Root> = ({
 
   return expander;
 };
+
+export const Expander = React.forwardRef(ExpanderPrimitive);
 
 Expander.displayName = 'Expander';

--- a/packages/react/src/primitives/Expander/ExpanderItem.tsx
+++ b/packages/react/src/primitives/Expander/ExpanderItem.tsx
@@ -1,9 +1,10 @@
 import classNames from 'classnames';
 import { Item, Header, Trigger, Content } from '@radix-ui/react-accordion';
+import * as React from 'react';
 
 import { IconExpandMore } from '../Icon';
 import { View } from '../View';
-import { Primitive } from '../types/view';
+import { PrimitiveWithForwardRef } from '../types/view';
 import { ExpanderItemProps } from '../types/expander';
 import { ComponentClassNames } from '../shared/constants';
 import { splitPrimitiveProps } from '../shared/styleUtils';
@@ -14,12 +15,10 @@ export const EXPANDER_HEADER_TEST_ID = 'expander-header';
 export const EXPANDER_ICON_TEST_ID = 'expander-icon';
 export const EXPANDER_CONTENT_TEXT_TEST_ID = 'expander-content-text';
 
-export const ExpanderItem: Primitive<ExpanderItemProps, typeof Item> = ({
-  children,
-  className,
-  title,
-  ..._rest
-}) => {
+const ExpanderItemPrimitive: PrimitiveWithForwardRef<
+  ExpanderItemProps,
+  typeof Item
+> = ({ children, className, title, ..._rest }, ref) => {
   const triggerId = useStableId();
   const contentId = useStableId();
   const { rest } = splitPrimitiveProps(_rest);
@@ -27,6 +26,7 @@ export const ExpanderItem: Primitive<ExpanderItemProps, typeof Item> = ({
     <Item
       className={classNames(ComponentClassNames.ExpanderItem, className)}
       data-testid={EXPANDER_ITEM_TEST_ID}
+      ref={ref}
       {...rest}
     >
       <Header
@@ -61,5 +61,7 @@ export const ExpanderItem: Primitive<ExpanderItemProps, typeof Item> = ({
     </Item>
   );
 };
+
+export const ExpanderItem = React.forwardRef(ExpanderItemPrimitive);
 
 ExpanderItem.displayName = 'ExpanderItem';

--- a/packages/react/src/primitives/Expander/__tests__/Expander.test.tsx
+++ b/packages/react/src/primitives/Expander/__tests__/Expander.test.tsx
@@ -146,7 +146,7 @@ describe('Expander: ', () => {
     expect(buttons[2]).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('should foward ref support on DOM element', async () => {
+  it('should forward ref support on DOM element', async () => {
     const testId = 'expander';
     const ref = React.createRef<HTMLDivElement>();
     render(<UncontrolledExpander testId={testId} ref={ref} />);

--- a/packages/react/src/primitives/Expander/__tests__/Expander.test.tsx
+++ b/packages/react/src/primitives/Expander/__tests__/Expander.test.tsx
@@ -8,41 +8,42 @@ import { ExpanderProps } from '../../types/expander';
 import { ComponentClassNames } from '../../shared/constants';
 
 describe('Expander: ', () => {
-  const UncontrolledExpander = (props: ExpanderProps) => {
-    return (
-      <Expander {...props}>
-        <ExpanderItem title="Section 1 title" value="item-1">
-          content 1
-        </ExpanderItem>
-        <ExpanderItem title="Section 2 title" value="item-2">
-          content 2
-        </ExpanderItem>
-        <ExpanderItem title="Section 3 title" value="item-3">
-          content 3
-        </ExpanderItem>
-      </Expander>
-    );
-  };
+  const UncontrolledExpander = React.forwardRef<HTMLDivElement, ExpanderProps>(
+    (props, ref) => {
+      return (
+        <Expander {...props} ref={ref}>
+          <ExpanderItem title="Section 1 title" value="item-1">
+            content 1
+          </ExpanderItem>
+          <ExpanderItem title="Section 2 title" value="item-2">
+            content 2
+          </ExpanderItem>
+          <ExpanderItem title="Section 3 title" value="item-3">
+            content 3
+          </ExpanderItem>
+        </Expander>
+      );
+    }
+  );
 
-  const ControlledExpander = ({
-    value: initialValue,
-    ...rest
-  }: ExpanderProps) => {
-    const [value, setValue] = React.useState(initialValue);
-    return (
-      <Expander value={value} onChange={setValue} {...rest}>
-        <ExpanderItem title="Section 1 title" value="item-1">
-          content 1
-        </ExpanderItem>
-        <ExpanderItem title="Section 2 title" value="item-2">
-          content 2
-        </ExpanderItem>
-        <ExpanderItem title="Section 3 title" value="item-3">
-          content 3
-        </ExpanderItem>
-      </Expander>
-    );
-  };
+  const ControlledExpander = React.forwardRef<HTMLDivElement, ExpanderProps>(
+    ({ value: initialValue, ...rest }, ref) => {
+      const [value, setValue] = React.useState(initialValue);
+      return (
+        <Expander value={value} onChange={setValue} ref={ref} {...rest}>
+          <ExpanderItem title="Section 1 title" value="item-1">
+            content 1
+          </ExpanderItem>
+          <ExpanderItem title="Section 2 title" value="item-2">
+            content 2
+          </ExpanderItem>
+          <ExpanderItem title="Section 3 title" value="item-3">
+            content 3
+          </ExpanderItem>
+        </Expander>
+      );
+    }
+  );
 
   it('should set default and custom classnames', async () => {
     const testId = 'expander';
@@ -143,5 +144,14 @@ describe('Expander: ', () => {
     expect(buttons[0]).toHaveAttribute('aria-expanded', 'true');
     expect(buttons[1]).toHaveAttribute('aria-expanded', 'true');
     expect(buttons[2]).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('should foward ref support on DOM element', async () => {
+    const testId = 'expander';
+    const ref = React.createRef<HTMLDivElement>();
+    render(<UncontrolledExpander testId={testId} ref={ref} />);
+
+    await screen.findByTestId(testId);
+    expect(ref.current.nodeName).toBe('DIV');
   });
 });

--- a/packages/react/src/primitives/Expander/__tests__/ExpanderItem.test.tsx
+++ b/packages/react/src/primitives/Expander/__tests__/ExpanderItem.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import * as React from 'react';
 
 import { Expander } from '../Expander';
 import {
@@ -99,5 +100,19 @@ describe('ExpanderItem: ', () => {
 
     const icon = await screen.findByTestId(EXPANDER_ICON_TEST_ID);
     expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should foward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <Expander type="single" defaultValue="item-value">
+        <ExpanderItem title="item-title" value="item-value" ref={ref}>
+          content
+        </ExpanderItem>
+      </Expander>
+    );
+
+    await screen.findByTestId(EXPANDER_ITEM_TEST_ID);
+    expect(ref.current.nodeName).toBe('DIV');
   });
 });

--- a/packages/react/src/primitives/types/alert.ts
+++ b/packages/react/src/primitives/types/alert.ts
@@ -29,4 +29,9 @@ export interface AlertProps extends FlexProps {
    * The heading property will affect the content of the Alert heading.
    */
   heading?: React.ReactNode;
+
+  /**
+   * The ref will be forwarded to the dismiss button
+   */
+  buttonRef?: React.Ref<HTMLButtonElement>;
 }

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -5,6 +5,8 @@ describe('@aws-amplify/ui', () => {
     it('should match snapshot', () => {
       expect(defaultTheme.cssText).toMatchInlineSnapshot(`
         "[data-amplify-theme=\\"default-theme\\"] {
+        --amplify-components-alert-align-items: center;
+        --amplify-components-alert-justify-content: space-between;
         --amplify-components-alert-color: var(--amplify-colors-font-primary);
         --amplify-components-alert-background-color: var(--amplify-colors-background-tertiary);
         --amplify-components-alert-padding-block: var(--amplify-space-small);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -55,6 +55,8 @@ describe('@aws-amplify/ui', () => {
     it('should match snapshot', () => {
       expect(themeWithOverrides.cssText).toMatchInlineSnapshot(`
         "[data-amplify-theme=\\"test-theme\\"] {
+        --amplify-components-alert-align-items: center;
+        --amplify-components-alert-justify-content: space-between;
         --amplify-components-alert-color: var(--amplify-colors-font-primary);
         --amplify-components-alert-background-color: var(--amplify-colors-background-tertiary);
         --amplify-components-alert-padding-block: var(--amplify-space-small);

--- a/packages/ui/src/theme/css/component/alert.scss
+++ b/packages/ui/src/theme/css/component/alert.scss
@@ -1,4 +1,6 @@
 .amplify-alert {
+  align-items: var(--amplify-components-alert-align-items);
+  justify-content: var(--amplify-components-alert-justify-content);
   background-color: var(--amplify-components-alert-background-color);
   padding-block: var(--amplify-components-alert-padding-block);
   padding-inline: var(--amplify-components-alert-padding-inline);

--- a/packages/ui/src/theme/tokens/components/alert.js
+++ b/packages/ui/src/theme/tokens/components/alert.js
@@ -1,5 +1,7 @@
 module.exports = {
   // Default styles
+  alignItems: { value: 'center' },
+  justifyContent: { value: 'space-between' },
   color: { value: '{colors.font.primary.value}' },
   backgroundColor: { value: '{colors.background.tertiary.value}' },
   paddingBlock: { value: '{space.small.value}' },


### PR DESCRIPTION
*Description of changes:*

Adding forward ref support for `Alert`, `ButtonGroup`, `Expander` & `ExpanderItem`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
