### PR TITLE
fix: fixing unaligned border outlines

### DIFF
--- a/.changeset/good-pandas-press.md
+++ b/.changeset/good-pandas-press.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix: fixing unaligned border outlines between `CountryCodeSelect` and `TextField` on `PhoneNumberField`

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -191,6 +191,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-checkboxfield-align-content: center;
         --amplify-components-checkboxfield-flex-direction: column;
         --amplify-components-checkboxfield-justify-content: center;
+        --amplify-components-countrycodeselect-height: 100%;
         --amplify-components-divider-border-style: solid;
         --amplify-components-divider-border-color: var(--amplify-colors-border-primary);
         --amplify-components-divider-border-width: var(--amplify-border-widths-medium);
@@ -428,6 +429,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-rating-filled-color: var(--amplify-colors-brand-secondary-80);
         --amplify-components-rating-empty-color: var(--amplify-colors-background-tertiary);
         --amplify-components-select-padding-inline-end: var(--amplify-space-xxl);
+        --amplify-components-select-wrapper-flex: 1;
         --amplify-components-select-wrapper-display: block;
         --amplify-components-select-wrapper-position: relative;
         --amplify-components-select-wrapper-cursor: pointer;

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -241,6 +241,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-checkboxfield-align-content: center;
         --amplify-components-checkboxfield-flex-direction: column;
         --amplify-components-checkboxfield-justify-content: center;
+        --amplify-components-countrycodeselect-height: 100%;
         --amplify-components-divider-border-style: solid;
         --amplify-components-divider-border-color: var(--amplify-colors-border-primary);
         --amplify-components-divider-border-width: var(--amplify-border-widths-medium);
@@ -478,6 +479,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-rating-filled-color: var(--amplify-colors-brand-secondary-80);
         --amplify-components-rating-empty-color: var(--amplify-colors-background-tertiary);
         --amplify-components-select-padding-inline-end: var(--amplify-space-xxl);
+        --amplify-components-select-wrapper-flex: 1;
         --amplify-components-select-wrapper-display: block;
         --amplify-components-select-wrapper-position: relative;
         --amplify-components-select-wrapper-cursor: pointer;

--- a/packages/ui/src/theme/css/component/countryCodeSelect.scss
+++ b/packages/ui/src/theme/css/component/countryCodeSelect.scss
@@ -1,0 +1,3 @@
+.amplify-countrycodeselect {
+  height: var(--amplify-components-countrycodeselect-height);
+}

--- a/packages/ui/src/theme/css/component/select.scss
+++ b/packages/ui/src/theme/css/component/select.scss
@@ -1,4 +1,5 @@
 .amplify-select__wrapper {
+  flex: var(--amplify-components-select-wrapper-flex);
   display: var(--amplify-components-select-wrapper-display);
   position: var(--amplify-components-select-wrapper-position);
   cursor: var(--amplify-components-select-wrapper-cursor);

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -60,6 +60,7 @@
 @import './component/collection.scss';
 @import './component/checkbox.scss';
 @import './component/checkboxField.scss';
+@import './component/countryCodeSelect.scss';
 @import './component/divider.scss';
 @import './component/expander.scss';
 @import './component/field.scss';

--- a/packages/ui/src/theme/tokens/components/countryCodeSelect.js
+++ b/packages/ui/src/theme/tokens/components/countryCodeSelect.js
@@ -1,0 +1,5 @@
+module.exports = {
+  height: {
+    value: '100%',
+  },
+};

--- a/packages/ui/src/theme/tokens/components/index.js
+++ b/packages/ui/src/theme/tokens/components/index.js
@@ -5,6 +5,7 @@ module.exports = {
   card: require('./card'),
   checkbox: require('./checkbox'),
   checkboxfield: require('./checkboxField'),
+  countrycodeselect: require('./countryCodeSelect'),
   divider: require('./divider'),
   expander: require('./expander'),
   field: require('./field'),

--- a/packages/ui/src/theme/tokens/components/select.js
+++ b/packages/ui/src/theme/tokens/components/select.js
@@ -2,6 +2,7 @@ module.exports = {
   paddingInlineEnd: { value: '{space.xxl.value}' },
   // wrappers
   wrapper: {
+    flex: { value: '1' },
     display: { value: 'block' },
     position: { value: 'relative' },
     cursor: { value: 'pointer' },


### PR DESCRIPTION
*Issue #, if available:*
#1095 

*Description of changes:*

Fixing `PhoneNumberField` styling to get the height of `CountryCodeSelect` and `TextField` matching

![Screen Shot 2022-01-06 at 12 42 39 PM](https://user-images.githubusercontent.com/40295569/148452386-48dcbcb0-30cc-41b0-9673-62837f314a4b.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
