### PR TITLE
ci: Enable tests to run on forks and action-created PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,37 @@ on:
   push:
     branches: [main]
 
-  pull_request:
+  pull_request_target:
     branches: [main]
+    types: [opened, synchronize, labeled]
+
+permissions: read-all
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    # We run tests only if it's:
+    #   1) push to main, or
+    #   2) pull request not from a fork (ie. internal PR), or
+    #   3) pull request from a fork (ie. external PR) that was added "run-tests" label
+    if: |
+      github.event_name == 'push' ||
+      (github.event.pull_request.head.repo.full_name == github.repository) || 
+      (github.event.action == 'labeled' && github.event.label.name == 'run-tests')
+    steps:
+      # This would be a good place to run and cache `yarn`, `yarn build`, etc
+      - name: Remove run-tests label, if applicable
+        if: always() && github.event.label.name == 'run-tests'
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+            const label = 'run-tests';
+            github.issues.removeLabel({ owner, repo, issue_number, name: label });
+
   unit:
+    needs: setup
     runs-on: ubuntu-latest
     env:
       NODE_ENV: test
@@ -28,6 +54,10 @@ jobs:
     steps:
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
 
       - name: Setup Node.js LTS
         uses: actions/setup-node@v2
@@ -73,6 +103,10 @@ jobs:
     steps:
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
 
       - name: Next.js Cache
         uses: actions/cache@v2
@@ -126,6 +160,10 @@ jobs:
     steps:
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
 
       - name: Setup Node.js LTS
         uses: actions/setup-node@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,9 @@ on:
     branches: [main]
     types: [opened, synchronize, labeled]
 
-permissions: read-all
+permissions:
+  pull-requests: write # used to remove label
+  # other permissions are defaulted to "none"
 
 jobs:
   setup:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
         with:
+          # For `pull_request_target`, we want ref to point to `pull_request.head.ref` because `github.ref`
+          # always points to the target branch.
+          # See: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
           ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false


### PR DESCRIPTION
*Issue #, if available:* Closes #845

### Description of changes 

This enables **maintainers** to run tests on forks and PRs created by `github-actions` like #838. Tests on forks couldn't run because environment secrets aren't passed for security reasons.

To enable tests on these cases, `tests.yml` trigger is updated to `pull_request_target`. It is granted a read/write repository token and can access secrets even when it is triggered from a fork, so we need to be very careful about the tokens/secrets we expose.

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ has practical advices. This PR uses label-based approach -- maintainer first checks that code changes do not tamper secrets/tokens, then they can add `run-tests` to trigger the tests. Tests will run only when the label was *added* and not on subsequent commits to prevent malicious commits after the label was added.

### Additional security hardening:

- [x] `GITHUB_TOKEN` should only have write access to `pull-requests`
- [x] Workflow will automatically remove `run-tests` label after the workflow was triggered.
- [x] #856 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
