### PR TITLE
fix: fixing the color and background color in pressed state

### DIFF
--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -64,10 +64,8 @@ export const theme: Theme = {
       },
       togglebutton: {
         borderColor: { value: '{colors.border.primary.value}' },
-        color: { value: '{colors.font.tertiary.value}' },
         pressed: {
           color: { value: '{colors.font.primary.value}' },
-          backgroundColor: { value: '{colors.background.secondary.value}' },
         },
       },
       fieldcontrol: {


### PR DESCRIPTION
*Issue #, if available:*
#983 

*Description of changes:*

Removing color and background color overrides in doc site theme

Light mode:

Unpressed
![Screen Shot 2022-01-04 at 10 18 55 AM](https://user-images.githubusercontent.com/40295569/148105323-9e4060cb-5867-4f29-a864-c8aa4fc1db15.png)

Pressed
![Screen Shot 2022-01-04 at 10 19 02 AM](https://user-images.githubusercontent.com/40295569/148105346-4ad558b2-48ad-4d10-83cf-432492c7215c.png)
![Screen Shot 2022-01-04 at 10 33 53 AM](https://user-images.githubusercontent.com/40295569/148107028-b9b31562-845d-428f-ad13-84a1fd9bd578.png)

--------------------------------

Dark mode:

Unpressed
![Screen Shot 2022-01-04 at 10 31 21 AM](https://user-images.githubusercontent.com/40295569/148106786-bbaf4aa3-4003-4d8f-94e0-02c67daadf97.png)

Pressed
![Screen Shot 2022-01-04 at 10 31 28 AM](https://user-images.githubusercontent.com/40295569/148106844-e1e9fb2d-9034-43df-b5e2-d99329bf28e9.png)
![Screen Shot 2022-01-04 at 10 35 31 AM](https://user-images.githubusercontent.com/40295569/148107198-5a5c2508-afe1-4cdc-a132-d39d9a89c957.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
