### PR TITLE
deps(angular): Pin @stencil/core to 2.8.0

### DIFF
--- a/.changeset/dull-years-judge.md
+++ b/.changeset/dull-years-judge.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-angular": patch
+---
+
+deps(angular): Pin @stencil/core to 2.8.0

--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@aws-amplify/ui-components": "^1.7.0",
     "@aws-amplify/ui": "3.0.6",
-    "@stencil/core": "^2.7.0",
+    "@stencil/core": "2.8.0",
     "nanoid": "^3.1.25",
     "qrcode": "^1.4.4",
     "tslib": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4993,10 +4993,10 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@stencil/core@^2.7.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.11.0.tgz#8accc2791e2c34cce2d2aa8b40864dd40be4e10c"
-  integrity sha512-/IubCWhVXCguyMUp/3zGrg3c882+RJNg/zpiKfyfJL3kRCOwe+/MD8OoAXVGdd+xAohZKIi1Ik+EHFlsptsjLg==
+"@stencil/core@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.8.0.tgz#87d950fbbf050dce1566f32ca48c98007239472b"
+  integrity sha512-WazFGUMnbumg8ePNvej8cIOEcxvuZ0ugKQkkE1xFbDYcl7DgJd62MiG+bIqCcQlIdLEfhjAdoixxlFdJgrgjyA==
 
 "@svgr/babel-plugin-add-jsx-attribute@^5.4.0":
   version "5.4.0"


### PR DESCRIPTION
*Issue #, if available:* Fixes #1091

*Description of changes:* This PR pins `@stencil/core` to `@2.8.0`. `@2.10.0` has known exports conflict with web components library built with previous versions: [[related](https://github.com/vime-js/vime/issues/261), [2](https://forum.ionicframework.com/t/stencil-v2-10-removed-attachshadow-from-bundle/217064)].

We could go the other direction and bump `@aws-amplify/ui-components`' stencil dependency to `2.10.0`, but it currently depends on previous major version `1.15.0`. Handling this from framework side to reduce any risk from breaking change.

On 2.10.0:

![Screen Shot 2022-01-05 at 1 31 19 PM](https://user-images.githubusercontent.com/43682783/148293139-79a1abd7-461e-45ea-abba-72a8dfee4065.png)

On 2.8.0:

![Screen Shot 2022-01-05 at 1 23 37 PM](https://user-images.githubusercontent.com/43682783/148293190-d10ead3b-3e92-4db7-bc27-7a0b72907cf0.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
