### PR TITLE
ForwardRef support - SwitchField

### DIFF
--- a/.changeset/perfect-scissors-melt.md
+++ b/.changeset/perfect-scissors-melt.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef support - SwitchField

--- a/packages/react/src/primitives/SwitchField/SwitchField.tsx
+++ b/packages/react/src/primitives/SwitchField/SwitchField.tsx
@@ -1,33 +1,40 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
-import { useSwitch } from './useSwitch';
-import { Label } from '../Label';
-import { Input } from '../Input';
-import { View } from '../View';
-import { Flex } from '../Flex';
-import { VisuallyHidden } from '../VisuallyHidden';
 import { ComponentClassNames } from '../shared/constants';
+import { Flex } from '../Flex';
+import { Input } from '../Input';
+import { Label } from '../Label';
+import { PrimitiveWithForwardRef, SwitchFieldProps } from '../types';
 import { useStableId } from '../shared/utils';
-import { Primitive, SwitchFieldProps } from '../types';
+import { useSwitch } from './useSwitch';
+import { View } from '../View';
+import { VisuallyHidden } from '../VisuallyHidden';
 
-export const SwitchField: Primitive<SwitchFieldProps, typeof Flex> = ({
-  className,
-  defaultChecked,
-  id,
-  isChecked,
-  isDisabled,
-  isLabelHidden,
-  label,
-  labelPosition,
-  name,
-  onChange,
-  size,
-  thumbColor,
-  trackColor,
-  trackCheckedColor,
-  value,
-  ...rest
-}) => {
+const SwitchFieldPrimitive: PrimitiveWithForwardRef<
+  SwitchFieldProps,
+  typeof Flex
+> = (
+  {
+    className,
+    defaultChecked,
+    id,
+    isChecked,
+    isDisabled,
+    isLabelHidden,
+    label,
+    labelPosition,
+    name,
+    onChange,
+    size,
+    thumbColor,
+    trackCheckedColor,
+    trackColor,
+    value,
+    ...rest
+  },
+  ref
+) => {
   const { isOn, changeHandler, isFocused, setIsFocused } = useSwitch({
     onChange,
     isChecked,
@@ -43,6 +50,7 @@ export const SwitchField: Primitive<SwitchFieldProps, typeof Flex> = ({
       className={classNames(ComponentClassNames.SwitchField, className)}
       data-size={size}
       data-label-position={labelPosition}
+      ref={ref}
       {...rest}
     >
       <VisuallyHidden>
@@ -91,5 +99,7 @@ export const SwitchField: Primitive<SwitchFieldProps, typeof Flex> = ({
     </Flex>
   );
 };
+
+export const SwitchField = React.forwardRef(SwitchFieldPrimitive);
 
 SwitchField.displayName = 'SwitchField';

--- a/packages/react/src/primitives/SwitchField/__tests__/SwitchField.test.tsx
+++ b/packages/react/src/primitives/SwitchField/__tests__/SwitchField.test.tsx
@@ -1,18 +1,20 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import kebabCase from 'lodash/kebabCase';
+import userEvent from '@testing-library/user-event';
 
-import { SwitchField } from '../SwitchField';
-import { ComponentClassNames } from '../../shared';
 import { AUTO_GENERATED_ID_PREFIX } from '../../shared/utils';
+import { ComponentClassNames } from '../../shared';
 import { ComponentPropsToStylePropsMap } from '../../types';
+import { SwitchField } from '../SwitchField';
 
 describe('Switch Field', () => {
   const label = 'My switch label';
+
   describe('Switch wrapper', () => {
     it('should pass through the className', async () => {
       const { container } = render(
-        <SwitchField label={label} className={'my-switch'} />
+        <SwitchField label={label} className="my-switch" />
       );
 
       const wrapper = container.getElementsByClassName(
@@ -21,10 +23,16 @@ describe('Switch Field', () => {
       expect(wrapper).toHaveClass('my-switch');
     });
 
+    it('should forward ref to DOM element', async () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(<SwitchField testId="testId" label={label} ref={ref} />);
+
+      await screen.findByLabelText(label);
+      expect(ref.current.nodeName).toBe('DIV');
+    });
+
     it('should set the data-size attribute', async () => {
-      const { container } = render(
-        <SwitchField label={label} size={'large'} />
-      );
+      const { container } = render(<SwitchField label={label} size="large" />);
 
       const wrapper = container.getElementsByClassName(
         ComponentClassNames.SwitchField
@@ -34,7 +42,7 @@ describe('Switch Field', () => {
 
     it('should set the label for attribute to match the passed in id', async () => {
       const { container } = render(
-        <SwitchField label={label} id={'my-switch'} />
+        <SwitchField label={label} id="my-switch" />
       );
 
       const wrapper = container.getElementsByClassName(
@@ -45,7 +53,7 @@ describe('Switch Field', () => {
 
     it('should set the data-label-position attribute', async () => {
       const { container } = render(
-        <SwitchField label={label} labelPosition={'end'} />
+        <SwitchField label={label} labelPosition="end" />
       );
 
       const wrapper = container.getElementsByClassName(
@@ -102,11 +110,7 @@ describe('Switch Field', () => {
 
     it('should pass through the name and value properties to the checkbox', async () => {
       const { container } = render(
-        <SwitchField
-          label={label}
-          name={'myCheckbox'}
-          value={'checkboxValue'}
-        />
+        <SwitchField label={label} name="myCheckbox" value="checkboxValue" />
       );
 
       const field = container.getElementsByTagName('input')[0];
@@ -153,7 +157,7 @@ describe('Switch Field', () => {
 
     it('should set the id on the input element', async () => {
       const { container } = render(
-        <SwitchField label={label} id={'my-switch'} />
+        <SwitchField label={label} id="my-switch" />
       );
 
       const field = container.getElementsByTagName('input')[0];
@@ -170,7 +174,7 @@ describe('Switch Field', () => {
   describe('Switch Track', () => {
     it('should set the track color for the unchecked switch', async () => {
       const { container } = render(
-        <SwitchField label={label} trackColor={'red'} />
+        <SwitchField label={label} trackColor="red" />
       );
 
       const track = container.getElementsByClassName(
@@ -187,7 +191,7 @@ describe('Switch Field', () => {
       const { container } = render(
         <SwitchField
           label={label}
-          trackCheckedColor={'red'}
+          trackCheckedColor="red"
           defaultChecked={true}
         />
       );
@@ -218,7 +222,7 @@ describe('Switch Field', () => {
   describe('Switch Thumb', () => {
     it('should change the switch thumb color', async () => {
       const { container } = render(
-        <SwitchField label={label} thumbColor={'red'} />
+        <SwitchField label={label} thumbColor="red" />
       );
 
       const track = container.getElementsByClassName(


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for the `SwitchField` primitive by wrapping it in `React.forwardRef`.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null); // ref.current.nodeName will be `DIV`
  
  return (
    <SwitchField ref={ref}  />
  );
};
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
