### PR TITLE
chore: removing unnecessary conditional check in useTheme

### DIFF
--- a/packages/react/src/hooks/useAmplify.ts
+++ b/packages/react/src/hooks/useAmplify.ts
@@ -3,15 +3,13 @@ import * as React from 'react';
 import { Theme } from '@aws-amplify/ui';
 
 import { AmplifyContext } from '../components/AmplifyProvider/AmplifyContext';
-import { getThemeFromContext } from './useTheme';
 
 interface UseAmplifyOutput {
   theme: Theme;
 }
 
 export function useAmplify(): UseAmplifyOutput {
-  const context = React.useContext(AmplifyContext);
-  const theme = getThemeFromContext(context);
+  const { theme } = React.useContext(AmplifyContext);
 
   return { theme };
 }

--- a/packages/react/src/hooks/useTheme.ts
+++ b/packages/react/src/hooks/useTheme.ts
@@ -1,24 +1,9 @@
 import * as React from 'react';
 
-import { defaultTheme, WebTheme } from '@aws-amplify/ui';
-import {
-  AmplifyContext,
-  AmplifyContextType,
-} from '../components/AmplifyProvider/AmplifyContext';
+import { WebTheme } from '@aws-amplify/ui';
+import { AmplifyContext } from '../components/AmplifyProvider/AmplifyContext';
 
 export const useTheme = (): WebTheme => {
-  const context = React.useContext(AmplifyContext);
-  return getThemeFromContext(context);
-};
-
-/**
- * Get current Theme object value from Amplify context.
- * Returns a default theme if context is not available
- */
-export const getThemeFromContext = (context: AmplifyContextType) => {
-  if (typeof context === 'undefined' || typeof context.theme === 'undefined') {
-    return defaultTheme;
-  }
-
-  return context.theme;
+  const { theme } = React.useContext(AmplifyContext);
+  return theme;
 };


### PR DESCRIPTION
*Description of changes:*

The conditional check inside `useTheme` is redundant for the below 2 reasons.

1. We created the context with `defaultTheme` as the `defaultValue`. The `defaultValue`  of a context will be used by React when a component does not have a matching Provider above it in the tree. 
```
export const AmplifyContext = React.createContext<AmplifyContextType>({
  theme: defaultTheme,
});
```

2. Inside `AmplifyProvider`, `theme` prop defaults to be `defaultTheme` if it is not supplied.
```
export function AmplifyProvider({
  children,
  colorMode,
  theme = defaultTheme,
}: AmplifyProviderProps) {
  const webTheme = createTheme(theme);
.....
```


Tests:

The existing test cases have cover all possible scenarios, for which the conditional check aims. By removing the check, tests still pass successfully.

<img width="588" alt="Screen Shot 2021-12-30 at 5 02 45 PM" src="https://user-images.githubusercontent.com/40295569/147797160-6034a4c8-ac02-49b4-ab80-d1cae7c0dcb4.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
