### PR TITLE
ForwardRef for StepperField

### DIFF
--- a/.changeset/forward-ref-stepperfield.md
+++ b/.changeset/forward-ref-stepperfield.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef support for StepperField

--- a/packages/react/src/primitives/StepperField/StepperField.tsx
+++ b/packages/react/src/primitives/StepperField/StepperField.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { useStepper } from './useStepper';
@@ -12,13 +13,16 @@ import { StepperFieldProps } from '../types/stepperField';
 import { ComponentClassNames } from '../shared/constants';
 import { SharedText } from '../shared/i18n';
 import { useStableId } from '../shared/utils';
-import { Primitive } from '../types/view';
+import { PrimitiveWithForwardRef } from '../types/view';
 import { splitPrimitiveProps } from '../shared/styleUtils';
 
 export const DECREASE_ICON = 'decrease-icon';
 export const INCREASE_ICON = 'increase-icon';
 
-export const StepperField: Primitive<StepperFieldProps, 'input'> = (props) => {
+const StepperFieldPrimitive: PrimitiveWithForwardRef<
+  StepperFieldProps,
+  'input'
+> = (props, ref) => {
   const {
     className,
     descriptiveText,
@@ -120,6 +124,7 @@ export const StepperField: Primitive<StepperFieldProps, 'input'> = (props) => {
           onBlur={handleOnBlur}
           onChange={handleOnChange}
           onWheel={handleOnWheel}
+          ref={ref}
           size={size}
           variation={variation}
           type="number"
@@ -132,5 +137,7 @@ export const StepperField: Primitive<StepperFieldProps, 'input'> = (props) => {
     </Flex>
   );
 };
+
+export const StepperField = React.forwardRef(StepperFieldPrimitive);
 
 StepperField.displayName = 'StepperField';

--- a/packages/react/src/primitives/StepperField/__tests__/StepperField.test.tsx
+++ b/packages/react/src/primitives/StepperField/__tests__/StepperField.test.tsx
@@ -91,6 +91,14 @@ describe('StepperField: ', () => {
       expect(stepperInput).toHaveClass(ComponentClassNames.StepperFieldInput);
     });
 
+    it('should forward ref to DOM element', async () => {
+      const ref = React.createRef<HTMLInputElement>();
+      render(<StepperField label={label} ref={ref} />);
+
+      await screen.findByLabelText(label);
+      expect(ref.current.nodeName).toBe('INPUT');
+    });
+
     it('should render labeled input when id is provided', async () => {
       render(<StepperField label={label} id="stepper-field" />);
       const stepperInput = await screen.findByLabelText(label);


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for the `StepperField` primitive by wrapping it in `React.forwardRef`.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null); // ref.current.nodeName will be `INPUT`
  
  return (
    <StepperField ref={ref}  />
  );
};
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
