### PR TITLE
ForwardRef support - Menu & Pagination primitives

### DIFF
--- a/.changeset/tricky-camels-tie.md
+++ b/.changeset/tricky-camels-tie.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+ForwardRef support - Menu & Pagination primitives

--- a/packages/react/src/primitives/Menu/Menu.tsx
+++ b/packages/react/src/primitives/Menu/Menu.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import classNames from 'classnames';
 import {
   DropdownMenu,
@@ -9,22 +10,25 @@ import { ButtonGroup } from '../ButtonGroup';
 import { ComponentClassNames } from '../shared/constants';
 import { IconMenu } from '../Icon';
 import { MenuButton } from './MenuButton';
-import { MenuProps, Primitive } from '../types';
+import { MenuProps, PrimitiveWithForwardRef } from '../types';
 
 export const MENU_TRIGGER_TEST_ID = 'amplify-menu-trigger-test-id';
 export const MENU_ITEMS_GROUP_TEST_ID = 'amplify-menu-items-group-test-id';
 
-export const Menu: Primitive<MenuProps, 'div'> = ({
-  menuAlign = 'start',
-  children,
-  className,
-  isOpen,
-  size,
-  trigger,
-  triggerClassName,
-  onOpenChange,
-  ...rest
-}) => (
+const MenuPrimitive: PrimitiveWithForwardRef<MenuProps, 'div'> = (
+  {
+    menuAlign = 'start',
+    children,
+    className,
+    isOpen,
+    size,
+    trigger,
+    triggerClassName,
+    onOpenChange,
+    ...rest
+  },
+  ref
+) => (
   <DropdownMenu onOpenChange={onOpenChange} open={isOpen}>
     <DropdownMenuTrigger asChild={true}>
       {trigger ?? (
@@ -44,8 +48,9 @@ export const Menu: Primitive<MenuProps, 'div'> = ({
     <DropdownMenuContent align={menuAlign}>
       <ButtonGroup
         className={classNames(ComponentClassNames.MenuContent, className)}
-        testId={MENU_ITEMS_GROUP_TEST_ID}
+        ref={ref}
         size={size}
+        testId={MENU_ITEMS_GROUP_TEST_ID}
         {...rest}
       >
         {children}
@@ -53,5 +58,7 @@ export const Menu: Primitive<MenuProps, 'div'> = ({
     </DropdownMenuContent>
   </DropdownMenu>
 );
+
+export const Menu = React.forwardRef(MenuPrimitive);
 
 Menu.displayName = 'Menu';

--- a/packages/react/src/primitives/Menu/__tests_/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests_/menu.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { screen, render, cleanup } from '@testing-library/react';
 
 import { ComponentClassNames } from '../../shared';
@@ -96,6 +97,14 @@ describe('Menu: ', () => {
         ComponentClassNames.MenuTrigger,
         triggerClassName
       );
+    });
+
+    it('should forward ref to DOM element', async () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(<Menu ref={ref} isOpen></Menu>);
+
+      await screen.findByTestId(MENU_ITEMS_GROUP_TEST_ID);
+      expect(ref.current.nodeName).toBe('DIV');
     });
 
     it('should set size attribute', async () => {

--- a/packages/react/src/primitives/Pagination/Pagination.tsx
+++ b/packages/react/src/primitives/Pagination/Pagination.tsx
@@ -1,21 +1,25 @@
+import * as React from 'react';
 import classNames from 'classnames';
 
 import { Flex } from '../Flex';
 import { View } from '../View';
 import { usePaginationItems } from './usePaginationItems';
-import { PaginationProps, Primitive } from '../types';
+import { PaginationProps, PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared/constants';
 
-export const Pagination: Primitive<PaginationProps, 'nav'> = ({
-  className,
-  currentPage,
-  totalPages,
-  siblingCount,
-  onNext,
-  onPrevious,
-  onChange,
-  ...rest
-}) => {
+const PaginationPrimitive: PrimitiveWithForwardRef<PaginationProps, 'nav'> = (
+  {
+    className,
+    currentPage,
+    totalPages,
+    siblingCount,
+    onNext,
+    onPrevious,
+    onChange,
+    ...rest
+  },
+  ref
+) => {
   const paginationItems = usePaginationItems(
     currentPage,
     totalPages,
@@ -29,6 +33,7 @@ export const Pagination: Primitive<PaginationProps, 'nav'> = ({
     <View
       as="nav"
       className={classNames(ComponentClassNames.Pagination, className)}
+      ref={ref}
       {...rest}
     >
       <Flex as="ol" justifyContent="center" alignItems="center" gap="inherit">
@@ -37,5 +42,7 @@ export const Pagination: Primitive<PaginationProps, 'nav'> = ({
     </View>
   );
 };
+
+export const Pagination = React.forwardRef(PaginationPrimitive);
 
 Pagination.displayName = 'Pagination';

--- a/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -31,6 +32,25 @@ describe('Pagination component test suite', () => {
       const lastPage = await screen.findByLabelText('Go to page 5');
       expect(lastPage.childNodes.length).toBe(1);
       expect(lastPage).toHaveTextContent('5');
+    });
+
+    it('should forward ref to DOM element', async () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(
+        <Pagination
+          currentPage={1}
+          id={id}
+          onChange={() => {}}
+          onNext={() => {}}
+          onPrevious={() => {}}
+          ref={ref}
+          siblingCount={2}
+          totalPages={10}
+        />
+      );
+
+      await screen.findByRole('navigation');
+      expect(ref.current.nodeName).toBe('NAV');
     });
 
     it('should disable previous page button but enable next page button if current page is the first page', async () => {


### PR DESCRIPTION
*Description of changes:*
This PR adds forward ref support for the `Menu` and `Pagination` primitives by wrapping them in `React.forwardRef`.

```jsx
const CustomerComponent = () => {
  const ref = React.useRef(null); // ref.current.nodeName will be `NAV`
  
  return (
    <Pagination ref={ref}  />
  );
};
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
