### PR TITLE
Revert "Add explicit state for initializing authMachine (#1142)"

### DIFF
--- a/.changeset/lucky-numbers-lay.md
+++ b/.changeset/lucky-numbers-lay.md
@@ -1,8 +1,0 @@
----
-"@aws-amplify/ui-react": patch
-"@aws-amplify/ui": patch
-"@aws-amplify/ui-vue": patch
-"@aws-amplify/ui-angular": patch
----
-
-Add explicit `INIT` step for initializing authMachine

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
@@ -37,20 +37,17 @@ export class AuthenticatorService implements OnDestroy {
     signUpAttributes,
     socialProviders,
   }: AuthenticatorMachineOptions) {
-    const machine = createAuthenticatorMachine();
-
-    const authService = interpret(machine).start();
-
-    authService.send({
-      type: 'INIT',
-      data: {
-        initialState,
-        loginMechanisms,
-        socialProviders,
-        signUpAttributes,
-        services,
-      },
+    const machine = createAuthenticatorMachine({
+      initialState,
+      loginMechanisms,
+      services,
+      signUpAttributes,
+      socialProviders,
     });
+
+    const authService = interpret(machine, {
+      devTools: process.env.NODE_ENV === 'development',
+    }).start();
 
     this._subscription = authService.subscribe((state) => {
       this._authState = state;

--- a/packages/react/src/components/Authenticator/Provider/index.tsx
+++ b/packages/react/src/components/Authenticator/Provider/index.tsx
@@ -23,20 +23,19 @@ const useAuthenticatorValue = ({
   signUpAttributes,
   services,
 }: ProviderProps) => {
-  const [state, send] = useMachine(() => createAuthenticatorMachine());
-
-  React.useEffect(() => {
-    send({
-      type: 'INIT',
-      data: {
+  const [state, send] = useMachine(
+    () =>
+      createAuthenticatorMachine({
         initialState,
         loginMechanisms,
-        socialProviders,
-        signUpAttributes,
         services,
-      },
-    });
-  }, []);
+        signUpAttributes,
+        socialProviders,
+      }),
+    {
+      devTools: process.env.NODE_ENV === 'development',
+    }
+  );
 
   const components = React.useMemo(
     () => ({ ...defaultComponents, ...customComponents }),

--- a/packages/react/src/components/Authenticator/Router/index.tsx
+++ b/packages/react/src/components/Authenticator/Router/index.tsx
@@ -60,7 +60,6 @@ export function Router({
             {(() => {
               switch (route) {
                 case 'idle':
-                case 'setup':
                   return null;
                 case 'confirmSignUp':
                   return <ConfirmSignUp />;

--- a/packages/ui/src/helpers/auth.ts
+++ b/packages/ui/src/helpers/auth.ts
@@ -226,8 +226,6 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
     switch (true) {
       case state.matches('idle'):
         return 'idle';
-      case state.matches('setup'):
-        return 'setup';
       case state.matches('signOut'):
         return 'signOut';
       case state.matches('authenticated'):

--- a/packages/ui/src/types/authMachine.ts
+++ b/packages/ui/src/types/authMachine.ts
@@ -1,7 +1,6 @@
 import { CognitoUser, CodeDeliveryDetails } from 'amazon-cognito-identity-js';
 import { Interpreter, State } from 'xstate';
 import { ValidationError } from './validator';
-import { defaultServices } from '../machines/authenticator/defaultServices';
 
 export type AuthFormData = Record<string, string>;
 
@@ -11,9 +10,7 @@ export interface AuthContext {
     loginMechanisms?: LoginMechanism[];
     signUpAttributes?: SignUpAttribute[];
     socialProviders?: SocialProvider[];
-    initialState?: 'signIn' | 'signUp' | 'resetPassword';
   };
-  services?: Partial<typeof defaultServices>;
   user?: CognitoUserAmplify;
   username?: string;
   password?: string;
@@ -134,7 +131,6 @@ export type AuthEventTypes =
   | 'SIGN_UP'
   | 'SKIP'
   | 'SUBMIT'
-  | 'INIT'
   | InvokeActorEventTypes;
 
 export enum AuthChallengeNames {

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useAuth } from '../composables/useAuth';
-import { ref, computed, useAttrs, watch, Ref, onMounted } from 'vue';
+import { ref, computed, useAttrs, watch, Ref } from 'vue';
 import { useActor, useInterpret } from '@xstate/vue';
 import {
   getActorState,
@@ -58,25 +58,20 @@ const emit = defineEmits([
   'verifyUserSubmit',
   'confirmVerifyUserSubmit',
 ]);
-const machine = createAuthenticatorMachine();
+const machine = createAuthenticatorMachine({
+  initialState,
+  loginMechanisms,
+  services,
+  signUpAttributes,
+  socialProviders,
+});
 
-const service = useInterpret(machine);
+const service = useInterpret(machine, {
+  devTools: process.env.NODE_ENV === 'development',
+});
 
 const { state, send } = useActor(service);
 useAuth(service);
-
-onMounted(() => {
-  send({
-    type: 'INIT',
-    data: {
-      initialState,
-      loginMechanisms,
-      socialProviders,
-      signUpAttributes,
-      services,
-    },
-  });
-});
 
 const actorState = computed(() => getActorState(state.value));
 


### PR DESCRIPTION
This reverts commit c3fccb7feb16a54c2bce739b08edabfd0d783126.

*Issue #, if available:*

*Description of changes:* This was causing "App Error" when someone clicks on any of the tabs in this section of docs (Default values, Sign in, etc. ) https://ui.docs.amplify.aws/components/authenticator#labels--text 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
