### PR TITLE
Fix path to /theming

### DIFF
--- a/docs/src/pages/components/authenticator/index.page.mdx
+++ b/docs/src/pages/components/authenticator/index.page.mdx
@@ -550,7 +550,7 @@ The following example customizes the Sign Up screen by:
 
 ### Styling
 
-You can customize the Authenticator's default [theme](/ui/theme) with [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
+You can customize the Authenticator's default [theme](/theming) with [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
 The example below uses a `<style>` tag to change the default colors to a dark theme:
 
 ```css


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

https://ui.docs.amplify.aws/components/authenticator#styling incorrectly links `theme` to https://ui.docs.amplify.aws/ui/theme/ instead of `/theming`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
