### PR TITLE
ForwardRef support for SearchField

### DIFF
--- a/.changeset/tidy-buckets-build.md
+++ b/.changeset/tidy-buckets-build.md
@@ -1,0 +1,6 @@
+---
+"docs": patch
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef support for SearchField

--- a/docs/src/pages/components/passwordfield/examples/refs.tsx
+++ b/docs/src/pages/components/passwordfield/examples/refs.tsx
@@ -10,8 +10,10 @@ export const RefExample = () => {
   }, []);
 
   React.useEffect(() => {
+    // Note: this example is contrived to demonstrate refs.
+    // Use the `onSubmit` prop on `SearchField` instead which
+    // responds to input field `Enter` keypresses and Submit button clicks.
     if (showPasswordButtonRef && showPasswordButtonRef.current) {
-      console.count('useeffect');
       showPasswordButtonRef.current.addEventListener(
         'click',
         onShowPasswordClick,

--- a/docs/src/pages/components/passwordfield/react.mdx
+++ b/docs/src/pages/components/passwordfield/react.mdx
@@ -272,7 +272,9 @@ Use the `hasError` and `errorMessage` fields to mark a PasswordField as having a
 
 ### Forward refs
 
-[Ref](https://reactjs.org/docs/forwarding-refs.html) props are available for more advanced use cases such as focus management. The standard `ref` prop will forward to the underlying `input` element, and the `showPasswordButtonRef` prop forwards to the show password `button` element.
+<Fragment>{() => import('./../shared/forwardRefAlert.mdx')}</Fragment>
+
+The standard `ref` prop will forward to the underlying `input` element, and the `showPasswordButtonRef` prop forwards to the show password `button` element.
 
 The following is an example demonstrating use of the `ref` and `showPasswordButtonRef` props:
 

--- a/docs/src/pages/components/phonenumberfield/react.mdx
+++ b/docs/src/pages/components/phonenumberfield/react.mdx
@@ -258,7 +258,9 @@ Use the `hasError` and `errorMessage` fields to mark a `PhoneNumberField` as hav
 
 ### Forward refs
 
-[Ref](https://reactjs.org/docs/forwarding-refs.html) props are available on the PhoneNumberField for more advanced use cases such as focus management. The standard `ref` prop will forward to the underlying `input` element, and the `countryCodeRef` prop forwards to the country code `select` element.
+<Fragment>{() => import('./../shared/forwardRefAlert.mdx')}</Fragment>
+
+The standard `ref` prop will forward to the underlying `input` element, and the `countryCodeRef` prop forwards to the country code `select` element.
 
 The following is a contrived example demonstrating use of the `ref` and `countryCodeRef` props:
 

--- a/docs/src/pages/components/searchfield/examples/refs.tsx
+++ b/docs/src/pages/components/searchfield/examples/refs.tsx
@@ -4,14 +4,10 @@ import { Flex, SearchField } from '@aws-amplify/ui-react';
 export const RefExample = () => {
   const inputRef = React.useRef(null);
   const searchButtonRef = React.useRef(null);
-  const clearButtonRef = React.useRef(null);
 
   const onClick = React.useCallback(() => {
     inputRef.current.focus();
-    alert(`You searched for: ${inputRef.current.value}.
-Clear button has aria-label of ${clearButtonRef?.current.getAttribute(
-      'aria-label'
-    )}`);
+    alert(`You searched for: ${inputRef.current.value}`);
   }, []);
 
   React.useEffect(() => {
@@ -31,7 +27,6 @@ Clear button has aria-label of ${clearButtonRef?.current.getAttribute(
       label="Password"
       ref={inputRef}
       searchButtonRef={searchButtonRef}
-      clearButtonRef={clearButtonRef}
     />
   );
 };

--- a/docs/src/pages/components/searchfield/examples/refs.tsx
+++ b/docs/src/pages/components/searchfield/examples/refs.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Flex, SearchField } from '@aws-amplify/ui-react';
+
+export const RefExample = () => {
+  const inputRef = React.useRef(null);
+  const searchButtonRef = React.useRef(null);
+  const clearButtonRef = React.useRef(null);
+
+  const onClick = React.useCallback(() => {
+    inputRef.current.focus();
+    alert(`You searched for: ${inputRef.current.value}.
+Clear button has aria-label of ${clearButtonRef?.current.getAttribute(
+      'aria-label'
+    )}`);
+  }, []);
+
+  React.useEffect(() => {
+    if (searchButtonRef && searchButtonRef.current) {
+      // Note: this example is contrived to demonstrate using refs.
+      // Use the `onSubmit` prop on `SearchField` instead which
+      // responds to input field `Enter` keypresses and Submit button clicks.
+      searchButtonRef.current.addEventListener('click', onClick, false);
+      return () => {
+        searchButtonRef.current.removeEventListener('click', onClick, false);
+      };
+    }
+  }, [onClick]);
+
+  return (
+    <SearchField
+      label="Password"
+      ref={inputRef}
+      searchButtonRef={searchButtonRef}
+      clearButtonRef={clearButtonRef}
+    />
+  );
+};

--- a/docs/src/pages/components/searchfield/react.mdx
+++ b/docs/src/pages/components/searchfield/react.mdx
@@ -84,7 +84,7 @@ There are two variation styles available: default and `quiet`.
 
 <Fragment>{() => import('./../shared/forwardRefAlert.mdx')}</Fragment>
 
-The standard `ref` prop will forward to the `input` element, the `searchButtonRef` prop forwards to the search `button` element, and the `clearButtonRef` will forward to the clear `button` element.
+The standard `ref` prop will forward to the `input` element, the `searchButtonRef` prop forwards to the search `button` element.
 
 The following is a contrived example demonstrating use of the ref props:
 

--- a/docs/src/pages/components/searchfield/react.mdx
+++ b/docs/src/pages/components/searchfield/react.mdx
@@ -1,8 +1,10 @@
 import { Flex, SearchField } from '@aws-amplify/ui-react';
-import { Example } from '@/components/Example';
+
+import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
 import { SearchFieldStyledPropsExample } from './examples';
 import { SearchFieldDemo } from './demo';
+import { RefExample } from './examples/refs';
 
 SearchField accepts query text for search. Users may clear the field by hitting the `Esc` key or by clicking the
 clear button. When users hit `Enter` key or click the search icon, the `onSubmit` event handler will be fired.
@@ -76,6 +78,25 @@ There are two variation styles available: default and `quiet`.
     <SearchField label="search" />
     <SearchField label="search" variation="quiet" />
   </Flex>
+</Example>
+
+### Forward refs
+
+<Fragment>{() => import('./../shared/forwardRefAlert.mdx')}</Fragment>
+
+The standard `ref` prop will forward to the `input` element, the `searchButtonRef` prop forwards to the search `button` element, and the `clearButtonRef` will forward to the clear `button` element.
+
+The following is a contrived example demonstrating use of the ref props:
+
+<Example>
+  <RefExample />
+<ExampleCode>
+
+```tsx file=./examples/refs.tsx
+
+```
+
+</ExampleCode>
 </Example>
 
 ## CSS Styling

--- a/docs/src/pages/components/shared/forwardRefAlert.mdx
+++ b/docs/src/pages/components/shared/forwardRefAlert.mdx
@@ -1,0 +1,9 @@
+import { Alert } from '@aws-amplify/ui-react';
+
+<Alert heading="Important" variation="warning" margin="0 0 2rem 0">
+
+Refs are an escape hatch to the underlying DOM element of our primitives, but are typically not necessary for most applications.
+
+See [Refs and the DOM](https://reactjs.org/docs/refs-and-the-dom.html) and [Forwarding Refs](https://reactjs.org/docs/forwarding-refs.html) for more information.
+
+</Alert>

--- a/packages/react/src/primitives/SearchField/SearchField.tsx
+++ b/packages/react/src/primitives/SearchField/SearchField.tsx
@@ -77,7 +77,6 @@ const SearchFieldPrimitive: PrimitiveWithForwardRef<SearchFieldProps, 'input'> =
     {
       autoComplete = 'off',
       className,
-      clearButtonRef,
       labelHidden = true,
       name = 'q',
       onSubmit,
@@ -101,7 +100,6 @@ const SearchFieldPrimitive: PrimitiveWithForwardRef<SearchFieldProps, 'input'> =
             excludeFromTabOrder={true}
             isVisible={strHasLength(value)}
             onClick={onClearHandler}
-            ref={clearButtonRef}
             size={size}
             variation="link"
           />

--- a/packages/react/src/primitives/SearchField/SearchField.tsx
+++ b/packages/react/src/primitives/SearchField/SearchField.tsx
@@ -6,7 +6,7 @@ import { TextField } from '../TextField';
 import { FieldClearButton } from '../Field';
 import { SearchFieldButton } from './SearchFieldButton';
 import { isFunction, strHasLength } from '../shared/utils';
-import { SearchFieldProps, InputProps, Primitive } from '../types';
+import { SearchFieldProps, PrimitiveWithForwardRef } from '../types';
 
 const ESCAPE_KEY = 'Escape';
 const ENTER_KEY = 'Enter';
@@ -72,46 +72,59 @@ export const useSearchField = ({
   };
 };
 
-export const SearchField: Primitive<SearchFieldProps, 'input'> = ({
-  autoComplete = 'off',
-  className,
-  labelHidden = true,
-  label,
-  name = 'q',
-  onSubmit,
-  onClear,
-  size,
-  ...rest
-}) => {
-  const { value, onClearHandler, onInput, onKeyDown, onClick } = useSearchField(
-    { onSubmit, onClear }
-  );
+const SearchFieldPrimitive: PrimitiveWithForwardRef<SearchFieldProps, 'input'> =
+  (
+    {
+      autoComplete = 'off',
+      className,
+      clearButtonRef,
+      labelHidden = true,
+      name = 'q',
+      onSubmit,
+      onClear,
+      searchButtonRef,
+      size,
+      ...rest
+    },
+    ref
+  ) => {
+    const { value, onClearHandler, onInput, onKeyDown, onClick } =
+      useSearchField({ onSubmit, onClear });
 
-  return (
-    <TextField
-      autoComplete={autoComplete}
-      className={classNames(ComponentClassNames.SearchField, className)}
-      labelHidden={labelHidden}
-      innerEndComponent={
-        <FieldClearButton
-          isVisible={strHasLength(value)}
-          onClick={onClearHandler}
-          excludeFromTabOrder={true}
-          variation="link"
-          size={size}
-        />
-      }
-      isMultiline={false}
-      label={label}
-      name={name}
-      onInput={onInput}
-      onKeyDown={onKeyDown}
-      outerEndComponent={<SearchFieldButton onClick={onClick} size={size} />}
-      size={size}
-      value={value}
-      {...rest}
-    />
-  );
-};
+    return (
+      <TextField
+        autoComplete={autoComplete}
+        className={classNames(ComponentClassNames.SearchField, className)}
+        labelHidden={labelHidden}
+        innerEndComponent={
+          <FieldClearButton
+            excludeFromTabOrder={true}
+            isVisible={strHasLength(value)}
+            onClick={onClearHandler}
+            ref={clearButtonRef}
+            size={size}
+            variation="link"
+          />
+        }
+        isMultiline={false}
+        name={name}
+        onInput={onInput}
+        onKeyDown={onKeyDown}
+        outerEndComponent={
+          <SearchFieldButton
+            onClick={onClick}
+            ref={searchButtonRef}
+            size={size}
+          />
+        }
+        ref={ref}
+        size={size}
+        value={value}
+        {...rest}
+      />
+    );
+  };
+
+export const SearchField = React.forwardRef(SearchFieldPrimitive);
 
 SearchField.displayName = 'SearchField';

--- a/packages/react/src/primitives/SearchField/SearchFieldButton.tsx
+++ b/packages/react/src/primitives/SearchField/SearchFieldButton.tsx
@@ -1,18 +1,22 @@
+import * as React from 'react';
+
+import { ComponentClassNames } from '../shared/constants';
 import { FieldGroupIconButton } from '../FieldGroupIcon';
 import { IconSearch } from '../Icon';
+import { PrimitiveWithForwardRef, SearchFieldButtonProps } from '../types';
 import { SharedText } from '../shared/i18n';
-import { Primitive, SearchFieldButtonProps } from '../types';
-import { ComponentClassNames } from '../shared/constants';
 
 const ariaLabelText = SharedText.SearchField.ariaLabel.search;
 
-export const SearchFieldButton: Primitive<SearchFieldButtonProps, 'button'> = (
-  props
-) => {
+const SearchFieldButtonPrimitive: PrimitiveWithForwardRef<
+  SearchFieldButtonProps,
+  'button'
+> = (props, ref) => {
   return (
     <FieldGroupIconButton
       ariaLabel={ariaLabelText}
       className={ComponentClassNames.SearchFieldSearch}
+      ref={ref}
       type="submit"
       {...props}
     >
@@ -20,5 +24,7 @@ export const SearchFieldButton: Primitive<SearchFieldButtonProps, 'button'> = (
     </FieldGroupIconButton>
   );
 };
+
+export const SearchFieldButton = React.forwardRef(SearchFieldButtonPrimitive);
 
 SearchFieldButton.displayName = 'SearchFieldButton';

--- a/packages/react/src/primitives/SearchField/__tests__/SearchField.test.tsx
+++ b/packages/react/src/primitives/SearchField/__tests__/SearchField.test.tsx
@@ -31,13 +31,11 @@ describe('SearchField component', () => {
 
   it('should forward refs to DOM elements', async () => {
     const ref = React.createRef<HTMLInputElement>();
-    const clearButtonRef = React.createRef<HTMLButtonElement>();
     const searchButtonRef = React.createRef<HTMLButtonElement>();
 
     render(
       <SearchField
         className="custom-class"
-        clearButtonRef={clearButtonRef}
         label={label}
         name="q"
         ref={ref}
@@ -49,7 +47,6 @@ describe('SearchField component', () => {
     await screen.findByRole('button');
 
     expect(ref.current.nodeName).toBe('INPUT');
-    expect(clearButtonRef.current.nodeName).toBe('BUTTON');
     expect(searchButtonRef.current.nodeName).toBe('BUTTON');
   });
 

--- a/packages/react/src/primitives/SearchField/__tests__/SearchField.test.tsx
+++ b/packages/react/src/primitives/SearchField/__tests__/SearchField.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -26,6 +27,30 @@ describe('SearchField component', () => {
 
     expect(searchFieldWrapper).toHaveClass('custom-class');
     expect(searchFieldWrapper).toHaveClass(ComponentClassNames.SearchField);
+  });
+
+  it('should forward refs to DOM elements', async () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const clearButtonRef = React.createRef<HTMLButtonElement>();
+    const searchButtonRef = React.createRef<HTMLButtonElement>();
+
+    render(
+      <SearchField
+        className="custom-class"
+        clearButtonRef={clearButtonRef}
+        label={label}
+        name="q"
+        ref={ref}
+        searchButtonRef={searchButtonRef}
+        testId={testId}
+      />
+    );
+
+    await screen.findByRole('button');
+
+    expect(ref.current.nodeName).toBe('INPUT');
+    expect(clearButtonRef.current.nodeName).toBe('BUTTON');
+    expect(searchButtonRef.current.nodeName).toBe('BUTTON');
   });
 
   it('should be text input type', async () => {

--- a/packages/react/src/primitives/SearchField/__tests__/SearchFieldButton.test.tsx
+++ b/packages/react/src/primitives/SearchField/__tests__/SearchFieldButton.test.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { ComponentClassNames } from '../../shared';
+import { SearchFieldButton } from '../SearchFieldButton';
+
+import { SharedText } from '../../shared/i18n';
+
+const ariaLabelText = SharedText.SearchField.ariaLabel.search;
+
+describe('SearchFieldButton component', () => {
+  const testId = 'testId';
+
+  it('should render default classname for SearchFieldButton', async () => {
+    render(<SearchFieldButton />);
+
+    const button = await screen.findByRole('button');
+
+    expect(button).toHaveClass(ComponentClassNames.SearchFieldSearch);
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(<SearchFieldButton ref={ref} />);
+
+    await screen.findByRole('button');
+
+    expect(ref.current.nodeName).toBe('BUTTON');
+  });
+
+  it('should set correct ariaLabel', async () => {
+    render(<SearchFieldButton />);
+
+    const button = await screen.findByLabelText(ariaLabelText);
+
+    expect(button).not.toBeNull();
+  });
+});

--- a/packages/react/src/primitives/types/searchField.ts
+++ b/packages/react/src/primitives/types/searchField.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { FieldGroupIconButtonProps } from './fieldGroupIcon';
 import { TextInputFieldProps } from './textField';
 
@@ -13,10 +14,20 @@ export interface SearchFieldProps extends TextInputFieldProps {
   onClear?: () => void;
 
   /**
+   * Provides ref access to field clear button DOM element
+   */
+  clearButtonRef?: React.Ref<HTMLButtonElement>;
+
+  /**
    * Visually hide label
    * @default true
    */
   labelHidden?: boolean;
+
+  /**
+   * Provides ref access to search button DOM element
+   */
+  searchButtonRef?: React.Ref<HTMLButtonElement>;
 }
 
 export interface SearchFieldButtonProps

--- a/packages/react/src/primitives/types/searchField.ts
+++ b/packages/react/src/primitives/types/searchField.ts
@@ -14,11 +14,6 @@ export interface SearchFieldProps extends TextInputFieldProps {
   onClear?: () => void;
 
   /**
-   * Provides ref access to field clear button DOM element
-   */
-  clearButtonRef?: React.Ref<HTMLButtonElement>;
-
-  /**
    * Visually hide label
    * @default true
    */


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for the `SearchField` primitive by wrapping it in `React.forwardRef`. In this case we're supporting both the standard `ref` for access to the `input` field, and `searchButtonRef` for access to the `button` elements.

```jsx
const CustomerComponent = () => {
  const inputRef = React.useRef(null);
  const searchButtonRef = React.useRef(null);
  
  return (
    <SearchField label="search" 
      ref={inputRef}
      searchButtonRef={searchButtonRef}
      />
  );
};
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
