### PR TITLE
Validate/modify formData on SignUp 

### DIFF
--- a/.changeset/late-snails-cover.md
+++ b/.changeset/late-snails-cover.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui': patch
+---
+
+Added new services to override handleSignup, handleSignIn, handleConfirmSignIn, handleConfirmSignUp, handleForgotPasswordSubmit, handleForgotPassword

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.html
@@ -1,4 +1,4 @@
-<amplify-authenticator initialState="signUp">
+<amplify-authenticator [services]="services" initialState="signUp">
   <ng-template
     amplifySlot="authenticated"
     let-user="user"

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Amplify } from 'aws-amplify';
+import { Amplify, Auth } from 'aws-amplify';
 import awsExports from './aws-exports';
 
 @Component({
@@ -10,4 +10,20 @@ export class SignUpWithEmailComponent {
   constructor() {
     Amplify.configure(awsExports);
   }
+
+  services = {
+    async handleSignUp(formData: Record<string, any>) {
+      const { username, password, attributes } = formData;
+      // custom username
+      const newAttributes = {
+        ...attributes,
+        email: attributes.email.toLowerCase(),
+      };
+      return Auth.signUp({
+        username: username.toLowerCase(),
+        password,
+        attributes: newAttributes,
+      });
+    },
+  };
 }

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.ts
@@ -13,16 +13,14 @@ export class SignUpWithEmailComponent {
 
   services = {
     async handleSignUp(formData: Record<string, any>) {
-      const { username, password, attributes } = formData;
+      let { username, password, attributes } = formData;
       // custom username
-      const newAttributes = {
-        ...attributes,
-        email: attributes.email.toLowerCase(),
-      };
+      username = username.toLowerCase();
+      attributes.email = attributes.email.toLowerCase();
       return Auth.signUp({
-        username: username.toLowerCase(),
+        username,
         password,
-        attributes: newAttributes,
+        attributes,
       });
     },
   };

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
@@ -9,16 +9,14 @@ Amplify.configure(awsExports);
 export default function AuthenticatorWithEmail() {
   const services = {
     async handleSignUp(formData) {
-      const { username, password, attributes } = formData;
+      let { username, password, attributes } = formData;
       // custom username
-      const newAttributes = {
-        ...attributes,
-        email: attributes.email.toLowerCase(),
-      };
+      username = username.toLowerCase();
+      attributes.email = attributes.email.toLowerCase();
       return Auth.signUp({
-        username: username.toLowerCase(),
+        username,
         password,
-        attributes: newAttributes,
+        attributes,
       });
     },
   };

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
@@ -1,4 +1,4 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify, Auth } from 'aws-amplify';
 
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
@@ -7,8 +7,24 @@ import awsExports from './aws-exports';
 Amplify.configure(awsExports);
 
 export default function AuthenticatorWithEmail() {
+  const services = {
+    async handleSignUp(formData) {
+      const { username, password, attributes } = formData;
+      // custom username
+      const newAttributes = {
+        ...attributes,
+        email: attributes.email.toLowerCase(),
+      };
+      return Auth.signUp({
+        username: username.toLowerCase(),
+        password,
+        attributes: newAttributes,
+      });
+    },
+  };
+
   return (
-    <Authenticator initialState="signUp">
+    <Authenticator services={services} initialState="signUp">
       {({ signOut }) => <button onClick={signOut}>Sign out</button>}
     </Authenticator>
   );

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
@@ -1,14 +1,22 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import Amplify, { Auth } from 'aws-amplify';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from './aws-exports';
 
 Amplify.configure(aws_exports);
+
+const services = {
+  async handleSignUp(e) {
+    const { username, password, attributes } = e;
+    console.log('custom login');
+    return Auth.signUp({ username, password, attributes });
+  },
+};
 </script>
 
 <template>
-  <authenticator>
+  <authenticator :services="services">
     <template v-slot="{ user, signOut }">
       <h1>Hello {{ user.username }}!</h1>
       <button @click="signOut">Sign Out</button>

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
@@ -9,7 +9,6 @@ Amplify.configure(aws_exports);
 const services = {
   async handleSignUp(e) {
     const { username, password, attributes } = e;
-    console.log('custom login');
     return Auth.signUp({ username, password, attributes });
   },
 };

--- a/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
@@ -8,16 +8,14 @@ Amplify.configure(aws_exports);
 
 const services = {
   async handleSignUp(formData) {
-    const { username, password, attributes } = formData;
+    let { username, password, attributes } = formData;
     // custom username
-    const newAttributes = {
-      ...attributes,
-      email: attributes.email.toLowerCase(),
-    };
+    username = username.toLowerCase();
+    attributes.email = attributes.email.toLowerCase();
     return Auth.signUp({
-      username: username.toLowerCase(),
+      username,
       password,
-      attributes: newAttributes,
+      attributes,
     });
   },
 };

--- a/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
@@ -1,13 +1,30 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import Amplify, { Auth } from 'aws-amplify';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from './aws-exports';
+
 Amplify.configure(aws_exports);
+
+const services = {
+  async handleSignUp(formData) {
+    const { username, password, attributes } = formData;
+    // custom username
+    const newAttributes = {
+      ...attributes,
+      email: attributes.email.toLowerCase(),
+    };
+    return Auth.signUp({
+      username: username.toLowerCase(),
+      password,
+      attributes: newAttributes,
+    });
+  },
+};
 </script>
 
 <template>
-  <authenticator initial-state="signUp">
+  <authenticator :services="services" initial-state="signUp">
     <template v-slot="{ user, signOut }">
       <h1>Hello {{ user.username }}!</h1>
       <button @click="signOut">Sign Out</button>

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -31,9 +31,13 @@ Given(
       throw error;
     }
 
-    cy.intercept(routeMatcher, { fixture });
+    cy.intercept(routeMatcher, { fixture }).as('route');
   }
 );
+
+Given('I verify the body has {string} included', (value: string) => {
+  cy.wait('@route').its('request.body.Username').should('include', value);
+});
 
 Given(
   'I intercept {string} with error fixture {string}',
@@ -79,6 +83,13 @@ When('I type an invalid password', () => {
 When('I type a new {string}', (field: string) => {
   cy.findInputField(field).typeAliasWithStatus(field, `${Date.now()}`);
 });
+
+When(
+  'I type a new {string} with value {string}',
+  (field: string, value: string) => {
+    cy.findInputField(field).type(value);
+  }
+);
 
 When('I click the {string} tab', (label: string) => {
   cy.findByRole('tab', {

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
@@ -12,6 +12,16 @@ Feature: Sign Up with Email
     And I don't see "Phone Number" as an input field
 
   @angular @react @vue  
+  Scenario: Sign up with a new email & password and lowercase the email 
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-email"
+    When I type a new "email" with value "TEST@example.com"
+    And I type my password
+    And I confirm my password
+    And I click the "Create Account" button
+    And I verify the body has "test@example.com" included
+    Then I see "Confirmation Code"
+
+@angular @react @vue  
   Scenario: Sign up with a new email & password
     Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-email"
     When I type a new "email"

--- a/packages/ui/src/machines/authenticator/actors/resetPassword.ts
+++ b/packages/ui/src/machines/authenticator/actors/resetPassword.ts
@@ -1,6 +1,5 @@
 import { Auth } from 'aws-amplify';
 import { createMachine, sendUpdate } from 'xstate';
-
 import { AuthEvent, ResetPasswordContext } from '../../../types';
 import { runValidators } from '../../../validators';
 import {
@@ -17,183 +16,191 @@ import {
 } from '../actions';
 import { defaultServices } from '../defaultServices';
 
-// TODO `createResetPasswordMachine` that accepts `services`
-export const resetPasswordActor = createMachine<
-  ResetPasswordContext,
-  AuthEvent
->(
-  {
-    id: 'resetPasswordActor',
-    initial: 'init',
-    states: {
-      init: {
-        always: [
-          { target: 'confirmResetPassword', cond: 'shouldAutoConfirmReset' },
-          { target: 'resetPassword' },
-        ],
-      },
-      resetPassword: {
-        initial: 'edit',
-        exit: ['clearFormValues', 'clearError', 'clearTouched'],
-        states: {
-          edit: {
-            entry: sendUpdate(),
-            on: {
-              SUBMIT: 'submit',
-              CHANGE: { actions: 'handleInput' },
-              BLUR: { actions: 'handleBlur' },
-            },
-          },
-          submit: {
-            tags: ['pending'],
-            entry: [sendUpdate(), 'setUsername', 'clearError'],
-            invoke: {
-              src: 'resetPassword',
-              onDone: {
-                target: '#resetPasswordActor.confirmResetPassword',
-              },
-              onError: {
-                actions: ['setRemoteError'],
-                target: 'edit',
-              },
-            },
-          },
+export type ResetPasswordMachineOptions = {
+  services?: Partial<typeof defaultServices>;
+};
+
+export function resetPasswordActor({ services }: ResetPasswordMachineOptions) {
+  return createMachine<ResetPasswordContext, AuthEvent>(
+    {
+      id: 'resetPasswordActor',
+      initial: 'init',
+      states: {
+        init: {
+          always: [
+            { target: 'confirmResetPassword', cond: 'shouldAutoConfirmReset' },
+            { target: 'resetPassword' },
+          ],
         },
-      },
-      confirmResetPassword: {
-        type: 'parallel',
-        exit: [
-          'clearFormValues',
-          'clearError',
-          'clearUsername',
-          'clearTouched',
-        ],
-        states: {
-          validation: {
-            initial: 'pending',
-            states: {
-              pending: {
-                invoke: {
-                  src: 'validateFields',
-                  onDone: {
-                    target: 'valid',
-                    actions: 'clearValidationError',
-                  },
-                  onError: {
-                    target: 'invalid',
-                    actions: 'setFieldErrors',
-                  },
-                },
-              },
-              valid: { entry: sendUpdate() },
-              invalid: { entry: sendUpdate() },
-            },
-            on: {
-              CHANGE: {
-                actions: 'handleInput',
-                target: '.pending',
-              },
-              BLUR: {
-                actions: 'handleBlur',
-                target: '.pending',
+        resetPassword: {
+          initial: 'edit',
+          exit: ['clearFormValues', 'clearError', 'clearTouched'],
+          states: {
+            edit: {
+              entry: sendUpdate(),
+              on: {
+                SUBMIT: 'submit',
+                CHANGE: { actions: 'handleInput' },
+                BLUR: { actions: 'handleBlur' },
               },
             },
-          },
-          submission: {
-            initial: 'idle',
-            states: {
-              idle: {
-                entry: sendUpdate(),
-                on: {
-                  SUBMIT: 'validate',
-                  RESEND: 'resendCode',
-                  CHANGE: { actions: 'handleInput' },
-                  BLUR: { actions: 'handleBlur' },
+            submit: {
+              tags: ['pending'],
+              entry: [sendUpdate(), 'setUsername', 'clearError'],
+              invoke: {
+                src: 'resetPassword',
+                onDone: {
+                  target: '#resetPasswordActor.confirmResetPassword',
                 },
-              },
-              validate: {
-                entry: sendUpdate(),
-                invoke: {
-                  src: 'validateFields',
-                  onDone: {
-                    target: 'pending',
-                    actions: 'clearValidationError',
-                  },
-                  onError: {
-                    target: 'idle',
-                    actions: 'setFieldErrors',
-                  },
-                },
-              },
-              resendCode: {
-                tags: ['pending'],
-                entry: ['clearError', sendUpdate()],
-                invoke: {
-                  src: 'resetPassword',
-                  onDone: { target: 'idle' },
-                  onError: {
-                    actions: 'setRemoteError',
-                    target: 'idle',
-                  },
-                },
-              },
-              pending: {
-                tags: ['pending'],
-                entry: ['clearError', sendUpdate()],
-                invoke: {
-                  src: 'confirmResetPassword',
-                  onDone: {
-                    actions: 'clearUsername',
-                    target: '#resetPasswordActor.resolved',
-                  },
-                  onError: {
-                    actions: 'setRemoteError',
-                    target: 'idle',
-                  },
+                onError: {
+                  actions: ['setRemoteError'],
+                  target: 'edit',
                 },
               },
             },
           },
         },
+        confirmResetPassword: {
+          type: 'parallel',
+          exit: [
+            'clearFormValues',
+            'clearError',
+            'clearUsername',
+            'clearTouched',
+          ],
+          states: {
+            validation: {
+              initial: 'pending',
+              states: {
+                pending: {
+                  invoke: {
+                    src: 'validateFields',
+                    onDone: {
+                      target: 'valid',
+                      actions: 'clearValidationError',
+                    },
+                    onError: {
+                      target: 'invalid',
+                      actions: 'setFieldErrors',
+                    },
+                  },
+                },
+                valid: { entry: sendUpdate() },
+                invalid: { entry: sendUpdate() },
+              },
+              on: {
+                CHANGE: {
+                  actions: 'handleInput',
+                  target: '.pending',
+                },
+                BLUR: {
+                  actions: 'handleBlur',
+                  target: '.pending',
+                },
+              },
+            },
+            submission: {
+              initial: 'idle',
+              states: {
+                idle: {
+                  entry: sendUpdate(),
+                  on: {
+                    SUBMIT: 'validate',
+                    RESEND: 'resendCode',
+                    CHANGE: { actions: 'handleInput' },
+                    BLUR: { actions: 'handleBlur' },
+                  },
+                },
+                validate: {
+                  entry: sendUpdate(),
+                  invoke: {
+                    src: 'validateFields',
+                    onDone: {
+                      target: 'pending',
+                      actions: 'clearValidationError',
+                    },
+                    onError: {
+                      target: 'idle',
+                      actions: 'setFieldErrors',
+                    },
+                  },
+                },
+                resendCode: {
+                  tags: ['pending'],
+                  entry: ['clearError', sendUpdate()],
+                  invoke: {
+                    src: 'resetPassword',
+                    onDone: { target: 'idle' },
+                    onError: {
+                      actions: 'setRemoteError',
+                      target: 'idle',
+                    },
+                  },
+                },
+                pending: {
+                  tags: ['pending'],
+                  entry: ['clearError', sendUpdate()],
+                  invoke: {
+                    src: 'confirmResetPassword',
+                    onDone: {
+                      actions: 'clearUsername',
+                      target: '#resetPasswordActor.resolved',
+                    },
+                    onError: {
+                      actions: 'setRemoteError',
+                      target: 'idle',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        resolved: { type: 'final' },
       },
-      resolved: { type: 'final' },
     },
-  },
-  {
-    actions: {
-      clearError,
-      clearFormValues,
-      clearTouched,
-      clearUsername,
-      clearValidationError,
-      handleInput,
-      handleBlur,
-      setFieldErrors,
-      setRemoteError,
-      setUsername,
-    },
-    guards: {
-      shouldAutoConfirmReset: (context, event): boolean => {
-        return !!(context.intent && context.intent === 'confirmPasswordReset');
+    {
+      actions: {
+        clearError,
+        clearFormValues,
+        clearTouched,
+        clearUsername,
+        clearValidationError,
+        handleInput,
+        handleBlur,
+        setFieldErrors,
+        setRemoteError,
+        setUsername,
       },
-    },
-    services: {
-      async resetPassword(context) {
-        const username = context.formValues?.username ?? context.username;
+      guards: {
+        shouldAutoConfirmReset: (context, event): boolean => {
+          return !!(
+            context.intent && context.intent === 'confirmPasswordReset'
+          );
+        },
+      },
+      services: {
+        async resetPassword(context) {
+          const username = context.formValues?.username ?? context.username;
 
-        return Auth.forgotPassword(username);
-      },
-      async confirmResetPassword(context) {
-        const { username } = context;
-        const { confirmation_code: code, password } = context.formValues;
+          return services.handleForgotPassword(username);
+        },
+        async confirmResetPassword(context) {
+          const { username } = context;
+          const { confirmation_code: code, password } = context.formValues;
 
-        return Auth.forgotPasswordSubmit(username, code, password);
+          return services.handleForgotPasswordSubmit({
+            username,
+            code,
+            password,
+          });
+        },
+        async validateFields(context, event) {
+          return runValidators(context.formValues, context.touched, [
+            defaultServices.validateConfirmPassword,
+          ]);
+        },
       },
-      async validateFields(context, event) {
-        return runValidators(context.formValues, context.touched, [
-          defaultServices.validateConfirmPassword,
-        ]);
-      },
-    },
-  }
-);
+    }
+  );
+}

--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -2,7 +2,6 @@ import { Auth } from 'aws-amplify';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import { createMachine, sendUpdate } from 'xstate';
-
 import { AuthChallengeNames, AuthEvent, SignInContext } from '../../../types';
 import { runValidators } from '../../../validators';
 import {
@@ -27,442 +26,451 @@ import {
 } from '../actions';
 import { defaultServices } from '../defaultServices';
 
-export const signInActor = createMachine<SignInContext, AuthEvent>(
-  {
-    initial: 'init',
-    id: 'signInActor',
-    states: {
-      init: {
-        always: [{ target: 'signIn' }],
-      },
-      signIn: {
-        initial: 'edit',
-        exit: ['clearFormValues', 'clearTouched'],
-        states: {
-          edit: {
-            entry: sendUpdate(),
-            on: {
-              SUBMIT: 'submit',
-              CHANGE: { actions: 'handleInput' },
-              FEDERATED_SIGN_IN: 'federatedSignIn',
+export type SignInMachineOptions = {
+  services?: Partial<typeof defaultServices>;
+};
+
+export function signInActor({ services }: SignInMachineOptions) {
+  return createMachine<SignInContext, AuthEvent>(
+    {
+      initial: 'init',
+      id: 'signInActor',
+      states: {
+        init: {
+          always: [{ target: 'signIn' }],
+        },
+        signIn: {
+          initial: 'edit',
+          exit: ['clearFormValues', 'clearTouched'],
+          states: {
+            edit: {
+              entry: sendUpdate(),
+              on: {
+                SUBMIT: 'submit',
+                CHANGE: { actions: 'handleInput' },
+                FEDERATED_SIGN_IN: 'federatedSignIn',
+              },
             },
-          },
-          federatedSignIn: {
-            tags: ['pending'],
-            entry: [sendUpdate(), 'clearError'],
-            invoke: {
-              src: 'federatedSignIn',
-              // getting navigated out anyway, only track errors.
-              // onDone: '#signInActor.resolved',
-              onError: { actions: 'setRemoteError' },
+            federatedSignIn: {
+              tags: ['pending'],
+              entry: [sendUpdate(), 'clearError'],
+              invoke: {
+                src: 'federatedSignIn',
+                // getting navigated out anyway, only track errors.
+                // onDone: '#signInActor.resolved',
+                onError: { actions: 'setRemoteError' },
+              },
             },
-          },
-          submit: {
-            tags: ['pending'],
-            entry: ['clearError', sendUpdate()],
-            invoke: {
-              src: 'signIn',
-              onDone: [
-                {
-                  cond: 'shouldSetupTOTP',
-                  actions: ['setUser', 'setChallengeName'],
-                  target: '#signInActor.setupTOTP',
-                },
-                {
-                  cond: 'shouldConfirmSignIn',
-                  actions: ['setUser', 'setChallengeName'],
-                  target: '#signInActor.confirmSignIn',
-                },
-                {
-                  cond: 'shouldForceChangePassword',
-                  actions: ['setUser', 'setChallengeName'],
-                  target: '#signInActor.forceNewPassword',
-                },
-                {
-                  actions: 'setUser',
-                  target: 'verifying',
-                },
-              ],
-              onError: [
-                {
-                  cond: 'shouldRedirectToConfirmSignUp',
-                  actions: ['setCredentials', 'setConfirmSignUpIntent'],
-                  target: 'rejected',
-                },
-                {
-                  cond: 'shouldRedirectToConfirmResetPassword',
-                  actions: [
-                    'setUsernameAuthAttributes',
-                    'setConfirmResetPasswordIntent',
-                  ],
-                  target: 'rejected',
-                },
-                {
+            submit: {
+              tags: ['pending'],
+              entry: ['clearError', sendUpdate()],
+              invoke: {
+                src: 'signIn',
+                onDone: [
+                  {
+                    cond: 'shouldSetupTOTP',
+                    actions: ['setUser', 'setChallengeName'],
+                    target: '#signInActor.setupTOTP',
+                  },
+                  {
+                    cond: 'shouldConfirmSignIn',
+                    actions: ['setUser', 'setChallengeName'],
+                    target: '#signInActor.confirmSignIn',
+                  },
+                  {
+                    cond: 'shouldForceChangePassword',
+                    actions: ['setUser', 'setChallengeName'],
+                    target: '#signInActor.forceNewPassword',
+                  },
+                  {
+                    actions: 'setUser',
+                    target: 'verifying',
+                  },
+                ],
+                onError: [
+                  {
+                    cond: 'shouldRedirectToConfirmSignUp',
+                    actions: ['setCredentials', 'setConfirmSignUpIntent'],
+                    target: 'rejected',
+                  },
+                  {
+                    cond: 'shouldRedirectToConfirmResetPassword',
+                    actions: [
+                      'setUsernameAuthAttributes',
+                      'setConfirmResetPasswordIntent',
+                    ],
+                    target: 'rejected',
+                  },
+                  {
+                    actions: 'setRemoteError',
+                    target: 'edit',
+                  },
+                ],
+              },
+            },
+            verifying: {
+              tags: ['pending'],
+              entry: ['clearError', sendUpdate()],
+              invoke: {
+                src: 'checkVerifiedContact',
+                onDone: [
+                  {
+                    cond: 'shouldRequestVerification',
+                    target: '#signInActor.verifyUser',
+                    actions: 'setUnverifiedAttributes',
+                  },
+                  {
+                    target: 'resolved',
+                  },
+                ],
+                onError: {
                   actions: 'setRemoteError',
                   target: 'edit',
                 },
-              ],
-            },
-          },
-          verifying: {
-            tags: ['pending'],
-            entry: ['clearError', sendUpdate()],
-            invoke: {
-              src: 'checkVerifiedContact',
-              onDone: [
-                {
-                  cond: 'shouldRequestVerification',
-                  target: '#signInActor.verifyUser',
-                  actions: 'setUnverifiedAttributes',
-                },
-                {
-                  target: 'resolved',
-                },
-              ],
-              onError: {
-                actions: 'setRemoteError',
-                target: 'edit',
               },
             },
+            resolved: { always: '#signInActor.resolved' },
+            rejected: { always: '#signInActor.rejected' },
           },
-          resolved: { always: '#signInActor.resolved' },
-          rejected: { always: '#signInActor.rejected' },
         },
-      },
-      confirmSignIn: {
-        initial: 'edit',
-        exit: ['clearFormValues', 'clearError', 'clearTouched'],
-        states: {
-          edit: {
-            entry: sendUpdate(),
-            on: {
-              SUBMIT: 'submit',
-              SIGN_IN: '#signInActor.signIn',
-              CHANGE: { actions: 'handleInput' },
-            },
-          },
-          submit: {
-            tags: ['pending'],
-            entry: ['clearError', sendUpdate()],
-            invoke: {
-              src: 'confirmSignIn',
-              onDone: {
-                target: '#signInActor.resolved',
-                actions: ['setUser', 'clearChallengeName'],
+        confirmSignIn: {
+          initial: 'edit',
+          exit: ['clearFormValues', 'clearError', 'clearTouched'],
+          states: {
+            edit: {
+              entry: sendUpdate(),
+              on: {
+                SUBMIT: 'submit',
+                SIGN_IN: '#signInActor.signIn',
+                CHANGE: { actions: 'handleInput' },
               },
-              onError: {
-                target: 'edit',
-                actions: 'setRemoteError',
+            },
+            submit: {
+              tags: ['pending'],
+              entry: ['clearError', sendUpdate()],
+              invoke: {
+                src: 'confirmSignIn',
+                onDone: {
+                  target: '#signInActor.resolved',
+                  actions: ['setUser', 'clearChallengeName'],
+                },
+                onError: {
+                  target: 'edit',
+                  actions: 'setRemoteError',
+                },
               },
             },
           },
         },
-      },
-      forceNewPassword: {
-        type: 'parallel',
-        exit: ['clearFormValues', 'clearError', 'clearTouched'],
-        states: {
-          validation: {
-            initial: 'pending',
-            states: {
-              pending: {
-                invoke: {
-                  src: 'validateFields',
-                  onDone: {
-                    target: 'valid',
-                    actions: 'clearValidationError',
-                  },
-                  onError: {
-                    target: 'invalid',
-                    actions: 'setFieldErrors',
-                  },
-                },
-              },
-              valid: { entry: sendUpdate() },
-              invalid: { entry: sendUpdate() },
-            },
-            on: {
-              CHANGE: {
-                actions: 'handleInput',
-                target: '.pending',
-              },
-              BLUR: {
-                actions: 'handleBlur',
-                target: '.pending',
-              },
-            },
-          },
-          submit: {
-            initial: 'idle',
-            entry: 'clearError',
-            states: {
-              idle: {
-                entry: sendUpdate(),
-                on: {
-                  SUBMIT: 'validate',
-                },
-              },
-              validate: {
-                entry: sendUpdate(),
-                invoke: {
-                  src: 'validateFields',
-                  onDone: {
-                    target: 'pending',
-                    actions: 'clearValidationError',
-                  },
-                  onError: {
-                    target: 'idle',
-                    actions: 'setFieldErrors',
+        forceNewPassword: {
+          type: 'parallel',
+          exit: ['clearFormValues', 'clearError', 'clearTouched'],
+          states: {
+            validation: {
+              initial: 'pending',
+              states: {
+                pending: {
+                  invoke: {
+                    src: 'validateFields',
+                    onDone: {
+                      target: 'valid',
+                      actions: 'clearValidationError',
+                    },
+                    onError: {
+                      target: 'invalid',
+                      actions: 'setFieldErrors',
+                    },
                   },
                 },
+                valid: { entry: sendUpdate() },
+                invalid: { entry: sendUpdate() },
               },
-              pending: {
-                tags: ['pending'],
-                entry: [sendUpdate(), 'clearError'],
-                invoke: {
-                  src: 'forceNewPassword',
-                  onDone: {
-                    target: 'resolved',
-                    actions: ['setUser', 'setCredentials'],
-                  },
-                  onError: {
-                    target: 'idle',
-                    actions: 'setRemoteError',
-                  },
+              on: {
+                CHANGE: {
+                  actions: 'handleInput',
+                  target: '.pending',
+                },
+                BLUR: {
+                  actions: 'handleBlur',
+                  target: '.pending',
                 },
               },
-              resolved: { type: 'final', always: '#signInActor.resolved' },
             },
-          },
-        },
-      },
-      setupTOTP: {
-        initial: 'edit',
-        exit: ['clearFormValues', 'clearError', 'clearTouched'],
-        states: {
-          edit: {
-            entry: sendUpdate(),
-            on: {
-              SUBMIT: 'submit',
-              SIGN_IN: '#signInActor.signIn',
-              CHANGE: { actions: 'handleInput' },
-            },
-          },
-          submit: {
-            tags: ['pending'],
-            entry: [sendUpdate(), 'clearError'],
-            invoke: {
-              src: 'verifyTotpToken',
-              onDone: {
-                actions: ['setUser', 'clearChallengeName'],
-                target: '#signInActor.resolved',
-              },
-              onError: {
-                actions: 'setRemoteError',
-                target: 'edit',
+            submit: {
+              initial: 'idle',
+              entry: 'clearError',
+              states: {
+                idle: {
+                  entry: sendUpdate(),
+                  on: {
+                    SUBMIT: 'validate',
+                  },
+                },
+                validate: {
+                  entry: sendUpdate(),
+                  invoke: {
+                    src: 'validateFields',
+                    onDone: {
+                      target: 'pending',
+                      actions: 'clearValidationError',
+                    },
+                    onError: {
+                      target: 'idle',
+                      actions: 'setFieldErrors',
+                    },
+                  },
+                },
+                pending: {
+                  tags: ['pending'],
+                  entry: [sendUpdate(), 'clearError'],
+                  invoke: {
+                    src: 'forceNewPassword',
+                    onDone: {
+                      target: 'resolved',
+                      actions: ['setUser', 'setCredentials'],
+                    },
+                    onError: {
+                      target: 'idle',
+                      actions: 'setRemoteError',
+                    },
+                  },
+                },
+                resolved: { type: 'final', always: '#signInActor.resolved' },
               },
             },
           },
         },
-      },
-      verifyUser: {
-        initial: 'edit',
-        exit: ['clearFormValues', 'clearError', 'clearTouched'],
-        states: {
-          edit: {
-            entry: sendUpdate(),
-            on: {
-              SUBMIT: 'submit',
-              SKIP: '#signInActor.resolved',
-              CHANGE: { actions: 'handleInput' },
-            },
-          },
-          submit: {
-            tags: ['pending'],
-            entry: 'clearError',
-            invoke: {
-              src: 'verifyUser',
-              onDone: {
-                target: '#signInActor.confirmVerifyUser',
-              },
-              onError: {
-                actions: 'setRemoteError',
-                target: 'edit',
+        setupTOTP: {
+          initial: 'edit',
+          exit: ['clearFormValues', 'clearError', 'clearTouched'],
+          states: {
+            edit: {
+              entry: sendUpdate(),
+              on: {
+                SUBMIT: 'submit',
+                SIGN_IN: '#signInActor.signIn',
+                CHANGE: { actions: 'handleInput' },
               },
             },
-          },
-        },
-      },
-      confirmVerifyUser: {
-        initial: 'edit',
-        exit: [
-          'clearFormValues',
-          'clearError',
-          'clearUnverifiedAttributes',
-          'clearAttributeToVerify',
-          'clearTouched',
-        ],
-        states: {
-          edit: {
-            entry: sendUpdate(),
-            on: {
-              SUBMIT: 'submit',
-              SKIP: '#signInActor.resolved',
-              CHANGE: { actions: 'handleInput' },
-            },
-          },
-          submit: {
-            tags: ['pending'],
-            entry: 'clearError',
-            invoke: {
-              src: 'confirmVerifyUser',
-              onDone: {
-                target: '#signInActor.resolved',
-              },
-              onError: {
-                actions: 'setRemoteError',
-                target: 'edit',
+            submit: {
+              tags: ['pending'],
+              entry: [sendUpdate(), 'clearError'],
+              invoke: {
+                src: 'verifyTotpToken',
+                onDone: {
+                  actions: ['setUser', 'clearChallengeName'],
+                  target: '#signInActor.resolved',
+                },
+                onError: {
+                  actions: 'setRemoteError',
+                  target: 'edit',
+                },
               },
             },
           },
         },
-      },
-      resolved: {
-        type: 'final',
-        data: (context) => ({
-          user: context.user,
-        }),
-      },
-      rejected: {
-        type: 'final',
-        data: (context, event) => {
-          return {
-            intent: context.redirectIntent,
-            authAttributes: context.authAttributes,
-          };
+        verifyUser: {
+          initial: 'edit',
+          exit: ['clearFormValues', 'clearError', 'clearTouched'],
+          states: {
+            edit: {
+              entry: sendUpdate(),
+              on: {
+                SUBMIT: 'submit',
+                SKIP: '#signInActor.resolved',
+                CHANGE: { actions: 'handleInput' },
+              },
+            },
+            submit: {
+              tags: ['pending'],
+              entry: 'clearError',
+              invoke: {
+                src: 'verifyUser',
+                onDone: {
+                  target: '#signInActor.confirmVerifyUser',
+                },
+                onError: {
+                  actions: 'setRemoteError',
+                  target: 'edit',
+                },
+              },
+            },
+          },
+        },
+        confirmVerifyUser: {
+          initial: 'edit',
+          exit: [
+            'clearFormValues',
+            'clearError',
+            'clearUnverifiedAttributes',
+            'clearAttributeToVerify',
+            'clearTouched',
+          ],
+          states: {
+            edit: {
+              entry: sendUpdate(),
+              on: {
+                SUBMIT: 'submit',
+                SKIP: '#signInActor.resolved',
+                CHANGE: { actions: 'handleInput' },
+              },
+            },
+            submit: {
+              tags: ['pending'],
+              entry: 'clearError',
+              invoke: {
+                src: 'confirmVerifyUser',
+                onDone: {
+                  target: '#signInActor.resolved',
+                },
+                onError: {
+                  actions: 'setRemoteError',
+                  target: 'edit',
+                },
+              },
+            },
+          },
+        },
+        resolved: {
+          type: 'final',
+          data: (context) => ({
+            user: context.user,
+          }),
+        },
+        rejected: {
+          type: 'final',
+          data: (context, event) => {
+            return {
+              intent: context.redirectIntent,
+              authAttributes: context.authAttributes,
+            };
+          },
         },
       },
     },
-  },
-  {
-    actions: {
-      clearAttributeToVerify,
-      clearChallengeName,
-      clearError,
-      clearFormValues,
-      clearTouched,
-      clearUnverifiedAttributes,
-      clearValidationError,
-      handleInput,
-      handleBlur,
-      setChallengeName,
-      setConfirmResetPasswordIntent,
-      setConfirmSignUpIntent,
-      setCredentials,
-      setFieldErrors,
-      setRemoteError,
-      setUnverifiedAttributes,
-      setUser,
-      setUsernameAuthAttributes,
-    },
-    guards: {
-      shouldConfirmSignIn: (_, event): boolean => {
-        const challengeName = get(event, 'data.challengeName');
-        const validChallengeNames = [
-          AuthChallengeNames.SMS_MFA,
-          AuthChallengeNames.SOFTWARE_TOKEN_MFA,
-        ];
+    {
+      actions: {
+        clearAttributeToVerify,
+        clearChallengeName,
+        clearError,
+        clearFormValues,
+        clearTouched,
+        clearUnverifiedAttributes,
+        clearValidationError,
+        handleInput,
+        handleBlur,
+        setChallengeName,
+        setConfirmResetPasswordIntent,
+        setConfirmSignUpIntent,
+        setCredentials,
+        setFieldErrors,
+        setRemoteError,
+        setUnverifiedAttributes,
+        setUser,
+        setUsernameAuthAttributes,
+      },
+      guards: {
+        shouldConfirmSignIn: (_, event): boolean => {
+          const challengeName = get(event, 'data.challengeName');
+          const validChallengeNames = [
+            AuthChallengeNames.SMS_MFA,
+            AuthChallengeNames.SOFTWARE_TOKEN_MFA,
+          ];
 
-        return validChallengeNames.includes(challengeName);
-      },
-      shouldRedirectToConfirmSignUp: (_, event): boolean => {
-        return event.data.code === 'UserNotConfirmedException';
-      },
-      shouldRedirectToConfirmResetPassword: (_, event): boolean => {
-        return event.data.code === 'PasswordResetRequiredException';
-      },
-      shouldSetupTOTP: (_, event): boolean => {
-        const challengeName = get(event, 'data.challengeName');
+          return validChallengeNames.includes(challengeName);
+        },
+        shouldRedirectToConfirmSignUp: (_, event): boolean => {
+          return event.data.code === 'UserNotConfirmedException';
+        },
+        shouldRedirectToConfirmResetPassword: (_, event): boolean => {
+          return event.data.code === 'PasswordResetRequiredException';
+        },
+        shouldSetupTOTP: (_, event): boolean => {
+          const challengeName = get(event, 'data.challengeName');
 
-        return challengeName === AuthChallengeNames.MFA_SETUP;
-      },
-      shouldForceChangePassword: (_, event): boolean => {
-        const challengeName = get(event, 'data.challengeName');
+          return challengeName === AuthChallengeNames.MFA_SETUP;
+        },
+        shouldForceChangePassword: (_, event): boolean => {
+          const challengeName = get(event, 'data.challengeName');
 
-        return challengeName === AuthChallengeNames.NEW_PASSWORD_REQUIRED;
-      },
-      shouldRequestVerification: (_, event): boolean => {
-        const { unverified, verified } = event.data;
+          return challengeName === AuthChallengeNames.NEW_PASSWORD_REQUIRED;
+        },
+        shouldRequestVerification: (_, event): boolean => {
+          const { unverified, verified } = event.data;
 
-        return isEmpty(verified) && !isEmpty(unverified);
+          return isEmpty(verified) && !isEmpty(unverified);
+        },
       },
-    },
-    services: {
-      async signIn(context) {
-        const source = context.formValues;
-        const { country_code, username, password } = source;
+      services: {
+        async signIn(context) {
+          const source = context.formValues;
+          const { country_code, username, password } = source;
 
-        return Auth.signIn((country_code ?? '') + username, password);
+          return await services.handleSignIn({
+            username: (country_code ?? '') + username,
+            password,
+          });
+        },
+        async confirmSignIn(context, event) {
+          const { challengeName, user } = context;
+          const { confirmation_code: code } = context.formValues;
+
+          let mfaType;
+          if (
+            challengeName === AuthChallengeNames.SMS_MFA ||
+            challengeName === AuthChallengeNames.SOFTWARE_TOKEN_MFA
+          ) {
+            mfaType = challengeName;
+          }
+
+          return await services.handleConfirmSignIn({ user, code, mfaType });
+        },
+        async forceNewPassword(context, event) {
+          const { user, formValues } = context;
+          const { password } = formValues;
+
+          return Auth.completeNewPassword(user, password);
+        },
+        async verifyTotpToken(context, event) {
+          const { user } = context;
+          const { confirmation_code } = context.formValues;
+
+          return Auth.verifyTotpToken(user, confirmation_code);
+        },
+        async federatedSignIn(_, event) {
+          const { provider } = event.data;
+
+          return await Auth.federatedSignIn({ provider });
+        },
+        async checkVerifiedContact(context, event) {
+          const { user } = context;
+          const result = await Auth.verifiedContact(user);
+
+          return result;
+        },
+        async verifyUser(context, event) {
+          const { unverifiedAttr } = context.formValues;
+          const result = await Auth.verifyCurrentUserAttribute(unverifiedAttr);
+
+          context.attributeToVerify = unverifiedAttr;
+
+          return result;
+        },
+        async confirmVerifyUser(context, event) {
+          const { attributeToVerify } = context;
+          const { confirmation_code } = context.formValues;
+
+          return await Auth.verifyCurrentUserAttributeSubmit(
+            attributeToVerify,
+            confirmation_code
+          );
+        },
+        async validateFields(context, event) {
+          return runValidators(context.formValues, context.touched, [
+            defaultServices.validateConfirmPassword,
+          ]);
+        },
       },
-      async confirmSignIn(context, event) {
-        const { challengeName, user } = context;
-        const { confirmation_code: code } = context.formValues;
-
-        let mfaType;
-        if (
-          challengeName === AuthChallengeNames.SMS_MFA ||
-          challengeName === AuthChallengeNames.SOFTWARE_TOKEN_MFA
-        ) {
-          mfaType = challengeName;
-        }
-
-        return Auth.confirmSignIn(user, code, mfaType);
-      },
-      async forceNewPassword(context, event) {
-        const { user, formValues } = context;
-        const { password } = formValues;
-
-        return Auth.completeNewPassword(user, password);
-      },
-      async verifyTotpToken(context, event) {
-        const { user } = context;
-        const { confirmation_code } = context.formValues;
-
-        return Auth.verifyTotpToken(user, confirmation_code);
-      },
-      async federatedSignIn(_, event) {
-        const { provider } = event.data;
-
-        return await Auth.federatedSignIn({ provider });
-      },
-      async checkVerifiedContact(context, event) {
-        const { user } = context;
-        const result = await Auth.verifiedContact(user);
-
-        return result;
-      },
-      async verifyUser(context, event) {
-        const { unverifiedAttr } = context.formValues;
-        const result = await Auth.verifyCurrentUserAttribute(unverifiedAttr);
-
-        context.attributeToVerify = unverifiedAttr;
-
-        return result;
-      },
-      async confirmVerifyUser(context, event) {
-        const { attributeToVerify } = context;
-        const { confirmation_code } = context.formValues;
-
-        return await Auth.verifyCurrentUserAttributeSubmit(
-          attributeToVerify,
-          confirmation_code
-        );
-      },
-      async validateFields(context, event) {
-        return runValidators(context.formValues, context.touched, [
-          defaultServices.validateConfirmPassword,
-        ]);
-      },
-    },
-  }
-);
+    }
+  );
+}

--- a/packages/ui/src/machines/authenticator/defaultServices.ts
+++ b/packages/ui/src/machines/authenticator/defaultServices.ts
@@ -1,6 +1,6 @@
 import { Amplify, Auth } from 'aws-amplify';
 
-import { ValidatorResult } from '../../types';
+import { AuthChallengeNames, ValidatorResult } from '../../types';
 
 export const defaultServices = {
   async getAmplifyConfig() {
@@ -9,6 +9,43 @@ export const defaultServices = {
 
   async getCurrentUser() {
     return Auth.currentAuthenticatedUser();
+  },
+
+  async handleSignUp(formData): Promise<any> {
+    return Auth.signUp(formData);
+  },
+  async handleSignIn(formData: {
+    username: string;
+    password: string;
+  }): Promise<any> {
+    const { username, password } = formData;
+    return Auth.signIn(username, password);
+  },
+  async handleConfirmSignIn(formData: {
+    user: string;
+    code: string;
+    mfaType: AuthChallengeNames.SMS_MFA | AuthChallengeNames.SOFTWARE_TOKEN_MFA;
+  }): Promise<any> {
+    const { user, code, mfaType } = formData;
+    return Auth.confirmSignIn(user, code, mfaType);
+  },
+  async handleConfirmSignUp(formData: {
+    username: string;
+    code: string;
+  }): Promise<any> {
+    const { username, code } = formData;
+    return await Auth.confirmSignUp(username, code);
+  },
+  async handleForgotPasswordSubmit(formData: {
+    username: string;
+    code: string;
+    password: string;
+  }): Promise<any> {
+    const { username, code, password } = formData;
+    return Auth.forgotPasswordSubmit(username, code, password);
+  },
+  async handleForgotPassword(formData: string): Promise<any> {
+    return Auth.forgotPassword(formData);
   },
 
   // Validation hooks for overriding

--- a/packages/ui/src/machines/authenticator/defaultServices.ts
+++ b/packages/ui/src/machines/authenticator/defaultServices.ts
@@ -14,34 +14,44 @@ export const defaultServices = {
   async handleSignUp(formData): Promise<any> {
     return Auth.signUp(formData);
   },
-  async handleSignIn(formData: {
+  async handleSignIn({
+    username,
+    password,
+  }: {
     username: string;
     password: string;
   }): Promise<any> {
-    const { username, password } = formData;
     return Auth.signIn(username, password);
   },
-  async handleConfirmSignIn(formData: {
+  async handleConfirmSignIn({
+    user,
+    code,
+    mfaType,
+  }: {
     user: string;
     code: string;
     mfaType: AuthChallengeNames.SMS_MFA | AuthChallengeNames.SOFTWARE_TOKEN_MFA;
   }): Promise<any> {
-    const { user, code, mfaType } = formData;
     return Auth.confirmSignIn(user, code, mfaType);
   },
-  async handleConfirmSignUp(formData: {
+  async handleConfirmSignUp({
+    username,
+    code,
+  }: {
     username: string;
     code: string;
   }): Promise<any> {
-    const { username, code } = formData;
     return await Auth.confirmSignUp(username, code);
   },
-  async handleForgotPasswordSubmit(formData: {
+  async handleForgotPasswordSubmit({
+    username,
+    code,
+    password,
+  }: {
     username: string;
     code: string;
     password: string;
   }): Promise<any> {
-    const { username, code, password } = formData;
     return Auth.forgotPasswordSubmit(username, code, password);
   },
   async handleForgotPassword(formData: string): Promise<any> {

--- a/packages/ui/src/machines/authenticator/defaultServices.ts
+++ b/packages/ui/src/machines/authenticator/defaultServices.ts
@@ -1,6 +1,6 @@
 import { Amplify, Auth } from 'aws-amplify';
 
-import { AuthChallengeNames, ValidatorResult } from '../../types';
+import { AuthChallengeNames, SignInResult, ValidatorResult } from '../../types';
 
 export const defaultServices = {
   async getAmplifyConfig() {
@@ -28,7 +28,7 @@ export const defaultServices = {
     code,
     mfaType,
   }: {
-    user: string;
+    user: any;
     code: string;
     mfaType: AuthChallengeNames.SMS_MFA | AuthChallengeNames.SOFTWARE_TOKEN_MFA;
   }): Promise<any> {
@@ -51,10 +51,10 @@ export const defaultServices = {
     username: string;
     code: string;
     password: string;
-  }): Promise<any> {
+  }): Promise<SignInResult> {
     return Auth.forgotPasswordSubmit(username, code, password);
   },
-  async handleForgotPassword(formData: string): Promise<any> {
+  async handleForgotPassword(formData): Promise<any> {
     return Auth.forgotPassword(formData);
   },
 

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -1,6 +1,6 @@
 import { assign, createMachine, forwardTo, spawn } from 'xstate';
 
-import { AuthContext, AuthEvent } from '../../types';
+import { AuthContext, AuthEvent, ServicesContext } from '../../types';
 import { stopActor } from './actions';
 import { resetPasswordActor, signInActor, signOutActor } from './actors';
 import { defaultServices } from './defaultServices';

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -176,7 +176,7 @@ export function createAuthenticatorMachine({
         }),
         spawnSignInActor: assign({
           actorRef: (context, event) => {
-            const actor = signInActor.withContext({
+            const actor = signInActor({ services }).withContext({
               authAttributes: event.data?.authAttributes,
               user: event.data?.user,
               intent: event.data?.intent,
@@ -207,7 +207,7 @@ export function createAuthenticatorMachine({
         }),
         spawnResetPasswordActor: assign({
           actorRef: (context, event) => {
-            const actor = resetPasswordActor.withContext({
+            const actor = resetPasswordActor({ services }).withContext({
               formValues: {},
               touched: {},
               intent: event.data?.intent,

--- a/packages/ui/src/machines/authenticator/signUp.ts
+++ b/packages/ui/src/machines/authenticator/signUp.ts
@@ -261,7 +261,7 @@ export function createSignUpMachine({ services }: SignUpMachineOptions) {
             get(user, 'username') || get(authAttributes, 'username');
           const { password } = authAttributes;
 
-          await Auth.confirmSignUp(username, code);
+          await services.handleConfirmSignUp({ username, code });
 
           return await Auth.signIn(username, password);
         },
@@ -320,13 +320,15 @@ export function createSignUpMachine({ services }: SignUpMachineOptions) {
             }
           });
 
-          const result = await Auth.signUp({ username, password, attributes });
-
-          // TODO `cond`itionally transition to `signUp.confirm` or `resolved` based on result
-          return result;
+          return await services.handleSignUp({
+            username,
+            password,
+            attributes,
+          });
         },
         async validateSignUp(context, event) {
           // This needs to exist in the machine to reference new `services`
+
           return runValidators(context.formValues, context.touched, [
             // Validation for default form fields
             services.validateConfirmPassword,

--- a/packages/ui/src/types/authMachine.ts
+++ b/packages/ui/src/types/authMachine.ts
@@ -12,6 +12,18 @@ export interface AuthContext {
     socialProviders?: SocialProvider[];
   };
   user?: CognitoUserAmplify;
+  username?: string;
+  password?: string;
+  code?: string;
+  mfaType?: AuthChallengeNames.SMS_MFA | AuthChallengeNames.SOFTWARE_TOKEN_MFA;
+}
+
+export interface ServicesContext {
+  username?: string;
+  password?: string;
+  user?: string;
+  code?: string;
+  mfaType: AuthChallengeNames.SMS_MFA | AuthChallengeNames.SOFTWARE_TOKEN_MFA;
 }
 
 interface BaseFormContext {

--- a/packages/ui/src/types/validator.ts
+++ b/packages/ui/src/types/validator.ts
@@ -1,4 +1,4 @@
-import { AuthFormData } from './authMachine';
+import { AuthChallengeNames, AuthFormData } from './authMachine';
 
 export type ValidationError = Record<string, string>;
 
@@ -6,6 +6,7 @@ export type ValidationError = Record<string, string>;
  * Return type of validator. This is `null` if there are no error, and `ValidationError` otherwise.
  */
 export type ValidatorResult = void | null | ValidationError; // null if there are no error, `ValidationError` otherwise
+export type SignInResult = string; // null if there are no error, `ValidationError` otherwise
 
 /**
  * Validates the given formData. This can be synchronous or asynchronous.
@@ -14,3 +15,9 @@ export type Validator = (
   formData: AuthFormData,
   touchData?: AuthFormData
 ) => ValidatorResult | Promise<ValidatorResult>;
+
+export type SignInTypes = (
+  user: string,
+  code: string,
+  mfaType: AuthChallengeNames.SMS_MFA | AuthChallengeNames.SOFTWARE_TOKEN_MFA
+) => SignInResult | Promise<SignInResult>;


### PR DESCRIPTION
*Issue #, if available:*
#836

*Description of changes:*
Added additional ways to override common submissions for the following:

handleSignUp: SignUp
handleSignIn: Sign In
handleConfirmSignIn: Confirm Sign In
handleConfirmSignUp: Confirm Sign Up
handleForgotPasswordSubmit: Forgot Password Submit
handleForgotPassword: Forgot Password

I'll add docs for this feature in #974

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
