### PR TITLE
Better mobile layout for demo on primitive pages

### DIFF
--- a/docs/src/components/Demo.tsx
+++ b/docs/src/components/Demo.tsx
@@ -35,8 +35,14 @@ export const Demo = ({
   };
 
   return (
-    <Card className="docs-component-demo" variation="outlined">
-      <Flex direction="row" alignItems="stretch">
+    <View className="docs-component-demo">
+      <Flex
+        direction={{
+          base: 'column',
+          medium: 'row',
+        }}
+        alignItems="stretch"
+      >
         <Flex direction="column" flex="1">
           <View>{children}</View>
           <Tabs>
@@ -75,6 +81,6 @@ export const Demo = ({
           </Highlight>
         </View>
       </Flex>
-    </Card>
+    </View>
   );
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Made the layout for the demo area of primitive pages responsive. 

https://user-images.githubusercontent.com/321279/146978510-c73518d5-a55e-48cc-a4de-26d158544706.mp4


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
