### PR TITLE
fix: change box-sizing to have less specificity

### DIFF
--- a/.changeset/gorgeous-queens-kick.md
+++ b/.changeset/gorgeous-queens-kick.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix: change box-sizing to have less specificity

--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -38,8 +38,6 @@ html {
 
 // Remove this when this gets fixed in the UI package
 * {
-  box-sizing: border-box;
-
   /* Selection */
   &::-moz-selection {
     background: var(--amplify-colors-overlay-10);
@@ -111,7 +109,9 @@ code {
   background-color: var(--amplify-colors-background-secondary);
   font-size: 0.875em;
   border-radius: 0.3em;
-  font-family: "Source Code Pro", "Fira Code", "Fira Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: 'Source Code Pro', 'Fira Code', 'Fira Mono', ui-monospace,
+    SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
   direction: ltr;
   text-align: left;
   white-space: pre;

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -13,14 +13,15 @@
   }
 }
 
-[class*='amplify'] {
-  all: unset; /* protect against external styles */
+// Note: This rule can be easily overwritten when
+// needed due to very low specificity of 0 0 0
+* {
+  box-sizing: border-box;
 }
 
-// Must be defined AFTER `[class*='amplify']
-// or rules will be unset to initial/default
-[data-amplify-theme] * {
-  box-sizing: border-box;
+[class*='amplify'] {
+  all: unset; /* protect against external styles */
+  box-sizing: border-box; /* set box-sizing after unset above */
 }
 
 .sr-only {


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/aws-amplify/amplify-ui/issues/1092

*Description of changes:*
This PR fixes an issue where a customer was using a library which injected its CSS too early to override ours. Our `box-sizing` CSS rule had a specificity of `0 1 0`. We primarily need this level of specificity for the `amplify*` classes, but can reduce the specificity to`0 0 0` for other elements. This means any element used in an Amplify UI app will have a default `box-sizing` of `border-box`, but can easily override it with any level of specificity. This should allow other library UI components to be used inside of Amplify UI components such as `Flex` without changing their `box-sizing` styling. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
