### PR TITLE
ForwardRef support for Table/TableBody/TableHeader/TableFoot/TableCell

### DIFF
--- a/.changeset/slimy-walls-marry.md
+++ b/.changeset/slimy-walls-marry.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef support for Table/TableBody/TableHeader/TableFoot/TableCell

--- a/packages/react/src/primitives/Table/Table.tsx
+++ b/packages/react/src/primitives/Table/Table.tsx
@@ -1,24 +1,29 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { Primitive, TableProps } from '../types';
+import { PrimitiveWithForwardRef, TableProps } from '../types';
 import { View } from '../View';
 
-export const Table: Primitive<TableProps, 'table'> = ({
-  caption,
-  children,
-  className,
-  highlightOnHover = false,
-  size,
-  variation,
-  ...rest
-}) => (
+const TablePrimitive: PrimitiveWithForwardRef<TableProps, 'table'> = (
+  {
+    caption,
+    children,
+    className,
+    highlightOnHover = false,
+    size,
+    variation,
+    ...rest
+  },
+  ref
+) => (
   <View
     as="table"
     className={classNames(ComponentClassNames.Table, className)}
     data-highlightonhover={highlightOnHover}
     data-size={size}
     data-variation={variation}
+    ref={ref}
     {...rest}
   >
     {caption && (
@@ -29,5 +34,7 @@ export const Table: Primitive<TableProps, 'table'> = ({
     {children}
   </View>
 );
+
+export const Table = React.forwardRef(TablePrimitive);
 
 Table.displayName = 'Table';

--- a/packages/react/src/primitives/Table/TableBody.tsx
+++ b/packages/react/src/primitives/Table/TableBody.tsx
@@ -1,21 +1,24 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { Primitive, TableBodyProps } from '../types';
+import { PrimitiveWithForwardRef, TableBodyProps } from '../types';
 import { View } from '../View';
 
-export const TableBody: Primitive<TableBodyProps, 'tbody'> = ({
-  children,
-  className,
-  ...rest
-}) => (
+const TableBodyPrimitive: PrimitiveWithForwardRef<TableBodyProps, 'tbody'> = (
+  { children, className, ...rest },
+  ref
+) => (
   <View
     as="tbody"
     className={classNames(ComponentClassNames.TableBody, className)}
+    ref={ref}
     {...rest}
   >
     {children}
   </View>
 );
+
+export const TableBody = React.forwardRef(TableBodyPrimitive);
 
 TableBody.displayName = 'TableBody';

--- a/packages/react/src/primitives/Table/TableCell.tsx
+++ b/packages/react/src/primitives/Table/TableCell.tsx
@@ -1,15 +1,18 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { Primitive, TableCellElement, TableCellProps } from '../types';
+import {
+  PrimitiveWithForwardRef,
+  TableCellElement,
+  TableCellProps,
+} from '../types';
 import { View } from '../View';
 
-export const TableCell: Primitive<TableCellProps, TableCellElement> = ({
-  as: asElementTag = 'td',
-  children,
-  className,
-  ...rest
-}) => (
+const TableCellPrimitive: PrimitiveWithForwardRef<
+  TableCellProps,
+  TableCellElement
+> = ({ as: asElementTag = 'td', children, className, ...rest }, ref) => (
   <View
     as={asElementTag}
     className={classNames(
@@ -18,10 +21,13 @@ export const TableCell: Primitive<TableCellProps, TableCellElement> = ({
         : ComponentClassNames.TableTh,
       className
     )}
+    ref={ref}
     {...rest}
   >
     {children}
   </View>
 );
+
+export const TableCell = React.forwardRef(TableCellPrimitive);
 
 TableCell.displayName = 'TableCell';

--- a/packages/react/src/primitives/Table/TableFoot.tsx
+++ b/packages/react/src/primitives/Table/TableFoot.tsx
@@ -1,21 +1,24 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { Primitive, TableFootProps } from '../types';
+import { PrimitiveWithForwardRef, TableFootProps } from '../types';
 import { View } from '../View';
 
-export const TableFoot: Primitive<TableFootProps, 'tfoot'> = ({
-  children,
-  className,
-  ...rest
-}) => (
+const TableFootPrimitive: PrimitiveWithForwardRef<TableFootProps, 'tfoot'> = (
+  { children, className, ...rest },
+  ref
+) => (
   <View
     as="tfoot"
     className={classNames(ComponentClassNames.TableFoot, className)}
+    ref={ref}
     {...rest}
   >
     {children}
   </View>
 );
+
+export const TableFoot = React.forwardRef(TableFootPrimitive);
 
 TableFoot.displayName = 'TableFoot';

--- a/packages/react/src/primitives/Table/TableHead.tsx
+++ b/packages/react/src/primitives/Table/TableHead.tsx
@@ -1,21 +1,24 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { Primitive, TableHeadProps } from '../types';
+import { PrimitiveWithForwardRef, TableHeadProps } from '../types';
 import { View } from '../View';
 
-export const TableHead: Primitive<TableHeadProps, 'thead'> = ({
-  children,
-  className,
-  ...rest
-}) => (
+const TableHeadPrimitive: PrimitiveWithForwardRef<TableHeadProps, 'thead'> = (
+  { children, className, ...rest },
+  ref
+) => (
   <View
     as="thead"
     className={classNames(ComponentClassNames.TableHead, className)}
+    ref={ref}
     {...rest}
   >
     {children}
   </View>
 );
+
+export const TableHead = React.forwardRef(TableHeadPrimitive);
 
 TableHead.displayName = 'TableHead';

--- a/packages/react/src/primitives/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/primitives/Table/__tests__/Table.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import {
@@ -153,5 +154,13 @@ describe('Table primitive', () => {
 
       expect($table).toHaveAttribute('data-variation', variation);
     });
+  });
+
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLTableElement>();
+    render(<Table testId="testId" ref={ref} />);
+
+    await screen.findByTestId('testId');
+    expect(ref.current.nodeName).toBe('TABLE');
   });
 });

--- a/packages/react/src/primitives/Table/__tests__/TableBody.test.tsx
+++ b/packages/react/src/primitives/Table/__tests__/TableBody.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { Table } from '../Table';
+import { TableBody } from '../TableBody';
+
+describe('TableBody primitive', () => {
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLTableSectionElement>();
+    render(
+      <Table>
+        <TableBody testId="testId" ref={ref} />
+      </Table>
+    );
+
+    await screen.findByTestId('testId');
+    expect(ref.current.nodeName).toBe('TBODY');
+  });
+});

--- a/packages/react/src/primitives/Table/__tests__/TableCell.test.tsx
+++ b/packages/react/src/primitives/Table/__tests__/TableCell.test.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { Table } from '../Table';
+import { TableBody } from '../TableBody';
+import { TableCell } from '../TableCell';
+import { TableRow } from '../TableRow';
+
+describe('TableCell primitive', () => {
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLTableCellElement>();
+    render(
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell testId="testId" ref={ref} />
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    await screen.findByTestId('testId');
+    expect(ref.current.nodeName).toBe('TD');
+  });
+});

--- a/packages/react/src/primitives/Table/__tests__/TableFoot.test.tsx
+++ b/packages/react/src/primitives/Table/__tests__/TableFoot.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { Table } from '../Table';
+import { TableFoot } from '../TableFoot';
+
+describe('TableFoot primitive', () => {
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLTableSectionElement>();
+    render(
+      <Table>
+        <TableFoot testId="testId" ref={ref} />
+      </Table>
+    );
+
+    await screen.findByTestId('testId');
+    expect(ref.current.nodeName).toBe('TFOOT');
+  });
+});

--- a/packages/react/src/primitives/Table/__tests__/TableHead.test.tsx
+++ b/packages/react/src/primitives/Table/__tests__/TableHead.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { Table } from '../Table';
+import { TableHead } from '../TableHead';
+
+describe('TableHead primitive', () => {
+  it('should forward ref to DOM element', async () => {
+    const ref = React.createRef<HTMLTableSectionElement>();
+    render(
+      <Table>
+        <TableHead testId="testId" ref={ref} />
+      </Table>
+    );
+
+    await screen.findByTestId('testId');
+    expect(ref.current.nodeName).toBe('THEAD');
+  });
+});


### PR DESCRIPTION
*Description of changes:*
This PR adds ForwardRef support for `Table/TableBody/TableHeader/TableFoot/TableCell` primitives.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null); // ref.current.nodeName will be `TABLE`
  
  return (
    <Table ref={ref}  />
  );
};
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
