### PR TITLE
Force Change Password should also check for SETUP TOTP

### DIFF
--- a/.changeset/modern-ligers-attack.md
+++ b/.changeset/modern-ligers-attack.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui': patch
+---
+
+Updated Xstate so users who are in the FORCE CHANGE PASSWORD state also check for setup TOTP MFA.

--- a/packages/e2e/cypress/fixtures/force-change-password-mfa-setup.json
+++ b/packages/e2e/cypress/fixtures/force-change-password-mfa-setup.json
@@ -1,0 +1,7 @@
+{
+  "ChallengeName": "MFA_SETUP",
+  "ChallengeParameters": {
+    "MFAS_CAN_SETUP": "[\"SMS_MFA\",\"SOFTWARE_TOKEN_MFA\"]"
+  },
+  "Session": "••••••••••••••••••••••••••••••••••••••••••••••••"
+}

--- a/packages/e2e/features/ui/components/authenticator/sign-in-totp-mfa.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-totp-mfa.feature
@@ -37,3 +37,19 @@ Feature: Sign In with TOTP MFA
     And I type my password
     And I click the "Sign in" button
     Then I see "User does not exist"
+
+
+@angular @react @vue
+  Scenario: Sign in with force change password with mfa setup
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge" } }' with fixture "force-change-password"
+    When I type my "email" with status "FORCE_CHANGE_PASSWORD"
+    And I type my password
+    And I click the "Sign in" button
+    Then I see "Change Password"
+    And I type my password
+    And I confirm my password
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge" } }' with fixture "force-change-password-mfa-setup"
+    And I click the "Change Password" button
+    Then I will be redirected to the setup totp page
+
+

--- a/packages/e2e/features/ui/components/authenticator/sign-in-totp-mfa.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-totp-mfa.feature
@@ -50,6 +50,6 @@ Feature: Sign In with TOTP MFA
     And I confirm my password
     Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge" } }' with fixture "force-change-password-mfa-setup"
     And I click the "Change Password" button
-    Then I will be redirected to the setup totp page
+    Then I see "Setup TOTP"
 
 

--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -231,7 +231,11 @@ export function signInActor({ services }: SignInMachineOptions) {
                         actions: ['setUser', 'setChallengeName'],
                         target: '#signInActor.confirmSignIn',
                       },
-
+                      {
+                        cond: 'shouldSetupTOTP',
+                        actions: ['setUser', 'setChallengeName'],
+                        target: '#signInActor.setupTOTP',
+                      },
                       {
                         target: 'resolved',
                         actions: ['setUser', 'setCredentials'],


### PR DESCRIPTION
*Issue #, if available:*
#995 

*Description of changes:*
Updated code so it also checks for SETUP TOTP after force change password, not just SMS MFA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
