### PR TITLE
Add primitives.json to package exports

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,7 +16,8 @@
       "import": "./dist/esm/legacy.js",
       "require": "./dist/legacy.js"
     },
-    "./styles.css": "./dist/index.css"
+    "./styles.css": "./dist/index.css",
+    "./primitives.json": "./dist/primitives.json"
   },
   "browser": {
     "./styles.css": "./dist/index.css"


### PR DESCRIPTION
*Description of changes:*
Adding a missing entry for `primitives.json` file in package.json `exports` section


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
