### PR TITLE
Add custom translatable error messages from Cognito

### DIFF
--- a/.changeset/quiet-carpets-swim.md
+++ b/.changeset/quiet-carpets-swim.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/ui-angular': patch
+'@aws-amplify/ui-react': patch
+'@aws-amplify/ui-vue': patch
+---
+
+Added a way for users to add in custom translations for error messages returned from cognito.

--- a/examples/angular/src/pages/ui/components/authenticator/i18n/aws-exports.js
+++ b/examples/angular/src/pages/ui/components/authenticator/i18n/aws-exports.js
@@ -1,2 +1,2 @@
-import awsExports from '@environments/auth-with-email/src/aws-exports';
+import awsExports from '@environments/auth-with-username-no-attributes/src/aws-exports';
 export default awsExports;

--- a/examples/angular/src/pages/ui/components/authenticator/i18n/i18n.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/i18n/i18n.component.ts
@@ -14,7 +14,10 @@ export class I18nComponent implements OnInit {
   ngOnInit() {
     I18n.putVocabularies(translations);
     I18n.setLanguage('ja');
-    I18n.putVocabulariesForLanguage('ja', { 'Sign In': 'Sign In Custom' });
+    I18n.putVocabulariesForLanguage('ja', {
+      'Sign In': 'Sign In Custom',
+      'User does not exist.': 'Error with your user',
+    });
   }
 
   ngOnDestroy() {

--- a/examples/next/pages/ui/components/authenticator/i18n/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/i18n/index.page.tsx
@@ -9,7 +9,10 @@ Amplify.configure(awsExports);
 
 I18n.putVocabularies(translations);
 I18n.setLanguage('ja');
-I18n.putVocabulariesForLanguage('ja', { 'Sign In': 'Sign In Custom' });
+I18n.putVocabulariesForLanguage('ja', {
+  'Sign In': 'Sign In Custom',
+  'User does not exist.': 'Error with your user',
+});
 
 function App({ signOut, user }) {
   return (

--- a/examples/vue/src/pages/ui/components/authenticator/i18n/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/i18n/index.vue
@@ -7,7 +7,10 @@ import aws_exports from './aws-exports';
 
 I18n.putVocabularies(translations);
 I18n.setLanguage('ja');
-I18n.putVocabulariesForLanguage('ja', { 'Sign In': 'Sign In Custom' });
+I18n.putVocabulariesForLanguage('ja', {
+  'Sign In': 'Sign In Custom',
+  'User does not exist.': 'Error with your user',
+});
 
 Amplify.configure(aws_exports);
 </script>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.ts
@@ -62,7 +62,7 @@ export class FormFieldComponent implements OnInit {
       this.authenticator.authState
     );
     const { validationError } = formContext;
-    return validationError[this.name];
+    return translate(validationError[this.name]);
   }
 
   public onBlur($event: Event) {

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
@@ -13,6 +13,7 @@ import {
 } from '@aws-amplify/ui';
 import { Event, interpret, Subscription } from 'xstate';
 import { AuthSubscriptionCallback } from '../common';
+import { translate } from '@aws-amplify/ui';
 
 const logger = new Logger('state-machine');
 
@@ -66,7 +67,7 @@ export class AuthenticatorService implements OnDestroy {
    */
 
   public get error() {
-    return this._facade?.error;
+    return translate(this._facade?.error);
   }
 
   public get hasValidationErrors() {

--- a/packages/e2e/cypress/integration/ui/components/authenticator/i18n/i18n.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/i18n/i18n.steps.ts
@@ -27,6 +27,24 @@ And('the {string} input is in {string}', (label: string, language: string) => {
   cy.findByPlaceholderText(translations[language][label].trim());
 });
 
+And(
+  'the {string} input is in {string} and I type the wrong username or password',
+  (label: string, language: string) => {
+    cy.findByPlaceholderText(translations[language][label].trim()).type(
+      'UNKNOWN@UNKNOWN.com'
+    );
+  }
+);
+
+And(
+  'the {string} button is in {string} and I click it',
+  (label: string, language: string) => {
+    cy.findByRole('button', {
+      name: translations[language][label].trim(),
+    }).click();
+  }
+);
+
 And('the {string} button is in {string}', (label: string, language: string) => {
   cy.findByRole('button', {
     name: translations[language][label].trim(),

--- a/packages/e2e/features/ui/components/authenticator/i18n.feature
+++ b/packages/e2e/features/ui/components/authenticator/i18n.feature
@@ -12,6 +12,15 @@ Feature: Internationalization (I18n)
     And the "Confirm Password" input is in "ja"
     And the "Create Account" button is in "ja"
 
+
+  @angular @react @vue
+  Scenario: Show custom error message when signing in
+    When I click "Sign In Custom"
+    And the "Username" input is in "ja" and I type the wrong username or password 
+    And the "Password" input is in "ja" and I type the wrong username or password
+    And the "Sign in" button is in "ja" and I click it
+    Then I see "Error with your user"
+
 @angular @react @vue
   Scenario: Authenticator reflects updated vocabularies for `I18n.setLanguage('ja')`
     Then I see "Sign In Custom"

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -76,7 +76,7 @@ export const ForceNewPassword = (): JSX.Element => {
 
           {!!validationError['confirm_password'] && (
             <Text role="alert" variation="error">
-              {validationError['confirm_password']}
+              {translate(validationError['confirm_password'])}
             </Text>
           )}
         </Flex>

--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -83,7 +83,7 @@ export const ConfirmResetPassword = (): JSX.Element => {
 
           {!!validationError['confirm_password'] && (
             <Text role="alert" variation="error">
-              {validationError['confirm_password']}
+              {translate(validationError['confirm_password'])}
             </Text>
           )}
         </Flex>

--- a/packages/react/src/components/Authenticator/SignUp/FormFields.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/FormFields.tsx
@@ -61,7 +61,7 @@ export function FormFields() {
 
       {validationError['confirm_password'] && (
         <Text role="alert" variation="error">
-          {validationError['confirm_password']}
+          {translate(validationError['confirm_password'])}
         </Text>
       )}
 

--- a/packages/react/src/components/Authenticator/shared/RemoteErrorMessage.tsx
+++ b/packages/react/src/components/Authenticator/shared/RemoteErrorMessage.tsx
@@ -1,5 +1,6 @@
 import { useAuthenticator } from '..';
 import { Alert } from '../../..';
+import { translate } from '@aws-amplify/ui';
 
 export const RemoteErrorMessage = (): JSX.Element => {
   const { error } = useAuthenticator();
@@ -8,7 +9,7 @@ export const RemoteErrorMessage = (): JSX.Element => {
     <>
       {error ? (
         <Alert variation="error" isDismissible={true}>
-          {error}
+          {translate(error)}
         </Alert>
       ) : null}
     </>

--- a/packages/vue/src/components/authenticator-sign-up-form-fields.vue
+++ b/packages/vue/src/components/authenticator-sign-up-form-fields.vue
@@ -94,7 +94,7 @@ const loginMechanism = fieldNames.shift() as LoginMechanism;
     class="amplify-text"
     v-if="!!validationErrors.confirm_password"
   >
-    {{ validationErrors.confirm_password }}
+    {{ translate(validationErrors.confirm_password) }}
   </p>
 
   <template v-for="(field, idx) in fieldNames" :key="idx">

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -174,6 +174,7 @@ const onConfirmVerifyUserSubmitI = (e: Event) => {
 };
 
 // watchers
+
 /**
  * Update service facade when context updates
  */

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -174,7 +174,6 @@ const onConfirmVerifyUserSubmitI = (e: Event) => {
 };
 
 // watchers
-
 /**
  * Update service facade when context updates
  */

--- a/packages/vue/src/components/confirm-reset-password.vue
+++ b/packages/vue/src/components/confirm-reset-password.vue
@@ -170,10 +170,10 @@ function onBlur(e: Event) {
               class="amplify-text"
               v-if="!!(actorContext.validationError as ValidationError)['confirm_password']"
             >
-              {{ (actorContext.validationError as ValidationError)['confirm_password'] }}
+              {{ translate(actorContext.validationError?.confirm_password as string) }}
             </base-box>
             <base-alert v-if="actorState?.context?.remoteError">
-              {{ actorState?.context?.remoteError }}
+              {{ translate(actorState?.context?.remoteError) }}
             </base-alert>
             <amplify-button
               class="amplify-field-group__control"

--- a/packages/vue/src/components/confirm-sign-in.vue
+++ b/packages/vue/src/components/confirm-sign-in.vue
@@ -43,7 +43,7 @@
           </base-wrapper>
           <base-footer class="amplify-flex" style="flex-direction: column">
             <base-alert v-if="actorState?.context?.remoteError">
-              {{ actorState?.context?.remoteError }}
+              {{ translate(actorState?.context?.remoteError) }}
             </base-alert>
             <amplify-button
               class="amplify-field-group__control"

--- a/packages/vue/src/components/confirm-sign-up.vue
+++ b/packages/vue/src/components/confirm-sign-up.vue
@@ -110,7 +110,7 @@ const onLostCodeClicked = (): void => {
             style="flex-direction: column; align-items: unset"
           >
             <base-alert v-if="error">
-              {{ error }}
+              {{ translate(error) }}
             </base-alert>
             <amplify-button
               class="amplify-field-group__control"

--- a/packages/vue/src/components/confirm-verify-user.vue
+++ b/packages/vue/src/components/confirm-verify-user.vue
@@ -39,7 +39,7 @@
 
           <base-footer class="amplify-flex" style="flex-direction: column">
             <base-alert v-if="actorState?.context?.remoteError">
-              {{ actorState?.context.remoteError }}
+              {{ translate(actorState?.context.remoteError) }}
             </base-alert>
             <amplify-button
               class="amplify-field-group__control"

--- a/packages/vue/src/components/force-new-password.vue
+++ b/packages/vue/src/components/force-new-password.vue
@@ -148,10 +148,10 @@ function onBlur(e: Event) {
               class="amplify-text"
               v-if="!!(actorContext.validationError as ValidationError)['confirm_password']"
             >
-              {{ (actorContext.validationError as ValidationError)['confirm_password'] }}
+              {{ translate((actorContext.validationError as ValidationError)['confirm_password']) }}
             </base-box>
             <base-alert data-ui-error v-if="actorState.context.remoteError">
-              {{ actorState.context.remoteError }}
+              {{ translate(actorState.context.remoteError) }}
             </base-alert>
             <amplify-button
               class="amplify-field-group__control"

--- a/packages/vue/src/components/reset-password.vue
+++ b/packages/vue/src/components/reset-password.vue
@@ -105,7 +105,7 @@ const onBackToSignInClicked = (): void => {
           style="flex-direction: column; align-items: unset"
         >
           <base-alert v-if="error">
-            {{ error }}
+            {{ translate(error) }}
           </base-alert>
           <amplify-button
             class="amplify-field-group__control"

--- a/packages/vue/src/components/setup-totp.vue
+++ b/packages/vue/src/components/setup-totp.vue
@@ -56,7 +56,7 @@
               </base-wrapper>
               <base-footer class="amplify-flex" style="flex-direction: column">
                 <base-alert v-if="actorState.context?.remoteError">
-                  {{ actorState.context.remoteError }}
+                  {{ translate(actorState.context.remoteError) }}
                 </base-alert>
                 <amplify-button
                   class="amplify-field-group__control"

--- a/packages/vue/src/components/sign-in.vue
+++ b/packages/vue/src/components/sign-in.vue
@@ -118,7 +118,7 @@ const onForgotPasswordClicked = (): void => {
             </base-wrapper>
           </base-field-set>
           <base-alert v-if="actorState.context.remoteError">
-            {{ actorState.context.remoteError }}
+            {{ translate(actorState.context.remoteError) }}
           </base-alert>
 
           <amplify-button

--- a/packages/vue/src/components/sign-up.vue
+++ b/packages/vue/src/components/sign-up.vue
@@ -59,7 +59,7 @@ const submit = (): void => {
             <authenticator-sign-up-form-fields />
           </base-field-set>
           <base-alert v-if="error">
-            {{ error }}
+            {{ translate(error) }}
           </base-alert>
           <amplify-button
             class="amplify-field-group__control"

--- a/packages/vue/src/components/verify-user.vue
+++ b/packages/vue/src/components/verify-user.vue
@@ -58,7 +58,7 @@
           </base-wrapper>
           <base-footer class="amplify-flex" style="flex-direction: column">
             <base-alert v-if="actorState?.context?.remoteError">
-              {{ actorState?.context.remoteError }}
+              {{ translate(actorState?.context.remoteError) }}
             </base-alert>
             <amplify-button
               class="amplify-field-group__control"


### PR DESCRIPTION
*Issue #, if available:*
#255 

*Description of changes:*
This fix will allow users to overwrite any error or validation error message in the application. For example a user can overwrite the error message when a user does not exist when logging in.

```
I18n.putVocabularies(translations);
    I18n.setLanguage('ja');
    I18n.putVocabulariesForLanguage('ja', {
      'Sign In': 'Sign In Custom',
      'User does not exist.': 'Error with your user',
    });
```
![image](https://user-images.githubusercontent.com/65630/144939485-7597652d-6ff9-4ec0-9548-ebc7caef462e.png)

You can see an example of this in our `i18n` feature test. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
