### PR TITLE
Docs fix: add missing dep @aws-amplify/ui-react required by Webpack 5

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -7,7 +7,7 @@ applications:
             - nvm install 14
             - nvm use 14
             - node -v
-            - (cd .. && yarn install)
+            - (cd .. && yarn install && yarn build)
         build:
           commands:
             - nvm install 14
@@ -17,7 +17,7 @@ applications:
       artifacts:
         baseDirectory: out
         files:
-          - '**/*'
+          - "**/*"
       cache:
         paths:
           - node_modules/**/*

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,7 @@
     "test": "$_ run build"
   },
   "dependencies": {
+    "@aws-amplify/ui-react": "^2.1.5",
     "@aws-amplify/ui-react-v1": "npm:@aws-amplify/ui-react",
     "@codesandbox/sandpack-react": "0.1.9",
     "@cucumber/gherkin": "^19.0.3",


### PR DESCRIPTION
*Description of changes:*
This fixes an issue where the Amplify Hosting build is failing when using Webpack 5 because the docs/package.json doesn't explicitly declare the `@aws-amplify/ui-react` dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
