### PR TITLE
ci: cache artifacts and remove repeated steps

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
       - name: Install and build packages
-        run: yarn --frozen-lockfile
+        run: yarn --frozen-lockfile --prefer-offline && yarn build
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           node-version: lts/*
           cache: 'yarn'
-      - name: Install packages
-        run: yarn --frozen-lockfile
+      - name: Install and build packages
+        run: yarn --frozen-lockfile --prefer-offline && yarn build
       - name: Add changeset that bumps all public packages
         # There needs to be a changeset for @aws-amplify/ui[-framework] to publish.
         run: cp .github/changeset-presets/bump-versions.md .changeset

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,15 +60,18 @@ jobs:
         run: yarn --frozen-lockfile
       - name: build @aws-amplify/ui package
         run: yarn ui build
+      - name: Cache cypress runner
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
       - name: Cache build
         uses: actions/cache@v2
-        id: build-cache
         with:
           path: |
             ./node_modules
-            **/node_modules
             ./packages/ui/dist
-            ~/.cache/Cypress
+            **/node_modules
           key: ${{ runner.os }}-yarn-${{ steps.get-ref.outputs.commit }}
   unit:
     needs: setup
@@ -172,6 +175,13 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
 
+      - name: Restore cypress runner Cache
+        uses: actions/cache@v2
+        id: restore-cypress-cache
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
+
       - name: Restore Cache
         uses: actions/cache@v2
         id: restore-cache
@@ -184,7 +194,7 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile
 
       - name: Build @aws-amplify/ui package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         id: get-ref
         run: |
           echo "::set-output name=key::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
-          echo "::set-output name=commit::$(git rev-parse --short "$GITHUB_SHA")
+          echo "::set-output name=commit::$(git rev-parse --short "$GITHUB_SHA")"
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,7 @@ jobs:
             ./node_modules
             **/node_modules
             **/dist
+            ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-${{ steps.get-ref.outputs.commit }}
   unit:
     needs: setup
@@ -104,6 +105,7 @@ jobs:
             ./node_modules
             **/node_modules
             **/dist
+            ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
@@ -170,6 +172,7 @@ jobs:
             ./node_modules
             **/node_modules
             **/dist
+            ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
 
       - name: Install packages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,9 +113,6 @@ jobs:
       - name: Lint packages
         run: yarn workspace ${{ matrix.package }} lint
 
-      - name: Build ${{ matrix.package }} package
-        run: yarn workspace ${{ matrix.package }} build
-
       - name: Run ${{ matrix.package }} tests
         run: yarn workspace ${{ matrix.package}} test
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,48 @@ jobs:
             const { issue: { number: issue_number }, repo: { owner, repo } } = context;
             const label = 'run-tests';
             github.issues.removeLabel({ owner, repo, issue_number, name: label });
+      - name: Get commit ref
+        id: get-commit-ref
+        run: echo "::set-output name=ref::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
+      - run: echo ${{ steps.get-commit-ref.ref }}
+      - name: Checkout Amplify UI
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.get-commit-ref.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
+      - name: Checkout Amplify UI
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
 
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+          cache: 'yarn'
+
+      - name: Install packages
+        run: yarn --frozen-lockfile
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache build
+        uses: actions/cache@v2
+        id: build-cache
+        with:
+          path: |
+            **/.ultra.cache.json
+            **/dist
+            **/node_modules
+            ~/.cache/Cypress
+            node_modules
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-${{ steps.get-commit-ref.ref }}
   unit:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,10 +87,10 @@ jobs:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         package:
-          - '@aws-amplify/ui'
-          - '@aws-amplify/ui-angular'
-          - '@aws-amplify/ui-vue'
-          - '@aws-amplify/ui-react'
+          - ui
+          - angular
+          - vue
+          - react
 
     steps:
       - name: Checkout Amplify UI
@@ -126,13 +126,13 @@ jobs:
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile --prefer-offline  --prefer-offline
 
-      - name: Build @aws-amplify/ui package
-        if: ${{ steps.restore-ui-cache.outputs.cache-hit != 'true' && matrix.package != '@aws-amplify/ui' }}
+      - name: Build ui package
+        if: ${{ steps.restore-ui-cache.outputs.cache-hit != 'true' && matrix.package != 'ui' }}
         run: yarn ui build
 
       - name: Build ${{ matrix.package }} package
         if: ${{ matrix.package != '@aws-amplify/ui' }}
-        run: yarn workspace ${{ matrix.package }} build
+        run: yarn ${{ matrix.package }} build
 
       - name: Cache ${{ matrix.package }}/dist
         uses: actions/cache@v2
@@ -141,10 +141,10 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.package }}-${{ needs.setup.outputs.commit }}
 
       - name: Lint packages
-        run: yarn workspace ${{ matrix.package }} lint
+        run: yarn ${{ matrix.package }} lint
 
       - name: Run ${{ matrix.package }} tests
-        run: yarn workspace ${{ matrix.package}} test
+        run: yarn ${{ matrix.package}} test
 
   e2e:
     # Only run e2e tests if unit tests pass
@@ -161,15 +161,15 @@ jobs:
       matrix:
         include:
           - framework: angular
-            package: '@aws-amplify/ui-angular'
+            package: angular
             tags: '@angular and not (@skip or @todo-angular)'
 
           - framework: next
-            package: '@aws-amplify/ui-react'
+            package: next
             tags: '@react and not (@skip or @todo-react)'
 
           - framework: vue
-            package: '@aws-amplify/ui-vue'
+            package: vue
             tags: '@vue and not (@skip or @todo-vue)'
 
     steps:
@@ -233,9 +233,9 @@ jobs:
         if: steps.restore-ui-cache.outputs.cache-hit != 'true'
         run: yarn ui build
 
-      - name: Build ${{ matrix.framework }} package
+      - name: Build ${{ matrix.package }} package
         if: steps.restore-package-cache.outputs.cache-hit != 'true'
-        run: yarn workspace ${{ matrix.package }} build
+        run: yarn ${{ matrix.package }} build
 
       - name: Add Amplify CLI
         run: yarn global add @aws-amplify/cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,13 +38,13 @@ jobs:
             const label = 'run-tests';
             github.issues.removeLabel({ owner, repo, issue_number, name: label });
       - name: Get commit ref
