### PR TITLE
fix: upgrading json-schema to 0.4.0 or later

### DIFF
--- a/.changeset/nice-cougars-reflect.md
+++ b/.changeset/nice-cougars-reflect.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+fix: upgrading json-schema to 0.4.0 or later

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "jest": "^26.6.3",
     "ts-jest": "^26.5.6",
     "prismjs": "^1.25.0",
-    "vscode-vue-languageservice": "0.27.26"
+    "vscode-vue-languageservice": "0.27.26",
+    "json-schema": "^0.4.0"
   },
   "dependencies": {
     "patch-package": "^6.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13894,10 +13894,10 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+json-schema@0.2.3, json-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
*Issue #, if available:*

Vulnerable versions of `json-schema`: < 0.4.0

*Description of changes:*

Upgrade to `^0.4.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
