### PR TITLE
Add back in dangerouslySetInnerHTML for theme

### DIFF
--- a/.changeset/happy-shirts-doubt.md
+++ b/.changeset/happy-shirts-doubt.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Add back in dangerouslySetInnerHTML for theme. Not using this was causing hydration issues in NextJS

--- a/packages/react/src/components/AmplifyProvider/index.tsx
+++ b/packages/react/src/components/AmplifyProvider/index.tsx
@@ -31,7 +31,10 @@ export function AmplifyProvider({
         <div data-amplify-theme={name} data-amplify-color-mode={colorMode}>
           {children}
         </div>
-        <style id={`amplify-theme-${name}`}>{cssText}</style>
+        <style
+          id={`amplify-theme-${name}`}
+          dangerouslySetInnerHTML={{ __html: cssText }}
+        />
       </IdProvider>
     </AmplifyContext.Provider>
   );


### PR DESCRIPTION
*Issue #, if available:* #876

*Description of changes:* This adds back in dangerouslySetInnerHTML for the theme injection because without it there are hydration issues in NextJS because on the server the quotes are turned into html entities like `&quot;` and on the client they are not. 

https://user-images.githubusercontent.com/321279/143313100-a46e92b1-49e1-4c3c-a4e7-b14b7babe1c9.mp4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