-        id: get-commit-ref
+        id: get-ref
         run: echo "::set-output name=ref::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
-      - run: echo ${{ steps.get-commit-ref.ref }}
+      - run: echo ${{ steps.get-ref.outputs.ref }}
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
         with:
-          ref: ${{ steps.get-commit-ref.ref }}
+          ref: ${{ steps.get-ref.outputs.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
       - name: Checkout Amplify UI
@@ -78,7 +78,7 @@ jobs:
             ~/.cache/Cypress
             node_modules
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-${{ steps.get-commit-ref.ref }}
+          key: ${{ runner.os }}-${{ steps.get-ref.outputs.ref }}
   unit:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,29 +206,41 @@ jobs:
           USERNAME: ${{ secrets.USERNAME }}
           NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
           VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
-  # docs:
-  #   # Only run docs tests if e2e tests pass
-  #   needs: e2e
-  #   runs-on: ubuntu-latest
-  #   environment: ci
-  #   env:
-  #     NODE_ENV: test
-  #   steps:
-  #     - name: Checkout Amplify UI
-  #       uses: actions/checkout@v2
-  #       with:
-  #         ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
-  #         repository: ${{github.event.pull_request.head.repo.full_name}}
-  #         persist-credentials: false
+  docs:
+    # Only run docs tests if e2e tests pass
+    needs: [setup, unit]
+    runs-on: ubuntu-latest
+    environment: ci
+    env:
+      NODE_ENV: test
+    steps:
+      - name: Checkout Amplify UI
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
 
-  #     - name: Setup Node.js LTS
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: lts/*
-  #         cache: 'yarn'
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+          cache: 'yarn'
 
-  #     - name: Install packages
-  #       run: yarn --frozen-lockfile
+      - name: Restore Cache
+        uses: actions/cache@v2
+        id: restore-cache
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+            **/dist
+            ~/.cache/Cypress
+          key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
 
-  #     - name: Build docs package
-  #       run: yarn docs build
+      - name: Install packages
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile
+
+      - name: Build docs package
+        run: yarn docs build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -198,11 +198,11 @@ jobs:
         run: yarn --frozen-lockfile --prefer-offline
 
       - name: Build @aws-amplify/ui package
-        if: steps.restore-cache.outputs.cache-hit != 'true' || ${{ matrix.framework == '@aws-amplify/ui' }}
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn ui build
 
       - name: Build ${{ matrix.framework }} package
-        run: yarn ${{ matrix.framework }} build
+        run: yarn ${{ matrix.framework == 'next' && 'react' || ${{ matrix.framework }} }} build
 
       - name: Add Amplify CLI
         run: yarn global add @aws-amplify/cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,8 +197,11 @@ jobs:
         if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile
 
+      - name: Build packages
+        run: yarn workspace ${{ matrix.package }} build
+
       - name: Build @aws-amplify/ui package
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.restore-cache.outputs.cache-hit != 'true' || ${{ matrix.package == '@aws-amplify/ui' }}
         run: yarn ui build
 
       - name: Add Amplify CLI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,6 @@ jobs:
             const { issue: { number: issue_number }, repo: { owner, repo } } = context;
             const label = 'run-tests';
             github.issues.removeLabel({ owner, repo, issue_number, name: label });
-      - name: Get ref and commit
-        id: get-ref
-        run: |
-          echo "::set-output name=key::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
-          echo "::set-output name=commit::$(git rev-parse --short "$GITHUB_SHA")"
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
         with:
@@ -53,10 +48,13 @@ jobs:
         with:
           node-version: lts/*
           cache: 'yarn'
-
+      - name: Get ref and commit
+        id: get-ref
+        run: |
+          echo "::set-output name=key::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
+          echo "::set-output name=commit::$(git rev-parse --short "$GITHUB_SHA")"
       - name: Install packages
         run: yarn --frozen-lockfile
-
       - name: Cache build
         uses: actions/cache@v2
         id: build-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,13 @@ jobs:
         with:
           path: ./packages/ui/dist
           key: ${{ runner.os }}-ui-${{ steps.get-ref.outputs.commit }}
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+          key: ${{ runner.os }}-nodemodules-${{ steps.get-ref.outputs.commit }}
   unit:
     needs: setup
     runs-on: ubuntu-latest
@@ -99,6 +106,15 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
 
+      - name: Restore node_modules cache
+        uses: actions/cache@v2
+        id: restore-cache
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
+
       - name: Restore ui/dist cache
         uses: actions/cache@v2
         id: restore-ui-cache
@@ -107,7 +123,8 @@ jobs:
           key: ${{ runner.os }}-ui-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
-        run: yarn --frozen-lockfile --prefer-offline
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile --prefer-offline  --prefer-offline
 
       - name: Build ui package
         if: ${{ steps.restore-ui-cache.outputs.cache-hit != 'true' && matrix.package != 'ui' }}
@@ -185,6 +202,15 @@ jobs:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
 
+      - name: Restore node_modules cache
+        uses: actions/cache@v2
+        id: restore-cache
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
+
       - name: Restore ui/dist cache
         uses: actions/cache@v2
         id: restore-ui-cache
@@ -200,6 +226,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.package }}-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
+        if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile --prefer-offline
 
       - name: Build @aws-amplify/ui package
@@ -270,7 +297,17 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
 
+      - name: Restore Cache
+        uses: actions/cache@v2
+        id: restore-cache
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
+
       - name: Install packages
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile --prefer-offline
 
       - name: Restore ui/dist cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,20 +40,12 @@ jobs:
       - name: Get commit ref
         id: get-ref
         run: echo "::set-output name=ref::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
-      - run: echo ${{ steps.get-ref.outputs.ref }}
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
         with:
           ref: ${{ steps.get-ref.outputs.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
-      - name: Checkout Amplify UI
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          persist-credentials: false
-
       - name: Setup Node.js LTS
         uses: actions/setup-node@v2
         with:
@@ -72,12 +64,9 @@ jobs:
         id: build-cache
         with:
           path: |
-            **/.ultra.cache.json
-            **/dist
+            ./node_modules
             **/node_modules
-            ~/.cache/Cypress
-            node_modules
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            **/dist
           key: ${{ runner.os }}-${{ steps.get-ref.outputs.ref }}
   unit:
     needs: setup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
           path: |
             ./node_modules
             **/node_modules
-          key: ${{ runner.os }}-yarn-${{ steps.get-ref.outputs.commit }}
+          key: ${{ runner.os }}-nodemodules-${{ steps.get-ref.outputs.commit }}
   unit:
     needs: setup
     runs-on: ubuntu-latest
@@ -113,14 +113,14 @@ jobs:
           path: |
             ./node_modules
             **/node_modules
-          key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
+          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
 
-      - name: Restore packages/ui/dist cache
+      - name: Restore ui/dist cache
         uses: actions/cache@v2
         id: restore-ui-cache
         with:
           path: ./packages/ui/dist
-          key: ${{ runner.os }}-ui-${{ steps.get-ref.outputs.commit }}
+          key: ${{ runner.os }}-ui-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
@@ -130,9 +130,15 @@ jobs:
         if: steps.restore-ui-cache.outputs.cache-hit != 'true' && ${{ matrix.package != '@aws-amplify/ui' }}
         run: yarn ui build
 
-      - name: Build packages
+      - name: Build ${{ matrix.package }} package
         if: ${{ matrix.package != '@aws-amplify/ui' }}
         run: yarn workspace ${{ matrix.package }} build
+
+      - name: Cache ${{ matrix.package }}/dist
+        uses: actions/cache@v2
+        with:
+          path: ./packages/${{ matrix.package }}/dist
+          key: ${{ runner.os }}-${{ matrix.package }}-${{ needs.setup.outputs.commit }}
 
       - name: Lint packages
         run: yarn workspace ${{ matrix.package }} lint
@@ -155,12 +161,15 @@ jobs:
       matrix:
         include:
           - framework: angular
+            package: angular
             tags: '@angular and not (@skip or @todo-angular)'
 
           - framework: next
+            package: react
             tags: '@react and not (@skip or @todo-react)'
 
           - framework: vue
+            package: vue
             tags: '@vue and not (@skip or @todo-vue)'
 
     steps:
@@ -200,14 +209,21 @@ jobs:
           path: |
             ./node_modules
             **/node_modules
-          key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
+          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
 
-      - name: Restore packages/ui/dist cache
+      - name: Restore ui/dist cache
         uses: actions/cache@v2
         id: restore-ui-cache
         with:
           path: ./packages/ui/dist
-          key: ${{ runner.os }}-ui-${{ steps.get-ref.outputs.commit }}
+          key: ${{ runner.os }}-ui-${{ needs.setup.outputs.commit }}
+
+      - name: Restore ${{ matrix.package }}/dist cache
+        id: restore-{{ matrix.package }}-cache
+        uses: actions/cache@v2
+        with:
+          path: ./packages/${{ matrix.package }}/dist
+          key: ${{ runner.os }}-${{ matrix.package }}-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
@@ -218,7 +234,8 @@ jobs:
         run: yarn ui build
 
       - name: Build ${{ matrix.framework }} package
-        run: yarn ${{ matrix.framework == 'next' && 'react' || matrix.framework }} build
+        if: steps.restore-{{ matrix.package }}-cache.outputs.cache-hit != 'true'
+        run: yarn ${{ matrix.package }} build
 
       - name: Add Amplify CLI
         run: yarn global add @aws-amplify/cli
@@ -275,24 +292,32 @@ jobs:
           path: |
             ./node_modules
             **/node_modules
-          key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
+          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile --prefer-offline
 
-      - name: Restore packages/ui/dist cache
+      - name: Restore ui/dist cache
         uses: actions/cache@v2
         id: restore-ui-cache
         with:
           path: ./packages/ui/dist
-          key: ${{ runner.os }}-ui-${{ steps.get-ref.outputs.commit }}
+          key: ${{ runner.os }}-ui-${{ needs.setup.outputs.commit }}
+
+      - name: Restore react/dist cache
+        uses: actions/cache@v2
+        id: restore-react-cache
+        with:
+          path: ./packages/react/dist
+          key: ${{ runner.os }}-react-${{ needs.setup.outputs.commit }}
 
       - name: Build @aws-amplify/ui package
         if: steps.restore-ui-cache.outputs.cache-hit != 'true'
         run: yarn ui build
 
       - name: build react package
+        if: steps.restore-react-cache.outputs.cache-hit != 'true'
         run: yarn react build
 
       - name: Build docs package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,7 +202,7 @@ jobs:
         run: yarn ui build
 
       - name: Build ${{ matrix.framework }} package
-        run: yarn workspace ${{ matrix.framework }} build
+        run: yarn ${{ matrix.framework }} build
 
       - name: Add Amplify CLI
         run: yarn global add @aws-amplify/cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,11 +117,11 @@ jobs:
         run: yarn --frozen-lockfile --prefer-offline
 
       - name: Build @aws-amplify/ui package
-        if: steps.restore-cache.outputs.cache-hit != 'true' && ${{ matrix.package }} != '@aws-amplify/ui'
+        if: steps.restore-cache.outputs.cache-hit != 'true' && ${{ matrix.package != '@aws-amplify/ui' }}
         run: yarn ui build
 
-      - name: Build {{ matrix.package }} package
-        run: yarn {{ matrix.package }} build
+      - name: Build packages
+        run: yarn ${{ matrix.package }} build
 
       - name: Lint packages
         run: yarn workspace ${{ matrix.package }} lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,11 @@ jobs:
             const { issue: { number: issue_number }, repo: { owner, repo } } = context;
             const label = 'run-tests';
             github.issues.removeLabel({ owner, repo, issue_number, name: label });
-      - name: Get commit ref
+      - name: Get ref and commit
         id: get-ref
-        run: echo "::set-output name=ref::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
+        run: |
+          echo "::set-output name=key::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
+          echo "::set-output name=commit::$(git rev-parse --short "$GITHUB_SHA")
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
         with:
@@ -55,10 +57,6 @@ jobs:
       - name: Install packages
         run: yarn --frozen-lockfile
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
       - name: Cache build
         uses: actions/cache@v2
         id: build-cache
@@ -67,7 +65,7 @@ jobs:
             ./node_modules
             **/node_modules
             **/dist
-          key: ${{ runner.os }}-${{ steps.get-ref.outputs.ref }}
+          key: ${{ runner.os }}-${{ steps.get-ref.outputs.commit }}
   unit:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -219,7 +219,7 @@ jobs:
           key: ${{ runner.os }}-ui-${{ needs.setup.outputs.commit }}
 
       - name: Restore ${{ matrix.package }}/dist cache
-        id: restore-{{ matrix.package }}-cache
+        id: restore-package-cache
         uses: actions/cache@v2
         with:
           path: ./packages/${{ matrix.package }}/dist
@@ -234,7 +234,7 @@ jobs:
         run: yarn ui build
 
       - name: Build ${{ matrix.framework }} package
-        if: steps.restore-{{ matrix.package }}-cache.outputs.cache-hit != 'true'
+        if: steps.restore-package-cache.outputs.cache-hit != 'true'
         run: yarn ${{ matrix.package }} build
 
       - name: Add Amplify CLI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
         run: yarn --frozen-lockfile --prefer-offline  --prefer-offline
 
       - name: Build @aws-amplify/ui package
-        if: steps.restore-ui-cache.outputs.cache-hit != 'true' && ${{ matrix.package != '@aws-amplify/ui' }}
+        if: ${{ steps.restore-ui-cache.outputs.cache-hit != 'true' && matrix.package != '@aws-amplify/ui' }}
         run: yarn ui build
 
       - name: Build ${{ matrix.package }} package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,8 +108,8 @@ jobs:
         with:
           path: |
             ./node_modules
-            **/node_modules
             ./packages/ui/dist
+            **/node_modules
           key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
@@ -189,9 +189,8 @@ jobs:
         with:
           path: |
             ./node_modules
-            **/node_modules
             ./packages/ui/dist
-            ~/.cache/Cypress
+            **/node_modules
           key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
 
       - name: Install packages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,8 @@ jobs:
           echo "::set-output name=commit::$(git rev-parse --short "$GITHUB_SHA")"
       - name: Install packages
         run: yarn --frozen-lockfile
+      - name: build @aws-amplify/ui package
+        run: yarn ui build
       - name: Cache build
         uses: actions/cache@v2
         id: build-cache
@@ -65,7 +67,7 @@ jobs:
           path: |
             ./node_modules
             **/node_modules
-            **/dist
+            ./packages/ui/dist
             ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-${{ steps.get-ref.outputs.commit }}
   unit:
@@ -104,13 +106,19 @@ jobs:
           path: |
             ./node_modules
             **/node_modules
-            **/dist
-            ~/.cache/Cypress
+            ./packages/ui/dist
           key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile --prefer-offline
+
+      - name: Build @aws-amplify/ui package
+        if: steps.restore-cache.outputs.cache-hit != 'true' && ${{ matrix.package }} != '@aws-amplify/ui'
+        run: yarn ui build
+
+      - name: Build {{ matrix.package }} package
+        run: yarn {{ matrix.package }} build
 
       - name: Lint packages
         run: yarn workspace ${{ matrix.package }} lint
@@ -171,13 +179,17 @@ jobs:
           path: |
             ./node_modules
             **/node_modules
-            **/dist
+            ./packages/ui/dist
             ~/.cache/Cypress
           key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile
+
+      - name: Build @aws-amplify/ui package
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: yarn ui build
 
       - name: Add Amplify CLI
         run: yarn global add @aws-amplify/cli
@@ -234,13 +246,19 @@ jobs:
           path: |
             ./node_modules
             **/node_modules
-            **/dist
-            ~/.cache/Cypress
+            ./packages/ui/dist
           key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile
+
+      - name: Build @aws-amplify/ui package
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: yarn ui build
+
+      - name: build react package
+        run: yarn react build
 
       - name: Build docs package
         run: yarn docs build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,9 @@ jobs:
       github.event_name == 'push' ||
       (github.event.pull_request.head.repo.full_name == github.repository) || 
       (github.event.action == 'labeled' && github.event.label.name == 'run-tests')
+    outputs:
+      ref: ${{ steps.get-ref.outputs.ref }}
+      commit: ${{ steps.get-ref.outputs.commit }}
     steps:
       # This would be a good place to run and cache `yarn`, `yarn build`, etc
       - name: Remove run-tests label, if applicable
@@ -63,7 +66,7 @@ jobs:
             ./node_modules
             **/node_modules
             **/dist
-          key: ${{ runner.os }}-${{ steps.get-ref.outputs.commit }}
+          key: ${{ runner.os }}-yarn-${{ steps.get-ref.outputs.commit }}
   unit:
     needs: setup
     runs-on: ubuntu-latest
@@ -93,8 +96,19 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
 
+      - name: Restore Cache
+        uses: actions/cache@v2
+        id: restore-cache
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+            **/dist
+          key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
+
       - name: Install packages
-        run: yarn --frozen-lockfile
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile --prefer-offline
 
       - name: Lint packages
         run: yarn workspace ${{ matrix.package }} lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,19 +156,19 @@ jobs:
 
     strategy:
       # Run each examples (e.g. `next-example`) which uses a library (e.g. `@aws-amplify/ui-react`)
-      # BUT, Exclude `@skip` tests in `main` and exclude `@todo-${{ framework }}` tests in PRs
+      # BUT, Exclude `@skip` tests in `main` and exclude `@todo-${{ package }}` tests in PRs
       # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
       matrix:
         include:
-          - framework: angular
+          - example: angular
             package: angular
             tags: '@angular and not (@skip or @todo-angular)'
 
-          - framework: next
+          - example: next
             package: react
             tags: '@react and not (@skip or @todo-react)'
 
-          - framework: vue
+          - example: vue
             package: vue
             tags: '@vue and not (@skip or @todo-vue)'
 
@@ -258,13 +258,13 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Build ${{ matrix.framework }} example
-        run: yarn workspace ${{ matrix.framework }}-example build
+      - name: Build ${{ matrix.example }} example
+        run: yarn workspace ${{ matrix.example }}-example build
 
-      - name: Start ${{ matrix.framework }} example
-        run: yarn workspace ${{ matrix.framework }}-example start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000/ui/components/authenticator/sign-in-with-username
+      - name: Start ${{ matrix.example }} example
+        run: yarn workspace ${{ matrix.example }}-example start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000/ui/components/authenticator/sign-in-with-username
 
-      - name: Run E2E tests against ${{ matrix.framework }} example
+      - name: Run E2E tests against ${{ matrix.example }} example
         run: yarn workspace e2e test
         env:
           # Override on the default value in `cypress.json` with framework-specific tag

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
             tags: '@angular and not (@skip or @todo-angular)'
 
           - framework: next
-            package: next
+            package: react
             tags: '@react and not (@skip or @todo-react)'
 
           - framework: vue

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,8 @@ jobs:
         run: yarn ui build
 
       - name: Build packages
-        run: yarn ${{ matrix.package }} build
+        if: ${{ matrix.package != '@aws-amplify/ui' }}
+        run: yarn workspace ${{ matrix.package }} build
 
       - name: Lint packages
         run: yarn workspace ${{ matrix.package }} lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,12 +197,12 @@ jobs:
         if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile --prefer-offline
 
-      - name: Build packages
-        run: yarn workspace ${{ matrix.package }} build
-
       - name: Build @aws-amplify/ui package
-        if: steps.restore-cache.outputs.cache-hit != 'true' || ${{ matrix.package == '@aws-amplify/ui' }}
+        if: steps.restore-cache.outputs.cache-hit != 'true' || ${{ matrix.framework == '@aws-amplify/ui' }}
         run: yarn ui build
+
+      - name: Build ${{ matrix.framework }} package
+        run: yarn workspace ${{ matrix.framework }} build
 
       - name: Add Amplify CLI
         run: yarn global add @aws-amplify/cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
 
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [opened, synchronize, labeled]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,15 +161,15 @@ jobs:
       matrix:
         include:
           - framework: angular
-            package: angular
+            package: '@aws-amplify/ui-angular'
             tags: '@angular and not (@skip or @todo-angular)'
 
           - framework: next
-            package: react
+            package: '@aws-amplify/ui-react'
             tags: '@react and not (@skip or @todo-react)'
 
           - framework: vue
-            package: vue
+            package: '@aws-amplify/ui-vue'
             tags: '@vue and not (@skip or @todo-vue)'
 
     steps:
@@ -235,7 +235,7 @@ jobs:
 
       - name: Build ${{ matrix.framework }} package
         if: steps.restore-package-cache.outputs.cache-hit != 'true'
-        run: yarn ${{ matrix.package }} build
+        run: yarn workspace ${{ matrix.package }} build
 
       - name: Add Amplify CLI
         run: yarn global add @aws-amplify/cli
@@ -310,7 +310,7 @@ jobs:
         id: restore-react-cache
         with:
           path: ./packages/react/dist
-          key: ${{ runner.os }}-react-${{ needs.setup.outputs.commit }}
+          key: ${{ runner.os }}-@aws-amplify/ui-react-${{ needs.setup.outputs.commit }}
 
       - name: Build @aws-amplify/ui package
         if: steps.restore-ui-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,7 +202,7 @@ jobs:
         run: yarn ui build
 
       - name: Build ${{ matrix.framework }} package
-        run: yarn ${{ matrix.framework == 'next' && 'react' || ${{ matrix.framework }} }} build
+        run: yarn ${{ matrix.framework == 'next' && 'react' || matrix.framework }} build
 
       - name: Add Amplify CLI
         run: yarn global add @aws-amplify/cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,82 +116,93 @@ jobs:
       - name: Run ${{ matrix.package }} tests
         run: yarn workspace ${{ matrix.package}} test
 
-  # e2e:
-  #   # Only run e2e tests if unit tests pass
-  #   needs: unit
-  #   runs-on: ubuntu-latest
-  #   environment: ci
-  #   env:
-  #     NODE_ENV: test
+  e2e:
+    # Only run e2e tests if unit tests pass
+    needs: [setup, unit]
+    runs-on: ubuntu-latest
+    environment: ci
+    env:
+      NODE_ENV: test
 
-  #   strategy:
-  #     # Run each examples (e.g. `next-example`) which uses a library (e.g. `@aws-amplify/ui-react`)
-  #     # BUT, Exclude `@skip` tests in `main` and exclude `@todo-${{ framework }}` tests in PRs
-  #     # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
-  #     matrix:
-  #       include:
-  #         - framework: angular
-  #           tags: '@angular and not (@skip or @todo-angular)'
+    strategy:
+      # Run each examples (e.g. `next-example`) which uses a library (e.g. `@aws-amplify/ui-react`)
+      # BUT, Exclude `@skip` tests in `main` and exclude `@todo-${{ framework }}` tests in PRs
+      # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
+      matrix:
+        include:
+          - framework: angular
+            tags: '@angular and not (@skip or @todo-angular)'
 
-  #         - framework: next
-  #           tags: '@react and not (@skip or @todo-react)'
+          - framework: next
+            tags: '@react and not (@skip or @todo-react)'
 
-  #         - framework: vue
-  #           tags: '@vue and not (@skip or @todo-vue)'
+          - framework: vue
+            tags: '@vue and not (@skip or @todo-vue)'
 
-  #   steps:
-  #     - name: Checkout Amplify UI
-  #       uses: actions/checkout@v2
-  #       with:
-  #         # For `pull_request_target`, we want ref to point to `pull_request.head.ref` because `github.ref`
-  #         # always points to the target branch.
-  #         # See: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
-  #         ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
-  #         repository: ${{github.event.pull_request.head.repo.full_name}}
-  #         persist-credentials: false
+    steps:
+      - name: Checkout Amplify UI
+        uses: actions/checkout@v2
+        with:
+          # For `pull_request_target`, we want ref to point to `pull_request.head.ref` because `github.ref`
+          # always points to the target branch.
+          # See: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
 
-  #     - name: Next.js Cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: ${{ github.workspace }}/.next/cache
-  #         key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}
+      - name: Next.js Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}
 
-  #     - name: Setup Node.js LTS
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: lts/*
-  #         cache: 'yarn'
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+          cache: 'yarn'
 
-  #     - name: Install packages
-  #       run: yarn --frozen-lockfile
+      - name: Restore Cache
+        uses: actions/cache@v2
+        id: restore-cache
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+            **/dist
+          key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
 
-  #     - name: Add Amplify CLI
-  #       run: yarn global add @aws-amplify/cli
+      - name: Install packages
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile
 
-  #     - name: Pull down AWS environments
-  #       run: yarn environments pull
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Add Amplify CLI
+        run: yarn global add @aws-amplify/cli
 
-  #     - name: Build ${{ matrix.framework }} example
-  #       run: yarn workspace ${{ matrix.framework }}-example build
+      - name: Pull down AWS environments
+        run: yarn environments pull
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-  #     - name: Start ${{ matrix.framework }} example
-  #       run: yarn workspace ${{ matrix.framework }}-example start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000/ui/components/authenticator/sign-in-with-username
+      - name: Build ${{ matrix.framework }} example
+        run: yarn workspace ${{ matrix.framework }}-example build
 
-  #     - name: Run E2E tests against ${{ matrix.framework }} example
-  #       run: yarn workspace e2e test
-  #       env:
-  #         # Override on the default value in `cypress.json` with framework-specific tag
-  #         TAGS: '${{ matrix.tags }}'
+      - name: Start ${{ matrix.framework }} example
+        run: yarn workspace ${{ matrix.framework }}-example start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000/ui/components/authenticator/sign-in-with-username
 
-  #         # Env values for testing flows
-  #         DOMAIN: ${{ secrets.DOMAIN }}
-  #         PHONE_NUMBER: ${{ secrets.PHONE_NUMBER }}
-  #         USERNAME: ${{ secrets.USERNAME }}
-  #         NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
-  #         VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
+      - name: Run E2E tests against ${{ matrix.framework }} example
+        run: yarn workspace e2e test
+        env:
+          # Override on the default value in `cypress.json` with framework-specific tag
+          TAGS: '${{ matrix.tags }}'
+
+          # Env values for testing flows
+          DOMAIN: ${{ secrets.DOMAIN }}
+          PHONE_NUMBER: ${{ secrets.PHONE_NUMBER }}
+          USERNAME: ${{ secrets.USERNAME }}
+          NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
+          VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
   # docs:
   #   # Only run docs tests if e2e tests pass
   #   needs: e2e

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,105 +120,105 @@ jobs:
       - name: Run ${{ matrix.package }} tests
         run: yarn workspace ${{ matrix.package}} test
 
-  e2e:
-    # Only run e2e tests if unit tests pass
-    needs: unit
-    runs-on: ubuntu-latest
-    environment: ci
-    env:
-      NODE_ENV: test
+  # e2e:
+  #   # Only run e2e tests if unit tests pass
+  #   needs: unit
+  #   runs-on: ubuntu-latest
+  #   environment: ci
+  #   env:
+  #     NODE_ENV: test
 
-    strategy:
-      # Run each examples (e.g. `next-example`) which uses a library (e.g. `@aws-amplify/ui-react`)
-      # BUT, Exclude `@skip` tests in `main` and exclude `@todo-${{ framework }}` tests in PRs
-      # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
-      matrix:
-        include:
-          - framework: angular
-            tags: '@angular and not (@skip or @todo-angular)'
+  #   strategy:
+  #     # Run each examples (e.g. `next-example`) which uses a library (e.g. `@aws-amplify/ui-react`)
+  #     # BUT, Exclude `@skip` tests in `main` and exclude `@todo-${{ framework }}` tests in PRs
+  #     # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
+  #     matrix:
+  #       include:
+  #         - framework: angular
+  #           tags: '@angular and not (@skip or @todo-angular)'
 
-          - framework: next
-            tags: '@react and not (@skip or @todo-react)'
+  #         - framework: next
+  #           tags: '@react and not (@skip or @todo-react)'
 
-          - framework: vue
-            tags: '@vue and not (@skip or @todo-vue)'
+  #         - framework: vue
+  #           tags: '@vue and not (@skip or @todo-vue)'
 
-    steps:
-      - name: Checkout Amplify UI
-        uses: actions/checkout@v2
-        with:
-          # For `pull_request_target`, we want ref to point to `pull_request.head.ref` because `github.ref`
-          # always points to the target branch.
-          # See: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
-          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          persist-credentials: false
+  #   steps:
+  #     - name: Checkout Amplify UI
+  #       uses: actions/checkout@v2
+  #       with:
+  #         # For `pull_request_target`, we want ref to point to `pull_request.head.ref` because `github.ref`
+  #         # always points to the target branch.
+  #         # See: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+  #         ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
+  #         repository: ${{github.event.pull_request.head.repo.full_name}}
+  #         persist-credentials: false
 
-      - name: Next.js Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}
+  #     - name: Next.js Cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: ${{ github.workspace }}/.next/cache
+  #         key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Setup Node.js LTS
-        uses: actions/setup-node@v2
-        with:
-          node-version: lts/*
-          cache: 'yarn'
+  #     - name: Setup Node.js LTS
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: lts/*
+  #         cache: 'yarn'
 
-      - name: Install packages
-        run: yarn --frozen-lockfile
+  #     - name: Install packages
+  #       run: yarn --frozen-lockfile
 
-      - name: Add Amplify CLI
-        run: yarn global add @aws-amplify/cli
+  #     - name: Add Amplify CLI
+  #       run: yarn global add @aws-amplify/cli
 
-      - name: Pull down AWS environments
-        run: yarn environments pull
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #     - name: Pull down AWS environments
+  #       run: yarn environments pull
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Build ${{ matrix.framework }} example
-        run: yarn workspace ${{ matrix.framework }}-example build
+  #     - name: Build ${{ matrix.framework }} example
+  #       run: yarn workspace ${{ matrix.framework }}-example build
 
-      - name: Start ${{ matrix.framework }} example
-        run: yarn workspace ${{ matrix.framework }}-example start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000/ui/components/authenticator/sign-in-with-username
+  #     - name: Start ${{ matrix.framework }} example
+  #       run: yarn workspace ${{ matrix.framework }}-example start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000/ui/components/authenticator/sign-in-with-username
 
-      - name: Run E2E tests against ${{ matrix.framework }} example
-        run: yarn workspace e2e test
-        env:
-          # Override on the default value in `cypress.json` with framework-specific tag
-          TAGS: '${{ matrix.tags }}'
+  #     - name: Run E2E tests against ${{ matrix.framework }} example
+  #       run: yarn workspace e2e test
+  #       env:
+  #         # Override on the default value in `cypress.json` with framework-specific tag
+  #         TAGS: '${{ matrix.tags }}'
 
-          # Env values for testing flows
-          DOMAIN: ${{ secrets.DOMAIN }}
-          PHONE_NUMBER: ${{ secrets.PHONE_NUMBER }}
-          USERNAME: ${{ secrets.USERNAME }}
-          NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
-          VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
-  docs:
-    # Only run docs tests if e2e tests pass
-    needs: e2e
-    runs-on: ubuntu-latest
-    environment: ci
-    env:
-      NODE_ENV: test
-    steps:
-      - name: Checkout Amplify UI
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          persist-credentials: false
+  #         # Env values for testing flows
+  #         DOMAIN: ${{ secrets.DOMAIN }}
+  #         PHONE_NUMBER: ${{ secrets.PHONE_NUMBER }}
+  #         USERNAME: ${{ secrets.USERNAME }}
+  #         NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
+  #         VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
+  # docs:
+  #   # Only run docs tests if e2e tests pass
+  #   needs: e2e
+  #   runs-on: ubuntu-latest
+  #   environment: ci
+  #   env:
+  #     NODE_ENV: test
+  #   steps:
+  #     - name: Checkout Amplify UI
+  #       uses: actions/checkout@v2
+  #       with:
+  #         ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
+  #         repository: ${{github.event.pull_request.head.repo.full_name}}
+  #         persist-credentials: false
 
-      - name: Setup Node.js LTS
-        uses: actions/setup-node@v2
-        with:
-          node-version: lts/*
-          cache: 'yarn'
+  #     - name: Setup Node.js LTS
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: lts/*
+  #         cache: 'yarn'
 
-      - name: Install packages
-        run: yarn --frozen-lockfile
+  #     - name: Install packages
+  #       run: yarn --frozen-lockfile
 
-      - name: Build docs package
-        run: yarn docs build
+  #     - name: Build docs package
+  #       run: yarn docs build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -252,6 +252,7 @@ jobs:
           key: ${{ runner.os }}-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('environments/**/amplify/**') }}
 
       - name: Pull down AWS environments
+        if: steps.environments-cache.outputs.cache-hit != 'true'
         run: yarn environments pull
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
           echo "::set-output name=key::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
           echo "::set-output name=commit::$(git rev-parse --short "$GITHUB_SHA")"
       - name: Install packages
-        run: yarn --frozen-lockfile
+        run: yarn --frozen-lockfile --prefer-offline
       - name: build @aws-amplify/ui package
         run: yarn ui build
       - name: Cache cypress runner
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: yarn --frozen-lockfile --prefer-offline
+        run: yarn --frozen-lockfile --prefer-offline  --prefer-offline
 
       - name: Build @aws-amplify/ui package
         if: steps.restore-cache.outputs.cache-hit != 'true' && ${{ matrix.package != '@aws-amplify/ui' }}
@@ -195,7 +195,7 @@ jobs:
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
-        run: yarn --frozen-lockfile
+        run: yarn --frozen-lockfile --prefer-offline
 
       - name: Build packages
         run: yarn workspace ${{ matrix.package }} build
@@ -264,7 +264,7 @@ jobs:
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: yarn --frozen-lockfile
+        run: yarn --frozen-lockfile --prefer-offline
 
       - name: Build @aws-amplify/ui package
         if: steps.restore-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
 
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, synchronize, labeled]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,6 +240,17 @@ jobs:
       - name: Add Amplify CLI
         run: yarn global add @aws-amplify/cli
 
+      - name: Get CLI versions
+        id: cli-version
+        run: echo "::set-output name=version::$(amplify --version)"
+
+      - name: Create or restore environments cache
+        id: environments-cache
+        uses: actions/cache@v2
+        with:
+          path: environments/**/aws-exports.js
+          key: ${{ runner.os }}-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('environments/**/amplify/**') }}
+
       - name: Pull down AWS environments
         run: yarn environments pull
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
           echo "::set-output name=commit::$(git rev-parse --short "$GITHUB_SHA")"
       - name: Install packages
         run: yarn --frozen-lockfile --prefer-offline
