### PR TITLE
Adds TypeScript and JavaScript tabs to getting started theming screen

### DIFF
--- a/docs/src/pages/theming/getting-started.react.mdx
+++ b/docs/src/pages/theming/getting-started.react.mdx
@@ -13,42 +13,20 @@ const App = (
 
 Step 2: Use the theme to style components
 
-<Tabs>
-  <TabItem title="JavaScript">
-    ```jsx
-    // Option 1: Use the theme through component variations
-    import { Text } from '@aws-amplify/ui-react';
-    const MyComponent = ({ children }) => {
-      return <Text variation="primary">{children}</Text>;
-    };
+```jsx
+// Option 1: Use the theme through component variations
+import { Text } from '@aws-amplify/ui-react';
+const MyComponent = ({ children }) => {
+  return <Text variation="primary">{children}</Text>;
+};
 
-    // Option 2: Get the theme object through the useTheme hook and style components with it
-    import { Text, useTheme } from '@aws-amplify/ui-react';
-    const MyComponent = ({ children }) => {
-      const { tokens } = useTheme();
-      return <Text color={tokens.colors.font.tertiary}>{children}</Text>;
-    };
-    ```
-
-  </TabItem>
-  <TabItem title="TypeScript">
-    ```jsx
-    // Option 1: Reference the theme object through component variations
-    import { Text } from '@aws-amplify/ui-react';
-    const MyComponent = ({ children }: React.PropsWithChildren<{}>) => {
-      return <Text variation="primary">{children}</Text>;
-    };
-
-    // Option 2: Get the theme object through the useTheme hook and style components with it
-    import { Text, useTheme } from '@aws-amplify/ui-react';
-    const MyComponent = ({ children }: React.PropsWithChildren<{}>) => {
-      const { tokens } = useTheme();
-      return <Text color={tokens.colors.font.tertiary}>{children}</Text>;
-    };
-    ```
-
-  </TabItem>
-</Tabs>
+// Option 2: Get the theme object through the useTheme hook and style components with it
+import { Text, useTheme } from '@aws-amplify/ui-react';
+const MyComponent = ({ children }) => {
+  const { tokens } = useTheme();
+  return <Text color={tokens.colors.font.tertiary}>{children}</Text>;
+};
+```
 
 Optional: To extend or override a token in the default theme, create a custom theme:
 

--- a/docs/src/pages/theming/getting-started.react.mdx
+++ b/docs/src/pages/theming/getting-started.react.mdx
@@ -79,7 +79,7 @@ Optional: To extend or override a token in the default theme, create a custom th
 
   </TabItem>
   <TabItem title="TypeScript">
-    ```jsx
+    ```tsx
     import { AmplifyProvider, Theme } from '@aws-amplify/ui-react';
 
     // Step 1: Create a new Theme with your custom values

--- a/docs/src/pages/theming/getting-started.react.mdx
+++ b/docs/src/pages/theming/getting-started.react.mdx
@@ -1,48 +1,106 @@
+import { Tabs, TabItem } from '@aws-amplify/ui-react';
+
+Step 1: Wrap your App with `AmplifyProvider`
+
 ```jsx
 import { AmplifyProvider } from '@aws-amplify/ui-react';
-// Step 1: Wrap your APP with `AmplifyProvider`
 const App = (
   <AmplifyProvider>
     <MyApp>/* AmplifyUI */</MyApp>
   </AmplifyProvider>
 );
-
-// Step 2: Get the theme object through useTheme hook and style components with it
-import { Text, useTheme } from '@aws-amplify/ui-react';
-
-const MyComponent = ({ children }) => {
-  const { tokens } = useTheme();
-  return <Text color={tokens.colors.font.tertiary}>{children}</Text>;
-};
 ```
 
-To extend or override a token in the default theme, create a custom theme:
+Step 2: Use the theme to style components
 
-```jsx
-import { AmplifyProvider, Theme } from '@aws-amplify/ui-react';
+<Tabs>
+  <TabItem title="JavaScript">
+    ```jsx
+    // Option 1: Reference the theme object through component variations
+    import { Text } from '@aws-amplify/ui-react';
+    const MyComponent = ({ children }) => {
+      return <Text variation="primary">{children}</Text>;
+    };
 
-// Step 1: Create a new Theme with your custom values
-const theme: Theme = {
-  name: 'my-theme',
-  tokens: {
-    colors: {
-      font: {
-        primary: { value: '#008080' },
-        // ...
+    // Option 2: Get the theme object through the useTheme hook and style components with it
+    import { Text, useTheme } from '@aws-amplify/ui-react';
+    const MyComponent = ({ children }) => {
+      const { tokens } = useTheme();
+      return <Text color={tokens.colors.font.tertiary}>{children}</Text>;
+    };
+    ```
+
+  </TabItem>
+  <TabItem title="TypeScript">
+    ```jsx
+    // Option 1: Reference the theme object through component variations
+    import { Text } from '@aws-amplify/ui-react';
+    const MyComponent = ({ children }: React.PropsWithChildren<{}>) => {
+      return <Text variation="primary">{children}</Text>;
+    };
+
+    // Option 2: Get the theme object through the useTheme hook and style components with it
+    import { Text, useTheme } from '@aws-amplify/ui-react';
+    const MyComponent = ({ children }: React.PropsWithChildren<{}>) => {
+      const { tokens } = useTheme();
+      return <Text color={tokens.colors.font.tertiary}>{children}</Text>;
+    };
+    ```
+
+  </TabItem>
+</Tabs>
+
+Optional: To extend or override a token in the default theme, create a custom theme:
+
+<Tabs>
+  <TabItem title="JavaScript">
+    ```jsx
+    import { AmplifyProvider, Theme } from '@aws-amplify/ui-react';
+
+    // Step 1: Create a new Theme with your custom values
+    const theme = {
+      name: 'my-theme',
+      tokens: {
+        colors: {
+          font: {
+            primary: { value: '#008080' },
+            // ...
+          },
+        },
       },
-    },
-  },
-});
+    };
 
-// Step 2: Pass the new theme to `AmplifyProvider`
-// this will apply the theme to all Amplify UI components
-<AmplifyProvider theme={theme}>
-  <App />
-</AmplifyProvider>;
+    // Step 2: Pass the new theme to `AmplifyProvider`
+    // this will apply the theme to all Amplify UI components
+    <AmplifyProvider theme={theme}>
+      <App />
+    </AmplifyProvider>;
+    ```
 
-// Step 3: You can also use the theme tokens in your components
-const MyComponent = ({ children }) => {
-  const { tokens } = useTheme();
-  return <Text color={tokens.colors.brand.primary}>{children}</Text>;
-};
-```
+  </TabItem>
+  <TabItem title="TypeScript">
+    ```jsx
+    import { AmplifyProvider, Theme } from '@aws-amplify/ui-react';
+
+    // Step 1: Create a new Theme with your custom values
+    const theme: Theme = {
+      name: 'my-theme',
+      tokens: {
+        colors: {
+          font: {
+            primary: { value: '#008080' },
+            // ...
+          },
+        },
+      },
+    };
+
+    // Step 2: Pass the new theme to `AmplifyProvider`
+    // this will apply the theme to all Amplify UI components
+    <AmplifyProvider theme={theme}>
+      <App />
+    </AmplifyProvider>;
+    ```
+
+  </TabItem>
+</Tabs>

--- a/docs/src/pages/theming/getting-started.react.mdx
+++ b/docs/src/pages/theming/getting-started.react.mdx
@@ -50,9 +50,11 @@ Optional: To extend or override a token in the default theme, create a custom th
 
     // Step 2: Pass the new theme to `AmplifyProvider`
     // this will apply the theme to all Amplify UI components
-    <AmplifyProvider theme={theme}>
-      <App />
-    </AmplifyProvider>;
+    const App = (
+      <AmplifyProvider theme={theme}>
+        <MyApp>/* AmplifyUI */</MyApp>
+      </AmplifyProvider>
+    );
     ```
 
   </TabItem>
@@ -75,9 +77,11 @@ Optional: To extend or override a token in the default theme, create a custom th
 
     // Step 2: Pass the new theme to `AmplifyProvider`
     // this will apply the theme to all Amplify UI components
-    <AmplifyProvider theme={theme}>
-      <App />
-    </AmplifyProvider>;
+    const App = (
+      <AmplifyProvider theme={theme}>
+        <MyApp>/* AmplifyUI */</MyApp>
+      </AmplifyProvider>
+    );
     ```
 
   </TabItem>

--- a/docs/src/pages/theming/getting-started.react.mdx
+++ b/docs/src/pages/theming/getting-started.react.mdx
@@ -16,7 +16,7 @@ Step 2: Use the theme to style components
 <Tabs>
   <TabItem title="JavaScript">
     ```jsx
-    // Option 1: Reference the theme object through component variations
+    // Option 1: Use the theme through component variations
     import { Text } from '@aws-amplify/ui-react';
     const MyComponent = ({ children }) => {
       return <Text variation="primary">{children}</Text>;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds TypeScript and JavaScript tabs to getting started theming screen
Adds a component variation example to the "use the theme" step
Makes small formatting adjustments

Addresses comments from https://github.com/aws-amplify/amplify-ui/pull/960. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
