### PR TITLE
docs fix: pin homepage demo ui-react dep to latest

### DIFF
--- a/docs/src/pages/index.page.tsx
+++ b/docs/src/pages/index.page.tsx
@@ -218,7 +218,7 @@ const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
               }}
               customSetup={{
                 dependencies: {
-                  '@aws-amplify/ui-react': 'next',
+                  '@aws-amplify/ui-react': 'latest',
                   'aws-amplify': 'latest',
                 },
                 entry: '/index.js',


### PR DESCRIPTION
*Description of changes:*
This PR changes the `@aws-amplify/ui-react` dependency version used by the demo on the homepage  from `next` to `latest`. This will protect the homepage demo from breaking from changes on `next`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