-      - name: build @aws-amplify/ui package
+      - name: build packages/ui package
         run: yarn ui build
       - name: Cache cypress runner
         uses: actions/cache@v2
@@ -106,7 +106,7 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
 
-      - name: Restore Cache
+      - name: Restore node_modules cache
         uses: actions/cache@v2
         id: restore-cache
         with:
@@ -144,7 +144,7 @@ jobs:
         run: yarn ${{ matrix.package }} lint
 
       - name: Run ${{ matrix.package }} tests
-        run: yarn ${{ matrix.package}} test
+        run: yarn ${{ matrix.package }} test
 
   e2e:
     # Only run e2e tests if unit tests pass
@@ -202,7 +202,7 @@ jobs:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
 
-      - name: Restore Cache
+      - name: Restore node_modules cache
         uses: actions/cache@v2
         id: restore-cache
         with:
@@ -251,7 +251,7 @@ jobs:
           path: environments/**/aws-exports.js
           key: ${{ runner.os }}-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('environments/**/amplify/**') }}
 
-      - name: Pull down AWS environments
+      - name: Pull down AWS environments on cache miss
         if: steps.environments-cache.outputs.cache-hit != 'true'
         run: yarn environments pull
         env:
@@ -324,11 +324,11 @@ jobs:
           path: ./packages/react/dist
           key: ${{ runner.os }}-@aws-amplify/ui-react-${{ needs.setup.outputs.commit }}
 
