### PR TITLE
Fix build console

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -5,13 +5,13 @@ applications:
         preBuild:
           commands:
             - nvm install 14
-            - nvm use
+            - nvm use 14
             - node -v
             - (cd .. && yarn install)
         build:
           commands:
             - nvm install 14
-            - nvm use
+            - nvm use 14
             - node -v
             - yarn build
       artifacts:

--- a/amplify.yml
+++ b/amplify.yml
@@ -4,13 +4,13 @@ applications:
       phases:
         preBuild:
           commands:
-            - nvm install
+            - nvm install 14
             - nvm use
             - node -v
             - (cd .. && yarn install)
         build:
           commands:
-            - nvm install
+            - nvm install 14
             - nvm use
             - node -v
             - yarn build


### PR DESCRIPTION
*Issue #, if available:*

To fix error in console add in `nvm use 14`

2021-11-26T23:11:49.680Z [INFO]: Found '/codebuild/output/src626742148/src/amplify-ui/.nvmrc' with version <lts/*>
2021-11-26T23:11:49.763Z [WARNING]: N/A: version "lts/* -> N/A" is not yet installed.
2021-11-26T23:11:49.764Z [WARNING]: You need to run "nvm install lts/*" to install it before using it.
2021-11-26T23:11:49.764Z [ERROR]: !!! Build failed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
