### PR TITLE
Docs: update sandpack to not autorun on homepage

### DIFF
--- a/docs/src/pages/index.page.tsx
+++ b/docs/src/pages/index.page.tsx
@@ -208,6 +208,7 @@ const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
             }}
             theme={sandPackTheme}
             options={{
+              autorun: false,
               editorHeight: 500,
               showNavigator: true, // this will show a top navigator bar instead of the refresh button
               showTabs: true, // you can toggle the tabs on/off manually


### PR DESCRIPTION
*Description of changes:*
This PR fixes an issue where Firefox locks up on homepage when running the demo (sandpack). The fix is to disable `autorun` so that it only runs when clicking `run`. This is a stopgap measure, as clicking `run` in Firefox will still lock up the browser, so a follow up fix is needed for a complete solution. However, this will make the homepage useable in Firefox.

_Before in Firefox (Initial page load):_

![2021-12-01 12 56 27](https://user-images.githubusercontent.com/6165315/144317098-2a1160df-70a1-491d-876f-e88295e32212.gif)

_After in Firefox (Initial page load):_

![2021-12-01 13 27 18](https://user-images.githubusercontent.com/6165315/144317177-0fa78d4b-5c31-459f-91e3-943ed5382c17.gif)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