-      - name: Build @aws-amplify/ui package
+      - name: Build ui package
         if: steps.restore-ui-cache.outputs.cache-hit != 'true'
         run: yarn ui build
 
-      - name: build react package
+      - name: Build react package
         if: steps.restore-react-cache.outputs.cache-hit != 'true'
         run: yarn react build
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
           echo "::set-output name=commit::$(git rev-parse --short "$GITHUB_SHA")"
       - name: Install packages
         run: yarn --frozen-lockfile --prefer-offline
-      - name: build packages/ui package
+      - name: Build ui package
         run: yarn ui build
       - name: Cache cypress runner
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,12 +65,16 @@ jobs:
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
-      - name: Cache build
+      - name: Cache packages/ui/dist
+        uses: actions/cache@v2
+        with:
+          path: ./packages/ui/dist
+          key: ${{ runner.os }}-ui-${{ steps.get-ref.outputs.commit }}
+      - name: Cache node_modules
         uses: actions/cache@v2
         with:
           path: |
             ./node_modules
-            ./packages/ui/dist
             **/node_modules
           key: ${{ runner.os }}-yarn-${{ steps.get-ref.outputs.commit }}
   unit:
@@ -108,16 +112,22 @@ jobs:
         with:
           path: |
             ./node_modules
-            ./packages/ui/dist
             **/node_modules
           key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
