### PR TITLE
Remove trailing space on "Forgot your password? "

### DIFF
--- a/.changeset/many-pigs-chew.md
+++ b/.changeset/many-pigs-chew.md
@@ -1,0 +1,8 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-vue": patch
+"@aws-amplify/ui-angular": patch
+---
+
+Remove trailing space on "Forgot your password? "

--- a/docs/src/pages/components/authenticator/LabelsAndTextDemo.tsx
+++ b/docs/src/pages/components/authenticator/LabelsAndTextDemo.tsx
@@ -28,7 +28,7 @@ function Screen({ Component }: ScreenProps) {
       'Sign in to your account': 'Welcome Back!', // Header text
       Username: 'Enter your username', // Username label
       Password: 'Enter your password', // Password label
-      'Forgot your password? ': 'Reset Password',
+      'Forgot your password?': 'Reset Password',
 
       // Sign Up screen
       'Create Account': 'Register', // Tab header

--- a/docs/src/pages/components/authenticator/index.page.mdx
+++ b/docs/src/pages/components/authenticator/index.page.mdx
@@ -463,7 +463,7 @@ Using the same techniques as [Internationalization (I18n)](#internationalization
       'Sign in to your account': 'Welcome Back!',
       Username: 'Enter your username', // Username label
       Password: 'Enter your password', // Password label
-      'Forgot your password? ': 'Reset Password',
+      'Forgot your password?': 'Reset Password',
     });
     ```
 

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.ts
@@ -11,8 +11,7 @@ export class SignInComponent {
   @HostBinding('attr.data-amplify-authenticator-signin') dataAttr = '';
 
   // translated phrases
-  // TODO: Fully ignore trailing space on next major version.
-  // https://github.com/aws-amplify/amplify-ui/pull/1088
+  // Support backwards compatibility for legacy key with trailing space
   public forgotPasswordText = !hasTranslation('Forgot your password? ')
     ? translate('Forgot your password?')
     : translate('Forgot your password? ');

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.ts
@@ -1,11 +1,6 @@
-import {
-  Component,
-  HostBinding,
-  Input,
-  ViewEncapsulation,
-} from '@angular/core';
+import { Component, HostBinding, ViewEncapsulation } from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
-import { translate } from '@aws-amplify/ui';
+import { translate, hasTranslation } from '@aws-amplify/ui';
 
 @Component({
   selector: 'amplify-sign-in',
@@ -16,7 +11,11 @@ export class SignInComponent {
   @HostBinding('attr.data-amplify-authenticator-signin') dataAttr = '';
 
   // translated phrases
-  public forgotPasswordText = translate('Forgot your password?');
+  // TODO: Fully ignore trailing space on next major version.
+  // https://github.com/aws-amplify/amplify-ui/pull/1088
+  public forgotPasswordText = !hasTranslation('Forgot your password? ')
+    ? translate('Forgot your password?')
+    : translate('Forgot your password? ');
   public signInButtonText = translate('Sign in');
 
   constructor(public authenticator: AuthenticatorService) {}

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.ts
@@ -16,7 +16,7 @@ export class SignInComponent {
   @HostBinding('attr.data-amplify-authenticator-signin') dataAttr = '';
 
   // translated phrases
-  public forgotPasswordText = translate('Forgot your password? ');
+  public forgotPasswordText = translate('Forgot your password?');
   public signInButtonText = translate('Sign in');
 
   constructor(public authenticator: AuthenticatorService) {}

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -1,4 +1,4 @@
-import { translate } from '@aws-amplify/ui';
+import { translate, hasTranslation } from '@aws-amplify/ui';
 
 import { useAuthenticator } from '..';
 import { Button, Flex, PasswordField, View } from '../../..';
@@ -86,6 +86,11 @@ SignIn.Header = (): JSX.Element => null;
 SignIn.Footer = () => {
   const { toResetPassword } = useAuthenticator();
 
+  // Support backwards compatibility for legacy key with trailing space.
+  const forgotPasswordText = !hasTranslation('Forgot your password? ')
+    ? translate('Forgot your password?')
+    : translate('Forgot your password? ');
+
   return (
     <View data-amplify-footer="">
       <Button
@@ -94,7 +99,7 @@ SignIn.Footer = () => {
         size="small"
         variation="link"
       >
-        {translate('Forgot your password?')}
+        {forgotPasswordText}
       </Button>
     </View>
   );

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -94,7 +94,7 @@ SignIn.Footer = () => {
         size="small"
         variation="link"
       >
-        {translate('Forgot your password? ')}
+        {translate('Forgot your password?')}
       </Button>
     </View>
   );

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -86,7 +86,7 @@ SignIn.Header = (): JSX.Element => null;
 SignIn.Footer = () => {
   const { toResetPassword } = useAuthenticator();
 
-  // Support backwards compatibility for legacy key with trailing space.
+  // Support backwards compatibility for legacy key with trailing space
   const forgotPasswordText = !hasTranslation('Forgot your password? ')
     ? translate('Forgot your password?')
     : translate('Forgot your password? ');

--- a/packages/ui/src/i18n/dictionaries/authenticator/de.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/de.ts
@@ -19,7 +19,7 @@ export const deDict = {
   'Enter your password': 'Geben Sie Ihr Passwort ein',
   'Enter your username': 'Geben Sie Ihren Benutzernamen ein',
   'Forgot Password': 'Passwort vergessen',
-  'Forgot your password? ': 'Passwort vergessen? ',
+  'Forgot your password?': 'Passwort vergessen? ',
   'Have an account? ': 'Schon registriert? ',
   'Incorrect username or password':
     'Falscher Benutzername oder falsches Passwort',

--- a/packages/ui/src/i18n/dictionaries/authenticator/defaultTexts.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/defaultTexts.ts
@@ -20,6 +20,7 @@ export const defaultTexts = {
   FAMILY_NAME: 'Family Name',
   GIVEN_NAME: 'Given Name',
   FORGOT_YOUR_PASSWORD: 'Forgot your password?',
+  FORGOT_YOUR_PASSWORD_LEGACY: 'Forgot your password? ',
   HIDE_PASSWORD: 'Hide password',
   LOADING: 'Loading',
   LOGIN_NAME: 'Username',

--- a/packages/ui/src/i18n/dictionaries/authenticator/defaultTexts.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/defaultTexts.ts
@@ -19,7 +19,7 @@ export const defaultTexts = {
   ENTER_USERNAME: 'Enter your username',
   FAMILY_NAME: 'Family Name',
   GIVEN_NAME: 'Given Name',
-  FORGOT_YOUR_PASSWORD: 'Forgot your password? ',
+  FORGOT_YOUR_PASSWORD: 'Forgot your password?',
   HIDE_PASSWORD: 'Hide password',
   LOADING: 'Loading',
   LOGIN_NAME: 'Username',

--- a/packages/ui/src/i18n/dictionaries/authenticator/en.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/en.ts
@@ -18,7 +18,7 @@ export const enDict = {
   'Enter your username': 'Enter your username',
   'Enter your phone number': 'Enter your phone number',
   'Enter your email': 'Enter your email',
-  'Forgot your password? ': 'Forgot your password? ',
+  'Forgot your password?': 'Forgot your password?',
   'Hide password': 'Hide password',
   Loading: 'Loading',
   Username: 'Username',

--- a/packages/ui/src/i18n/dictionaries/authenticator/fr.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/fr.ts
@@ -25,7 +25,7 @@ export const frDict = {
   'Enter your phone number': 'Saisissez votre numéro de téléphone',
   'Enter your username': "Saisissez votre nom d'utilisateur",
   'Forgot Password': 'Mot de passe oublié',
-  'Forgot your password? ': 'Mot de passe oublié ? ',
+  'Forgot your password?': 'Mot de passe oublié ? ',
   'Have an account? ': 'Déjà un compte ? ',
   Hello: 'Bonjour',
   'Incorrect username or password': 'Identifiant ou mot de passe incorrect',

--- a/packages/ui/src/i18n/dictionaries/authenticator/it.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/it.ts
@@ -19,7 +19,7 @@ export const itDict = {
   'Enter your password': 'Inserire la password',
   'Enter your username': 'Inserisci il tuo nome utente',
   'Forgot Password': 'Password dimenticata',
-  'Forgot your password? ': 'Password dimenticata?',
+  'Forgot your password?': 'Password dimenticata?',
   'Have an account? ': 'Già registrato?',
   'Incorrect username or password': 'Nome utente o password errati',
   'Invalid password format': 'Formato della password non valido',

--- a/packages/ui/src/i18n/dictionaries/authenticator/ja.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/ja.ts
@@ -19,7 +19,7 @@ export const jaDict = {
   'Enter your password': 'パスワードを入力 ',
   'Enter your username': 'ユーザー名を入力 ',
   'Forgot Password': 'パスワードを忘れた ',
-  'Forgot your password? ': 'パスワードを忘れましたか？ ',
+  'Forgot your password?': 'パスワードを忘れましたか？ ',
   'Have an account? ': 'アカウントを持っていますか？',
   'Incorrect username or password': 'ユーザー名かパスワードが異なります ',
   'Invalid password format': 'パスワードの形式が無効です ',

--- a/packages/ui/src/i18n/dictionaries/authenticator/kr.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/kr.ts
@@ -19,7 +19,7 @@ export const krDict = {
   'Enter your username': '아이디를 입력해주세요',
   'Family Name': '성',
   'Given Name': '이름',
-  'Forgot your password? ': '비밀번호를 잊으셨나요?',
+  'Forgot your password?': '비밀번호를 잊으셨나요?',
   'Hide password': '비밀번호 숨기기',
   Loading: '로딩중',
   Username: '아이디',

--- a/packages/ui/src/i18n/dictionaries/authenticator/nl.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/nl.ts
@@ -18,7 +18,7 @@ export const nlDict = {
   'Enter your username': 'Vul je gebruikersnaam in',
   'Enter your phone number': 'Vul je telefoonnummer in',
   'Enter your email': 'Vul je e-mail in',
-  'Forgot your password? ': 'Wachtwoord vergeten? ',
+  'Forgot your password?': 'Wachtwoord vergeten? ',
   'Hide password': 'Verberg wachtwoord',
   Loading: 'Laden',
   Username: 'Gebruikersnaam',

--- a/packages/ui/src/i18n/dictionaries/authenticator/pl.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/pl.ts
@@ -19,7 +19,7 @@ export const plDict = {
   'Enter your username': 'Wprowadź swoją nazwę użytkownika',
   'Family Name': 'Nazwisko',
   'Given Name': 'Pierwsze imię',
-  'Forgot your password? ': 'Zapomniałeś hasła? ',
+  'Forgot your password?': 'Zapomniałeś hasła? ',
   'Hide password': 'Ukryj hasło',
   Loading: 'Ładowanie',
   Username: 'Nazwa użytkownika',

--- a/packages/ui/src/i18n/dictionaries/authenticator/pt.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/pt.ts
@@ -18,7 +18,7 @@ export const ptDict = {
   'Enter your username': 'entre com seu nome de usuário',
   'Enter your phone number': 'Digite seu número de telefone',
   'Enter your email': 'Digite seu e-mail',
-  'Forgot your password? ': 'Esqueceu sua senha? ',
+  'Forgot your password?': 'Esqueceu sua senha? ',
   'Hide password': 'Esconder a senha',
   Loading: 'Carregando',
   Username: 'Nome do usuário',

--- a/packages/ui/src/i18n/translations.ts
+++ b/packages/ui/src/i18n/translations.ts
@@ -64,6 +64,13 @@ export function translate<T = Phrase>(phrase: NoInfer<T>): string {
   return I18n.get(phrase);
 }
 
+/**
+ * Whether I18n has a translation entry for given phrase
+ */
+export function hasTranslation(phrase: string) {
+  return I18n.get(phrase) !== phrase;
+}
+
 export const translations: Record<string, Dict> = {
   de: deDict,
   en: enDict,

--- a/packages/vue/src/components/sign-in.vue
+++ b/packages/vue/src/components/sign-in.vue
@@ -23,8 +23,7 @@ const emit = defineEmits([
 
 const passwordLabel = computed(() => translate('Password'));
 const forgotYourPasswordLink = computed(() =>
-  // TODO: Fully ignore trailing space on next major version.
-  // https://github.com/aws-amplify/amplify-ui/pull/1088
+  // Support backwards compatibility for legacy key with trailing space
   !hasTranslation('Forgot your password? ')
     ? translate('Forgot your password?')
     : translate('Forgot your password? ')

--- a/packages/vue/src/components/sign-in.vue
+++ b/packages/vue/src/components/sign-in.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { computed, ComputedRef, useAttrs } from 'vue';
-import { getActorState, SignInState, translate } from '@aws-amplify/ui';
+import {
+  getActorState,
+  hasTranslation,
+  SignInState,
+  translate,
+} from '@aws-amplify/ui';
 
 import PasswordControl from './password-control.vue';
 import UserNameAlias from './user-name-alias.vue';
@@ -18,7 +23,11 @@ const emit = defineEmits([
 
 const passwordLabel = computed(() => translate('Password'));
 const forgotYourPasswordLink = computed(() =>
-  translate('Forgot your password?')
+  // TODO: Fully ignore trailing space on next major version.
+  // https://github.com/aws-amplify/amplify-ui/pull/1088
+  !hasTranslation('Forgot your password? ')
+    ? translate('Forgot your password?')
+    : translate('Forgot your password? ')
 );
 
 const signInButtonText = computed(() => translate('Sign in'));

--- a/packages/vue/src/components/sign-in.vue
+++ b/packages/vue/src/components/sign-in.vue
@@ -18,7 +18,7 @@ const emit = defineEmits([
 
 const passwordLabel = computed(() => translate('Password'));
 const forgotYourPasswordLink = computed(() =>
-  translate('Forgot your password? ')
+  translate('Forgot your password?')
 );
 
 const signInButtonText = computed(() => translate('Sign in'));


### PR DESCRIPTION
*Issue #, if available:* Fixes #900.

*Description of changes:* Removes trailing space on "Forgot your password? ". This extra space was used in legacy authenticator to put spacing between "Forgot your password" and "Reset your password":

![image](https://user-images.githubusercontent.com/43682783/148144359-569df551-94ba-4f2f-9db9-3e7df2e8486e.png)

This is no longer needed or desired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
