### PR TITLE
Build `ui` styles into `ui-react` package

### DIFF
--- a/.changeset/hungry-forks-play.md
+++ b/.changeset/hungry-forks-play.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Build ui styles into ui-react package to fix [parcel](https://parceljs.org/) and [UMIJS](https://umijs.org/) apps.

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1,1 +1,1 @@
-@import '@aws-amplify/ui/styles.css';
+@import '../../ui/dist/styles.css';

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -1,0 +1,1 @@
+import './styles.css';

--- a/packages/react/tsup.config.js
+++ b/packages/react/tsup.config.js
@@ -8,6 +8,7 @@ module.exports = {
     'src/legacy.tsx',
     'src/icons.tsx',
     'src/internal.tsx',
+    'src/styles.ts',
   ],
   // `aws-amplify` is external, but sub-dependencies weren't automatically externalized ("require" statements were included)
   external: ['`aws-amplify', /^@aws-amplify\//],


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws-amplify/amplify-ui/issues/1020 and https://github.com/aws-amplify/amplify-ui/issues/1005

*Description of changes:*
Customers are experiencing an issue with the [parcel bundler](https://parceljs.org/recipes/react/) where the CSS statement `@import '@aws-amplify/ui/styles.css';` pointing to `ui` package cannot be resolved via `node_modules`. This PR fixes this by building the styles from `ui` into `ui-react` using `tsup`.


Testing TODO:

- [x] Test in ViteJS (Scott)
- [x] Test in Parcel (Scott)
- [x] Test in NextJS (Scott)
- [x] Test in CRA (Scott)
- [x] Test in UMJS (Erik)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
