### PR TITLE
fix: fixing View description on component page

### DIFF
--- a/docs/src/data/links.ts
+++ b/docs/src/data/links.ts
@@ -11,7 +11,7 @@ export const baseComponents: ComponentNavItem[] = [
   {
     href: '/components/view',
     label: 'View',
-    body: `An Alert displays a brief, important message in a way that attracts the user's attention without interrupting the user's task. Alerts are typically intended to be read out dynamically by a screen reader.`,
+    body: `View is a container that contains stuff. View is the most abstract component on top of which all other components live.`,
   },
   {
     href: '/components/text',


### PR DESCRIPTION
*Issue #, if available:*

#1112 
The description for `View` on components page is wrongly placed with the one for `Alert`.

*Description of changes:*

This PR will be updating the description for `View` to use the correct one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
