### PR TITLE
Docs: constrain homepage content width on larger screens

### DIFF
--- a/docs/src/pages/index.page.tsx
+++ b/docs/src/pages/index.page.tsx
@@ -138,7 +138,7 @@ const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
   };
   return (
     <>
-      <View as="section" className="docs-home-section-bg">
+      <View as="section" className="docs-home-section-bg container">
         <HomeLogo />
         <Image
           alt=""
@@ -199,34 +199,36 @@ const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
         <Heading level={2} textAlign="center" margin={tokens.space.xl}>
           Take it for a test drive
         </Heading>
-        <Card style={{ width: '100%', padding: 0 }} variation="outlined">
-          <Sandpack
-            template="react"
-            files={{
-              '/App.js': { code: code, active: true },
-              '/theme.js': { code: themeCode },
-            }}
-            theme={sandPackTheme}
-            options={{
-              autorun: false,
-              editorHeight: 500,
-              showNavigator: true, // this will show a top navigator bar instead of the refresh button
-              showTabs: true, // you can toggle the tabs on/off manually
-              showLineNumbers: true, // this is off by default, but you can show line numbers for the editor
-              wrapContent: true, // also off by default, this wraps the code instead of creating horizontal overflow
-            }}
-            customSetup={{
-              dependencies: {
-                '@aws-amplify/ui-react': 'next',
-                'aws-amplify': 'latest',
-              },
-              entry: '/index.js',
-            }}
-          />
-        </Card>
+        <View className="container">
+          <Card style={{ width: '100%', padding: 0 }} variation="outlined">
+            <Sandpack
+              template="react"
+              files={{
+                '/App.js': { code: code, active: true },
+                '/theme.js': { code: themeCode },
+              }}
+              theme={sandPackTheme}
+              options={{
+                autorun: false,
+                editorHeight: 500,
+                showNavigator: true, // this will show a top navigator bar instead of the refresh button
+                showTabs: true, // you can toggle the tabs on/off manually
+                showLineNumbers: true, // this is off by default, but you can show line numbers for the editor
+                wrapContent: true, // also off by default, this wraps the code instead of creating horizontal overflow
+              }}
+              customSetup={{
+                dependencies: {
+                  '@aws-amplify/ui-react': 'next',
+                  'aws-amplify': 'latest',
+                },
+                entry: '/index.js',
+              }}
+            />
+          </Card>
+        </View>
       </View>
 
-      <View as="section" className="docs-home-section">
+      <View as="section" className="docs-home-section container">
         <Flex
           direction={{
             base: 'column-reverse',
@@ -258,6 +260,7 @@ const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
         backgroundColor={tokens.colors.background.secondary}
       >
         <Flex
+          className="container"
           direction={{
             base: 'column',
             large: 'row',
@@ -316,10 +319,12 @@ const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
 
       <View as="section" className="docs-home-section">
         <Flex
+          className="container"
           direction={{
             base: 'column',
             large: 'row',
           }}
+          gap={tokens.space.xxl}
         >
           <View maxWidth="100%" overflow="hidden">
             <HomePrimitivePreview />
@@ -345,6 +350,7 @@ const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
         backgroundColor={tokens.colors.background.secondary}
       >
         <Flex
+          className="container"
           direction={{
             base: 'column',
             large: 'row',
@@ -377,7 +383,8 @@ const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
           Looking for other Amplify Products?
         </Heading>
         <Grid
-          templateColumns="1fr 1fr"
+          className="container"
+          templateColumns={{ base: '1fr', medium: '1fr 1fr' }}
           templateRows="1fr 1fr 1fr"
           gap={tokens.space.medium}
           flex="1"

--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -199,7 +199,7 @@ h3:hover > a .icon-link {
 }
 
 .container {
-  max-width: 2000px;
+  max-width: 125em; // 2000px;
   margin-right: auto;
   margin-left: auto;
 }

--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -18,16 +18,16 @@
 
 @font-face {
   font-family: 'Inter';
-  font-style:  normal;
+  font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/fonts/Inter-Regular.woff2?v=3.19') format("woff2"),
-       url('/fonts/Inter-Regular.woff?v=3.19') format("woff");
+  src: url('/fonts/Inter-Regular.woff2?v=3.19') format('woff2'),
+    url('/fonts/Inter-Regular.woff?v=3.19') format('woff');
 }
 
 html {
   /* this enables some alternative styles and contextual characters to the font */
-  font-feature-settings: "ss01", "ss02", "case", "salt";
+  font-feature-settings: 'ss01', 'ss02', 'case', 'salt';
 }
 
 @media screen and (prefers-reduced-motion: no-preference) {
@@ -39,13 +39,13 @@ html {
 // Remove this when this gets fixed in the UI package
 * {
   box-sizing: border-box;
-  
+
   /* Selection */
   &::-moz-selection {
     background: var(--amplify-colors-overlay-10);
     color: inherit;
   }
-  
+
   &::selection {
     background: var(--amplify-colors-overlay-10);
     color: inherit;
@@ -54,7 +54,7 @@ html {
 
 html {
   // https://rsms.me/inter/#features
-  font-feature-settings: "ss01", "ss02", "case", "salt";
+  font-feature-settings: 'ss01', 'ss02', 'case', 'salt';
 }
 
 body {
@@ -68,12 +68,12 @@ a {
   [data-amplify-theme] & {
     cursor: pointer;
   }
-  
+
   &:hover,
   &:focus {
     color: var(--amplify-components-link-hover-color);
   }
-  
+
   &:active {
     color: var(--amplify-components-link-active-color);
   }
@@ -106,20 +106,16 @@ ul {
   list-style-type: disc;
 }
 
-
 code {
   padding: var(--amplify-space-xxxs) var(--amplify-space-xxs);
   background-color: var(--amplify-colors-background-secondary);
   font-size: 0.875em;
   border-radius: 0.3em;
-  
-  &[class*=language-] {
+
+  &[class*='language-'] {
     padding: 0;
   }
 }
-
-
-
 
 h2 {
   font-size: var(--amplify-components-heading-2-font-size);
@@ -143,14 +139,15 @@ h3[id] {
 
 h2[id] {
   margin-top: var(--amplify-space-xxl);
-  
+
   &::before {
     content: '';
     position: absolute;
     top: -1rem;
     left: 0;
     width: 5rem;
-    border-top: var(--amplify-border-widths-large) solid var(--amplify-colors-border-tertiary);
+    border-top: var(--amplify-border-widths-large) solid
+      var(--amplify-colors-border-tertiary);
   }
 }
 
@@ -159,7 +156,7 @@ h3[id] > a {
   position: absolute;
   left: -1.75rem;
   text-decoration: none;
-  
+
   &:hover {
     text-decoration: none;
   }
@@ -185,7 +182,7 @@ h3:hover > a .icon-link {
   background-color: var(--amplify-colors-background-primary);
   color: var(--amplify-colors-font-primary);
   min-height: 100vh;
-  
+
   --amplify-components-fieldcontrol-line-height: 1.5;
   --amplify-borders-primary: var(--amplify-border-widths-small) solid
     var(--amplify-colors-border-primary);
@@ -196,7 +193,13 @@ h3:hover > a .icon-link {
 
   --amplify-components-heading-1-font-size: 3rem;
   --amplify-components-heading-1-font-weight: 750;
-  
+
   /* custom vars */
   --docs-header-height: 4rem;
+}
+
+.container {
+  max-width: 2000px;
+  margin-right: auto;
+  margin-left: auto;
 }

--- a/docs/src/styles/docs/header.scss
+++ b/docs/src/styles/docs/header.scss
@@ -2,7 +2,7 @@
   display: flex;
   position: sticky;
   top: 0;
-  width: 100vw;
+  width: 100%;
   background-color: var(--amplify-colors-background-primary);
   z-index: 100;
   border-bottom: var(--amplify-borders-primary);
@@ -10,7 +10,7 @@
   justify-content: flex-start;
   align-items: center;
   padding: var(--amplify-space-small) var(--amplify-space-xl);
-  
+
   @media (min-width: 62rem) {
     justify-content: space-between;
   }
@@ -19,7 +19,7 @@
 .docs-header-mobile-nav {
   background-color: var(--amplify-colors-background-primary);
   z-index: 99;
-  
+
   .expanded + & {
     position: fixed;
     width: 100vw;
@@ -42,19 +42,20 @@
 .docs-nav,
 .docs-settings {
   display: none;
-  
+
   @media (min-width: 62rem) {
     display: flex;
     padding: 0 var(--amplify-space-medium);
   }
-  
+
   .docs-header-mobile-nav & {
     display: flex;
     width: 100%;
     visibility: visible;
     white-space: nowrap;
     overflow-x: auto;
-    border-bottom: var(--amplify-border-widths-small) solid var(--amplify-colors-border-primary);
+    border-bottom: var(--amplify-border-widths-small) solid
+      var(--amplify-colors-border-primary);
     padding-block: var(--amplify-space-medium);
   }
 }
@@ -83,7 +84,6 @@
   color: var(--amplify-colors-font-hover);
   background-color: var(--amplify-colors-brand-primary-10);
 }
-
 
 .docs-logo-svg {
   height: 1.5rem;


### PR DESCRIPTION
*Issue #, if available:*
Closes #923 

*Description of changes:*
This PR constrains the width of the homepage content to prevent it from getting too wide on large screens.

*Also fixed:*
* Horizontal scrollbar bug caused by vertical scrollbar (`100vw` => `100%`)
* Made "Looking for other Amplify Products?" list collapse to single column on smaller screens



https://user-images.githubusercontent.com/6165315/144944106-e983f74d-7d76-4b97-be66-b7dbe873d9c6.mp4

https://user-images.githubusercontent.com/6165315/144944118-0673121c-bb31-4daa-8ad5-6d7620f33d00.mp4

https://user-images.githubusercontent.com/6165315/144944094-512d5f7a-5838-47e9-9a2f-a0ae6d0b039f.mp4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
