### PR TITLE
Add DataStore.observeQuery support

### DIFF
--- a/.changeset/rotten-glasses-explode.md
+++ b/.changeset/rotten-glasses-explode.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Add DataStore.observeQuery support

--- a/packages/react/src/primitives/types/datastore.ts
+++ b/packages/react/src/primitives/types/datastore.ts
@@ -17,8 +17,7 @@ export type DataStoreCollectionProps<Model extends PersistentModel> = {
 };
 
 type DataStoreBaseResult = {
-  error: Error;
-  fetch: () => void;
+  error?: Error;
   isLoading: boolean;
 };
 


### PR DESCRIPTION
*Description of changes:*
Add `DataStore.observeQuery` support for `useDataStoreCollection` hook


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
