### PR TITLE
Pin all @aws-amplify/ui-react dependencies

### DIFF
--- a/.changeset/five-moons-stare.md
+++ b/.changeset/five-moons-stare.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Pin all @aws-amplify/ui-react dependencies

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -56,12 +56,12 @@
     "@radix-ui/react-id": "0.1.1",
     "@radix-ui/react-slider": "0.1.1",
     "@radix-ui/react-tabs": "0.1.1",
-    "@xstate/react": "^1.4.0",
-    "classnames": "^2.3.1",
-    "deepmerge": "^4.2.2",
-    "lodash": "^4.17.21",
-    "qrcode": "^1.4.4",
-    "react-generate-context": "^1.0.0"
+    "@xstate/react": "1.6.3",
+    "classnames": "2.3.1",
+    "deepmerge": "4.2.2",
+    "lodash": "4.17.21",
+    "qrcode": "1.5.0",
+    "react-generate-context": "1.0.1"
   },
   "peerDependencies": {
     "aws-amplify": "3.x.x || 4.x.x",


### PR DESCRIPTION
*Issue #, if available:* Part of CoE

*Description of changes:*

In order to prevent new dependency versions from breaking our library, we need to pin all our dependencies to specific versions. 

This PR pins all `package.json` 3rd-party dependencies to specific versions. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