+
+      - name: Restore packages/ui/dist cache
+        uses: actions/cache@v2
+        id: restore-ui-cache
+        with:
+          path: ./packages/ui/dist
+          key: ${{ runner.os }}-ui-${{ steps.get-ref.outputs.commit }}
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile --prefer-offline  --prefer-offline
 
       - name: Build @aws-amplify/ui package
-        if: steps.restore-cache.outputs.cache-hit != 'true' && ${{ matrix.package != '@aws-amplify/ui' }}
+        if: steps.restore-ui-cache.outputs.cache-hit != 'true' && ${{ matrix.package != '@aws-amplify/ui' }}
         run: yarn ui build
 
       - name: Build packages
@@ -189,16 +199,22 @@ jobs:
         with:
           path: |
             ./node_modules
-            ./packages/ui/dist
             **/node_modules
           key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
+
+      - name: Restore packages/ui/dist cache
+        uses: actions/cache@v2
+        id: restore-ui-cache
+        with:
+          path: ./packages/ui/dist
+          key: ${{ runner.os }}-ui-${{ steps.get-ref.outputs.commit }}
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile --prefer-offline
 
       - name: Build @aws-amplify/ui package
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.restore-ui-cache.outputs.cache-hit != 'true'
         run: yarn ui build
 
       - name: Build ${{ matrix.framework }} package
