### PR TITLE
Add explicit state for initializing authMachine

### DIFF
--- a/.changeset/lucky-numbers-lay.md
+++ b/.changeset/lucky-numbers-lay.md
@@ -1,0 +1,8 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-vue": patch
+"@aws-amplify/ui-angular": patch
+---
+
+Add explicit `INIT` step for initializing authMachine

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
@@ -37,17 +37,20 @@ export class AuthenticatorService implements OnDestroy {
     signUpAttributes,
     socialProviders,
   }: AuthenticatorMachineOptions) {
-    const machine = createAuthenticatorMachine({
-      initialState,
-      loginMechanisms,
-      services,
-      signUpAttributes,
-      socialProviders,
-    });
+    const machine = createAuthenticatorMachine();
 
-    const authService = interpret(machine, {
-      devTools: process.env.NODE_ENV === 'development',
-    }).start();
+    const authService = interpret(machine).start();
+
+    authService.send({
+      type: 'INIT',
+      data: {
+        initialState,
+        loginMechanisms,
+        socialProviders,
+        signUpAttributes,
+        services,
+      },
+    });
 
     this._subscription = authService.subscribe((state) => {
       this._authState = state;

--- a/packages/react/src/components/Authenticator/Provider/index.tsx
+++ b/packages/react/src/components/Authenticator/Provider/index.tsx
@@ -23,19 +23,24 @@ const useAuthenticatorValue = ({
   signUpAttributes,
   services,
 }: ProviderProps) => {
-  const [state, send] = useMachine(
-    () =>
-      createAuthenticatorMachine({
+  const [state, send] = useMachine(() => createAuthenticatorMachine(), {
+    devTools: process.env.NODE_ENV === 'development',
+  });
+
+  React.useEffect(() => {
+    send({
+      type: 'INIT',
+      data: {
         initialState,
         loginMechanisms,
-        services,
-        signUpAttributes,
         socialProviders,
-      }),
-    {
-      devTools: process.env.NODE_ENV === 'development',
-    }
-  );
+        signUpAttributes,
+        services,
+      },
+    });
+  }, []);
+
+  console.log(state);
 
   const components = React.useMemo(
     () => ({ ...defaultComponents, ...customComponents }),

--- a/packages/react/src/components/Authenticator/Provider/index.tsx
+++ b/packages/react/src/components/Authenticator/Provider/index.tsx
@@ -23,9 +23,7 @@ const useAuthenticatorValue = ({
   signUpAttributes,
   services,
 }: ProviderProps) => {
-  const [state, send] = useMachine(() => createAuthenticatorMachine(), {
-    devTools: process.env.NODE_ENV === 'development',
-  });
+  const [state, send] = useMachine(() => createAuthenticatorMachine());
 
   React.useEffect(() => {
     send({

--- a/packages/react/src/components/Authenticator/Provider/index.tsx
+++ b/packages/react/src/components/Authenticator/Provider/index.tsx
@@ -40,8 +40,6 @@ const useAuthenticatorValue = ({
     });
   }, []);
 
-  console.log(state);
-
   const components = React.useMemo(
     () => ({ ...defaultComponents, ...customComponents }),
     [customComponents]

--- a/packages/react/src/components/Authenticator/Router/index.tsx
+++ b/packages/react/src/components/Authenticator/Router/index.tsx
@@ -60,6 +60,7 @@ export function Router({
             {(() => {
               switch (route) {
                 case 'idle':
+                case 'setup':
                   return null;
                 case 'confirmSignUp':
                   return <ConfirmSignUp />;

--- a/packages/ui/src/helpers/auth.ts
+++ b/packages/ui/src/helpers/auth.ts
@@ -226,6 +226,8 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
     switch (true) {
       case state.matches('idle'):
         return 'idle';
+      case state.matches('setup'):
+        return 'setup';
       case state.matches('signOut'):
         return 'signOut';
       case state.matches('authenticated'):

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -9,7 +9,7 @@ import { createSignUpMachine } from './signUp';
 const DEFAULT_COUNTRY_CODE = '+1';
 
 export type AuthenticatorMachineOptions = AuthContext['config'] & {
-  services: AuthContext['services'];
+  services?: AuthContext['services'];
 };
 
 export function createAuthenticatorMachine() {

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -91,7 +91,7 @@ export function createAuthenticatorMachine() {
           on: {
             SIGN_IN: 'signIn',
             'done.invoke.signUpActor': {
-              target: 'idle',
+              target: 'setup',
               actions: 'setUser',
             },
           },
@@ -171,7 +171,6 @@ export function createAuthenticatorMachine() {
               socialProviders,
               initialState,
             } = context.config;
-            console.log(context.config);
             return {
               loginMechanisms: loginMechanisms ?? cliLoginMechanisms,
               signUpAttributes:
@@ -207,7 +206,6 @@ export function createAuthenticatorMachine() {
         spawnSignUpActor: assign({
           actorRef: (context, event) => {
             const { services } = context;
-            console.log(services);
             const actor = createSignUpMachine({ services }).withContext({
               authAttributes: event.data?.authAttributes ?? {},
               country_code: DEFAULT_COUNTRY_CODE,

--- a/packages/ui/src/types/authMachine.ts
+++ b/packages/ui/src/types/authMachine.ts
@@ -1,6 +1,7 @@
 import { CognitoUser, CodeDeliveryDetails } from 'amazon-cognito-identity-js';
 import { Interpreter, State } from 'xstate';
 import { ValidationError } from './validator';
+import { defaultServices } from '../machines/authenticator/defaultServices';
 
 export type AuthFormData = Record<string, string>;
 
@@ -10,7 +11,9 @@ export interface AuthContext {
     loginMechanisms?: LoginMechanism[];
     signUpAttributes?: SignUpAttribute[];
     socialProviders?: SocialProvider[];
+    initialState?: 'signIn' | 'signUp' | 'resetPassword';
   };
+  services?: Partial<typeof defaultServices>;
   user?: CognitoUserAmplify;
   username?: string;
   password?: string;
@@ -131,6 +134,7 @@ export type AuthEventTypes =
   | 'SIGN_UP'
   | 'SKIP'
   | 'SUBMIT'
+  | 'INIT'
   | InvokeActorEventTypes;
 
 export enum AuthChallengeNames {

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -58,20 +58,23 @@ const emit = defineEmits([
   'verifyUserSubmit',
   'confirmVerifyUserSubmit',
 ]);
-const machine = createAuthenticatorMachine({
-  initialState,
-  loginMechanisms,
-  services,
-  signUpAttributes,
-  socialProviders,
-});
+const machine = createAuthenticatorMachine();
 
-const service = useInterpret(machine, {
-  devTools: process.env.NODE_ENV === 'development',
-});
+const service = useInterpret(machine);
 
 const { state, send } = useActor(service);
 useAuth(service);
+
+send({
+  type: 'INIT',
+  data: {
+    initialState,
+    loginMechanisms,
+    socialProviders,
+    signUpAttributes,
+    services,
+  },
+});
 
 const actorState = computed(() => getActorState(state.value));
 

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useAuth } from '../composables/useAuth';
-import { ref, computed, useAttrs, watch, Ref } from 'vue';
+import { ref, computed, useAttrs, watch, Ref, onMounted } from 'vue';
 import { useActor, useInterpret } from '@xstate/vue';
 import {
   getActorState,
@@ -22,6 +22,7 @@ import ResetPassword from './reset-password.vue';
 import ConfirmResetPassword from './confirm-reset-password.vue';
 import VerifyUser from './verify-user.vue';
 import ConfirmVerifyUser from './confirm-verify-user.vue';
+import { tryOnMounted } from '@vueuse/core';
 
 const attrs = useAttrs();
 
@@ -65,15 +66,17 @@ const service = useInterpret(machine);
 const { state, send } = useActor(service);
 useAuth(service);
 
-send({
-  type: 'INIT',
-  data: {
-    initialState,
-    loginMechanisms,
-    socialProviders,
-    signUpAttributes,
-    services,
-  },
+onMounted(() => {
+  send({
+    type: 'INIT',
+    data: {
+      initialState,
+      loginMechanisms,
+      socialProviders,
+      signUpAttributes,
+      services,
+    },
+  });
 });
 
 const actorState = computed(() => getActorState(state.value));

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -22,7 +22,6 @@ import ResetPassword from './reset-password.vue';
 import ConfirmResetPassword from './confirm-reset-password.vue';
 import VerifyUser from './verify-user.vue';
 import ConfirmVerifyUser from './confirm-verify-user.vue';
-import { tryOnMounted } from '@vueuse/core';
 
 const attrs = useAttrs();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR refactors `authMachine` to have an explicit `INIT` step that takes in all `authenticatorMachineProps` and applies it to its `context`. 

### Context

Previously, machine props need to be passed in *before* the machine was created:

https://github.com/aws-amplify/amplify-ui/blob/933d08dd9fccd1e313d4377e2f72969c4a0e025f/packages/react/src/components/Authenticator/Provider/index.tsx#L28-L32

### Problem

This behavior is susceptible to timing issues -- machine can be only created after `authenticator` is mounted with proper props (and Provider on React). For example, if customer tries to use `useAuthenticator` React hook outside `<Authenticator/ >`, their `useAuthenticator` runs before `Authenticator` is mounted before `machineProps` are passed in. This results in `useAuthenticator` trying to use `useMachine` before `machine` is ready to be created and fails. 

### Proposed Solution

The easiest way IMO to resolve it is to adjust `authMachine` so that it doesn't have to wait for `AuthenticatorMachineProps`. That way, machine can be flexibly created any timing as long as it is followed up with `INIT` step.

![image](https://user-images.githubusercontent.com/43682783/149396811-650308cf-aabb-4559-8200-15f8b4c93a2a.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
