### PR TITLE
Add Vite troubleshooting docs for missing node var

### DIFF
--- a/docs/src/pages/getting-started/installation/troubleshooting.react.mdx
+++ b/docs/src/pages/getting-started/installation/troubleshooting.react.mdx
@@ -43,13 +43,3 @@ export default defineConfig({
     "skipLibCheck": true,
 ...
 ```
-
-**4.** Update the `package.json` file and add `@aws-amplify/ui` to `resolutions`:
-
-```js
-...
-  "resolutions": {
-    "@aws-amplify/ui": "^3.0.0"
-  },
-...
-```

--- a/docs/src/pages/getting-started/installation/troubleshooting.react.mdx
+++ b/docs/src/pages/getting-started/installation/troubleshooting.react.mdx
@@ -9,8 +9,11 @@ When working with a [Vite](https://vitejs.dev) project you must make a few modif
 ```html
 ...
   <script>
-        window.global = window;
-        var exports = {};
+    window.global = window;
+    window.process = {
+      env: { DEBUG: undefined },
+    };
+    var exports = {};
   </script>
 </body>
 ```
@@ -38,5 +41,15 @@ export default defineConfig({
 ...
   "compilerOptions": {
     "skipLibCheck": true,
+...
+```
+
+**4.** Update the `package.json` file and add `@aws-amplify/ui` to `resolutions`:
+
+```js
+...
+  "resolutions": {
+    "@aws-amplify/ui": "^3.0.0"
+  },
 ...
 ```


### PR DESCRIPTION
*Description of changes:*
This PR adds more troubleshooting docs for using ui-react with Vite. In particular it solves the following errors:

1. `process is not defined`

This error message is caused because, unlike Webpack, Vite doesn't shim the NodeJS `process`. The solution is to add a shim for it as detailed [here](https://docs.amplify.aws/start/getting-started/setup/q/integration/angular/#angular-6-support).



*REMOVED: as this solution only worked for `yarn` and not `npm`*

2. `[vite] Internal server error: Failed to find '@aws-amplify/ui/styles.css'`-

This is caused by our peer dependency on `aws-amplify`, which has a dependency on `@aws-amplify/ui@v2`. The older version of  `@aws-amplify/ui` doesn't have the browser aliases which redirect `'@aws-amplify/ui/styles.css'` => `'@aws-amplify/ui/dist/index.css'`. The workaround here is for Vite users to pin the ui version to 3.x. Long term solution should be to remove the dependency on `@aws-amplify/ui@v2` from `aws-amplify`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
