### PR TITLE
Adjust getting started with react example to use createTheme

### DIFF
--- a/docs/src/pages/theming/getting-started.react.mdx
+++ b/docs/src/pages/theming/getting-started.react.mdx
@@ -22,7 +22,7 @@ To extend or override a token in the default theme with `createTheme`
 import { AmplifyProvider, Theme } from '@aws-amplify/ui-react';
 
 // Step 1: Create a new Theme with your custom values
-const theme: Theme = {
+const theme = createTheme({
   name: 'my-theme',
   tokens: {
     colors: {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
On https://ui.docs.amplify.aws/theming
under "To extend or override a token in the default theme with createTheme" the code example in the documentation doesn't include createTheme. It is currently a ts js hybrid with no opening paren. 

This PR adjusts the example so that it works as expected if copied. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