@@ -259,15 +275,21 @@ jobs:
           path: |
             ./node_modules
             **/node_modules
-            ./packages/ui/dist
           key: ${{ runner.os }}-yarn-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile --prefer-offline
 
+      - name: Restore packages/ui/dist cache
+        uses: actions/cache@v2
+        id: restore-ui-cache
+        with:
+          path: ./packages/ui/dist
+          key: ${{ runner.os }}-ui-${{ steps.get-ref.outputs.commit }}
+
       - name: Build @aws-amplify/ui package
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.restore-ui-cache.outputs.cache-hit != 'true'
         run: yarn ui build
 
       - name: build react package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,13 +70,6 @@ jobs:
         with:
           path: ./packages/ui/dist
           key: ${{ runner.os }}-ui-${{ steps.get-ref.outputs.commit }}
-      - name: Cache node_modules
-        uses: actions/cache@v2
-        with:
-          path: |
-            ./node_modules
-            **/node_modules
-          key: ${{ runner.os }}-nodemodules-${{ steps.get-ref.outputs.commit }}
   unit:
     needs: setup
     runs-on: ubuntu-latest
@@ -106,15 +99,6 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
 
-      - name: Restore node_modules cache
-        uses: actions/cache@v2
-        id: restore-cache
-        with:
-          path: |
-            ./node_modules
-            **/node_modules
-          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
-
       - name: Restore ui/dist cache
         uses: actions/cache@v2
         id: restore-ui-cache
