### PR TITLE
Update media query logic to return correct breakpoint

### DIFF
--- a/.changeset/dull-turkeys-juggle.md
+++ b/.changeset/dull-turkeys-juggle.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Fix media query logic to return correct breakpoint

--- a/packages/react/src/primitives/shared/responsive/__tests__/getMediaQueries.test.ts
+++ b/packages/react/src/primitives/shared/responsive/__tests__/getMediaQueries.test.ts
@@ -21,31 +21,31 @@ const expectedMediaQueries = [
     breakpoint: 'xl',
     maxWidth: 96,
     minWidth: 80,
-    query: '(min-width: 80em) and (max-width: 95em)',
+    query: '(min-width: 80em) and (max-width: calc(96em - 1px))',
   },
   {
     breakpoint: 'large',
     maxWidth: 80,
     minWidth: 62,
-    query: '(min-width: 62em) and (max-width: 79em)',
+    query: '(min-width: 62em) and (max-width: calc(80em - 1px))',
   },
   {
     breakpoint: 'medium',
     maxWidth: 62,
     minWidth: 48,
-    query: '(min-width: 48em) and (max-width: 61em)',
+    query: '(min-width: 48em) and (max-width: calc(62em - 1px))',
   },
   {
     breakpoint: 'small',
     maxWidth: 48,
     minWidth: 30,
-    query: '(min-width: 30em) and (max-width: 47em)',
+    query: '(min-width: 30em) and (max-width: calc(48em - 1px))',
   },
   {
     breakpoint: 'base',
     maxWidth: 30,
     minWidth: 0,
-    query: '(min-width: 0em) and (max-width: 29em)',
+    query: '(min-width: 0em) and (max-width: calc(30em - 1px))',
   },
 ];
 
@@ -69,7 +69,7 @@ describe('getMediaQueries', () => {
     };
     const expectedMediaQueriesNegWidth = [...expectedMediaQueries];
     expectedMediaQueriesNegWidth[5].minWidth = -1;
-    expectedMediaQueriesNegWidth[5].query = '(max-width: 29em)';
+    expectedMediaQueriesNegWidth[5].query = '(max-width: calc(30em - 1px))';
 
     expect(
       getMediaQueries({

--- a/packages/react/src/primitives/shared/responsive/getMediaQueries.ts
+++ b/packages/react/src/primitives/shared/responsive/getMediaQueries.ts
@@ -28,7 +28,7 @@ export const getMediaQueries: GetMediaQueries = ({
       if (query) {
         query += ' and ';
       }
-      query += `(max-width: ${maxWidth - 1}${breakpointUnit})`;
+      query += `(max-width: calc(${maxWidth}${breakpointUnit} - 1px))`;
     }
 
     return {


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/aws-amplify/amplify-ui/issues/1059

*Description of changes:*
Because `em`'s are calculated based on the base font size, there was a 14px gap below breakpoints where the default breakpoint of `base` is returned. This fixes the issue using `calc()` to calculate the max-width as the upper breakpoint minus `1px`. This allows us to continue using `em` breakpoints while returning the correct breakpoint styling for 1-14px below a given breakpoint.

**Before fix**
At 767px (1px below medium 768px), background color rendering **incorrectly** as `base: "red"`.

![Screen Shot 2021-12-29 at 10 48 24 AM](https://user-images.githubusercontent.com/6165315/147698921-00b4f722-751b-4a75-abf1-c46e14d0dd0a.png)

**After fix**
At 767px (1px below medium 768px), background color rendering **correctly** as `small: "orange"`
![Screen Shot 2021-12-29 at 12 03 42 PM](https://user-images.githubusercontent.com/6165315/147699361-4f994522-6fd2-4d81-8263-2b8017b1d529.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
