### PR TITLE
docs fix: img src csp blocking external demo images

### DIFF
--- a/docs/public/amplify-logo.svg
+++ b/docs/public/amplify-logo.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="126px" height="94px" viewBox="0 0 126 94" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 58 (84663) - https://sketch.com -->
+    <title>Fill-1</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="100%" y1="22.1718317%" x2="0%" y2="77.8281683%" id="linearGradient-1">
+            <stop stop-color="#FF9900" offset="0%"></stop>
+            <stop stop-color="#FFC300" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M27.4193646,78 L62.9093796,78 L72,94 L71.743892,94 L0,94 L25.2808604,50.192137 L35.8751825,31.8473288 L44.9710103,47.6084247 L27.4193646,78 Z M40.6554116,23.5512493 L49.3887526,8.41853699 L98.814466,93.9997425 L81.3108879,93.9997425 L40.6554116,23.5512493 Z M54.249635,0 L71.7299104,0 L126,94 L108.497716,94 L54.249635,0 Z" id="Fill-1" fill="url(#linearGradient-1)" fill-rule="nonzero"></path>
+    </g>
+</svg>

--- a/docs/src/pages/components/authenticator/index.page.mdx
+++ b/docs/src/pages/components/authenticator/index.page.mdx
@@ -295,10 +295,7 @@ The following example customizes these slots with:
         const { tokens } = useTheme();
         return (
           <View textAlign="center" padding={tokens.space.large}>
-            <Image
-              alt="Amplify logo"
-              src="https://docs.amplify.aws/assets/logo-dark.svg"
-            />
+            <Image alt="Amplify logo" src="/amplify-logo.svg" />
           </View>
         );
       },
@@ -451,7 +448,7 @@ Using the same techniques as [Internationalization (I18n)](#internationalization
   </TabItem>
 
   <TabItem title="Sign Up">
-    
+
     ```js
     I18n.putVocabulariesForLanguage('en', {
       'Create Account': 'Register', // Tab header
@@ -469,7 +466,7 @@ Using the same techniques as [Internationalization (I18n)](#internationalization
   </TabItem>
 
   <TabItem title="Reset Password">
-    
+
     ```js
     I18n.putVocabulariesForLanguage('en', {
       'Reset your password': 'Forgot your password?',

--- a/docs/src/pages/components/image/demo.tsx
+++ b/docs/src/pages/components/image/demo.tsx
@@ -22,7 +22,7 @@ export const ImageDemo = () => {
     padding: '0',
   });
   const imageProps = useImageProps({
-    src: 'https://docs.amplify.aws/assets/logo-dark.svg',
+    src: '/amplify-logo.svg',
     alt: 'Amplify logo',
     objectFit: 'fill',
     objectPosition: 'initial',

--- a/docs/src/pages/components/scrollview/demo.tsx
+++ b/docs/src/pages/components/scrollview/demo.tsx
@@ -19,7 +19,7 @@ export const ScrollViewDemo = () => {
             <Image
               width="800px"
               maxWidth="800px"
-              src="https://docs.amplify.aws/assets/logo-dark.svg"
+              src="/amplify-logo.svg"
               alt="Amplify-logo"
             />
           </ScrollView>

--- a/docs/src/pages/components/scrollview/react.mdx
+++ b/docs/src/pages/components/scrollview/react.mdx
@@ -21,7 +21,7 @@ import '@aws-amplify/ui-react/styles.css';
   <Image
     width="800px"
     maxWidth="800px"
-    src="https://docs.amplify.aws/assets/logo-dark.svg"
+    src="/amplify-logo.svg"
     alt="Amplify-logo"
   />
 </ScrollView>;
@@ -33,7 +33,7 @@ import '@aws-amplify/ui-react/styles.css';
       <Image
         width="800px"
         maxWidth="800px"
-        src="https://docs.amplify.aws/assets/logo-dark.svg"
+        src="/amplify-logo.svg"
         alt="Amplify-logo"
       />
     </ScrollView>
@@ -56,7 +56,7 @@ import '@aws-amplify/ui-react/styles.css';
   <Image
     width="800px"
     maxWidth="800px"
-    src="https://docs.amplify.aws/assets/logo-dark.svg"
+    src="/amplify-logo.svg"
     alt="Amplify-logo"
   />
 </ScrollView>;
@@ -68,7 +68,7 @@ import '@aws-amplify/ui-react/styles.css';
       <Image
         width="800px"
         maxWidth="800px"
-        src="https://docs.amplify.aws/assets/logo-dark.svg"
+        src="/amplify-logo.svg"
         alt="Amplify-logo"
       />
     </ScrollView>


### PR DESCRIPTION
*Problem*
The new UI Docs site CSP rules block external images, so the ScrollView amplify logo loaded from [docs.amplify.aws](https://docs.amplify.aws/assets/logo-dark.svg) is not loading.

```
 Content Security Policy: The page’s settings blocked the loading of a resource at https://docs.amplify.aws/assets/logo-dark.svg (“default-src”).
```

*Solution*

This PR fixes this issue by moving the amplify logo file into UI repo so that we don't need any additional CSP rules, and don't have cross doc site dependencies.

_Before_
![Screen Shot 2021-12-15 at 12 23 00 PM](https://user-images.githubusercontent.com/6165315/146259932-1e04f2fe-cc3b-4a09-bfe1-c1e0d1f99a31.png)

_After_
![Screen Shot 2021-12-15 at 12 26 10 PM](https://user-images.githubusercontent.com/6165315/146260145-46fe5dce-b960-4761-adca-a8f01d0b4d30.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
