### PR TITLE
Fix secret key in QR code being empty string

### DIFF
--- a/.changeset/five-seas-flash.md
+++ b/.changeset/five-seas-flash.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Fix TOTP QR being incorrectly generated, as it was using an empty string as the secretKey

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -29,11 +29,12 @@ export const SetupTOTP = (): JSX.Element => {
 
   const generateQRCode = async (user): Promise<void> => {
     try {
-      setSecretKey(await Auth.setupTOTP(user));
+      const newSecretKey = await Auth.setupTOTP(user);
       const issuer = 'AWSCognito';
-      const totpCode = `otpauth://totp/${issuer}:${user.username}?secret=${secretKey}&issuer=${issuer}`;
+      const totpCode = `otpauth://totp/${issuer}:${user.username}?secret=${newSecretKey}&issuer=${issuer}`;
       const qrCodeImageSource = await QRCode.toDataURL(totpCode);
 
+      setSecretKey(newSecretKey);
       setQrCode(qrCodeImageSource);
     } catch (error) {
       logger.error(error);


### PR DESCRIPTION
Fixes #1158 

As described in the issue, a recent change to the code led to the QR code for TOTP being incorrectly generated, such that the `secretKey` encoded in the QR code was actually just an empty string. This is because the `secretKey` is being stored in a `React.useState` variable, which is not updated until the component rerenders, which is after the string to be used for the QR code is generated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
