### PR TITLE
Update getting started to include CSS import

### DIFF
--- a/docs/src/pages/getting-started/installation/dependencies.react.mdx
+++ b/docs/src/pages/getting-started/installation/dependencies.react.mdx
@@ -19,10 +19,11 @@ yarn add aws-amplify @aws-amplify/ui-react
 </TabItem>
 </Tabs>
 
-Wrap your application in `<AmplifyProvider/>`:
+Wrap your application in `<AmplifyProvider/>` and include default styling:
 
 ```jsx
 import { AmplifyProvider } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css'; // default theme
 
 export default = () => (
   <AmplifyProvider>

--- a/docs/src/pages/getting-started/installation/index.page.mdx
+++ b/docs/src/pages/getting-started/installation/index.page.mdx
@@ -7,11 +7,13 @@ import Link from 'next/link';
 
 ## Dependencies
 
+### Packages
+
 <Fragment>
   {({ platform }) => import(`./dependencies.${platform}.mdx`)}
 </Fragment>
 
-## Styles
+### Styles
 
 Amplify UI ships with a default [theme](/ui/theme) that you can customize to match the look and feel of your project.
 


### PR DESCRIPTION
*Description of changes:*
Building some sample apps I've found myself forgetting to add the CSS file via `import '@aws-amplify/ui-react/styles.css'`. This is my attempt to make the getting started instructions a bit clearer.

Changes:

1. _Add the CSS import in the main code block, so customers can copy paste a single code block to get started_
```
import { AmplifyProvider } from '@aws-amplify/ui-react';
import '@aws-amplify/ui-react/styles.css'; // <--- added CSS import here

export default = () => (
  <AmplifyProvider>
    <App />
  </AmplifyProvider>
);
```
2. Add Packages and Styles as Level 3 headings to put them under Dependencies.

 
![Screen Shot 2021-11-29 at 6 47 17 PM](https://user-images.githubusercontent.com/6165315/143977843-f15da0b7-b13f-4396-bf4f-9e18bbfae043.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
