### PR TITLE
Rename *Inner primitive names

### DIFF
--- a/packages/react/src/primitives/Badge/Badge.tsx
+++ b/packages/react/src/primitives/Badge/Badge.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared/constants';
 import { BadgeProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const BadgeInner: PrimitiveWithForwardRef<BadgeProps, 'span'> = (
+const BadgePrimitive: PrimitiveWithForwardRef<BadgeProps, 'span'> = (
   { className, children, variation, size, ...rest },
   ref
 ) => (
@@ -21,6 +21,6 @@ const BadgeInner: PrimitiveWithForwardRef<BadgeProps, 'span'> = (
   </View>
 );
 
-export const Badge = React.forwardRef(BadgeInner);
+export const Badge = React.forwardRef(BadgePrimitive);
 
 Badge.displayName = 'Badge';

--- a/packages/react/src/primitives/Button/Button.tsx
+++ b/packages/react/src/primitives/Button/Button.tsx
@@ -6,7 +6,7 @@ import { ButtonProps, PrimitiveWithForwardRef } from '../types';
 import { Text } from '../Text';
 import { View } from '../View';
 
-const ButtonInner: PrimitiveWithForwardRef<ButtonProps, 'button'> = (
+const ButtonPrimitive: PrimitiveWithForwardRef<ButtonProps, 'button'> = (
   {
     className,
     children,
@@ -47,6 +47,6 @@ const ButtonInner: PrimitiveWithForwardRef<ButtonProps, 'button'> = (
   );
 };
 
-export const Button = React.forwardRef(ButtonInner);
+export const Button = React.forwardRef(ButtonPrimitive);
 
 Button.displayName = 'Button';

--- a/packages/react/src/primitives/Card/Card.tsx
+++ b/packages/react/src/primitives/Card/Card.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared/constants';
 import { CardProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const CardInner: PrimitiveWithForwardRef<CardProps, 'div'> = (
+const CardPrimitive: PrimitiveWithForwardRef<CardProps, 'div'> = (
   { className, children, variation, ...rest },
   ref
 ) => (
@@ -19,6 +19,6 @@ const CardInner: PrimitiveWithForwardRef<CardProps, 'div'> = (
   </View>
 );
 
-export const Card = React.forwardRef(CardInner);
+export const Card = React.forwardRef(CardPrimitive);
 
 Card.displayName = 'Card';

--- a/packages/react/src/primitives/Checkbox/Checkbox.tsx
+++ b/packages/react/src/primitives/Checkbox/Checkbox.tsx
@@ -13,7 +13,7 @@ import { splitPrimitiveProps } from '../shared/styleUtils';
 import { ComponentClassNames } from '../shared/constants';
 import { useTestId } from '../utils/testUtils';
 
-const CheckboxInner: PrimitiveWithForwardRef<CheckboxProps, 'input'> = (
+const CheckboxPrimitive: PrimitiveWithForwardRef<CheckboxProps, 'input'> = (
   {
     checked,
     className,
@@ -99,6 +99,6 @@ const CheckboxInner: PrimitiveWithForwardRef<CheckboxProps, 'input'> = (
   );
 };
 
-export const Checkbox = React.forwardRef(CheckboxInner);
+export const Checkbox = React.forwardRef(CheckboxPrimitive);
 
 Checkbox.displayName = 'Checkbox';

--- a/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
+++ b/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
@@ -8,41 +8,43 @@ import { CheckboxFieldProps, PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared';
 import { useTestId } from '../utils/testUtils';
 
-const CheckboxFieldInner: PrimitiveWithForwardRef<CheckboxFieldProps, 'input'> =
-  (
-    {
-      className,
-      errorMessage,
-      hasError = false,
-      labelHidden = false,
-      testId,
-      size,
-      ...rest
-    },
-    ref
-  ) => {
-    const checkboxTestId = useTestId(testId, ComponentClassNames.Checkbox);
-    return (
-      <Flex
-        className={classNames(
-          ComponentClassNames.Field,
-          ComponentClassNames.CheckboxField,
-          className
-        )}
-        data-size={size}
-        testId={testId}
-      >
-        <Checkbox
-          hasError={hasError}
-          labelHidden={labelHidden}
-          testId={checkboxTestId}
-          ref={ref}
-          {...rest}
-        />
-        <FieldErrorMessage hasError={hasError} errorMessage={errorMessage} />
-      </Flex>
-    );
-  };
-export const CheckboxField = React.forwardRef(CheckboxFieldInner);
+const CheckboxFieldPrimitive: PrimitiveWithForwardRef<
+  CheckboxFieldProps,
+  'input'
+> = (
+  {
+    className,
+    errorMessage,
+    hasError = false,
+    labelHidden = false,
+    testId,
+    size,
+    ...rest
+  },
+  ref
+) => {
+  const checkboxTestId = useTestId(testId, ComponentClassNames.Checkbox);
+  return (
+    <Flex
+      className={classNames(
+        ComponentClassNames.Field,
+        ComponentClassNames.CheckboxField,
+        className
+      )}
+      data-size={size}
+      testId={testId}
+    >
+      <Checkbox
+        hasError={hasError}
+        labelHidden={labelHidden}
+        testId={checkboxTestId}
+        ref={ref}
+        {...rest}
+      />
+      <FieldErrorMessage hasError={hasError} errorMessage={errorMessage} />
+    </Flex>
+  );
+};
+export const CheckboxField = React.forwardRef(CheckboxFieldPrimitive);
 
 CheckboxField.displayName = 'CheckboxField';

--- a/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
+++ b/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
@@ -45,6 +45,7 @@ const CheckboxFieldPrimitive: PrimitiveWithForwardRef<
     </Flex>
   );
 };
+
 export const CheckboxField = React.forwardRef(CheckboxFieldPrimitive);
 
 CheckboxField.displayName = 'CheckboxField';

--- a/packages/react/src/primitives/Divider/Divider.tsx
+++ b/packages/react/src/primitives/Divider/Divider.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared';
 import { DividerProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const DividerInner: PrimitiveWithForwardRef<DividerProps, 'hr'> = (
+const DividerPrimitive: PrimitiveWithForwardRef<DividerProps, 'hr'> = (
   { className, orientation = 'horizontal', size, ...rest },
   ref
 ) => (
@@ -19,6 +19,6 @@ const DividerInner: PrimitiveWithForwardRef<DividerProps, 'hr'> = (
   />
 );
 
-export const Divider = React.forwardRef(DividerInner);
+export const Divider = React.forwardRef(DividerPrimitive);
 
 Divider.displayName = 'Divider';

--- a/packages/react/src/primitives/FieldGroupIcon/FieldGroupIcon.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/FieldGroupIcon.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared/constants';
 import { FieldGroupIconProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const FieldGroupIconInner: PrimitiveWithForwardRef<
+const FieldGroupIconPrimitive: PrimitiveWithForwardRef<
   FieldGroupIconProps,
   'button' | 'div'
 > = (
@@ -30,6 +30,6 @@ const FieldGroupIconInner: PrimitiveWithForwardRef<
   ) : null;
 };
 
-export const FieldGroupIcon = React.forwardRef(FieldGroupIconInner);
+export const FieldGroupIcon = React.forwardRef(FieldGroupIconPrimitive);
 
 FieldGroupIcon.displayName = 'FieldGroupIcon';

--- a/packages/react/src/primitives/Flex/Flex.tsx
+++ b/packages/react/src/primitives/Flex/Flex.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared/constants';
 import { FlexProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const FlexInner: PrimitiveWithForwardRef<FlexProps, 'div'> = (
+const FlexPrimitive: PrimitiveWithForwardRef<FlexProps, 'div'> = (
   { className, children, ...rest },
   ref
 ) => (
@@ -18,6 +18,6 @@ const FlexInner: PrimitiveWithForwardRef<FlexProps, 'div'> = (
   </View>
 );
 
-export const Flex = React.forwardRef(FlexInner);
+export const Flex = React.forwardRef(FlexPrimitive);
 
 Flex.displayName = 'Flex';

--- a/packages/react/src/primitives/Grid/Grid.tsx
+++ b/packages/react/src/primitives/Grid/Grid.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared/constants';
 import { GridProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const GridInner: PrimitiveWithForwardRef<GridProps, 'div'> = (
+const GridPrimitive: PrimitiveWithForwardRef<GridProps, 'div'> = (
   { className, children, ...rest },
   ref
 ) => (
@@ -18,6 +18,6 @@ const GridInner: PrimitiveWithForwardRef<GridProps, 'div'> = (
   </View>
 );
 
-export const Grid = React.forwardRef(GridInner);
+export const Grid = React.forwardRef(GridPrimitive);
 
 Grid.displayName = 'Grid';

--- a/packages/react/src/primitives/Heading/Heading.tsx
+++ b/packages/react/src/primitives/Heading/Heading.tsx
@@ -20,7 +20,7 @@ const headingLevels: HeadingLevels = {
   6: 'h6',
 };
 
-const HeadingInner: PrimitiveWithForwardRef<HeadingProps, HeadingTag> = (
+const HeadingPrimitive: PrimitiveWithForwardRef<HeadingProps, HeadingTag> = (
   { className, children, level = 6, ...rest },
   ref
 ) => (
@@ -34,6 +34,6 @@ const HeadingInner: PrimitiveWithForwardRef<HeadingProps, HeadingTag> = (
   </View>
 );
 
-export const Heading = React.forwardRef(HeadingInner);
+export const Heading = React.forwardRef(HeadingPrimitive);
 
 Heading.displayName = 'Heading';

--- a/packages/react/src/primitives/Icon/Icon.tsx
+++ b/packages/react/src/primitives/Icon/Icon.tsx
@@ -7,7 +7,7 @@ import { View } from '../View';
 
 const defaultViewBox = { minX: 0, minY: 0, width: 24, height: 24 };
 
-const IconInner: PrimitiveWithForwardRef<IconProps, 'svg'> = (
+const IconPrimitive: PrimitiveWithForwardRef<IconProps, 'svg'> = (
   {
     className,
     fill = 'currentColor',
@@ -35,6 +35,6 @@ const IconInner: PrimitiveWithForwardRef<IconProps, 'svg'> = (
   );
 };
 
-export const Icon = React.forwardRef(IconInner);
+export const Icon = React.forwardRef(IconPrimitive);
 
 Icon.displayName = 'Icon';

--- a/packages/react/src/primitives/Image/Image.tsx
+++ b/packages/react/src/primitives/Image/Image.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared';
 import { ImageProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const ImageInner: PrimitiveWithForwardRef<ImageProps, 'img'> = (
+const ImagePrimitive: PrimitiveWithForwardRef<ImageProps, 'img'> = (
   { className, ...rest },
   ref
 ) => (
@@ -17,6 +17,6 @@ const ImageInner: PrimitiveWithForwardRef<ImageProps, 'img'> = (
   />
 );
 
-export const Image = React.forwardRef(ImageInner);
+export const Image = React.forwardRef(ImagePrimitive);
 
 Image.displayName = 'Image';

--- a/packages/react/src/primitives/Input/Input.tsx
+++ b/packages/react/src/primitives/Input/Input.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared';
 import { InputProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const InputInner: PrimitiveWithForwardRef<InputProps, 'input'> = (
+const InputPrimitive: PrimitiveWithForwardRef<InputProps, 'input'> = (
   {
     autoComplete,
     checked,
@@ -68,6 +68,6 @@ const InputInner: PrimitiveWithForwardRef<InputProps, 'input'> = (
   />
 );
 
-export const Input = React.forwardRef(InputInner);
+export const Input = React.forwardRef(InputPrimitive);
 
 Input.displayName = 'Input';

--- a/packages/react/src/primitives/Label/Label.tsx
+++ b/packages/react/src/primitives/Label/Label.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared/constants';
 import { LabelProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const LabelInner: PrimitiveWithForwardRef<LabelProps, 'label'> = (
+const LabelPrimitive: PrimitiveWithForwardRef<LabelProps, 'label'> = (
   { children, className, visuallyHidden, ...rest },
   ref
 ) => {
@@ -23,6 +23,6 @@ const LabelInner: PrimitiveWithForwardRef<LabelProps, 'label'> = (
   );
 };
 
-export const Label = React.forwardRef(LabelInner);
+export const Label = React.forwardRef(LabelPrimitive);
 
 Label.displayName = 'Label';

--- a/packages/react/src/primitives/Link/Link.tsx
+++ b/packages/react/src/primitives/Link/Link.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared';
 import { LinkProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const LinkInner: PrimitiveWithForwardRef<LinkProps, 'a'> = (
+const LinkPrimitive: PrimitiveWithForwardRef<LinkProps, 'a'> = (
   { as = 'a', children, className, isExternal, ...rest },
   ref
 ) => {
@@ -23,6 +23,6 @@ const LinkInner: PrimitiveWithForwardRef<LinkProps, 'a'> = (
   );
 };
 
-export const Link = React.forwardRef(LinkInner);
+export const Link = React.forwardRef(LinkPrimitive);
 
 Link.displayName = 'Link';

--- a/packages/react/src/primitives/Loader/Loader.tsx
+++ b/packages/react/src/primitives/Loader/Loader.tsx
@@ -11,7 +11,7 @@ export const LINEAR_FILLED = 'linear-filled';
 export const CIRCULAR_EMPTY = 'circular-empty';
 export const CIRCULAR_FILLED = 'circular-filled';
 
-const LoaderInner: PrimitiveWithForwardRef<LoaderProps, 'svg'> = (
+const LoaderPrimitive: PrimitiveWithForwardRef<LoaderProps, 'svg'> = (
   { className, filledColor, emptyColor, size, variation, ...rest },
   ref
 ) => {
@@ -73,6 +73,6 @@ const LoaderInner: PrimitiveWithForwardRef<LoaderProps, 'svg'> = (
   );
 };
 
-export const Loader = React.forwardRef(LoaderInner);
+export const Loader = React.forwardRef(LoaderPrimitive);
 
 Loader.displayName = 'Loader';

--- a/packages/react/src/primitives/Placeholder/Placeholder.tsx
+++ b/packages/react/src/primitives/Placeholder/Placeholder.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared';
 import { PlaceholderProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const PlaceholderInner: PrimitiveWithForwardRef<PlaceholderProps, 'div'> = (
+const PlaceholderPrimitive: PrimitiveWithForwardRef<PlaceholderProps, 'div'> = (
   { className, children, isLoaded, size, ...rest },
   ref
 ) => {
@@ -23,6 +23,6 @@ const PlaceholderInner: PrimitiveWithForwardRef<PlaceholderProps, 'div'> = (
   );
 };
 
-export const Placeholder = React.forwardRef(PlaceholderInner);
+export const Placeholder = React.forwardRef(PlaceholderPrimitive);
 
 Placeholder.displayName = 'Placeholder';

--- a/packages/react/src/primitives/Radio/Radio.tsx
+++ b/packages/react/src/primitives/Radio/Radio.tsx
@@ -8,7 +8,7 @@ import { Text } from '../Text';
 import { RadioProps, PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared';
 
-export const RadioInner: PrimitiveWithForwardRef<RadioProps, 'input'> = (
+export const RadioPrimitive: PrimitiveWithForwardRef<RadioProps, 'input'> = (
   { children, className, id, isDisabled, testId, value, ...rest },
   ref
 ) => {
@@ -79,6 +79,6 @@ export const RadioInner: PrimitiveWithForwardRef<RadioProps, 'input'> = (
   );
 };
 
-export const Radio = React.forwardRef(RadioInner);
+export const Radio = React.forwardRef(RadioPrimitive);
 
 Radio.displayName = 'Radio';

--- a/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
+++ b/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
@@ -11,7 +11,7 @@ import { useStableId } from '../shared/utils';
 
 // Note: RadioGroupField doesn't extend the JSX.IntrinsicElements<'input'> types (instead extending 'typeof Flex')
 // because all rest props are passed to Flex container
-const RadioGroupFieldInner: PrimitiveWithForwardRef<
+const RadioGroupFieldPrimitive: PrimitiveWithForwardRef<
   RadioGroupFieldProps,
   typeof Flex
 > = (
@@ -94,6 +94,6 @@ const RadioGroupFieldInner: PrimitiveWithForwardRef<
   );
 };
 
-export const RadioGroupField = React.forwardRef(RadioGroupFieldInner);
+export const RadioGroupField = React.forwardRef(RadioGroupFieldPrimitive);
 
 RadioGroupField.displayName = 'RadioGroupField';

--- a/packages/react/src/primitives/ScrollView/ScrollView.tsx
+++ b/packages/react/src/primitives/ScrollView/ScrollView.tsx
@@ -5,7 +5,7 @@ import { View } from '../View';
 import { PrimitiveWithForwardRef, ScrollViewProps } from '../types';
 import { ComponentClassNames } from '../shared/constants';
 
-const ScrollViewInner: PrimitiveWithForwardRef<ScrollViewProps, 'div'> = (
+const ScrollViewPrimitive: PrimitiveWithForwardRef<ScrollViewProps, 'div'> = (
   { children, className, orientation, ...rest },
   ref
 ) => (
@@ -19,6 +19,6 @@ const ScrollViewInner: PrimitiveWithForwardRef<ScrollViewProps, 'div'> = (
   </View>
 );
 
-export const ScrollView = React.forwardRef(ScrollViewInner);
+export const ScrollView = React.forwardRef(ScrollViewPrimitive);
 
 ScrollView.displayName = 'ScrollView';

--- a/packages/react/src/primitives/Select/Select.tsx
+++ b/packages/react/src/primitives/Select/Select.tsx
@@ -8,7 +8,7 @@ import { SelectProps } from '../types/select';
 import { PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared/constants';
 
-const SelectInner: PrimitiveWithForwardRef<SelectProps, 'select'> = (
+const SelectPrimitive: PrimitiveWithForwardRef<SelectProps, 'select'> = (
   {
     autoComplete,
     className,
@@ -65,6 +65,6 @@ const SelectInner: PrimitiveWithForwardRef<SelectProps, 'select'> = (
   );
 };
 
-export const Select = React.forwardRef(SelectInner);
+export const Select = React.forwardRef(SelectPrimitive);
 
 Select.displayName = 'Select';

--- a/packages/react/src/primitives/Text/Text.tsx
+++ b/packages/react/src/primitives/Text/Text.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared/constants';
 import { TextProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const TextInner: PrimitiveWithForwardRef<TextProps, 'p'> = (
+const TextPrimitive: PrimitiveWithForwardRef<TextProps, 'p'> = (
   { as = 'p', className, children, isTruncated, variation, ...rest },
   ref
 ) => (
@@ -21,6 +21,6 @@ const TextInner: PrimitiveWithForwardRef<TextProps, 'p'> = (
   </View>
 );
 
-export const Text = React.forwardRef(TextInner);
+export const Text = React.forwardRef(TextPrimitive);
 
 Text.displayName = 'Text';

--- a/packages/react/src/primitives/TextArea/TextArea.tsx
+++ b/packages/react/src/primitives/TextArea/TextArea.tsx
@@ -6,7 +6,7 @@ import { PrimitiveWithForwardRef } from '../types/view';
 import { TextAreaProps } from '../types/textArea';
 import { View } from '../View';
 
-const TextAreaInner: PrimitiveWithForwardRef<TextAreaProps, 'textarea'> = (
+const TextAreaPrimitive: PrimitiveWithForwardRef<TextAreaProps, 'textarea'> = (
   {
     className,
     isReadOnly,
@@ -35,6 +35,6 @@ const TextAreaInner: PrimitiveWithForwardRef<TextAreaProps, 'textarea'> = (
   />
 );
 
-export const TextArea = React.forwardRef(TextAreaInner);
+export const TextArea = React.forwardRef(TextAreaPrimitive);
 
 TextArea.displayName = 'TextArea';

--- a/packages/react/src/primitives/View/View.tsx
+++ b/packages/react/src/primitives/View/View.tsx
@@ -7,7 +7,7 @@ import {
   ViewProps,
 } from '../types';
 
-const ViewInner = <Element extends ElementType = 'div'>(
+const ViewPrimitive = <Element extends ElementType = 'div'>(
   {
     as = 'div',
     className,
@@ -42,6 +42,6 @@ const ViewInner = <Element extends ElementType = 'div'>(
   );
 };
 
-export const View = React.forwardRef(ViewInner);
+export const View = React.forwardRef(ViewPrimitive);
 
 View.displayName = 'View';

--- a/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
@@ -5,7 +5,7 @@ import { ComponentClassNames } from '../shared/constants';
 import { PrimitiveWithForwardRef, VisuallyHiddenProps } from '../types';
 import { View } from '../View';
 
-const VisuallyHiddenInner: PrimitiveWithForwardRef<
+const VisuallyHiddenPrimitive: PrimitiveWithForwardRef<
   VisuallyHiddenProps,
   'span'
 > = ({ as = 'span', children, className, ...rest }, ref) => (
@@ -19,6 +19,6 @@ const VisuallyHiddenInner: PrimitiveWithForwardRef<
   </View>
 );
 
-export const VisuallyHidden = React.forwardRef(VisuallyHiddenInner);
+export const VisuallyHidden = React.forwardRef(VisuallyHiddenPrimitive);
 
 VisuallyHidden.displayName = 'VisuallyHidden';


### PR DESCRIPTION
*Description of changes:*
Standardize primitive function names to use a `*Primitive` suffix (instead of `*Inner`)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
