### PR TITLE
Revert "Update media query logic to return correct breakpoint (#1060)"

### DIFF
--- a/.changeset/dull-turkeys-juggle.md
+++ b/.changeset/dull-turkeys-juggle.md
@@ -1,5 +1,0 @@
----
-"@aws-amplify/ui-react": patch
----
-
-Fix media query logic to return correct breakpoint

--- a/packages/react/src/primitives/shared/responsive/__tests__/getMediaQueries.test.ts
+++ b/packages/react/src/primitives/shared/responsive/__tests__/getMediaQueries.test.ts
@@ -21,31 +21,31 @@ const expectedMediaQueries = [
     breakpoint: 'xl',
     maxWidth: 96,
     minWidth: 80,
-    query: '(min-width: 80em) and (max-width: calc(96em - 1px))',
+    query: '(min-width: 80em) and (max-width: 95em)',
   },
   {
     breakpoint: 'large',
     maxWidth: 80,
     minWidth: 62,
-    query: '(min-width: 62em) and (max-width: calc(80em - 1px))',
+    query: '(min-width: 62em) and (max-width: 79em)',
   },
   {
     breakpoint: 'medium',
     maxWidth: 62,
     minWidth: 48,
-    query: '(min-width: 48em) and (max-width: calc(62em - 1px))',
+    query: '(min-width: 48em) and (max-width: 61em)',
   },
   {
     breakpoint: 'small',
     maxWidth: 48,
     minWidth: 30,
-    query: '(min-width: 30em) and (max-width: calc(48em - 1px))',
+    query: '(min-width: 30em) and (max-width: 47em)',
   },
   {
     breakpoint: 'base',
     maxWidth: 30,
     minWidth: 0,
-    query: '(min-width: 0em) and (max-width: calc(30em - 1px))',
+    query: '(min-width: 0em) and (max-width: 29em)',
   },
 ];
 
@@ -69,7 +69,7 @@ describe('getMediaQueries', () => {
     };
     const expectedMediaQueriesNegWidth = [...expectedMediaQueries];
     expectedMediaQueriesNegWidth[5].minWidth = -1;
-    expectedMediaQueriesNegWidth[5].query = '(max-width: calc(30em - 1px))';
+    expectedMediaQueriesNegWidth[5].query = '(max-width: 29em)';
 
     expect(
       getMediaQueries({

--- a/packages/react/src/primitives/shared/responsive/getMediaQueries.ts
+++ b/packages/react/src/primitives/shared/responsive/getMediaQueries.ts
@@ -28,7 +28,7 @@ export const getMediaQueries: GetMediaQueries = ({
       if (query) {
         query += ' and ';
       }
-      query += `(max-width: calc(${maxWidth}${breakpointUnit} - 1px))`;
+      query += `(max-width: ${maxWidth - 1}${breakpointUnit})`;
     }
 
     return {


### PR DESCRIPTION
This reverts commit 10af6031e8beb22e79c8ecb5a3ea57f7e2d0bb3c.

*Description of changes:*
While [calc is supported in media queries](https://caniuse.com/mdn-css_at-rules_media_calc) Chrome doesn't like multi-unit calc functions. Reverting while I figure out an alternative fix for the media query issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
