### PR TITLE
Angular + Vue: Fix Fonts

### DIFF
--- a/.changeset/orange-toys-remain.md
+++ b/.changeset/orange-toys-remain.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui-vue': patch
+'@aws-amplify/ui-angular': patch
+---
+
+Added back fonts that were deleted in previous PR

--- a/packages/angular/projects/ui-angular/theme.css
+++ b/packages/angular/projects/ui-angular/theme.css
@@ -1,1 +1,11 @@
 @import '@aws-amplify/ui/dist/styles.css';
+
+html {
+  font-family: var(--amplify-fonts-default-static);
+}
+
+@supports (font-variation-settings: normal) {
+  html {
+    font-family: var(--amplify-fonts-default-variable);
+  }
+}

--- a/packages/angular/projects/ui-angular/theme.css
+++ b/packages/angular/projects/ui-angular/theme.css
@@ -1,5 +1,7 @@
 @import '@aws-amplify/ui/dist/styles.css';
 
+/** These fonts are added in only temporarily until Angular has it's own theming system */
+
 html {
   font-family: var(--amplify-fonts-default-static);
 }

--- a/packages/vue/src/components/primitives/styles.css
+++ b/packages/vue/src/components/primitives/styles.css
@@ -1,3 +1,5 @@
+/** These fonts are added in only temporarily until Vue has it's own theming system */
+
 html {
   font-family: var(--amplify-fonts-default-static);
 }

--- a/packages/vue/src/components/primitives/styles.css
+++ b/packages/vue/src/components/primitives/styles.css
@@ -1,3 +1,12 @@
+html {
+  font-family: var(--amplify-fonts-default-static);
+}
+@supports (font-variation-settings: normal) {
+  html {
+    font-family: var(--amplify-fonts-default-variable);
+  }
+}
+
 [data-amplify-spacer] {
   @apply flex-1;
 }


### PR DESCRIPTION
*Description of changes:*
After we moved the fonts to `[data-amplify-theme]` in #1065 this caused the fonts in Vue and Angular to default back to Times New Roman.

To fix this, I added back these fonts only for Vue and Angular. When Vue and Angular implement their own theming/ component system, this can be deleted. 

Before:
![image](https://user-images.githubusercontent.com/65630/148110449-b28562d9-1b2c-4de1-bfe6-1693ec22a532.png)


After:

![image](https://user-images.githubusercontent.com/65630/148110941-aab24d5f-2aa0-4cb5-b214-a4f23ff5f19f.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
