### PR TITLE
Rename PrimitiveWithForwardRef => Primitive type

### DIFF
--- a/.changeset/green-papayas-invent.md
+++ b/.changeset/green-papayas-invent.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Rename PrimitiveWithForwardRef => Primitive type

--- a/packages/react/src/primitives/Alert/Alert.tsx
+++ b/packages/react/src/primitives/Alert/Alert.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { AlertProps, PrimitiveWithForwardRef } from '../types';
+import { AlertProps, Primitive } from '../types';
 import { View } from '../View';
 import { Flex } from '../Flex';
 import { Button } from '../Button';
@@ -10,7 +10,7 @@ import { AlertIcon } from './AlertIcon';
 import { IconClose } from '../Icon';
 import { isFunction } from '../shared/utils';
 
-const AlertPrimitive: PrimitiveWithForwardRef<AlertProps, typeof Flex> = (
+const AlertPrimitive: Primitive<AlertProps, typeof Flex> = (
   {
     buttonRef,
     children,

--- a/packages/react/src/primitives/Badge/Badge.tsx
+++ b/packages/react/src/primitives/Badge/Badge.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import { BadgeProps, Primitive } from '../types';
 import { ComponentClassNames } from '../shared/constants';
-import { BadgeProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const BadgePrimitive: PrimitiveWithForwardRef<BadgeProps, 'span'> = (
+const BadgePrimitive: Primitive<BadgeProps, 'span'> = (
   { className, children, variation, size, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Button/Button.tsx
+++ b/packages/react/src/primitives/Button/Button.tsx
@@ -1,12 +1,12 @@
 import classNames from 'classnames';
 import * as React from 'react';
 
+import { ButtonProps, Primitive } from '../types';
 import { ComponentClassNames } from '../shared/constants';
-import { ButtonProps, PrimitiveWithForwardRef } from '../types';
 import { Text } from '../Text';
 import { View } from '../View';
 
-const ButtonPrimitive: PrimitiveWithForwardRef<ButtonProps, 'button'> = (
+const ButtonPrimitive: Primitive<ButtonProps, 'button'> = (
   {
     className,
     children,

--- a/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
@@ -1,18 +1,11 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import { Flex } from '../Flex';
-import {
-  ButtonProps,
-  ButtonGroupProps,
-  PrimitiveWithForwardRef,
-} from '../types';
+import { ButtonProps, ButtonGroupProps, Primitive } from '../types';
 import { ComponentClassNames } from '../shared/constants';
+import { Flex } from '../Flex';
 
-const ButtonGroupPrimitive: PrimitiveWithForwardRef<
-  ButtonGroupProps,
-  typeof Flex
-> = (
+const ButtonGroupPrimitive: Primitive<ButtonGroupProps, typeof Flex> = (
   { className, children, role = 'group', size, variation, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Card/Card.tsx
+++ b/packages/react/src/primitives/Card/Card.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
 import * as React from 'react';
 
+import { CardProps, Primitive } from '../types';
 import { ComponentClassNames } from '../shared/constants';
-import { CardProps, PrimitiveWithForwardRef } from '../types';
 import { View } from '../View';
 
-const CardPrimitive: PrimitiveWithForwardRef<CardProps, 'div'> = (
+const CardPrimitive: Primitive<CardProps, 'div'> = (
   { className, children, variation, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Checkbox/Checkbox.tsx
+++ b/packages/react/src/primitives/Checkbox/Checkbox.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import { useCheckbox } from './useCheckbox';
+import { CheckboxProps } from '../types/checkbox';
+import { ComponentClassNames } from '../shared/constants';
 import { Flex } from '../Flex';
 import { IconCheck } from '../Icon';
 import { Input } from '../Input';
-import { Text } from '../Text';
-import { VisuallyHidden } from '../VisuallyHidden';
-import { CheckboxProps } from '../types/checkbox';
-import { PrimitiveWithForwardRef } from '../types/view';
+import { Primitive } from '../types/view';
 import { splitPrimitiveProps } from '../shared/styleUtils';
-import { ComponentClassNames } from '../shared/constants';
+import { Text } from '../Text';
+import { useCheckbox } from './useCheckbox';
+import { VisuallyHidden } from '../VisuallyHidden';
 import { useTestId } from '../utils/testUtils';
 
-const CheckboxPrimitive: PrimitiveWithForwardRef<CheckboxProps, 'input'> = (
+const CheckboxPrimitive: Primitive<CheckboxProps, 'input'> = (
   {
     checked,
     className,

--- a/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
+++ b/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
@@ -2,16 +2,13 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { Checkbox } from '../Checkbox';
+import { CheckboxFieldProps, Primitive } from '../types';
+import { ComponentClassNames } from '../shared';
 import { FieldErrorMessage } from '../Field';
 import { Flex } from '../Flex';
-import { CheckboxFieldProps, PrimitiveWithForwardRef } from '../types';
-import { ComponentClassNames } from '../shared';
 import { useTestId } from '../utils/testUtils';
 
-const CheckboxFieldPrimitive: PrimitiveWithForwardRef<
-  CheckboxFieldProps,
-  'input'
-> = (
+const CheckboxFieldPrimitive: Primitive<CheckboxFieldProps, 'input'> = (
   {
     className,
     errorMessage,

--- a/packages/react/src/primitives/Divider/Divider.tsx
+++ b/packages/react/src/primitives/Divider/Divider.tsx
@@ -2,10 +2,10 @@ import classNames from 'classnames';
 import * as React from 'react';
 
 import { ComponentClassNames } from '../shared';
-import { DividerProps, PrimitiveWithForwardRef } from '../types';
+import { DividerProps, Primitive } from '../types';
 import { View } from '../View';
 
-const DividerPrimitive: PrimitiveWithForwardRef<DividerProps, 'hr'> = (
+const DividerPrimitive: Primitive<DividerProps, 'hr'> = (
   { className, orientation = 'horizontal', size, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Expander/Expander.tsx
+++ b/packages/react/src/primitives/Expander/Expander.tsx
@@ -1,13 +1,13 @@
-import classNames from 'classnames';
-import { Root } from '@radix-ui/react-accordion';
 import * as React from 'react';
+import { Root } from '@radix-ui/react-accordion';
+import classNames from 'classnames';
 
-import { PrimitiveWithForwardRef } from '../types/view';
-import { ExpanderProps } from '../types/expander';
 import { ComponentClassNames } from '../shared/constants';
+import { ExpanderProps } from '../types/expander';
+import { Primitive } from '../types/view';
 import { splitPrimitiveProps } from '../shared/styleUtils';
 
-const ExpanderPrimitive: PrimitiveWithForwardRef<ExpanderProps, typeof Root> = (
+const ExpanderPrimitive: Primitive<ExpanderProps, typeof Root> = (
   {
     children,
     className,

--- a/packages/react/src/primitives/Expander/ExpanderItem.tsx
+++ b/packages/react/src/primitives/Expander/ExpanderItem.tsx
@@ -1,24 +1,24 @@
-import classNames from 'classnames';
-import { Item, Header, Trigger, Content } from '@radix-ui/react-accordion';
 import * as React from 'react';
+import { Item, Header, Trigger, Content } from '@radix-ui/react-accordion';
+import classNames from 'classnames';
 
-import { IconExpandMore } from '../Icon';
-import { View } from '../View';
-import { PrimitiveWithForwardRef } from '../types/view';
-import { ExpanderItemProps } from '../types/expander';
 import { ComponentClassNames } from '../shared/constants';
+import { ExpanderItemProps } from '../types/expander';
+import { IconExpandMore } from '../Icon';
+import { Primitive } from '../types/view';
 import { splitPrimitiveProps } from '../shared/styleUtils';
 import { useStableId } from '../shared/utils';
+import { View } from '../View';
 
 export const EXPANDER_ITEM_TEST_ID = 'expander-item';
 export const EXPANDER_HEADER_TEST_ID = 'expander-header';
 export const EXPANDER_ICON_TEST_ID = 'expander-icon';
 export const EXPANDER_CONTENT_TEXT_TEST_ID = 'expander-content-text';
 
-const ExpanderItemPrimitive: PrimitiveWithForwardRef<
-  ExpanderItemProps,
-  typeof Item
-> = ({ children, className, title, ..._rest }, ref) => {
+const ExpanderItemPrimitive: Primitive<ExpanderItemProps, typeof Item> = (
+  { children, className, title, ..._rest },
+  ref
+) => {
   const triggerId = useStableId();
   const contentId = useStableId();
   const { rest } = splitPrimitiveProps(_rest);

--- a/packages/react/src/primitives/Field/FieldClearButton.tsx
+++ b/packages/react/src/primitives/Field/FieldClearButton.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 
-import { FieldClearButtonProps, PrimitiveWithForwardRef } from '../types';
+import { FieldClearButtonProps, Primitive } from '../types';
 import { FieldGroupIconButton } from '../FieldGroupIcon';
 import { IconClose } from '../Icon';
 import { SharedText } from '../shared/i18n';
 
 const ariaLabelText = SharedText.Fields.ariaLabel.clearField;
 
-const FieldClearButtonPrimitive: PrimitiveWithForwardRef<
-  FieldClearButtonProps,
-  'button'
-> = (props, ref) => (
+const FieldClearButtonPrimitive: Primitive<FieldClearButtonProps, 'button'> = (
+  props,
+  ref
+) => (
   <FieldGroupIconButton ariaLabel={ariaLabelText} ref={ref} {...props}>
     <IconClose size={props.size} />
   </FieldGroupIconButton>

--- a/packages/react/src/primitives/FieldGroup/FieldGroup.tsx
+++ b/packages/react/src/primitives/FieldGroup/FieldGroup.tsx
@@ -2,14 +2,11 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { FieldGroupOptions, PrimitiveWithForwardRef } from '../types';
+import { FieldGroupOptions, Primitive } from '../types';
 import { Flex } from '../Flex';
 import { View } from '../View';
 
-const FieldGroupPrimitive: PrimitiveWithForwardRef<
-  FieldGroupOptions,
-  typeof Flex
-> = (
+const FieldGroupPrimitive: Primitive<FieldGroupOptions, typeof Flex> = (
   {
     children,
     className,

--- a/packages/react/src/primitives/FieldGroupIcon/FieldGroupIcon.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/FieldGroupIcon.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { FieldGroupIconProps, PrimitiveWithForwardRef } from '../types';
+import { FieldGroupIconProps, Primitive } from '../types';
 import { View } from '../View';
 
-const FieldGroupIconPrimitive: PrimitiveWithForwardRef<
+const FieldGroupIconPrimitive: Primitive<
   FieldGroupIconProps,
   'button' | 'div'
 > = (

--- a/packages/react/src/primitives/FieldGroupIcon/FieldGroupIconButton.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/FieldGroupIconButton.tsx
@@ -4,9 +4,9 @@ import classNames from 'classnames';
 import { Button } from '../Button';
 import { ComponentClassNames } from '../shared/constants';
 import { FieldGroupIcon } from './FieldGroupIcon';
-import { FieldGroupIconButtonProps, PrimitiveWithForwardRef } from '../types';
+import { FieldGroupIconButtonProps, Primitive } from '../types';
 
-const FieldGroupIconButtonPrimitive: PrimitiveWithForwardRef<
+const FieldGroupIconButtonPrimitive: Primitive<
   FieldGroupIconButtonProps,
   'button'
 > = ({ children, className, ...rest }, ref) => (

--- a/packages/react/src/primitives/Flex/Flex.tsx
+++ b/packages/react/src/primitives/Flex/Flex.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { FlexProps, PrimitiveWithForwardRef } from '../types';
+import { FlexProps, Primitive } from '../types';
 import { View } from '../View';
 
-const FlexPrimitive: PrimitiveWithForwardRef<FlexProps, 'div'> = (
+const FlexPrimitive: Primitive<FlexProps, 'div'> = (
   { className, children, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Grid/Grid.tsx
+++ b/packages/react/src/primitives/Grid/Grid.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { GridProps, PrimitiveWithForwardRef } from '../types';
+import { GridProps, Primitive } from '../types';
 import { View } from '../View';
 
-const GridPrimitive: PrimitiveWithForwardRef<GridProps, 'div'> = (
+const GridPrimitive: Primitive<GridProps, 'div'> = (
   { className, children, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Heading/Heading.tsx
+++ b/packages/react/src/primitives/Heading/Heading.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { HeadingProps, PrimitiveWithForwardRef } from '../types';
+import { HeadingProps, Primitive } from '../types';
 import { View } from '../View';
 
 type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
@@ -20,7 +20,7 @@ const headingLevels: HeadingLevels = {
   6: 'h6',
 };
 
-const HeadingPrimitive: PrimitiveWithForwardRef<HeadingProps, HeadingTag> = (
+const HeadingPrimitive: Primitive<HeadingProps, HeadingTag> = (
   { className, children, level = 6, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Icon/Icon.tsx
+++ b/packages/react/src/primitives/Icon/Icon.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import { IconProps, PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared';
+import { IconProps, Primitive } from '../types';
 import { View } from '../View';
 
 const defaultViewBox = { minX: 0, minY: 0, width: 24, height: 24 };
 
-const IconPrimitive: PrimitiveWithForwardRef<IconProps, 'svg'> = (
+const IconPrimitive: Primitive<IconProps, 'svg'> = (
   {
     className,
     fill = 'currentColor',

--- a/packages/react/src/primitives/Image/Image.tsx
+++ b/packages/react/src/primitives/Image/Image.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared';
-import { ImageProps, PrimitiveWithForwardRef } from '../types';
+import { ImageProps, Primitive } from '../types';
 import { View } from '../View';
 
-const ImagePrimitive: PrimitiveWithForwardRef<ImageProps, 'img'> = (
+const ImagePrimitive: Primitive<ImageProps, 'img'> = (
   { className, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Input/Input.tsx
+++ b/packages/react/src/primitives/Input/Input.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared';
-import { InputProps, PrimitiveWithForwardRef } from '../types';
+import { InputProps, Primitive } from '../types';
 import { View } from '../View';
 
-const InputPrimitive: PrimitiveWithForwardRef<InputProps, 'input'> = (
+const InputPrimitive: Primitive<InputProps, 'input'> = (
   {
     autoComplete,
     checked,

--- a/packages/react/src/primitives/Label/Label.tsx
+++ b/packages/react/src/primitives/Label/Label.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { LabelProps, PrimitiveWithForwardRef } from '../types';
+import { LabelProps, Primitive } from '../types';
 import { View } from '../View';
 
-const LabelPrimitive: PrimitiveWithForwardRef<LabelProps, 'label'> = (
+const LabelPrimitive: Primitive<LabelProps, 'label'> = (
   { children, className, visuallyHidden, ...rest },
   ref
 ) => {

--- a/packages/react/src/primitives/Link/Link.tsx
+++ b/packages/react/src/primitives/Link/Link.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared';
-import { LinkProps, PrimitiveWithForwardRef } from '../types';
+import { LinkProps, Primitive } from '../types';
 import { View } from '../View';
 
-const LinkPrimitive: PrimitiveWithForwardRef<LinkProps, 'a'> = (
+const LinkPrimitive: Primitive<LinkProps, 'a'> = (
   { as = 'a', children, className, isExternal, ...rest },
   ref
 ) => {

--- a/packages/react/src/primitives/Loader/Loader.tsx
+++ b/packages/react/src/primitives/Loader/Loader.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import { View } from '../View';
-import { LoaderProps } from '../types/loader';
-import { PrimitiveWithForwardRef } from '../types/view';
 import { ComponentClassNames } from '../shared/constants';
+import { LoaderProps } from '../types/loader';
+import { Primitive } from '../types/view';
+import { View } from '../View';
 
 export const LINEAR_EMPTY = 'linear-empty';
 export const LINEAR_FILLED = 'linear-filled';
 export const CIRCULAR_EMPTY = 'circular-empty';
 export const CIRCULAR_FILLED = 'circular-filled';
 
-const LoaderPrimitive: PrimitiveWithForwardRef<LoaderProps, 'svg'> = (
+const LoaderPrimitive: Primitive<LoaderProps, 'svg'> = (
   { className, filledColor, emptyColor, size, variation, ...rest },
   ref
 ) => {

--- a/packages/react/src/primitives/Menu/Menu.tsx
+++ b/packages/react/src/primitives/Menu/Menu.tsx
@@ -10,12 +10,12 @@ import { ButtonGroup } from '../ButtonGroup';
 import { ComponentClassNames } from '../shared/constants';
 import { IconMenu } from '../Icon';
 import { MenuButton } from './MenuButton';
-import { MenuProps, PrimitiveWithForwardRef } from '../types';
+import { MenuProps, Primitive } from '../types';
 
 export const MENU_TRIGGER_TEST_ID = 'amplify-menu-trigger-test-id';
 export const MENU_ITEMS_GROUP_TEST_ID = 'amplify-menu-items-group-test-id';
 
-const MenuPrimitive: PrimitiveWithForwardRef<MenuProps, 'div'> = (
+const MenuPrimitive: Primitive<MenuProps, 'div'> = (
   {
     menuAlign = 'start',
     children,

--- a/packages/react/src/primitives/Pagination/Pagination.tsx
+++ b/packages/react/src/primitives/Pagination/Pagination.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import { Flex } from '../Flex';
-import { View } from '../View';
-import { usePaginationItems } from './usePaginationItems';
-import { PaginationProps, PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared/constants';
+import { Flex } from '../Flex';
+import { PaginationProps, Primitive } from '../types';
+import { usePaginationItems } from './usePaginationItems';
+import { View } from '../View';
 
-const PaginationPrimitive: PrimitiveWithForwardRef<PaginationProps, 'nav'> = (
+const PaginationPrimitive: Primitive<PaginationProps, 'nav'> = (
   {
     className,
     currentPage,

--- a/packages/react/src/primitives/PasswordField/PasswordField.tsx
+++ b/packages/react/src/primitives/PasswordField/PasswordField.tsx
@@ -2,18 +2,11 @@ import classNames from 'classnames';
 import * as React from 'react';
 
 import { ComponentClassNames } from '../shared/constants';
-import {
-  PasswordFieldProps,
-  PasswordFieldType,
-  PrimitiveWithForwardRef,
-} from '../types';
+import { PasswordFieldProps, PasswordFieldType, Primitive } from '../types';
 import { ShowPasswordButton } from './ShowPasswordButton';
 import { TextField } from '../TextField';
 
-const PasswordFieldPrimitive: PrimitiveWithForwardRef<
-  PasswordFieldProps,
-  'input'
-> = (
+const PasswordFieldPrimitive: Primitive<PasswordFieldProps, 'input'> = (
   {
     autoComplete = 'current-password',
     label,

--- a/packages/react/src/primitives/PasswordField/ShowPasswordButton.tsx
+++ b/packages/react/src/primitives/PasswordField/ShowPasswordButton.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import { Button } from '../Button';
 import { ComponentClassNames } from '../shared/constants';
 import { IconVisibility, IconVisibilityOff } from '../Icon';
+import { Primitive, ShowPasswordButtonProps } from '../types';
 import { SharedText } from '../shared/i18n';
-import { PrimitiveWithForwardRef, ShowPasswordButtonProps } from '../types';
 
 const ariaLabelText = SharedText.ShowPasswordButton.ariaLabel;
 
-const ShowPasswordButtonPrimitive: PrimitiveWithForwardRef<
+const ShowPasswordButtonPrimitive: Primitive<
   ShowPasswordButtonProps,
   typeof Button
 > = ({ fieldType, size, ...rest }, ref) => {

--- a/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
@@ -2,36 +2,34 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { countryDialCodes } from '@aws-amplify/ui';
 
-import { SelectField } from '../SelectField';
 import { ComponentClassNames } from '../shared/constants';
-import { CountryCodeSelectProps, PrimitiveWithForwardRef } from '../types';
+import { CountryCodeSelectProps, Primitive } from '../types';
+import { SelectField } from '../SelectField';
 
-const CountryCodeSelectPrimitive: PrimitiveWithForwardRef<
-  CountryCodeSelectProps,
-  'select'
-> = ({ className, ...props }, ref) => {
-  const countryCodeOptions = React.useMemo(
-    () =>
-      countryDialCodes.map((dialCode) => (
-        <option key={dialCode} value={dialCode}>
-          {dialCode}
-        </option>
-      )),
-    [countryDialCodes]
-  );
+const CountryCodeSelectPrimitive: Primitive<CountryCodeSelectProps, 'select'> =
+  ({ className, ...props }, ref) => {
+    const countryCodeOptions = React.useMemo(
+      () =>
+        countryDialCodes.map((dialCode) => (
+          <option key={dialCode} value={dialCode}>
+            {dialCode}
+          </option>
+        )),
+      [countryDialCodes]
+    );
 
-  return (
-    <SelectField
-      autoComplete="tel-country-code"
-      className={classNames(ComponentClassNames.CountryCodeSelect, className)}
-      labelHidden={true}
-      ref={ref}
-      {...props}
-    >
-      {countryCodeOptions}
-    </SelectField>
-  );
-};
+    return (
+      <SelectField
+        autoComplete="tel-country-code"
+        className={classNames(ComponentClassNames.CountryCodeSelect, className)}
+        labelHidden={true}
+        ref={ref}
+        {...props}
+      >
+        {countryCodeOptions}
+      </SelectField>
+    );
+  };
 
 export const CountryCodeSelect = React.forwardRef(CountryCodeSelectPrimitive);
 

--- a/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
@@ -1,16 +1,13 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import { CountryCodeSelect } from './CountryCodeSelect';
-import { TextField } from '../TextField';
 import { ComponentClassNames } from '../shared/constants';
+import { CountryCodeSelect } from './CountryCodeSelect';
+import { PhoneNumberFieldProps, Primitive } from '../types';
 import { SharedText } from '../shared/i18n';
-import { PhoneNumberFieldProps, PrimitiveWithForwardRef } from '../types';
+import { TextField } from '../TextField';
 
-const PhoneNumberFieldPrimitive: PrimitiveWithForwardRef<
-  PhoneNumberFieldProps,
-  'input'
-> = (
+const PhoneNumberFieldPrimitive: Primitive<PhoneNumberFieldProps, 'input'> = (
   {
     autoComplete = 'tel-national',
     className,

--- a/packages/react/src/primitives/Placeholder/Placeholder.tsx
+++ b/packages/react/src/primitives/Placeholder/Placeholder.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared';
-import { PlaceholderProps, PrimitiveWithForwardRef } from '../types';
+import { PlaceholderProps, Primitive } from '../types';
 import { View } from '../View';
 
-const PlaceholderPrimitive: PrimitiveWithForwardRef<PlaceholderProps, 'div'> = (
+const PlaceholderPrimitive: Primitive<PlaceholderProps, 'div'> = (
   { className, children, isLoaded, size, ...rest },
   ref
 ) => {

--- a/packages/react/src/primitives/Radio/Radio.tsx
+++ b/packages/react/src/primitives/Radio/Radio.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import { ComponentClassNames } from '../shared';
 import { Flex } from '../Flex';
 import { Input } from '../Input';
-import { useRadioGroupContext } from '../RadioGroupField/context';
+import { RadioProps, Primitive } from '../types';
 import { Text } from '../Text';
-import { RadioProps, PrimitiveWithForwardRef } from '../types';
-import { ComponentClassNames } from '../shared';
+import { useRadioGroupContext } from '../RadioGroupField/context';
 
-export const RadioPrimitive: PrimitiveWithForwardRef<RadioProps, 'input'> = (
+export const RadioPrimitive: Primitive<RadioProps, 'input'> = (
   { children, className, id, isDisabled, testId, value, ...rest },
   ref
 ) => {

--- a/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
+++ b/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
@@ -1,20 +1,17 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import { RadioGroupContext, RadioGroupContextType } from './context';
+import { ComponentClassNames } from '../shared/constants';
 import { FieldErrorMessage, FieldDescription } from '../Field';
 import { Flex } from '../Flex';
 import { Label } from '../Label';
-import { RadioGroupFieldProps, PrimitiveWithForwardRef } from '../types';
-import { ComponentClassNames } from '../shared/constants';
+import { RadioGroupContext, RadioGroupContextType } from './context';
+import { RadioGroupFieldProps, Primitive } from '../types';
 import { useStableId } from '../shared/utils';
 
 // Note: RadioGroupField doesn't extend the JSX.IntrinsicElements<'input'> types (instead extending 'typeof Flex')
 // because all rest props are passed to Flex container
-const RadioGroupFieldPrimitive: PrimitiveWithForwardRef<
-  RadioGroupFieldProps,
-  typeof Flex
-> = (
+const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
   {
     children,
     className,

--- a/packages/react/src/primitives/Rating/Rating.tsx
+++ b/packages/react/src/primitives/Rating/Rating.tsx
@@ -2,18 +2,18 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { RatingProps, PrimitiveWithForwardRef } from '../types';
-import { RatingIcon } from './RatingIcon';
-import { RatingMixedIcon } from './RatingMixedIcon';
 import { Flex } from '../Flex';
 import { IconStar } from '../Icon';
-import { VisuallyHidden } from '../VisuallyHidden';
 import { isIconFilled, isIconEmpty, isIconMixed } from './utils';
+import { RatingIcon } from './RatingIcon';
+import { RatingMixedIcon } from './RatingMixedIcon';
+import { RatingProps, Primitive } from '../types';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 const RATING_DEFAULT_MAX_VALUE = 5;
 const RATING_DEFAULT_VALUE = 0;
 
-const RatingPrimitive: PrimitiveWithForwardRef<RatingProps, typeof Flex> = (
+const RatingPrimitive: Primitive<RatingProps, typeof Flex> = (
   {
     className,
     emptyColor,

--- a/packages/react/src/primitives/ScrollView/ScrollView.tsx
+++ b/packages/react/src/primitives/ScrollView/ScrollView.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import { View } from '../View';
-import { PrimitiveWithForwardRef, ScrollViewProps } from '../types';
 import { ComponentClassNames } from '../shared/constants';
+import { Primitive, ScrollViewProps } from '../types';
+import { View } from '../View';
 
-const ScrollViewPrimitive: PrimitiveWithForwardRef<ScrollViewProps, 'div'> = (
+const ScrollViewPrimitive: Primitive<ScrollViewProps, 'div'> = (
   { children, className, orientation, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/SearchField/SearchField.tsx
+++ b/packages/react/src/primitives/SearchField/SearchField.tsx
@@ -2,11 +2,11 @@ import classNames from 'classnames';
 import * as React from 'react';
 
 import { ComponentClassNames } from '../shared/constants';
-import { TextField } from '../TextField';
 import { FieldClearButton } from '../Field';
-import { SearchFieldButton } from './SearchFieldButton';
 import { isFunction, strHasLength } from '../shared/utils';
-import { SearchFieldProps, PrimitiveWithForwardRef } from '../types';
+import { SearchFieldButton } from './SearchFieldButton';
+import { SearchFieldProps, Primitive } from '../types';
+import { TextField } from '../TextField';
 
 const ESCAPE_KEY = 'Escape';
 const ENTER_KEY = 'Enter';
@@ -72,56 +72,56 @@ export const useSearchField = ({
   };
 };
 
-const SearchFieldPrimitive: PrimitiveWithForwardRef<SearchFieldProps, 'input'> =
-  (
-    {
-      autoComplete = 'off',
-      className,
-      labelHidden = true,
-      name = 'q',
-      onSubmit,
-      onClear,
-      searchButtonRef,
-      size,
-      ...rest
-    },
-    ref
-  ) => {
-    const { value, onClearHandler, onInput, onKeyDown, onClick } =
-      useSearchField({ onSubmit, onClear });
+const SearchFieldPrimitive: Primitive<SearchFieldProps, 'input'> = (
+  {
+    autoComplete = 'off',
+    className,
+    labelHidden = true,
+    name = 'q',
+    onSubmit,
+    onClear,
+    searchButtonRef,
+    size,
+    ...rest
+  },
+  ref
+) => {
+  const { value, onClearHandler, onInput, onKeyDown, onClick } = useSearchField(
+    { onSubmit, onClear }
+  );
 
-    return (
-      <TextField
-        autoComplete={autoComplete}
-        className={classNames(ComponentClassNames.SearchField, className)}
-        labelHidden={labelHidden}
-        innerEndComponent={
-          <FieldClearButton
-            excludeFromTabOrder={true}
-            isVisible={strHasLength(value)}
-            onClick={onClearHandler}
-            size={size}
-            variation="link"
-          />
-        }
-        isMultiline={false}
-        name={name}
-        onInput={onInput}
-        onKeyDown={onKeyDown}
-        outerEndComponent={
-          <SearchFieldButton
-            onClick={onClick}
-            ref={searchButtonRef}
-            size={size}
-          />
-        }
-        ref={ref}
-        size={size}
-        value={value}
-        {...rest}
-      />
-    );
-  };
+  return (
+    <TextField
+      autoComplete={autoComplete}
+      className={classNames(ComponentClassNames.SearchField, className)}
+      labelHidden={labelHidden}
+      innerEndComponent={
+        <FieldClearButton
+          excludeFromTabOrder={true}
+          isVisible={strHasLength(value)}
+          onClick={onClearHandler}
+          size={size}
+          variation="link"
+        />
+      }
+      isMultiline={false}
+      name={name}
+      onInput={onInput}
+      onKeyDown={onKeyDown}
+      outerEndComponent={
+        <SearchFieldButton
+          onClick={onClick}
+          ref={searchButtonRef}
+          size={size}
+        />
+      }
+      ref={ref}
+      size={size}
+      value={value}
+      {...rest}
+    />
+  );
+};
 
 export const SearchField = React.forwardRef(SearchFieldPrimitive);
 

--- a/packages/react/src/primitives/SearchField/SearchFieldButton.tsx
+++ b/packages/react/src/primitives/SearchField/SearchFieldButton.tsx
@@ -3,27 +3,25 @@ import * as React from 'react';
 import { ComponentClassNames } from '../shared/constants';
 import { FieldGroupIconButton } from '../FieldGroupIcon';
 import { IconSearch } from '../Icon';
-import { PrimitiveWithForwardRef, SearchFieldButtonProps } from '../types';
+import { Primitive, SearchFieldButtonProps } from '../types';
 import { SharedText } from '../shared/i18n';
 
 const ariaLabelText = SharedText.SearchField.ariaLabel.search;
 
-const SearchFieldButtonPrimitive: PrimitiveWithForwardRef<
-  SearchFieldButtonProps,
-  'button'
-> = (props, ref) => {
-  return (
-    <FieldGroupIconButton
-      ariaLabel={ariaLabelText}
-      className={ComponentClassNames.SearchFieldSearch}
-      ref={ref}
-      type="submit"
-      {...props}
-    >
-      <IconSearch size={props.size} />
-    </FieldGroupIconButton>
-  );
-};
+const SearchFieldButtonPrimitive: Primitive<SearchFieldButtonProps, 'button'> =
+  (props, ref) => {
+    return (
+      <FieldGroupIconButton
+        ariaLabel={ariaLabelText}
+        className={ComponentClassNames.SearchFieldSearch}
+        ref={ref}
+        type="submit"
+        {...props}
+      >
+        <IconSearch size={props.size} />
+      </FieldGroupIconButton>
+    );
+  };
 
 export const SearchFieldButton = React.forwardRef(SearchFieldButtonPrimitive);
 

--- a/packages/react/src/primitives/Select/Select.tsx
+++ b/packages/react/src/primitives/Select/Select.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import { Flex } from '../Flex';
-import { View } from '../View';
-import { IconExpandMore } from '../Icon';
-import { SelectProps } from '../types/select';
-import { PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared/constants';
+import { Flex } from '../Flex';
+import { IconExpandMore } from '../Icon';
+import { Primitive } from '../types';
+import { SelectProps } from '../types/select';
+import { View } from '../View';
 
-const SelectPrimitive: PrimitiveWithForwardRef<SelectProps, 'select'> = (
+const SelectPrimitive: Primitive<SelectProps, 'select'> = (
   {
     autoComplete,
     className,

--- a/packages/react/src/primitives/SelectField/SelectField.tsx
+++ b/packages/react/src/primitives/SelectField/SelectField.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import { ComponentClassNames } from '../shared/constants';
 import { FieldErrorMessage, FieldDescription } from '../Field';
 import { Flex } from '../Flex';
-import { Select } from '../Select';
 import { Label } from '../Label';
-import { ComponentClassNames } from '../shared/constants';
+import { Select } from '../Select';
+import { SelectFieldProps, Primitive } from '../types';
 import { splitPrimitiveProps } from '../shared/styleUtils';
 import { useStableId } from '../shared/utils';
-import { SelectFieldProps, PrimitiveWithForwardRef } from '../types';
 
-const SelectFieldPrimitive: PrimitiveWithForwardRef<
-  SelectFieldProps,
-  'select'
-> = (props, ref) => {
+const SelectFieldPrimitive: Primitive<SelectFieldProps, 'select'> = (
+  props,
+  ref
+) => {
   const {
     children,
     className,

--- a/packages/react/src/primitives/SliderField/SliderField.tsx
+++ b/packages/react/src/primitives/SliderField/SliderField.tsx
@@ -2,26 +2,23 @@ import classNames from 'classnames';
 import { Range, Root, Thumb, Track } from '@radix-ui/react-slider';
 import * as React from 'react';
 
+import { ComponentClassNames } from '../shared/constants';
 import { FieldDescription, FieldErrorMessage } from '../Field';
 import { FieldGroup } from '../FieldGroup';
 import { Flex } from '../Flex';
-import { Label } from '../Label';
-import { View } from '../View';
-import { SliderFieldProps } from '../types/sliderField';
-import { PrimitiveWithForwardRef } from '../types/view';
-import { ComponentClassNames } from '../shared/constants';
-import { splitPrimitiveProps } from '../shared/styleUtils';
 import { isFunction, useStableId } from '../shared/utils';
+import { Label } from '../Label';
+import { Primitive } from '../types/view';
+import { SliderFieldProps } from '../types/sliderField';
+import { splitPrimitiveProps } from '../shared/styleUtils';
+import { View } from '../View';
 
 export const SLIDER_LABEL_TEST_ID = 'slider-label';
 export const SLIDER_ROOT_TEST_ID = 'slider-root';
 export const SLIDER_TRACK_TEST_ID = 'slider-track';
 export const SLIDER_RANGE_TEST_ID = 'slider-range';
 
-const SliderFieldPrimitive: PrimitiveWithForwardRef<
-  SliderFieldProps,
-  typeof Root
-> = (
+const SliderFieldPrimitive: Primitive<SliderFieldProps, typeof Root> = (
   {
     ariaValuetext,
     className,

--- a/packages/react/src/primitives/StepperField/StepperField.tsx
+++ b/packages/react/src/primitives/StepperField/StepperField.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import { useStepper } from './useStepper';
+import { ComponentClassNames } from '../shared/constants';
 import { FieldDescription, FieldErrorMessage } from '../Field';
 import { FieldGroup } from '../FieldGroup';
 import { FieldGroupIconButton } from '../FieldGroupIcon';
@@ -9,20 +9,20 @@ import { Flex } from '../Flex';
 import { IconAdd, IconRemove } from '../Icon';
 import { Input } from '../Input';
 import { Label } from '../Label';
-import { StepperFieldProps } from '../types/stepperField';
-import { ComponentClassNames } from '../shared/constants';
+import { Primitive } from '../types/view';
 import { SharedText } from '../shared/i18n';
-import { useStableId } from '../shared/utils';
-import { PrimitiveWithForwardRef } from '../types/view';
 import { splitPrimitiveProps } from '../shared/styleUtils';
+import { StepperFieldProps } from '../types/stepperField';
+import { useStableId } from '../shared/utils';
+import { useStepper } from './useStepper';
 
 export const DECREASE_ICON = 'decrease-icon';
 export const INCREASE_ICON = 'increase-icon';
 
-const StepperFieldPrimitive: PrimitiveWithForwardRef<
-  StepperFieldProps,
-  'input'
-> = (props, ref) => {
+const StepperFieldPrimitive: Primitive<StepperFieldProps, 'input'> = (
+  props,
+  ref
+) => {
   const {
     className,
     descriptiveText,

--- a/packages/react/src/primitives/SwitchField/SwitchField.tsx
+++ b/packages/react/src/primitives/SwitchField/SwitchField.tsx
@@ -5,16 +5,13 @@ import { ComponentClassNames } from '../shared/constants';
 import { Flex } from '../Flex';
 import { Input } from '../Input';
 import { Label } from '../Label';
-import { PrimitiveWithForwardRef, SwitchFieldProps } from '../types';
+import { Primitive, SwitchFieldProps } from '../types';
 import { useStableId } from '../shared/utils';
 import { useSwitch } from './useSwitch';
 import { View } from '../View';
 import { VisuallyHidden } from '../VisuallyHidden';
 
-const SwitchFieldPrimitive: PrimitiveWithForwardRef<
-  SwitchFieldProps,
-  typeof Flex
-> = (
+const SwitchFieldPrimitive: Primitive<SwitchFieldProps, typeof Flex> = (
   {
     className,
     defaultChecked,

--- a/packages/react/src/primitives/Table/Table.tsx
+++ b/packages/react/src/primitives/Table/Table.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { PrimitiveWithForwardRef, TableProps } from '../types';
+import { Primitive, TableProps } from '../types';
 import { View } from '../View';
 
-const TablePrimitive: PrimitiveWithForwardRef<TableProps, 'table'> = (
+const TablePrimitive: Primitive<TableProps, 'table'> = (
   {
     caption,
     children,

--- a/packages/react/src/primitives/Table/TableBody.tsx
+++ b/packages/react/src/primitives/Table/TableBody.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { PrimitiveWithForwardRef, TableBodyProps } from '../types';
+import { Primitive, TableBodyProps } from '../types';
 import { View } from '../View';
 
-const TableBodyPrimitive: PrimitiveWithForwardRef<TableBodyProps, 'tbody'> = (
+const TableBodyPrimitive: Primitive<TableBodyProps, 'tbody'> = (
   { children, className, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Table/TableCell.tsx
+++ b/packages/react/src/primitives/Table/TableCell.tsx
@@ -2,17 +2,13 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import {
-  PrimitiveWithForwardRef,
-  TableCellElement,
-  TableCellProps,
-} from '../types';
+import { Primitive, TableCellElement, TableCellProps } from '../types';
 import { View } from '../View';
 
-const TableCellPrimitive: PrimitiveWithForwardRef<
-  TableCellProps,
-  TableCellElement
-> = ({ as: asElementTag = 'td', children, className, ...rest }, ref) => (
+const TableCellPrimitive: Primitive<TableCellProps, TableCellElement> = (
+  { as: asElementTag = 'td', children, className, ...rest },
+  ref
+) => (
   <View
     as={asElementTag}
     className={classNames(

--- a/packages/react/src/primitives/Table/TableFoot.tsx
+++ b/packages/react/src/primitives/Table/TableFoot.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { PrimitiveWithForwardRef, TableFootProps } from '../types';
+import { Primitive, TableFootProps } from '../types';
 import { View } from '../View';
 
-const TableFootPrimitive: PrimitiveWithForwardRef<TableFootProps, 'tfoot'> = (
+const TableFootPrimitive: Primitive<TableFootProps, 'tfoot'> = (
   { children, className, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Table/TableHead.tsx
+++ b/packages/react/src/primitives/Table/TableHead.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { PrimitiveWithForwardRef, TableHeadProps } from '../types';
+import { Primitive, TableHeadProps } from '../types';
 import { View } from '../View';
 
-const TableHeadPrimitive: PrimitiveWithForwardRef<TableHeadProps, 'thead'> = (
+const TableHeadPrimitive: Primitive<TableHeadProps, 'thead'> = (
   { children, className, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Table/TableRow.tsx
+++ b/packages/react/src/primitives/Table/TableRow.tsx
@@ -2,10 +2,10 @@ import classNames from 'classnames';
 import * as React from 'react';
 
 import { ComponentClassNames } from '../shared/constants';
-import { PrimitiveWithForwardRef, TableRowProps } from '../types';
+import { Primitive, TableRowProps } from '../types';
 import { View } from '../View';
 
-const TableRowPrimitive: PrimitiveWithForwardRef<TableRowProps, 'tr'> = (
+const TableRowPrimitive: Primitive<TableRowProps, 'tr'> = (
   { children, className, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Tabs/Tabs.tsx
+++ b/packages/react/src/primitives/Tabs/Tabs.tsx
@@ -7,10 +7,10 @@ import {
 } from '@radix-ui/react-tabs';
 import * as React from 'react';
 
-import { Flex } from '../Flex';
-import { View } from '../View';
-import { TabsProps, TabItemProps, PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared/constants';
+import { Flex } from '../Flex';
+import { TabsProps, TabItemProps, Primitive } from '../types';
+import { View } from '../View';
 
 const isTabsType = (child: any): child is React.Component<TabItemProps> => {
   return (
@@ -21,7 +21,7 @@ const isTabsType = (child: any): child is React.Component<TabItemProps> => {
   );
 };
 
-const TabsPrimitive: PrimitiveWithForwardRef<TabsProps, typeof Flex> = (
+const TabsPrimitive: Primitive<TabsProps, typeof Flex> = (
   {
     ariaLabel,
     children,
@@ -86,7 +86,7 @@ const TabsPrimitive: PrimitiveWithForwardRef<TabsProps, typeof Flex> = (
   );
 };
 
-const TabItemPrimitive: PrimitiveWithForwardRef<TabItemProps, 'div'> = (
+const TabItemPrimitive: Primitive<TabItemProps, 'div'> = (
   { className, title, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/Text/Text.tsx
+++ b/packages/react/src/primitives/Text/Text.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { TextProps, PrimitiveWithForwardRef } from '../types';
+import { TextProps, Primitive } from '../types';
 import { View } from '../View';
 
-const TextPrimitive: PrimitiveWithForwardRef<TextProps, 'p'> = (
+const TextPrimitive: Primitive<TextProps, 'p'> = (
   { as = 'p', className, children, isTruncated, variation, ...rest },
   ref
 ) => (

--- a/packages/react/src/primitives/TextArea/TextArea.tsx
+++ b/packages/react/src/primitives/TextArea/TextArea.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared';
-import { PrimitiveWithForwardRef } from '../types/view';
+import { Primitive } from '../types/view';
 import { TextAreaProps } from '../types/textArea';
 import { View } from '../View';
 
-const TextAreaPrimitive: PrimitiveWithForwardRef<TextAreaProps, 'textarea'> = (
+const TextAreaPrimitive: Primitive<TextAreaProps, 'textarea'> = (
   {
     className,
     isReadOnly,

--- a/packages/react/src/primitives/ToggleButton/ToggleButton.tsx
+++ b/packages/react/src/primitives/ToggleButton/ToggleButton.tsx
@@ -1,15 +1,12 @@
 import classNames from 'classnames';
 import * as React from 'react';
 
-import { useToggleButton } from './useToggleButton';
 import { Button } from '../Button';
-import { ToggleButtonProps, PrimitiveWithForwardRef } from '../types';
 import { ComponentClassNames } from '../shared/constants';
+import { ToggleButtonProps, Primitive } from '../types';
+import { useToggleButton } from './useToggleButton';
 
-const ToggleButtonPrimitive: PrimitiveWithForwardRef<
-  ToggleButtonProps,
-  typeof Button
-> = (
+const ToggleButtonPrimitive: Primitive<ToggleButtonProps, typeof Button> = (
   {
     className,
     children,

--- a/packages/react/src/primitives/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react/src/primitives/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,16 +1,12 @@
 import classNames from 'classnames';
 import * as React from 'react';
 
-import { useToggleButtonGroup } from './useToggleButtonGroup';
-import { Flex } from '../Flex';
 import { ComponentClassNames } from '../shared/constants';
-import {
-  PrimitiveWithForwardRef,
-  ToggleButtonProps,
-  ToggleButtonGroupProps,
-} from '../types';
+import { Flex } from '../Flex';
+import { Primitive, ToggleButtonProps, ToggleButtonGroupProps } from '../types';
+import { useToggleButtonGroup } from './useToggleButtonGroup';
 
-const ToggleButtonGroupPrimitive: PrimitiveWithForwardRef<
+const ToggleButtonGroupPrimitive: Primitive<
   ToggleButtonGroupProps,
   typeof Flex
 > = (

--- a/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { PrimitiveWithForwardRef, VisuallyHiddenProps } from '../types';
+import { Primitive, VisuallyHiddenProps } from '../types';
 import { View } from '../View';
 
-const VisuallyHiddenPrimitive: PrimitiveWithForwardRef<
-  VisuallyHiddenProps,
-  'span'
-> = ({ as = 'span', children, className, ...rest }, ref) => (
+const VisuallyHiddenPrimitive: Primitive<VisuallyHiddenProps, 'span'> = (
+  { as = 'span', children, className, ...rest },
+  ref
+) => (
   <View
     as={as}
     className={classNames(ComponentClassNames.VisuallyHidden, className)}

--- a/packages/react/src/primitives/types/view.ts
+++ b/packages/react/src/primitives/types/view.ts
@@ -54,11 +54,6 @@ export type PrimitivePropsWithRef<
 export type Primitive<
   Props extends ViewProps,
   Element extends ElementType
-> = React.FC<PrimitiveProps<Props, Element>>;
-
-export type PrimitiveWithForwardRef<
-  Props extends ViewProps,
-  Element extends ElementType
 > = React.ForwardRefRenderFunction<
   HTMLElementType<Element>,
   PrimitivePropsWithRef<Props, Element>


### PR DESCRIPTION
*Description of changes:*
Now that we've add ForwardRef support for all our primitives, we can rename the type from `PrimitiveWithForwardRef` to simply `Primitive`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
