### PR TITLE
Removes BrowserModule as Angular packages shouldn't import it

### DIFF
--- a/.changeset/JrPribs-885.md
+++ b/.changeset/JrPribs-885.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Removes BrowserModule as Angular packages shouldn't import it

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/authenticator.module.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/authenticator.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { BrowserModule } from '@angular/platform-browser';
 
 /**
  * Note: Angular components and directives inside module files has to be imported directly.

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/authenticator.module.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/authenticator.module.ts
@@ -67,7 +67,7 @@ import { AmplifySlotDirective } from '../../utilities/amplify-slot/amplify-slot.
     UserNameAliasComponent,
     VerifyUserComponent,
   ],
-  imports: [CommonModule, BrowserModule],
+  imports: [CommonModule],
   exports: [
     AmplifySlotDirective,
     AuthenticatorComponent,


### PR DESCRIPTION
This import is causing angular to attempt to import the BrowserModule twice

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
