### PR TITLE
CI: Get ref before checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,11 @@ jobs:
             const { issue: { number: issue_number }, repo: { owner, repo } } = context;
             const label = 'run-tests';
             github.issues.removeLabel({ owner, repo, issue_number, name: label });
+      - name: Get ref and commit
+        id: get-ref
+        run: |
+          echo "::set-output name=key::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
+          echo "::set-output name=commit::${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}"
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
         with:
@@ -51,11 +56,6 @@ jobs:
         with:
           node-version: lts/*
           cache: 'yarn'
-      - name: Get ref and commit
-        id: get-ref
-        run: |
-          echo "::set-output name=key::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
-          echo "::set-output name=commit::${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}"
       - name: Install packages
         run: yarn --frozen-lockfile --prefer-offline
       - name: Build ui package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Get ref and commit
         id: get-ref
         run: |
-          echo "::set-output name=key::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
+          echo "::set-output name=ref::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
           echo "::set-output name=commit::${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}"
       - name: Checkout Amplify UI
         uses: actions/checkout@v2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* tests/setup was checking out the wrong `ref` because `${{ steps.get-ref.outputs.ref }}` were undefined at that step. Reordering steps to correct it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
