### PR TITLE
Put yarn docs start into background process

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -336,7 +336,7 @@ jobs:
         run: yarn docs build
 
       - name: Start docs site
-        run: yarn docs start && npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000
+        run: yarn docs start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000
 
       - name: Run E2E tests against docs
         run: yarn workspace e2e test:theme


### PR DESCRIPTION
*Description of changes:*
We added new steps to tests github action to [run e2e tests on the docs site](https://github.com/aws-amplify/amplify-ui/blob/main/.github/workflows/tests.yml#L338-L342). I couldn't get the new steps to run on a separate branch, so it was merged to main without full testing. I'm seeing that the ["Start docs site" step is stuck](https://github.com/aws-amplify/amplify-ui/runs/4721645361?check_suite_focus=true). Based on the [other steps](https://github.com/aws-amplify/amplify-ui/blob/main/.github/workflows/tests.yml#L265), it looks like `yarn docs start` command is not exiting and should be put in the background using `&` to allow for the `npx wait-on` command to run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
