### PR TITLE
fix docs theme link

### DIFF
--- a/docs/src/pages/getting-started/installation/index.page.mdx
+++ b/docs/src/pages/getting-started/installation/index.page.mdx
@@ -15,7 +15,7 @@ import Link from 'next/link';
 
 ### Styles
 
-Amplify UI ships with a default [theme](/ui/theme) that you can customize to match the look and feel of your project.
+Amplify UI ships with a default [theme](/theme) that you can customize to match the look and feel of your project.
 
 <Fragment>{({ platform }) => import(`./styles.${platform}.mdx`)}</Fragment>
 


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/aws-amplify/amplify-ui/issues/1029

*Description of changes:*
Fix link to theme docs page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
