### PR TITLE
build: moving docs back to hybrid site to support redirects

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -15,9 +15,9 @@ applications:
             - node -v
             - yarn build
       artifacts:
-        baseDirectory: out
+        baseDirectory: .next
         files:
-          - "**/*"
+          - '**/*'
       cache:
         paths:
           - node_modules/**/*

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -51,7 +51,7 @@ module.exports = withNextPluginPreval({
   },
 
   // These redirects are because of the IA change from previous docs
-  redirects() {
+  async redirects() {
     return [
       // Normalizing URLs
       // these need to come before the generic redirects

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "next dev -p 5000",
-    "build": "next build && next export",
+    "build": "next build",
     "lint": "next lint",
     "start": "next start",
     "test": "$_ run build"

--- a/docs/src/pages/theming/index.page.mdx
+++ b/docs/src/pages/theming/index.page.mdx
@@ -61,7 +61,7 @@ If you want more customization than the design tokens provide, you can also over
 }
 ```
 
-Or if you prefer you can use [alternative styling with a styling libraries](alternativeStyling)
+Or if you prefer you can use [alternative styling with a styling libraries](/theming/alternative-styling)
 
 #### Unstyled
 


### PR DESCRIPTION
*Issue #, if available:*
#1111 

Some links on docs site that require redirects do not work as expect because we are deploying our docs site with SSG.

*Description of changes:*

Moving docs site back to SSR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
