### PR TITLE
ForwardRef support - Rating

### DIFF
--- a/.changeset/clever-turtles-live.md
+++ b/.changeset/clever-turtles-live.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef support - Rating

--- a/packages/react/src/primitives/Rating/Rating.tsx
+++ b/packages/react/src/primitives/Rating/Rating.tsx
@@ -1,7 +1,8 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { RatingProps, Primitive } from '../types';
+import { RatingProps, PrimitiveWithForwardRef } from '../types';
 import { RatingIcon } from './RatingIcon';
 import { RatingMixedIcon } from './RatingMixedIcon';
 import { Flex } from '../Flex';
@@ -12,17 +13,20 @@ import { isIconFilled, isIconEmpty, isIconMixed } from './utils';
 const RATING_DEFAULT_MAX_VALUE = 5;
 const RATING_DEFAULT_VALUE = 0;
 
-export const Rating: Primitive<RatingProps, typeof Flex> = ({
-  className,
-  emptyColor,
-  emptyIcon,
-  fillColor,
-  icon = <IconStar />,
-  maxValue = RATING_DEFAULT_MAX_VALUE,
-  size,
-  value = RATING_DEFAULT_VALUE,
-  ...rest
-}) => {
+const RatingPrimitive: PrimitiveWithForwardRef<RatingProps, typeof Flex> = (
+  {
+    className,
+    emptyColor,
+    emptyIcon,
+    fillColor,
+    icon = <IconStar />,
+    maxValue = RATING_DEFAULT_MAX_VALUE,
+    size,
+    value = RATING_DEFAULT_VALUE,
+    ...rest
+  },
+  ref
+) => {
   const items = new Array(Math.ceil(maxValue)).fill(1).map((val, index) => {
     const currentIconIndex = index + 1;
     if (isIconFilled(currentIconIndex, value))
@@ -59,6 +63,7 @@ export const Rating: Primitive<RatingProps, typeof Flex> = ({
     <Flex
       className={classNames(ComponentClassNames.Rating, className)}
       data-size={size}
+      ref={ref}
       {...rest}
     >
       {items}
@@ -68,5 +73,7 @@ export const Rating: Primitive<RatingProps, typeof Flex> = ({
     </Flex>
   );
 };
+
+export const Rating = React.forwardRef(RatingPrimitive);
 
 Rating.displayName = 'Rating';

--- a/packages/react/src/primitives/Rating/__test__/Rating.test.tsx
+++ b/packages/react/src/primitives/Rating/__test__/Rating.test.tsx
@@ -1,7 +1,7 @@
+import * as React from 'react';
+
 import { Rating } from '../Rating';
 import { render, screen } from '@testing-library/react';
-import { ComponentClassNames } from '../../shared';
-import kebabCase from 'lodash/kebabCase';
 
 describe('Rating: ', () => {
   let customIcon;
@@ -10,11 +10,20 @@ describe('Rating: ', () => {
       return <svg className={className}></svg>;
     };
   });
+
   it('should render a classname for Rating', async () => {
     render(<Rating testId="testId" className="my-rating-component" />);
 
     const rating = await screen.findByTestId('testId');
     expect(rating.className).toContain('my-rating-component');
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Rating testId="testId" ref={ref} />);
+
+    await screen.findByTestId('testId');
+    expect(ref.current.nodeName).toBe('DIV');
   });
 
   it('should render the data-size attribute', async () => {


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for the `Rating` primitive by wrapping it in `React.forwardRef`.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null); // ref.current.nodeName will be `DIV`
  
  return (
    <Rating ref={ref}  />
  );
};
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
