### PR TITLE
Move font-family rule to [data-amplify-theme]

### DIFF
--- a/.changeset/fuzzy-gifts-punch.md
+++ b/.changeset/fuzzy-gifts-punch.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+Fix issue where custom theme fonts are ignored

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -4,11 +4,11 @@
 
 @import 'dist/theme';
 
-html {
+[data-amplify-theme] {
   font-family: var(--amplify-fonts-default-static);
 }
 @supports (font-variation-settings: normal) {
-  html {
+  [data-amplify-theme] {
     font-family: var(--amplify-fonts-default-variable);
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws-amplify/amplify-ui/issues/1062

*Description of changes:*
This fixes an issue where defining a fonts token in custom theme didn't override the default Inter font. This was occurring because the `font-family: var(--amplify-fonts-default-static)` was only defined at the root. The `AmplifyProvider` converts custom theme tokens to CSS variables at the [data-amplify-theme] node and below. Since the rule was at the root node level, `--amplify-fonts-default-static` still had the original value of `Inter`, so the custom font token (defined at the [data-amplify-theme] node) wouldn't be read.

Solution:
Moving it to the [data-amplify-theme] ensures that the custom font token CSS variable is picked up correctly.
![Screen Shot 2021-12-29 at 5 05 11 PM](https://user-images.githubusercontent.com/6165315/147713924-fa3079ca-b098-4d3f-ad99-eb5c6ff7f90b.png)

![Screen Shot 2021-12-29 at 5 13 09 PM](https://user-images.githubusercontent.com/6165315/147713982-b7dc61ef-4386-45e1-b1c7-da4c8216cc68.png)

*Testing*
Manually tested using my [demo app in Webpack 5](https://github.com/reesscot/amplify-ui-build-systems/tree/css-import-order/react/webpack5) and confirmed that Open Sans is being rendered.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
