### PR TITLE
ci(@aws-amplify/ui-svelte): only enable publish from `packages/svelte`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,6 +16,9 @@
     "next-example",
     "vue-example",
     "amplify-ui-angular-mono",
-    "e2e"
+    "e2e",
+    "@aws-amplify/ui-angular",
+    "@aws-amplify/ui-react",
+    "@aws-amplify/ui-vue"
   ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This ignores `@aws-amplify/ui-angular` , `@aws-amplify/ui-vue`, and `@aws-amplify/ui-react` so that only `@aws-amplify/ui-svelte` is published to `@next` on `ui-svelte/main` branch. This prevents conflicts to `@next` tag from the two branches.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
