### PR TITLE
Fix equals sign color in dark mode

### DIFF
--- a/docs/src/styles/docs/code.scss
+++ b/docs/src/styles/docs/code.scss
@@ -8,7 +8,8 @@ code[class*='language-'],
 pre[class*='language-'] {
   background: var(--amplify-colors-background-secondary);
   color: var(--amplify-colors-font-primary);
-  font-family: 'Fira Code', 'Fira Mono', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+  font-family: 'Fira Code', 'Fira Mono', Menlo, Consolas, 'DejaVu Sans Mono',
+    monospace;
   direction: ltr;
   text-align: left;
   white-space: pre;
@@ -52,7 +53,7 @@ pre.language-shell code.language-shell::before {
   content: '$ ';
 }
 
-section > pre[class*=language-] {
+section > pre[class*='language-'] {
   margin-bottom: var(--amplify-space-medium);
 }
 
@@ -101,7 +102,7 @@ section > pre[class*=language-] {
 /* HTML overrides */
 .token.attr-value > .token.punctuation.attr-equals,
 .token.special-attr > .token.attr-value > .token.value.css {
-  color: hsl(230, 8%, 24%);
+  color: var(--amplify-colors-teal-80);
 }
 
 /* CSS overrides */
@@ -275,7 +276,6 @@ pre[id].linkable-line-numbers.linkable-line-numbers
 .command-line .command-line-prompt > span:before {
   color: hsl(230, 1%, 62%);
 }
-
 
 /* Diff Highlight plugin overrides */
 /* Taken from https://github.com/atom/github/blob/master/styles/variables.less */


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws-amplify/amplify-ui/issues/1030

*Description of changes:*
Fix color of equals sign so that it's visible in dark mode.

![Screen Shot 2021-12-21 at 11 31 59 AM](https://user-images.githubusercontent.com/6165315/146988957-bf12254b-8310-4b7b-9eb9-7babd0170a5b.png)
![Screen Shot 2021-12-21 at 11 31 50 AM](https://user-images.githubusercontent.com/6165315/146988961-d747a999-9b2b-4a34-83e6-e62d2880d6e1.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
