### PR TITLE
Don't use "username" as input type attribute for Reset Password

### DIFF
--- a/packages/vue/src/components/reset-password.vue
+++ b/packages/vue/src/components/reset-password.vue
@@ -86,7 +86,7 @@ const onBackToSignInClicked = (): void => {
             <base-label class="sr-only amplify-label" for="amplify-field-7dce">
               {{ labelText }}
             </base-label>
-            <base-wrapper class="amplify-flex">
+            <base-wrapper class="amplify-flex amplify-field-group">
               <base-input
                 class="amplify-input amplify-field-group__control"
                 id="amplify-field-7dce"

--- a/packages/vue/src/components/reset-password.vue
+++ b/packages/vue/src/components/reset-password.vue
@@ -14,8 +14,9 @@ const emit = defineEmits(['resetPasswordSubmit', 'backToSignInClicked']);
 const { state, send } = useAuthenticator();
 const { error, isPending } = toRefs(useAuthenticator());
 
-const { label } = getAliasInfoFromContext(state.context);
+const { label, type } = getAliasInfoFromContext(state.context);
 const labelText = `Enter your ${label.toLowerCase()}`;
+const inputType = type !== 'username' ? type : 'text';
 
 // Computed Properties
 const backSignInText = computed(() => translate('Back to Sign In'));
@@ -94,7 +95,7 @@ const onBackToSignInClicked = (): void => {
                 :placeholder="enterUsernameText"
                 autocomplete="username"
                 required
-                type="username"
+                :type="inputType"
               ></base-input>
             </base-wrapper>
           </base-wrapper>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The reset password screen has a HTML input field for entering the username (or other). The Label Text is dynamic and coming from the getAliasFromContext Helper (Never the less the label represents the type rather than an actual label).

As far as I could see the alias type can be **username**, **email** or **tel**, the last two are valid HTML input type's according to the docs:

https://www.w3schools.com/html/html_form_input_types.asp

So I added a check for checking if the type equals "username", if this is the case using a `input[type=text]` seems more appropriate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
