### PR TITLE
docs fix: CSP error for analytics domain

### DIFF
--- a/docs/src/pages/_document.page.tsx
+++ b/docs/src/pages/_document.page.tsx
@@ -26,7 +26,7 @@ const getCSPContent = (context: Readonly<HtmlProps>) => {
       font-src 'self' data:;
       frame-src *.codesandbox.io;
       img-src 'self' cm.everesttech.net amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net;
-      connect-src 'self' *.shortbread.aws.dev dpm.demdex.net;
+      connect-src 'self' *.shortbread.aws.dev amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net ;
       script-src 'unsafe-eval' 'self' '${cspInlineScriptHash}' a0.awsstatic.com;
     `;
   }
@@ -37,7 +37,7 @@ const getCSPContent = (context: Readonly<HtmlProps>) => {
     font-src 'self';
     frame-src *.codesandbox.io aws.demdex.net;
     img-src 'self' cm.everesttech.net amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net;
-    connect-src 'self' *.shortbread.aws.dev dpm.demdex.net;
+    connect-src 'self' *.shortbread.aws.dev amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net;
     script-src 'self' '${cspInlineScriptHash}' a0.awsstatic.com;
   `;
 };


### PR DESCRIPTION
*Issue #, if available:*
N/A

Seeing the following error message in console on [docs site](https://ui.docs.amplify.aws):
![Screen Shot 2021-12-16 at 5 42 36 PM](https://user-images.githubusercontent.com/6165315/146475241-a8324d65-480b-45c0-865f-ea281e11b116.png)

Note: I only see this error when refreshing the page, so it appears to be occurring on page unload.

*Description of changes:*
Update the CSP rule for `connect-src` with required URL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
