### PR TITLE
Add useTheme unit tests

### DIFF
--- a/packages/react/src/hooks/__tests__/useTheme.test.ts
+++ b/packages/react/src/hooks/__tests__/useTheme.test.ts
@@ -1,0 +1,46 @@
+import { createTheme, defaultTheme } from '@aws-amplify/ui';
+import * as React from 'react';
+import { useTheme } from '../useTheme';
+
+jest.mock('react');
+
+describe('useTheme', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('should return a theme object', () => {
+    const customTheme = createTheme({
+      name: 'my-theme',
+      tokens: {
+        colors: {
+          font: {
+            primary: { value: 'red' },
+          },
+        },
+      },
+    });
+
+    (React.useContext as jest.Mock).mockReturnValue({ theme: customTheme });
+
+    const theme = useTheme();
+
+    expect(theme).toBe(customTheme);
+  });
+
+  it('should return a default theme if context is not available', () => {
+    (React.useContext as jest.Mock).mockReturnValue(undefined);
+
+    const theme = useTheme();
+
+    expect(theme).toBe(defaultTheme);
+  });
+
+  it('should return a default theme if context.theme is undefined', () => {
+    (React.useContext as jest.Mock).mockReturnValue({
+      theme: undefined,
+    });
+
+    const theme = useTheme();
+
+    expect(theme).toBe(defaultTheme);
+  });
+});

--- a/packages/react/src/hooks/useTheme.ts
+++ b/packages/react/src/hooks/useTheme.ts
@@ -1,10 +1,14 @@
-import { useContext } from 'react';
+import * as React from 'react';
 
-import { WebTheme } from '@aws-amplify/ui';
+import { defaultTheme, WebTheme } from '@aws-amplify/ui';
 import { AmplifyContext } from '../components/AmplifyProvider/AmplifyContext';
 
 export const useTheme = (): WebTheme => {
-  const { theme } = useContext(AmplifyContext);
+  const context = React.useContext(AmplifyContext);
 
-  return theme;
+  if (typeof context === 'undefined' || typeof context.theme === 'undefined') {
+    return defaultTheme;
+  }
+
+  return context.theme;
 };


### PR DESCRIPTION
*Description of changes:*
Add unit tests for `useTheme` React hook. Also makes it more resilient, not assuming that `React.useContext` will return an expected value.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
