### PR TITLE
Add white-space (pre-wrap) behavior for Text components

### DIFF
--- a/packages/ui/src/theme/css/component/text.scss
+++ b/packages/ui/src/theme/css/component/text.scss
@@ -10,6 +10,10 @@
     display: inline;
   }
 
+  @at-root p#{&} {
+    white-space: pre-wrap;
+  }
+
   &[data-truncate='true'] {
     display: inline-block;
     max-width: 100%;


### PR DESCRIPTION
*Issue #, if available:*
#1048 

*Description of changes:*
Add a `pre-wrap` word-wrap behavior for `<Text>` components. Note: this only applies when the component is rendered as a HTML `p` tag.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
