### PR TITLE
Fix cats on 404

### DIFF
--- a/docs/src/pages/404.page.tsx
+++ b/docs/src/pages/404.page.tsx
@@ -5,6 +5,7 @@ import {
   View,
   Link,
   Image,
+  Flex,
   useTheme,
 } from '@aws-amplify/ui-react';
 
@@ -13,10 +14,11 @@ import { cats } from '@/data/cats';
 const Custom404 = () => {
   const { tokens } = useTheme();
   let [href, setHref] = React.useState('https://ui.docs.amplify.aws');
-  const cat = cats[Math.round(Math.random() * cats.length)];
+  let [cat, setCat] = React.useState(undefined);
 
   React.useEffect(() => {
     setHref(window.location.href);
+    setCat(cats[Math.floor(Math.random() * cats.length)]);
   }, []);
 
   return (
@@ -25,21 +27,23 @@ const Custom404 = () => {
       className="docs-home-section container"
       textAlign="center"
     >
-      <Heading level={1}>404</Heading>
-      <Text fontSize={tokens.fontSizes.large}>
-        {`Apologies––we can't seem to find this page.
-If this is a mistake, please `}
-        <Link
-          isExternal={true}
-          href={`https://github.com/aws-amplify/amplify-ui/issues/new?title=[missing-page]&labels=Documentation&body=${encodeURI(`**Page**: [\`${href}\`](${href})
+      <Flex direction="column" gap={tokens.space.large} alignItems="center">
+        <Heading level={1}>404</Heading>
+        <Text fontSize={tokens.fontSizes.large}>
+          {`Apologies—we can't seem to find this page.`} <br />
+          {`If this is a mistake, please `}
+          <Link
+            isExternal={true}
+            href={`https://github.com/aws-amplify/amplify-ui/issues/new?title=[missing-page]&labels=Documentation&body=${encodeURI(`**Page**: [\`${href}\`](${href})
 **Feedback**: <!-- your feedback here -->`)}`}
-        >
-          file an issue
-        </Link>
-        {` and we will get it fixed ASAP.`}
-      </Text>
+          >
+            file an issue
+          </Link>
+          {` and we will get it fixed ASAP.`}
+        </Text>
 
-      <Image src={cat.url} alt={cat.alt} maxHeight="50vh" />
+        {cat ? <Image src={cat.url} alt={cat.alt} maxHeight="50vh" /> : null}
+      </Flex>
     </View>
   );
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixing an issue with loading a cat photo on the 404 page. Now we are grabbing a random cat photo on the client side only so there isn't a flash of content and making sure we have a cat before rendering the image. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