@@ -123,8 +107,7 @@ jobs:
           key: ${{ runner.os }}-ui-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: yarn --frozen-lockfile --prefer-offline  --prefer-offline
+        run: yarn --frozen-lockfile --prefer-offline
 
       - name: Build ui package
         if: ${{ steps.restore-ui-cache.outputs.cache-hit != 'true' && matrix.package != 'ui' }}
@@ -202,15 +185,6 @@ jobs:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
 
-      - name: Restore node_modules cache
-        uses: actions/cache@v2
-        id: restore-cache
-        with:
-          path: |
-            ./node_modules
-            **/node_modules
-          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
-
       - name: Restore ui/dist cache
         uses: actions/cache@v2
         id: restore-ui-cache
@@ -226,7 +200,6 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.package }}-${{ needs.setup.outputs.commit }}
 
       - name: Install packages
-        if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile --prefer-offline
 
       - name: Build @aws-amplify/ui package
@@ -297,17 +270,7 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
 
-      - name: Restore Cache
-        uses: actions/cache@v2
-        id: restore-cache
-        with:
-          path: |
-            ./node_modules
-            **/node_modules
-          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
-
       - name: Install packages
-        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile --prefer-offline
 
       - name: Restore ui/dist cache

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -3,6 +3,7 @@
 . "$(dirname "$0")/common.sh"
 
 yarn install
