### PR TITLE
Add Webpack 5 troubleshooting

### DIFF
--- a/docs/src/pages/getting-started/installation/troubleshooting.react.mdx
+++ b/docs/src/pages/getting-started/installation/troubleshooting.react.mdx
@@ -1,4 +1,51 @@
+import { Alert, Tabs, TabItem } from '@aws-amplify/ui-react';
+
 ## Troubleshooting
+
+### Webpack 5+
+
+Follow the instructions below to if you are using Webpack 5:
+
+<Alert variation="info">
+*Note:*
+Polyfill is only required for Webpack 5+. In this version Node.js global variable shims required by the `aws-amplify` package were removed, which results in the following error message:
+
+```
+Uncaught ReferenceError: process is not defined
+```
+
+Webpack 4 already includes this polyfill.
+
+</Alert>
+
+1. Add
+   [node-polyfill-webpack-plugin](https://www.npmjs.com/package/node-polyfill-webpack-plugin)
+   as dev dependency:
+
+<Tabs>
+<TabItem title="npm">
+
+```shell
+npm install node-polyfill-webpack-plugin -D
+```
+
+</TabItem>
+<TabItem title="yarn">
+
+```shell
+yarn add node-polyfill-webpack-plugin -D
+```
+
+</TabItem>
+</Tabs>
+
+2. Add the plugin to your `webpack.config.js` plugins list:\_
+
+```js
+  plugins: [
+    new NodePolyfillPlugin(), // Polyfill Node.js globals (e.g. global, process, etc)
+  ],
+```
 
 ### Vite
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws-amplify/amplify-ui/issues/930

*Description of changes:*
This PR adds instructions on how to polyfill the Node.js globals needed by `aws-amplify` when using Webpack 5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
