### PR TITLE
fix: fixing option background color in darkmode for Firefox

### DIFF
--- a/.changeset/strange-ducks-search.md
+++ b/.changeset/strange-ducks-search.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix: fixing `option` background color in darkmode on Firefox

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -437,6 +437,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-select-icon-wrapper-right: var(--amplify-space-medium);
         --amplify-components-select-icon-wrapper-transform: translateY(-50%);
         --amplify-components-select-icon-wrapper-pointer-events: none;
+        --amplify-components-select-option-background-color: var(--amplify-colors-background-primary);
         --amplify-components-select-white-space: nowrap;
         --amplify-components-select-min-width: 6.5rem;
         --amplify-components-select-small-min-width: 5.5rem;

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -487,6 +487,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-select-icon-wrapper-right: var(--amplify-space-medium);
         --amplify-components-select-icon-wrapper-transform: translateY(-50%);
         --amplify-components-select-icon-wrapper-pointer-events: none;
+        --amplify-components-select-option-background-color: var(--amplify-colors-background-primary);
         --amplify-components-select-white-space: nowrap;
         --amplify-components-select-min-width: 6.5rem;
         --amplify-components-select-small-min-width: 5.5rem;

--- a/packages/ui/src/theme/css/component/select.scss
+++ b/packages/ui/src/theme/css/component/select.scss
@@ -20,6 +20,15 @@
   min-width: var(--amplify-components-select-min-width);
   white-space: var(--amplify-components-select-white-space);
 
+  // for Firefox only, to fix background color in darkmode
+  @-moz-document url-prefix() {
+    option {
+      background-color: var(
+        --amplify-components-select-option-background-color
+      );
+    }
+  }
+
   &[data-size='small'] {
     min-width: var(--amplify-components-select-small-min-width);
   }

--- a/packages/ui/src/theme/tokens/components/select.js
+++ b/packages/ui/src/theme/tokens/components/select.js
@@ -14,6 +14,10 @@ module.exports = {
     transform: { value: 'translateY(-50%)' },
     pointerEvents: { value: 'none' },
   },
+  // for Firefox only, to fix background color in darkmode
+  option: {
+    backgroundColor: { value: '{colors.background.primary.value}' },
+  },
   whiteSpace: { value: 'nowrap' },
   minWidth: { value: '6.5rem' },
   small: {


### PR DESCRIPTION
*Issue #, if available:*
#1104

*Description of changes:*

Firefox default background color on `option`  is not friendly in dark mode. This can be resolved by adding a more readable custom background color, targeting Firefox only.

Testing on Firefox 95.0

<img width="861" alt="Screen Shot 2022-01-06 at 4 29 41 PM" src="https://user-images.githubusercontent.com/40295569/148472819-0b053e16-8104-4a10-a67c-355ff1f765f4.png">
<img width="876" alt="Screen Shot 2022-01-06 at 4 30 12 PM" src="https://user-images.githubusercontent.com/40295569/148472835-8f2d969e-2182-4d14-b348-590f08b004f1.png">

<img width="553" alt="Screen Shot 2022-01-06 at 4 30 55 PM" src="https://user-images.githubusercontent.com/40295569/148472847-0d015c4d-9c13-4090-80d4-878d0b581d4f.png">
<img width="574" alt="Screen Shot 2022-01-06 at 4 31 14 PM" src="https://user-images.githubusercontent.com/40295569/148472856-d98ae191-1170-4778-b46a-0eea304a2903.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
