### PR TITLE
Removed unused Amplify auth import in reset password actor

### DIFF
--- a/packages/ui/src/machines/authenticator/actors/resetPassword.ts
+++ b/packages/ui/src/machines/authenticator/actors/resetPassword.ts
@@ -1,4 +1,3 @@
-import { Auth } from 'aws-amplify';
 import { createMachine, sendUpdate } from 'xstate';
 import { AuthEvent, ResetPasswordContext } from '../../../types';
 import { runValidators } from '../../../validators';

--- a/tough-numbers-notice.md
+++ b/tough-numbers-notice.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+Removed unused Amplify auth import in reset password actor


### PR DESCRIPTION
*Issue #, if available:*
I noticed the reset passwords actor has an unused import of Auth from aws-amplify, thought it should be removed.

*Description of changes:*
Removed import 👾

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
