### PR TITLE
handle null children in tabs

### DIFF
--- a/packages/react/src/primitives/Tabs/Tabs.tsx
+++ b/packages/react/src/primitives/Tabs/Tabs.tsx
@@ -14,6 +14,7 @@ import { View } from '../View';
 
 const isTabsType = (child: any): child is React.Component<TabItemProps> => {
   return (
+    child !== null &&
     typeof child === 'object' &&
     child.hasOwnProperty('props') &&
     child.props.title != null &&

--- a/packages/react/src/primitives/Tabs/Tabs.tsx
+++ b/packages/react/src/primitives/Tabs/Tabs.tsx
@@ -37,6 +37,7 @@ const TabsPrimitive: Primitive<TabsProps, typeof Flex> = (
   ref
 ) => {
   const tabs = React.Children.map(children, (child) => {
+    if (child === null) return {};
     if (!isTabsType(child)) {
       console.warn(
         'Amplify UI: <Tabs> component only accepts <TabItem> as children.'

--- a/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
@@ -42,6 +42,32 @@ describe('Tabs: ', () => {
     expect(ref.current.nodeName).toBe('DIV');
   });
 
+  it('should skip over null children', async () => {
+    render(
+      <Tabs testId="tabsTest">
+        <TabItem title="Tab 1">Tab 1</TabItem>
+        {null}
+      </Tabs>
+    );
+    const tabs = await screen.findByTestId('tabsTest');
+    expect(tabs.children.length).toEqual(1);
+  });
+
+  it('should log a warning for null children', async () => {
+    const warningMessage =
+      'Amplify UI: <Tabs> component only accepts <TabItem> as children.';
+    jest.spyOn(console, 'warn');
+
+    render(
+      <Tabs testId="tabsTest">
+        <TabItem title="Tab 1">Tab 1</TabItem>
+        {null}
+      </Tabs>
+    );
+
+    expect(console.warn).toHaveBeenCalledWith(warningMessage);
+  });
+
   describe('TabItem: ', () => {
     it('can render custom classnames', async () => {
       render(

--- a/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
@@ -53,7 +53,7 @@ describe('Tabs: ', () => {
     expect(tabs.children.length).toEqual(1);
   });
 
-  it('should log a warning for null children', async () => {
+  it('should not log a warning for null children', async () => {
     const warningMessage =
       'Amplify UI: <Tabs> component only accepts <TabItem> as children.';
     jest.spyOn(console, 'warn');
@@ -65,7 +65,34 @@ describe('Tabs: ', () => {
       </Tabs>
     );
 
-    expect(console.warn).toHaveBeenCalledWith(warningMessage);
+    expect(console.warn).not.toHaveBeenCalledWith(warningMessage);
+  });
+
+  it('should log a warning for children not matching the tabItem structure', async () => {
+    const invalidChildren = [
+      123,
+      'test',
+      <div title="someTitle"></div>,
+      <div>
+        <span></span>
+      </div>,
+    ];
+    const warningMessage =
+      'Amplify UI: <Tabs> component only accepts <TabItem> as children.';
+    const spy = jest.spyOn(console, 'warn');
+
+    invalidChildren.forEach((child) => {
+      render(
+        <Tabs testId="tabsTest">
+          <TabItem title="Tab 1">Tab 1</TabItem>
+          {child as any}
+        </Tabs>
+      );
+
+      expect(console.warn).toHaveBeenCalledWith(warningMessage);
+
+      spy.mockClear();
+    });
   });
 
   describe('TabItem: ', () => {


### PR DESCRIPTION
*Issue #1033

Add null check to tabs primitive to handle null children correctly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
