### PR TITLE
Update responsive breakpoints to use `px`

### DIFF
--- a/.changeset/good-toes-change.md
+++ b/.changeset/good-toes-change.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+Fix media query logic to return correct breakpoint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: lts/*
-          cache: 'yarn'
+          cache: "yarn"
       - name: Install packages
         run: yarn --frozen-lockfile --prefer-offline
       - name: Build ui package
@@ -104,7 +104,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: lts/*
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Restore node_modules cache
         uses: actions/cache@v2
@@ -162,15 +162,15 @@ jobs:
         include:
           - example: angular
             package: angular
-            tags: '@angular and not (@skip or @todo-angular)'
+            tags: "@angular and not (@skip or @todo-angular)"
 
           - example: next
             package: react
-            tags: '@react and not (@skip or @todo-react)'
+            tags: "@react and not (@skip or @todo-react)"
 
           - example: vue
             package: vue
-            tags: '@vue and not (@skip or @todo-vue)'
+            tags: "@vue and not (@skip or @todo-vue)"
 
     steps:
       - name: Checkout Amplify UI
@@ -193,7 +193,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: lts/*
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Restore cypress runner Cache
         uses: actions/cache@v2
@@ -295,7 +295,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: lts/*
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Restore Cache
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -336,7 +336,7 @@ jobs:
         run: yarn docs build
 
       - name: Start docs site
-        run: yarn docs start && npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:5000
+        run: yarn docs start && npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000
 
       - name: Run E2E tests against docs
         run: yarn workspace e2e test:theme

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     #   3) pull request from a fork (ie. external PR) that was added "run-tests" label
     if: |
       github.event_name == 'push' ||
-      (github.event.pull_request.head.repo.full_name == github.repository) || 
+      (github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event.action == 'labeled' && github.event.label.name == 'run-tests')
     outputs:
       ref: ${{ steps.get-ref.outputs.ref }}
@@ -265,10 +265,10 @@ jobs:
         run: yarn workspace ${{ matrix.example }}-example start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000/ui/components/authenticator/sign-in-with-username
 
       - name: Run E2E tests against ${{ matrix.example }} example
-        run: yarn workspace e2e test
+        run: yarn workspace e2e test:authenticator
         env:
           # Override on the default value in `cypress.json` with framework-specific tag
-          TAGS: '${{ matrix.tags }}'
+          TAGS: "${{ matrix.tags }}"
 
           # Env values for testing flows
           DOMAIN: ${{ secrets.DOMAIN }}
@@ -334,3 +334,9 @@ jobs:
 
       - name: Build docs package
         run: yarn docs build
+
+      - name: Start docs site
+        run: yarn docs dev && npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:5000
+
+      - name: Run E2E tests against docs
+        run: yarn workspace e2e test:theme

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -336,7 +336,7 @@ jobs:
         run: yarn docs build
 
       - name: Start docs site
-        run: yarn docs dev && npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:5000
+        run: yarn docs start && npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:5000
 
       - name: Run E2E tests against docs
         run: yarn workspace e2e test:theme

--- a/docs/src/pages/theming/responsive/index.page.mdx
+++ b/docs/src/pages/theming/responsive/index.page.mdx
@@ -12,11 +12,11 @@ are used for all breakpoints.
 ```js
 {
   base: '0',
-  small: '30em',      // 480px (16px base)
-  medium: '48em',     // 768px
-  large: '62em',      // 992px
-  xl: '80em',         // 1280px
-  xxl: '96em',        // 1536px
+  small: '480px',
+  medium: '768px',
+  large: '992px',
+  xl: '1280px',
+  xxl: '1536px',
 }
 ```
 

--- a/docs/src/pages/theming/responsive/react.mdx
+++ b/docs/src/pages/theming/responsive/react.mdx
@@ -3,7 +3,7 @@ import { Example } from '@/components/Example';
 
 ## Example
 
-Simply import any of our primitives and use either the object or array syntax to changes styles responsively. Resize your browser window window to see the styles change.
+Import any of our primitives and use either the object or array syntax to changes styles responsively. Resize your browser window window to see the styles change.
 
 ```jsx
 import { Flex, View } from '@aws-amplify/ui-react';

--- a/docs/src/pages/theming/responsive/react.mdx
+++ b/docs/src/pages/theming/responsive/react.mdx
@@ -3,7 +3,7 @@ import { Example } from '@/components/Example';
 
 ## Example
 
-Import any of our primitives and use either the object or array syntax to changes styles responsively. Resize your browser window window to see the styles change.
+Simply import any of our primitives and use either the object or array syntax to changes styles responsively. Resize your browser window window to see the styles change.
 
 ```jsx
 import { Flex, View } from '@aws-amplify/ui-react';
@@ -72,6 +72,7 @@ Or you can use the object syntax to specify styling for each breakpoint individu
 
 <Example>
   <View
+    testId="responsive-object-syntax-breakpoints"
     color={{
       base: 'black',
       small: 'black',

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -21,7 +21,6 @@ Given("I'm running the example {string}", (example: string) => {
 });
 
 Given("I'm running the docs page {string}", (page: string) => {
-  Cypress.config('baseUrl', 'http://localhost:5000/');
   cy.visit(page, {
     // See: https://glebbahmutov.com/blog/cypress-tips-and-tricks/#control-navigatorlanguage
     onBeforeLoad(win) {

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -20,6 +20,19 @@ Given("I'm running the example {string}", (example: string) => {
   });
 });
 
+Given("I'm running the docs page {string}", (page: string) => {
+  Cypress.config('baseUrl', 'http://localhost:5000/');
+  cy.visit(page, {
+    // See: https://glebbahmutov.com/blog/cypress-tips-and-tricks/#control-navigatorlanguage
+    onBeforeLoad(win) {
+      Object.defineProperty(win.navigator, 'language', { value: language });
+    },
+    onLoad(contentWindow) {
+      window = contentWindow;
+    },
+  });
+});
+
 Given(
   'I intercept {string} with fixture {string}',
   (json: string, fixture: string) => {

--- a/packages/e2e/cypress/integration/ui/theme/responsive/responsive.steps.ts
+++ b/packages/e2e/cypress/integration/ui/theme/responsive/responsive.steps.ts
@@ -1,0 +1,5 @@
+import { Then } from 'cypress-cucumber-preprocessor/steps';
+
+Then('the page contains {string}', (search: string) => {
+  cy.findByRole('document').contains(search);
+});

--- a/packages/e2e/cypress/integration/ui/theme/responsive/responsive.steps.ts
+++ b/packages/e2e/cypress/integration/ui/theme/responsive/responsive.steps.ts
@@ -1,4 +1,4 @@
-import { And, Then } from 'cypress-cucumber-preprocessor/steps';
+import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 const breakpoints = {
   base: 0,
@@ -14,20 +14,22 @@ Then('the page contains {string} section', (search: string) => {
   cy.findByRole('document').contains(search);
 });
 
-const getBreakpointsExample = () =>
-  cy.findByTestId('responsive-object-syntax-breakpoints').scrollIntoView();
+Then('the breakpoint is at {string}', (breakpoint: number) => {
+  cy.viewport(breakpoints[breakpoint], defaultHeight);
+});
 
-And(
-  'renders {string} breakpoint with appropriate background color {string}',
-  (breakpoint, color) => {
-    cy.viewport(breakpoints[breakpoint], defaultHeight);
-    getBreakpointsExample().should('have.css', 'background-color', color);
-  }
-);
-And(
-  'renders background color {string} at 1px less than {string}',
-  (color, breakpoint) => {
-    cy.viewport(breakpoints[breakpoint] - 1, defaultHeight);
-    getBreakpointsExample().should('have.css', 'background-color', color);
-  }
-);
+Then('I downsize the {string} viewport by 1px', (breakpoint: number) => {
+  cy.viewport(breakpoints[breakpoint] - 1, defaultHeight).wait(1000);
+});
+
+And('the breakpoints example is in view', () => {
+  cy.findByTestId('responsive-object-syntax-breakpoints').scrollIntoView();
+});
+
+And('the background color should be {string}', (color: string) => {
+  cy.findByTestId('responsive-object-syntax-breakpoints').should(
+    'have.css',
+    'background-color',
+    color
+  );
+});

--- a/packages/e2e/cypress/integration/ui/theme/responsive/responsive.steps.ts
+++ b/packages/e2e/cypress/integration/ui/theme/responsive/responsive.steps.ts
@@ -1,5 +1,33 @@
-import { Then } from 'cypress-cucumber-preprocessor/steps';
+import { And, Then } from 'cypress-cucumber-preprocessor/steps';
 
-Then('the page contains {string}', (search: string) => {
+const breakpoints = {
+  base: 0,
+  small: 480,
+  medium: 768,
+  large: 992,
+  xl: 1280,
+  xxl: 1536,
+};
+const defaultHeight = 844;
+
+Then('the page contains {string} section', (search: string) => {
   cy.findByRole('document').contains(search);
 });
+
+const getBreakpointsExample = () =>
+  cy.findByTestId('responsive-object-syntax-breakpoints').scrollIntoView();
+
+And(
+  'renders {string} breakpoint with appropriate background color {string}',
+  (breakpoint, color) => {
+    cy.viewport(breakpoints[breakpoint], defaultHeight);
+    getBreakpointsExample().should('have.css', 'background-color', color);
+  }
+);
+And(
+  'renders background color {string} at 1px less than {string}',
+  (color, breakpoint) => {
+    cy.viewport(breakpoints[breakpoint] - 1, defaultHeight);
+    getBreakpointsExample().should('have.css', 'background-color', color);
+  }
+);

--- a/packages/e2e/features/ui/theme/responsive.feature
+++ b/packages/e2e/features/ui/theme/responsive.feature
@@ -4,17 +4,41 @@ Feature: Responsive Theme support
 
   Background:
     Given I'm running the docs page "theming/responsive"
+    And the breakpoints example is in view
 
   Scenario: Theme renders breakpoints correctly on responsive demo
     Then the page contains "Object Syntax" section
-    And renders "base" breakpoint with appropriate background color "rgb(255, 0, 0)"
-    And renders "small" breakpoint with appropriate background color "rgb(255, 165, 0)"
-    And renders "medium" breakpoint with appropriate background color "rgb(255, 255, 0)"
-    And renders "large" breakpoint with appropriate background color "rgb(0, 128, 0)"
-    And renders "xl" breakpoint with appropriate background color "rgb(0, 0, 255)"
-    And renders "xxl" breakpoint with appropriate background color "rgb(128, 0, 128)"
-    And renders background color "rgb(255, 0, 0)" at 1px less than "small"
-    And renders background color "rgb(255, 165, 0)" at 1px less than "medium"
-    And renders background color "rgb(255, 255, 0)" at 1px less than "large"
-    And renders background color "rgb(0, 128, 0)" at 1px less than "xl"
-    And renders background color "rgb(0, 0, 255)" at 1px less than "xxl"
+
+    Then the breakpoint is at "base"
+    And the background color should be "rgb(255, 0, 0)"
+
+    Then the breakpoint is at "small"
+    And the background color should be "rgb(255, 165, 0)"
+
+    Then the breakpoint is at "medium"
+    And the background color should be "rgb(255, 255, 0)"
+
+    Then the breakpoint is at "large"
+    And the background color should be "rgb(0, 128, 0)"
+
+    Then the breakpoint is at "xl"
+    And the background color should be "rgb(0, 0, 255)"
+
+    Then the breakpoint is at "xxl"
+    And the background color should be "rgb(128, 0, 128)"
+
+  Scenario: Resizing breakpoints 1px smaller
+    Then I downsize the "small" viewport by 1px
+    And the background color should be "rgb(255, 0, 0)"
+
+    Then I downsize the "medium" viewport by 1px
+    And the background color should be "rgb(255, 165, 0)"
+
+    Then I downsize the "large" viewport by 1px
+    And the background color should be "rgb(255, 255, 0)"
+
+    Then I downsize the "xl" viewport by 1px
+    And the background color should be "rgb(0, 128, 0)"
+
+    Then I downsize the "xxl" viewport by 1px
+    And the background color should be "rgb(0, 0, 255)"

--- a/packages/e2e/features/ui/theme/responsive.feature
+++ b/packages/e2e/features/ui/theme/responsive.feature
@@ -1,0 +1,10 @@
+Feature: Responsive Theme support
+
+  The theme supports responsive breakpoints
+
+  Background:
+    Given I'm running the docs page "theming/responsive"
+
+  @react
+  Scenario: Testing 123
+    Then the page contains "Object Syntax"

--- a/packages/e2e/features/ui/theme/responsive.feature
+++ b/packages/e2e/features/ui/theme/responsive.feature
@@ -5,6 +5,16 @@ Feature: Responsive Theme support
   Background:
     Given I'm running the docs page "theming/responsive"
 
-  @react
-  Scenario: Testing 123
-    Then the page contains "Object Syntax"
+  Scenario: Theme renders breakpoints correctly on responsive demo
+    Then the page contains "Object Syntax" section
+    And renders "base" breakpoint with appropriate background color "rgb(255, 0, 0)"
+    And renders "small" breakpoint with appropriate background color "rgb(255, 165, 0)"
+    And renders "medium" breakpoint with appropriate background color "rgb(255, 255, 0)"
+    And renders "large" breakpoint with appropriate background color "rgb(0, 128, 0)"
+    And renders "xl" breakpoint with appropriate background color "rgb(0, 0, 255)"
+    And renders "xxl" breakpoint with appropriate background color "rgb(128, 0, 128)"
+    And renders background color "rgb(255, 0, 0)" at 1px less than "small"
+    And renders background color "rgb(255, 165, 0)" at 1px less than "medium"
+    And renders background color "rgb(255, 255, 0)" at 1px less than "large"
+    And renders background color "rgb(0, 128, 0)" at 1px less than "xl"
+    And renders background color "rgb(0, 0, 255)" at 1px less than "xxl"

--- a/packages/e2e/features/ui/theme/theme.features
+++ b/packages/e2e/features/ui/theme/theme.features
@@ -1,0 +1,2 @@
+# This file bundles automatically bundles all `.feature` files
+# See: https://github.com/TheBrainFamily/cypress-cucumber-preprocessor#bundled-features-files

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "TZ=UTC cypress open",
+    "test": "TZ=UTC cypress run --spec features/ui/components/authenticator/*.features",
     "test:authenticator": "TZ=UTC cypress run --spec features/ui/components/authenticator/*.features",
     "test:theme": "TZ=UTC CYPRESS_BASE_URL=http://localhost:5000 cypress run --spec features/ui/theme/*.features"
   },

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "dev": "TZ=UTC cypress open",
-    "test": "TZ=UTC cypress run --spec **/*.features"
+    "test:authenticator": "TZ=UTC cypress run --spec features/ui/components/authenticator/*.features",
+    "test:theme": "TZ=UTC CYPRESS_BASE_URL=http://localhost:5000 cypress run --spec features/ui/theme/*.features"
   },
   "cypress-cucumber-preprocessor": {
     "nonGlobalStepDefinitions": true,

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -7,7 +7,7 @@
     "dev": "TZ=UTC cypress open",
     "test": "TZ=UTC cypress run --spec features/ui/components/authenticator/*.features",
     "test:authenticator": "TZ=UTC cypress run --spec features/ui/components/authenticator/*.features",
-    "test:theme": "TZ=UTC CYPRESS_BASE_URL=http://localhost:5000 cypress run --spec features/ui/theme/*.features"
+    "test:theme": "TZ=UTC cypress run --spec features/ui/theme/*.features"
   },
   "cypress-cucumber-preprocessor": {
     "nonGlobalStepDefinitions": true,

--- a/packages/react/src/hooks/useThemeBreakpoint.ts
+++ b/packages/react/src/hooks/useThemeBreakpoint.ts
@@ -8,16 +8,11 @@ import { Breakpoint } from '../primitives/types/responsive';
  */
 export const useThemeBreakpoint = (): Breakpoint => {
   const {
-    breakpoints: {
-      values: breakpoints,
-      unit: breakpointUnit,
-      defaultBreakpoint,
-    },
+    breakpoints: { values: breakpoints, defaultBreakpoint },
   } = useTheme();
 
   const breakpoint = useBreakpoint({
     breakpoints,
-    breakpointUnit,
     defaultBreakpoint: defaultBreakpoint as Breakpoint,
   });
 

--- a/packages/react/src/primitives/shared/responsive/__tests__/getMediaQueries.test.ts
+++ b/packages/react/src/primitives/shared/responsive/__tests__/getMediaQueries.test.ts
@@ -2,64 +2,63 @@ import { Breakpoints } from '../../../types/responsive';
 import { getMediaQueries } from '../getMediaQueries';
 
 const unSortedBreakpoints: Breakpoints = {
-  xl: 80,
-  small: 30,
+  xl: 1280,
+  small: 480,
   base: 0,
-  large: 62,
-  medium: 48,
-  xxl: 96,
+  large: 992,
+  medium: 768,
+  xxl: 1536,
 };
 
 const expectedMediaQueries = [
   {
     breakpoint: 'xxl',
     maxWidth: null,
-    minWidth: 96,
-    query: '(min-width: 96em)',
+    minWidth: 1536,
+    query: '(min-width: 1536px)',
   },
   {
     breakpoint: 'xl',
-    maxWidth: 96,
-    minWidth: 80,
-    query: '(min-width: 80em) and (max-width: 95em)',
+    maxWidth: 1535,
+    minWidth: 1280,
+    query: '(min-width: 1280px) and (max-width: 1535px)',
   },
   {
     breakpoint: 'large',
-    maxWidth: 80,
-    minWidth: 62,
-    query: '(min-width: 62em) and (max-width: 79em)',
+    maxWidth: 1279,
+    minWidth: 992,
+    query: '(min-width: 992px) and (max-width: 1279px)',
   },
   {
     breakpoint: 'medium',
-    maxWidth: 62,
-    minWidth: 48,
-    query: '(min-width: 48em) and (max-width: 61em)',
+    maxWidth: 991,
+    minWidth: 768,
+    query: '(min-width: 768px) and (max-width: 991px)',
   },
   {
     breakpoint: 'small',
-    maxWidth: 48,
-    minWidth: 30,
-    query: '(min-width: 30em) and (max-width: 47em)',
+    maxWidth: 767,
+    minWidth: 480,
+    query: '(min-width: 480px) and (max-width: 767px)',
   },
   {
     breakpoint: 'base',
-    maxWidth: 30,
+    maxWidth: 479,
     minWidth: 0,
-    query: '(min-width: 0em) and (max-width: 29em)',
+    query: '(min-width: 0px) and (max-width: 479px)',
   },
 ];
 
 describe('getMediaQueries', () => {
-  it('should return a sorted list of queries and use breakpointUnit', () => {
+  it('should return a sorted list of queries using px unit', () => {
     const result = getMediaQueries({
       breakpoints: unSortedBreakpoints,
-      breakpointUnit: 'em',
     });
     // Didn't use a snapshot here because snapshots are too
     // easy to ignore and update without understanding why
     // they changed
     expect(result).toEqual(expectedMediaQueries);
-    expect(result[0].query.includes('em')).toBe(true);
+    expect(result[0].query.includes('px')).toBe(true);
   });
 
   it('should handle negative min-width', () => {
@@ -69,12 +68,11 @@ describe('getMediaQueries', () => {
     };
     const expectedMediaQueriesNegWidth = [...expectedMediaQueries];
     expectedMediaQueriesNegWidth[5].minWidth = -1;
-    expectedMediaQueriesNegWidth[5].query = '(max-width: 29em)';
+    expectedMediaQueriesNegWidth[5].query = '(max-width: 479px)';
 
     expect(
       getMediaQueries({
         breakpoints: negativeBreakpoints,
-        breakpointUnit: 'em',
       })
     ).toEqual(expectedMediaQueriesNegWidth);
   });

--- a/packages/react/src/primitives/shared/responsive/__tests__/useBreakpoint.test.ts
+++ b/packages/react/src/primitives/shared/responsive/__tests__/useBreakpoint.test.ts
@@ -16,25 +16,24 @@ const mockUseDebugValue = React.useDebugValue as jest.Mock<
 >;
 
 const breakpoints: Breakpoints = {
-  xl: 80,
-  small: 30,
+  xl: 1280,
+  small: 480,
   base: 0,
-  large: 62,
-  medium: 48,
-  xxl: 96,
+  medium: 768,
+  large: 992,
+  xxl: 1536,
 };
 
-const breakpointUnit = 'em';
 const defaultBreakpoint = 'base';
 
 let matchMedia: MatchMediaMock;
-let mediaQueries = getMediaQueries({ breakpointUnit: 'em', breakpoints });
+let mediaQueries = getMediaQueries({ breakpoints });
 
 const testBreakpoints = (m) => {
   it(`should return ${m.breakpoint} breakpoint`, () => {
     matchMedia.useMediaQuery(m.query);
     const { result } = renderHook(() =>
-      useBreakpoint({ breakpoints, breakpointUnit, defaultBreakpoint })
+      useBreakpoint({ breakpoints, defaultBreakpoint })
     );
     const breakpoint = result.current;
 
@@ -63,7 +62,7 @@ describe('useBreakpoint', () => {
 
   it('should return default breakpoint', () => {
     const { result } = renderHook(() =>
-      useBreakpoint({ breakpoints, breakpointUnit, defaultBreakpoint })
+      useBreakpoint({ breakpoints, defaultBreakpoint })
     );
     const breakpoint = result.current;
 

--- a/packages/react/src/primitives/shared/responsive/getMediaQueries.ts
+++ b/packages/react/src/primitives/shared/responsive/getMediaQueries.ts
@@ -3,10 +3,7 @@
 
 import { Breakpoint, GetMediaQueries } from '../../types/responsive';
 
-export const getMediaQueries: GetMediaQueries = ({
-  breakpoints,
-  breakpointUnit,
-}) => {
+export const getMediaQueries: GetMediaQueries = ({ breakpoints }) => {
   const sortedBreakpoints = Object.keys(breakpoints).sort(
     (a, b) => breakpoints[b] - breakpoints[a]
   );
@@ -18,17 +15,17 @@ export const getMediaQueries: GetMediaQueries = ({
     const nextBreakpoint = sortedBreakpoints[index - 1] as
       | Breakpoint
       | undefined;
-    const maxWidth = nextBreakpoint ? breakpoints[nextBreakpoint] : null;
+    const maxWidth = nextBreakpoint ? breakpoints[nextBreakpoint] - 1 : null;
 
     if (minWidth >= 0) {
-      query = `(min-width: ${minWidth}${breakpointUnit})`;
+      query = `(min-width: ${minWidth}px)`;
     }
 
     if (maxWidth !== null) {
       if (query) {
         query += ' and ';
       }
-      query += `(max-width: ${maxWidth - 1}${breakpointUnit})`;
+      query += `(max-width: ${maxWidth}px)`;
     }
 
     return {

--- a/packages/react/src/primitives/shared/responsive/useBreakpoint.ts
+++ b/packages/react/src/primitives/shared/responsive/useBreakpoint.ts
@@ -10,7 +10,6 @@ const useIsomorphicEffect =
 
 export const useBreakpoint: UseBreakpoint = ({
   breakpoints,
-  breakpointUnit,
   defaultBreakpoint,
 }) => {
   const supportMatchMedia =
@@ -18,13 +17,12 @@ export const useBreakpoint: UseBreakpoint = ({
   const matchMedia = supportMatchMedia ? window.matchMedia : null;
 
   const mediaQueries = React.useMemo(
-    () => getMediaQueries({ breakpoints, breakpointUnit }),
-    [breakpoints, breakpointUnit]
+    () => getMediaQueries({ breakpoints }),
+    [breakpoints]
   );
 
-  const [breakpoint, setBreakpoint] = React.useState<Breakpoint>(
-    defaultBreakpoint
-  );
+  const [breakpoint, setBreakpoint] =
+    React.useState<Breakpoint>(defaultBreakpoint);
 
   const updateBreakpoint = React.useCallback(
     (matches: boolean, breakpoint: Breakpoint) => {

--- a/packages/react/src/primitives/shared/styleUtils.ts
+++ b/packages/react/src/primitives/shared/styleUtils.ts
@@ -51,16 +51,11 @@ export const useTransformStyleProps = (props: ViewProps): ViewProps => {
 
 export const usePropStyles = (props: ViewProps, style: React.CSSProperties) => {
   const {
-    breakpoints: {
-      values: breakpoints,
-      unit: breakpointUnit,
-      defaultBreakpoint,
-    },
+    breakpoints: { values: breakpoints, defaultBreakpoint },
   } = useTheme();
 
   const breakpoint = useBreakpoint({
     breakpoints,
-    breakpointUnit,
     defaultBreakpoint: defaultBreakpoint as Breakpoint,
   });
 

--- a/packages/react/src/primitives/types/responsive.ts
+++ b/packages/react/src/primitives/types/responsive.ts
@@ -11,7 +11,6 @@ export interface MediaQueryBreakpoint {
 
 export interface GetMediaQueriesParams {
   breakpoints: Breakpoints;
-  breakpointUnit: string;
 }
 
 export interface GetMediaQueries {
@@ -21,7 +20,6 @@ export interface GetMediaQueries {
 export interface UseBreakpointParams {
   breakpoints: Breakpoints;
   defaultBreakpoint: Breakpoint;
-  breakpointUnit: string;
 }
 
 export interface UseBreakpoint {

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -868,13 +868,13 @@ describe('@aws-amplify/ui', () => {
           }
         }
 
-        @media (min-width: 30em) {
+        @media (min-width: 480px) {
           [data-amplify-theme=\\"test-theme\\"] {
             --amplify-space-medium: 0.5rem;
           }
         }
 
-        @media (min-width: 62em) {
+        @media (min-width: 992px) {
           [data-amplify-theme=\\"test-theme\\"] {
             --amplify-space-medium: 2.5rem;
           }

--- a/packages/ui/src/theme/breakpoints.ts
+++ b/packages/ui/src/theme/breakpoints.ts
@@ -7,19 +7,18 @@ export interface Breakpoints {
     xl: number;
     xxl: number;
   };
-  unit: string;
   defaultBreakpoint: string;
 }
 
+// Breakpoint unit is in pixels
 export const breakpoints: Breakpoints = {
   values: {
     base: 0,
-    small: 30, // 480px (16px base)
-    medium: 48, // 768px
-    large: 62, // 992px
-    xl: 80, // 1280px
-    xxl: 96, // 1536px
+    small: 480, // breakpoint unit is px
+    medium: 768,
+    large: 992,
+    xl: 1280,
+    xxl: 1536,
   },
-  unit: 'em',
   defaultBreakpoint: 'base',
 };

--- a/packages/ui/src/theme/createTheme.ts
+++ b/packages/ui/src/theme/createTheme.ts
@@ -111,8 +111,7 @@ export function createTheme(
       }
       if ('breakpoint' in override) {
         const breakpoint = mergedTheme.breakpoints.values[override.breakpoint];
-        const breakpointUnit = mergedTheme.breakpoints.unit;
-        cssText += `\n@media (min-width: ${breakpoint}${breakpointUnit}) {
+        cssText += `\n@media (min-width: ${breakpoint}px) {
   [data-amplify-theme="${name}"] {
     ${customProperties}
   }


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/aws-amplify/amplify-ui/issues/1059

*Description of changes:*
This PR updates the responsive breakpoint logic to use `px` instead of `em`. Previous fix for https://github.com/aws-amplify/amplify-ui/issues/1059 attempted to use `calc` to subtract `1px` from the `em` value of the next breakpoint. This didn't work correctly in Chrome, which doesn't support mixing units while using calc in media queries, so I [did more experiments](https://codepen.io/reescott/pen/RwLQbVg).

**Background**: 
I originally built the responsive support using `em`s because `em`s are based on the [user's font size choice](https://css-tricks.com/weekly-platform-news-focus-rings-donut-scope-ditching-em-units-and-global-privacy-control/#the-case-for-em-based-media-queries), making it a more accessible option.

**Solution:** 
What works in all browsers is to revert to using `px` over `em`.   This works because we define media queries that are a range of min-width to max-width, where max-width is a `1px` less than the next breakpoint up. You may think we could simply use `min-width` to solve this problem and drop `max-width` rules, as we can do with CSS. However, to return the current breakpoint while resizing the window using `matchMedia`, we must have both min-width and max-width rules in order to get an event while resizing the window both wider and narrower (To test this out see Experiment 3 here: https://codepen.io/reescott/pen/RwLQbVg).

_Diff of media queries_
```diff
- (min-width: 0em) and (max-width: 29em)
+ (min-width: 0px) and (max-width: 479px)
```
```diff
- (min-width: 30em) and (max-width: 47em)
+ (min-width: 480px) and (max-width: 767px)
```

**Testing**

- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [x] Added additional e2e tests

_Chrome: narrowing the window_
![2022-01-03 19 56 02](https://user-images.githubusercontent.com/6165315/148008802-13a33490-f822-411a-b427-3ace70d1bdcd.gif)

_Chrome: widening the window_
![2022-01-03 19 55 34](https://user-images.githubusercontent.com/6165315/148008812-12be486d-9dde-4fb0-952f-e354f9d69a76.gif)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
