### PR TITLE
Update Node Version for Amplify UI Docs Console Build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,13 +4,13 @@ applications:
       phases:
         preBuild:
           commands:
-            - nvm install
+            - nvm install 14
             - nvm use
             - node -v
             - (cd .. && yarn install)
         build:
           commands:
-            - nvm install
+            - nvm install 14
             - nvm use
             - node -v
             - yarn build


### PR DESCRIPTION
*Issue #, if available:*

Set console Amplify UI build to use Node 14, instead of 16, so build will deploy correctly in console. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
