### PR TITLE
Add missing translation

### DIFF
--- a/.changeset/rude-bobcats-grin.md
+++ b/.changeset/rude-bobcats-grin.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+Add missing Confirm Password translation for German language

--- a/packages/ui/src/i18n/dictionaries/authenticator/de.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/de.ts
@@ -5,6 +5,7 @@ export const deDict = {
     'Ein Account mit dieser Email existiert bereits.',
   'Back to Sign In': 'Zurück zur Anmeldung',
   'Change Password': 'Passwort ändern',
+  'Confirm Password': 'Passwort bestätigen',
   Code: 'Code',
   Confirm: 'Bestätigen',
   'Confirm a Code': 'Code bestätigen',


### PR DESCRIPTION
Add the missing Confirm Password to the german translation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
