### PR TITLE
Authenticator: fix issue where phone_number validation fails

### DIFF
--- a/.changeset/green-onions-cheer.md
+++ b/.changeset/green-onions-cheer.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+Fix issue where phone_number validation fails on multiple signup submissions


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/aws-amplify/amplify-ui/issues/1008

*Description of changes:*

This fixes an issue where phone number validation fails for country code `+1` when there are other form validation errors such as a short password. This causes the `phone_number` value to be mutated, and `N` number of `+1`'s to be appended (where N is number of times the form has been submitted):
```
UserAttributes: { phone_number: "+1+1+12223334444"}
Username: "+1+1+12223334444
```

The fix ensures that `formValues.phone_number` is not mutated on each `signUp` call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