+yarn build
 
 # React's build doesn't pick up on patch changes, so we need to run it twice
 yarn patch-package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 1. [`nvm install`](https://github.com/nvm-sh/nvm)
 1. [`nvm use`](https://github.com/nvm-sh/nvm)
 1. `yarn install`
+1. `yarn build`
 
 ## Documentation Development
 
@@ -163,5 +164,3 @@ Guidelines for bug reports:
 - Format any code snippets using [Markdown](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) syntax
 
 Finally, thank you for taking the time to read this, and taking the time to write a good bug report.
-
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "scripts": {
-    "install": "yarn build",
     "postinstall": "patch-package",
     "build": "npx ultra -r --filter '@aws-amplify/*' build",
     "angular": "yarn workspace @aws-amplify/ui-angular",


### PR DESCRIPTION
*Issue #, if available:* Fixes #927

*Description of changes:* This uses [`actions/cache`](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows) to shorten the CI runtime to reuse artifacts and dependencies.

## Cache strategy

Cache is identified by a unique key. With `hashFiles` and other identifiers, we can construct keys to explicitly define the criteria for cache hit. For example, I use 

```
key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
``` 
to cache cypress runner. This ensures that we reuse the same cypress file between workflows as long as they have the same `yarn.lock` file. If `yarn.lock` changes, which means cypress runner have possible changes, we rebuild and cache the new cypress runner.

## Minor improvements

This PR also separates `build` from `install` to allow for finer optimizations. We were rebuilding ui packages multiple times due to this.

## For reviewers

For reviewing, please see `pull_request` runs instead of `pull_request_target`. `pull_request_target` runs against the workflow on `main`, which isn't up-to-date with these changes and fail. Here's the latest run: https://github.com/aws-amplify/amplify-ui/actions/runs/1560372622






By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
