### PR TITLE
Checkout the head_branch when publish `@next`

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with: 
-          ref: {{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_branch }}
       - name: Setup Node.js LTS
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with: 
+          ref: github.event.workflow_run.head_branch
       - name: Setup Node.js LTS
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with: 
-          ref: github.event.workflow_run.head_branch
+          ref: {{ github.event.workflow_run.head_branch }}
       - name: Setup Node.js LTS
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* With `ui-svelte/main` branch set up, this workflow now needs to checkout the head branch that triggered the workflow, instead of assuming it to be `main`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
