### PR TITLE
Fix docs tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -304,6 +304,15 @@ jobs:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
 
+      - name: Restore node_modules cache
+        uses: actions/cache@v2
+        id: restore-cache
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
+
       - name: Restore Cache
         uses: actions/cache@v2
         id: restore-cache
@@ -347,3 +356,10 @@ jobs:
 
       - name: Run E2E tests against docs
         run: yarn workspace e2e test:theme
+        env:
+          # Env values for testing flows
+          DOMAIN: ${{ secrets.DOMAIN }}
+          PHONE_NUMBER: ${{ secrets.PHONE_NUMBER }}
+          USERNAME: ${{ secrets.USERNAME }}
+          NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
+          VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main, ui-svelte/main]
 
-  pull_request_target:
+  pull_request:
     branches: [main, ui-svelte/main]
     types: [opened, synchronize, labeled]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main, ui-svelte/main]
 
-  pull_request:
+  pull_request_target:
     branches: [main, ui-svelte/main]
     types: [opened, synchronize, labeled]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -304,15 +304,6 @@ jobs:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
 
-      - name: Restore node_modules cache
-        uses: actions/cache@v2
-        id: restore-cache
-        with:
-          path: |
-            ./node_modules
-            **/node_modules
-          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
-
       - name: Restore Cache
         uses: actions/cache@v2
         id: restore-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -297,6 +297,13 @@ jobs:
           node-version: lts/*
           cache: "yarn"
 
+      - name: Restore cypress runner Cache
+        uses: actions/cache@v2
+        id: restore-cypress-cache
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
+
       - name: Restore Cache
         uses: actions/cache@v2
         id: restore-cache


### PR DESCRIPTION
*Description of changes:*
Fix docs build by restoring the cypress runner cache.

*Error message*:
```
$ TZ=UTC cypress run --spec features/ui/theme/*.features
The cypress npm package is installed, but the Cypress binary is missing.

We expected the binary to be installed here: /home/runner/.cache/Cypress/8.7.0/Cypress/Cypress

Reasons it may be missing:

- You're caching 'node_modules' but are not caching this path: /home/runner/.cache/Cypress
- You ran 'npm install' at an earlier build step but did not persist: /home/runner/.cache/Cypress

Properly caching the binary will fix this error and avoid downloading and unzipping Cypress.

Alternatively, you can run 'cypress install' to download the binary again.

https://on.cypress.io/not-installed-ci-error

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
