### PR TITLE
Docs update - Flex

### DIFF
--- a/docs/src/pages/components/flex/FlexPropControls.tsx
+++ b/docs/src/pages/components/flex/FlexPropControls.tsx
@@ -37,7 +37,7 @@ export const FlexPropControls: FlexPropControlsInterface = ({
       <SelectField
         name="direction"
         id="direction"
-        label="Direction"
+        label="direction"
         value={direction as string}
         onChange={(event) =>
           setDirection(event.target.value as FlexProps['direction'])
@@ -52,7 +52,7 @@ export const FlexPropControls: FlexPropControlsInterface = ({
       <SelectField
         name="justifyContent"
         id="justifyContent"
-        label="Justify Content"
+        label="justifyContent"
         value={justifyContent as string}
         onChange={(event) =>
           setJustifyContent(event.target.value as FlexProps['justifyContent'])
@@ -69,7 +69,7 @@ export const FlexPropControls: FlexPropControlsInterface = ({
       <SelectField
         name="alignItems"
         id="alignItems"
-        label="Align Items"
+        label="alignItems"
         value={alignItems as string}
         onChange={(event) =>
           setAlignItems(event.target.value as FlexProps['alignItems'])
@@ -85,7 +85,7 @@ export const FlexPropControls: FlexPropControlsInterface = ({
       <SelectField
         name="alignContent"
         id="alignContent"
-        label="Align Content"
+        label="alignContent"
         value={alignContent as string}
         onChange={(event) =>
           setAlignContent(event.target.value as FlexProps['alignContent'])
@@ -102,7 +102,7 @@ export const FlexPropControls: FlexPropControlsInterface = ({
       <SelectField
         name="wrap"
         id="wrap"
-        label="Wrap"
+        label="wrap"
         value={wrap as string}
         onChange={(event) => setWrap(event.target.value as FlexProps['wrap'])}
       >
@@ -112,7 +112,7 @@ export const FlexPropControls: FlexPropControlsInterface = ({
       </SelectField>
 
       <TextField
-        label="Gap"
+        label="gap"
         value={gap as string}
         onChange={(event) => setGap(event.target.value as FlexProps['gap'])}
       />

--- a/docs/src/pages/components/flex/FlexPropControls.tsx
+++ b/docs/src/pages/components/flex/FlexPropControls.tsx
@@ -1,0 +1,138 @@
+import { FlexProps, TextField, SelectField, Flex } from '@aws-amplify/ui-react';
+import React from 'react';
+
+export interface FlexPropControlsProps extends FlexProps {
+  setDirection: (value: React.SetStateAction<FlexProps['direction']>) => void;
+  setJustifyContent: (
+    value: React.SetStateAction<FlexProps['justifyContent']>
+  ) => void;
+  setAlignItems: (value: React.SetStateAction<FlexProps['alignItems']>) => void;
+  setAlignContent: (
+    value: React.SetStateAction<FlexProps['alignContent']>
+  ) => void;
+  setWrap: (value: React.SetStateAction<FlexProps['wrap']>) => void;
+  setGap: (value: React.SetStateAction<FlexProps['gap']>) => void;
+}
+
+interface FlexPropControlsInterface {
+  (props: FlexPropControlsProps): JSX.Element;
+}
+
+export const FlexPropControls: FlexPropControlsInterface = ({
+  direction,
+  setDirection,
+  justifyContent,
+  setJustifyContent,
+  alignItems,
+  setAlignItems,
+  alignContent,
+  setAlignContent,
+  wrap,
+  setWrap,
+  gap,
+  setGap,
+}) => {
+  return (
+    <Flex direction="column">
+      <SelectField
+        name="direction"
+        id="direction"
+        label="Direction"
+        value={direction as string}
+        onChange={(event) =>
+          setDirection(event.target.value as FlexProps['direction'])
+        }
+      >
+        <option value="row">row</option>
+        <option value="column">column</option>
+        <option value="column-reverse">column-reverse</option>
+        <option value="row-reverse">row-reverse</option>
+      </SelectField>
+
+      <SelectField
+        name="justifyContent"
+        id="justifyContent"
+        label="Justify Content"
+        value={justifyContent as string}
+        onChange={(event) =>
+          setJustifyContent(event.target.value as FlexProps['justifyContent'])
+        }
+      >
+        <option value="flex-start">flex-start</option>
+        <option value="flex-end">flex-end</option>
+        <option value="center">center</option>
+        <option value="space-between">space-between</option>
+        <option value="space-around">space-around</option>
+        <option value="space-evenly">space-evenly</option>
+      </SelectField>
+
+      <SelectField
+        name="justifyContent"
+        id="justifyContent"
+        label="Justify Content"
+        value={justifyContent as string}
+        onChange={(event) =>
+          setJustifyContent(event.target.value as FlexProps['justifyContent'])
+        }
+      >
+        <option value="flex-start">flex-start</option>
+        <option value="flex-end">flex-end</option>
+        <option value="center">center</option>
+        <option value="space-between">space-between</option>
+        <option value="space-around">space-around</option>
+        <option value="space-evenly">space-evenly</option>
+      </SelectField>
+
+      <SelectField
+        name="alignItems"
+        id="alignItems"
+        label="Align Items"
+        value={alignItems as string}
+        onChange={(event) =>
+          setAlignItems(event.target.value as FlexProps['alignItems'])
+        }
+      >
+        <option value="flex-start">flex-start</option>
+        <option value="flex-end">flex-end</option>
+        <option value="center">center</option>
+        <option value="baseline">baseline</option>
+        <option value="stretch">stretch</option>
+      </SelectField>
+
+      <SelectField
+        name="alignContent"
+        id="alignContent"
+        label="Align Content"
+        value={alignContent as string}
+        onChange={(event) =>
+          setAlignContent(event.target.value as FlexProps['alignContent'])
+        }
+      >
+        <option value="flex-start">flex-start</option>
+        <option value="flex-end">flex-end</option>
+        <option value="center">center</option>
+        <option value="space-between">space-between</option>
+        <option value="space-around">space-around</option>
+        <option value="stretch">stretch</option>
+      </SelectField>
+
+      <SelectField
+        name="wrap"
+        id="wrap"
+        label="Wrap"
+        value={wrap as string}
+        onChange={(event) => setWrap(event.target.value as FlexProps['wrap'])}
+      >
+        <option value="nowrap">nowrap</option>
+        <option value="wrap">wrap</option>
+        <option value="wrap-reverse">wrap-reverse</option>
+      </SelectField>
+
+      <TextField
+        label="Gap"
+        value={gap as string}
+        onChange={(event) => setGap(event.target.value as FlexProps['gap'])}
+      />
+    </Flex>
+  );
+};

--- a/docs/src/pages/components/flex/FlexPropControls.tsx
+++ b/docs/src/pages/components/flex/FlexPropControls.tsx
@@ -67,23 +67,6 @@ export const FlexPropControls: FlexPropControlsInterface = ({
       </SelectField>
 
       <SelectField
-        name="justifyContent"
-        id="justifyContent"
-        label="Justify Content"
-        value={justifyContent as string}
-        onChange={(event) =>
-          setJustifyContent(event.target.value as FlexProps['justifyContent'])
-        }
-      >
-        <option value="flex-start">flex-start</option>
-        <option value="flex-end">flex-end</option>
-        <option value="center">center</option>
-        <option value="space-between">space-between</option>
-        <option value="space-around">space-around</option>
-        <option value="space-evenly">space-evenly</option>
-      </SelectField>
-
-      <SelectField
         name="alignItems"
         id="alignItems"
         label="Align Items"

--- a/docs/src/pages/components/flex/FlexPropControls.tsx
+++ b/docs/src/pages/components/flex/FlexPropControls.tsx
@@ -75,11 +75,11 @@ export const FlexPropControls: FlexPropControlsInterface = ({
           setAlignItems(event.target.value as FlexProps['alignItems'])
         }
       >
+        <option value="stretch">stretch</option>
         <option value="flex-start">flex-start</option>
         <option value="flex-end">flex-end</option>
         <option value="center">center</option>
         <option value="baseline">baseline</option>
-        <option value="stretch">stretch</option>
       </SelectField>
 
       <SelectField

--- a/docs/src/pages/components/flex/demo.tsx
+++ b/docs/src/pages/components/flex/demo.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex } from '@aws-amplify/ui-react';
+import { Flex, View } from '@aws-amplify/ui-react';
 
 import { Demo } from '@/components/Demo';
 import { FlexPropControls } from './FlexPropControls';
@@ -6,17 +6,34 @@ import { useFlexProps } from './useFlexProps';
 
 const propsToCode = (props) => {
   return `<Flex
-    direction="${props.direction}"
-    justifyContent="${props.justifyContent}"
-    alignItems="${props.alignItems}"
-    alignContent="${props.alignContent}"
-    wrap="${props.wrap}"
-    gap="${props.gap}"
-  >
-    <Button>Button 1</Button>
-    <Button>Button 2</Button>
-    <Button>Button 3</Button>
-  </Flex>`;
+  direction="${props.direction}"
+  justifyContent="${props.justifyContent}"
+  alignItems="${props.alignItems}"
+  alignContent="${props.alignContent}"
+  wrap="${props.wrap}"
+  gap="${props.gap}"
+>
+  <View
+    height="2rem"
+    width="5rem"
+    backgroundColor="var(--amplify-colors-blue-20)"
+  ></View>
+  <View
+    height="2.5rem"
+    width="6.25rem"
+    backgroundColor="var(--amplify-colors-blue-40)"
+  ></View>
+  <View
+    height="3rem"
+    width="7.5rem"
+    backgroundColor="var(--amplify-colors-blue-60)"
+  ></View>
+  <View
+    height="3.5rem"
+    width="8.75rem"
+    backgroundColor="var(--amplify-colors-blue-80)"
+  ></View>
+</Flex>`;
 };
 
 export const FlexDemo = () => {
@@ -42,9 +59,26 @@ export const FlexDemo = () => {
         wrap={flexProps.wrap}
         gap={flexProps.gap}
       >
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-        <Button>Button 3</Button>
+        <View
+          height="2rem"
+          width="5rem"
+          backgroundColor="var(--amplify-colors-blue-20)"
+        ></View>
+        <View
+          height="2.5rem"
+          width="6.25rem"
+          backgroundColor="var(--amplify-colors-blue-40)"
+        ></View>
+        <View
+          height="3rem"
+          width="7.5rem"
+          backgroundColor="var(--amplify-colors-blue-60)"
+        ></View>
+        <View
+          height="3.5rem"
+          width="8.75rem"
+          backgroundColor="var(--amplify-colors-blue-80)"
+        ></View>
       </Flex>
     </Demo>
   );

--- a/docs/src/pages/components/flex/demo.tsx
+++ b/docs/src/pages/components/flex/demo.tsx
@@ -1,191 +1,51 @@
-import { useState } from 'react';
+import { Button, Flex } from '@aws-amplify/ui-react';
 
-import { Property } from 'csstype';
+import { Demo } from '@/components/Demo';
+import { FlexPropControls } from './FlexPropControls';
+import { useFlexProps } from './useFlexProps';
 
-import { Flex, Button, View, ViewProps } from '@aws-amplify/ui-react';
+const propsToCode = (props) => {
+  return `<Flex
+    direction="${props.direction}"
+    justifyContent="${props.justifyContent}"
+    alignItems="${props.alignItems}"
+    alignContent="${props.alignContent}"
+    wrap="${props.wrap}"
+    gap="${props.gap}"
+  >
+    <Button>Button 1</Button>
+    <Button>Button 2</Button>
+    <Button>Button 3</Button>
+  </Flex>`;
+};
 
-const JustifyContentProps: Property.JustifyContent[] = [
-  'flex-start',
-  'flex-end',
-  'center',
-  'space-between',
-  'space-around',
-  'space-evenly',
-];
-
-const AlignItemsProps: Property.AlignItems[] = [
-  'stretch',
-  'flex-start',
-  'flex-end',
-  'center',
-  'baseline',
-];
-
-const WrapProps: Property.FlexWrap[] = ['nowrap', 'wrap', 'wrap-reverse'];
-
-const DirectionProps: Property.FlexDirection[] = [
-  'row',
-  'column',
-  'column-reverse',
-  'row-reverse',
-];
-
-const Direction = () => {
-  const [direction, setDirection] = useState<Property.FlexDirection>('row');
+export const FlexDemo = () => {
+  const flexProps = useFlexProps({
+    direction: 'row',
+    justifyContent: 'flex-start',
+    alignItems: 'flex-start',
+    alignContent: 'flex-start',
+    wrap: 'nowrap',
+    gap: '1rem',
+  });
 
   return (
-    <View>
-      <Flex>
-        {DirectionProps.map((prop, i) => (
-          <Button
-            onClick={() => setDirection(prop)}
-            variation={prop === direction ? 'primary' : undefined}
-            size="small"
-            key={i}
-          >
-            {prop}
-          </Button>
-        ))}
+    <Demo
+      code={propsToCode(flexProps)}
+      propControls={<FlexPropControls {...flexProps} />}
+    >
+      <Flex
+        direction={flexProps.direction}
+        justifyContent={flexProps.justifyContent}
+        alignItems={flexProps.alignItems}
+        alignContent={flexProps.alignContent}
+        wrap={flexProps.wrap}
+        gap={flexProps.gap}
+      >
+        <Button>Button 1</Button>
+        <Button>Button 2</Button>
+        <Button>Button 3</Button>
       </Flex>
-      <br />
-      <Flex direction={direction}>{mockElements(3)}</Flex>
-    </View>
+    </Demo>
   );
 };
-
-const Gap = () => <Flex gap="3rem">{mockElements(3)}</Flex>;
-
-const JustifyContent = () => {
-  const [justifyContent, setJustifyContent] =
-    useState<Property.JustifyContent>('flex-start');
-
-  return (
-    <View>
-      <Flex>
-        {JustifyContentProps.map((prop, i) => (
-          <Button
-            onClick={() => setJustifyContent(prop)}
-            variation={prop === justifyContent ? 'primary' : undefined}
-            size="small"
-            key={i}
-          >
-            {prop}
-          </Button>
-        ))}
-      </Flex>
-      <br />
-      <Flex justifyContent={justifyContent} gap="20px">
-        {mockElements(3)}
-      </Flex>
-    </View>
-  );
-};
-
-const AlignItems = () => {
-  const [alignItems, setAlignItems] = useState<Property.AlignItems>('stretch');
-
-  return (
-    <View>
-      <Flex>
-        {AlignItemsProps.map((prop, i) => (
-          <Button
-            onClick={() => setAlignItems(prop)}
-            variation={prop === alignItems ? 'primary' : undefined}
-            size="small"
-            key={i}
-          >
-            {prop}
-          </Button>
-        ))}
-      </Flex>
-      <br />
-      <Flex alignItems={alignItems}>
-        <View
-          backgroundColor="#b794f4"
-          height="100px"
-          padding="2rem"
-          color="white"
-        >
-          Wow!
-        </View>
-        <View
-          backgroundColor="#805AD5"
-          padding="10px 2rem 0 2rem"
-          color="white"
-        >
-          I love to use
-        </View>
-        <View
-          backgroundColor="#322659"
-          height="70px"
-          padding="2rem"
-          color="white"
-        >
-          Flex
-        </View>
-      </Flex>
-    </View>
-  );
-};
-
-const Wrap = () => {
-  const [wrap, setWrap] = useState<Property.FlexWrap>('nowrap');
-
-  return (
-    <View>
-      <Flex>
-        {WrapProps.map((prop, i) => (
-          <Button
-            onClick={() => setWrap(prop)}
-            variation={prop === wrap ? 'primary' : undefined}
-            size="small"
-            key={i}
-          >
-            {prop}
-          </Button>
-        ))}
-      </Flex>
-      <br />
-      <Flex wrap={wrap}>{mockElements(6)}</Flex>
-    </View>
-  );
-};
-
-const mockStyle: ViewProps = {
-  width: '15rem',
-  height: '3rem',
-  borderRadius: '5px',
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  fontWeight: 'bold',
-  color: 'white',
-  backgroundColor: '#805AD5',
-};
-
-const mockElements = (elements) => {
-  const arr =
-    typeof elements === 'number' ? [...Array(elements)] : [...elements];
-  return arr.map((char, i) => (
-    <Flex {...mockStyle} key={i}>
-      {typeof elements === 'number' ? i + 1 : char}
-    </Flex>
-  ));
-};
-
-const selectDemo = (demoType) => {
-  switch (demoType) {
-    case 'direction':
-      return <Direction />;
-    case 'gap':
-      return <Gap />;
-    case 'justifyContent':
-      return <JustifyContent />;
-    case 'alignItems':
-      return <AlignItems />;
-    case 'wrap':
-      return <Wrap />;
-  }
-};
-
-export const FlexDemo = ({ demoType }) => <View>{selectDemo(demoType)}</View>;

--- a/docs/src/pages/components/flex/demo.tsx
+++ b/docs/src/pages/components/flex/demo.tsx
@@ -40,7 +40,7 @@ export const FlexDemo = () => {
   const flexProps = useFlexProps({
     direction: 'row',
     justifyContent: 'flex-start',
-    alignItems: 'flex-start',
+    alignItems: 'stretch',
     alignContent: 'flex-start',
     wrap: 'nowrap',
     gap: '1rem',

--- a/docs/src/pages/components/flex/examples/DefaultFlexExample.tsx
+++ b/docs/src/pages/components/flex/examples/DefaultFlexExample.tsx
@@ -1,0 +1,9 @@
+import { Flex, Button } from '@aws-amplify/ui-react';
+
+export const DefaultFlexExample = () => (
+  <Flex>
+    <Button backgroundColor="var(--amplify-colors-pink-10)">Button 1</Button>
+    <Button backgroundColor="var(--amplify-colors-pink-20)">Button 2</Button>
+    <Button backgroundColor="var(--amplify-colors-pink-40)">Button 3</Button>
+  </Flex>
+);

--- a/docs/src/pages/components/flex/examples/index.ts
+++ b/docs/src/pages/components/flex/examples/index.ts
@@ -1,0 +1,1 @@
+export { DefaultFlexExample } from './DefaultFlexExample';

--- a/docs/src/pages/components/flex/index.page.mdx
+++ b/docs/src/pages/components/flex/index.page.mdx
@@ -1,5 +1,6 @@
 ---
 title: Flex
+description: A layout container using Flexbox.
 isPrimitive: true
 ---
 

--- a/docs/src/pages/components/flex/oldDemo.tsx
+++ b/docs/src/pages/components/flex/oldDemo.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+
+import { Property } from 'csstype';
+
+import { Flex, Button, View, ViewProps } from '@aws-amplify/ui-react';
+
+const JustifyContentProps: Property.JustifyContent[] = [
+  'flex-start',
+  'flex-end',
+  'center',
+  'space-between',
+  'space-around',
+  'space-evenly',
+];
+
+const AlignItemsProps: Property.AlignItems[] = [
+  'stretch',
+  'flex-start',
+  'flex-end',
+  'center',
+  'baseline',
+];
+
+const WrapProps: Property.FlexWrap[] = ['nowrap', 'wrap', 'wrap-reverse'];
+
+const DirectionProps: Property.FlexDirection[] = [
+  'row',
+  'column',
+  'column-reverse',
+  'row-reverse',
+];
+
+const Direction = () => {
+  const [direction, setDirection] = useState<Property.FlexDirection>('row');
+
+  return (
+    <View>
+      <Flex>
+        {DirectionProps.map((prop, i) => (
+          <Button
+            onClick={() => setDirection(prop)}
+            variation={prop === direction ? 'primary' : undefined}
+            size="small"
+            key={i}
+          >
+            {prop}
+          </Button>
+        ))}
+      </Flex>
+      <br />
+      <Flex direction={direction}>{mockElements(3)}</Flex>
+    </View>
+  );
+};
+
+const Gap = () => <Flex gap="3rem">{mockElements(3)}</Flex>;
+
+const JustifyContent = () => {
+  const [justifyContent, setJustifyContent] =
+    useState<Property.JustifyContent>('flex-start');
+
+  return (
+    <View>
+      <Flex>
+        {JustifyContentProps.map((prop, i) => (
+          <Button
+            onClick={() => setJustifyContent(prop)}
+            variation={prop === justifyContent ? 'primary' : undefined}
+            size="small"
+            key={i}
+          >
+            {prop}
+          </Button>
+        ))}
+      </Flex>
+      <br />
+      <Flex justifyContent={justifyContent} gap="20px">
+        {mockElements(3)}
+      </Flex>
+    </View>
+  );
+};
+
+const AlignItems = () => {
+  const [alignItems, setAlignItems] = useState<Property.AlignItems>('stretch');
+
+  return (
+    <View>
+      <Flex>
+        {AlignItemsProps.map((prop, i) => (
+          <Button
+            onClick={() => setAlignItems(prop)}
+            variation={prop === alignItems ? 'primary' : undefined}
+            size="small"
+            key={i}
+          >
+            {prop}
+          </Button>
+        ))}
+      </Flex>
+      <br />
+      <Flex alignItems={alignItems}>
+        <View
+          backgroundColor="#b794f4"
+          height="100px"
+          padding="2rem"
+          color="white"
+        >
+          Wow!
+        </View>
+        <View
+          backgroundColor="#805AD5"
+          padding="10px 2rem 0 2rem"
+          color="white"
+        >
+          I love to use
+        </View>
+        <View
+          backgroundColor="#322659"
+          height="70px"
+          padding="2rem"
+          color="white"
+        >
+          Flex
+        </View>
+      </Flex>
+    </View>
+  );
+};
+
+const Wrap = () => {
+  const [wrap, setWrap] = useState<Property.FlexWrap>('nowrap');
+
+  return (
+    <View>
+      <Flex>
+        {WrapProps.map((prop, i) => (
+          <Button
+            onClick={() => setWrap(prop)}
+            variation={prop === wrap ? 'primary' : undefined}
+            size="small"
+            key={i}
+          >
+            {prop}
+          </Button>
+        ))}
+      </Flex>
+      <br />
+      <Flex wrap={wrap}>{mockElements(6)}</Flex>
+    </View>
+  );
+};
+
+const mockStyle: ViewProps = {
+  width: '15rem',
+  height: '3rem',
+  borderRadius: '5px',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  fontWeight: 'bold',
+  color: 'white',
+  backgroundColor: '#805AD5',
+};
+
+const mockElements = (elements) => {
+  const arr =
+    typeof elements === 'number' ? [...Array(elements)] : [...elements];
+  return arr.map((char, i) => (
+    <Flex {...mockStyle} key={i}>
+      {typeof elements === 'number' ? i + 1 : char}
+    </Flex>
+  ));
+};
+
+const selectDemo = (demoType) => {
+  switch (demoType) {
+    case 'direction':
+      return <Direction />;
+    case 'gap':
+      return <Gap />;
+    case 'justifyContent':
+      return <JustifyContent />;
+    case 'alignItems':
+      return <AlignItems />;
+    case 'wrap':
+      return <Wrap />;
+  }
+};
+
+export const FlexDemo = ({ demoType }) => <View>{selectDemo(demoType)}</View>;

--- a/docs/src/pages/components/flex/react.mdx
+++ b/docs/src/pages/components/flex/react.mdx
@@ -1,9 +1,9 @@
 import { Flex, Text, Button, View } from '@aws-amplify/ui-react';
-import { Example } from '@/components/Example';
-
 import { FlexDemo } from './demo';
+import { Example, ExampleCode } from '@/components/Example';
+import { DefaultFlexExample } from './examples';
 
-The Flex primitive provides a flex container with style `display: flex`. To learn how to use Flexbox CSS properties, see the following documentation:
+The Flex primitive provides a Flexbox container with style `display: flex`. To learn how to use Flexbox CSS properties, see the following documentation:
 
 - [Flex layout - MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox)
 - [A Complete Guide to Flex - CSS Tricks](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
@@ -14,26 +14,23 @@ The Flex primitive provides a flex container with style `display: flex`. To lear
 
 ## Usage
 
-Import the Flex component and styles.
+Import the Flex primitive.
 
-```jsx
-import { Flex, Button } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
+<Example>
+  <View>
+    <DefaultFlexExample />
+  </View>
+  
+  <ExampleCode>
 
-<Flex>
-  <Button backgroundColor="var(--amplify-colors-pink-10)">Button 1</Button>
-  <Button backgroundColor="var(--amplify-colors-pink-20)">Button 2</Button>
-  <Button backgroundColor="var(--amplify-colors-pink-40)">Button 3</Button>
-</Flex>;
+```jsx file=./examples/DefaultFlexExample.tsx
+
 ```
 
-<Flex>
-  <Button backgroundColor="var(--amplify-colors-pink-10)">Button 1</Button>
-  <Button backgroundColor="var(--amplify-colors-pink-20)">Button 2</Button>
-  <Button backgroundColor="var(--amplify-colors-pink-40)">Button 3</Button>
-</Flex>
+  </ExampleCode>
+</Example>
 
-### Mapping CSS Flexbox properties to Flex props
+### Mapping Flexbox CSS properties to Flex props
 
 #### Flexbox CSS property => Flex prop:
 
@@ -43,3 +40,12 @@ import '@aws-amplify/ui-react/styles.css';
 - `align-content` => `alignContent`
 - `flex-wrap` => `wrap`
 - `gap` => `gap`
+
+#### Default prop values:
+
+- `direction="row"`
+- `justifyContent="normal"`
+- `alignItems="stretch"`
+- `alignContent="normal"`
+- `wrap="nowrap"`
+- `gap="1rem"`

--- a/docs/src/pages/components/flex/react.mdx
+++ b/docs/src/pages/components/flex/react.mdx
@@ -1,8 +1,11 @@
 import { Flex, Text } from '@aws-amplify/ui-react';
-import { FlexDemo } from './demo';
 import { Example } from '@/components/Example';
 
-A layout container using Flexbox.
+import { FlexDemo } from './demo';
+
+## Demo
+
+<FlexDemo />
 
 ## Usage
 

--- a/docs/src/pages/components/flex/react.mdx
+++ b/docs/src/pages/components/flex/react.mdx
@@ -1,7 +1,12 @@
-import { Flex, Text } from '@aws-amplify/ui-react';
+import { Flex, Text, Button, View } from '@aws-amplify/ui-react';
 import { Example } from '@/components/Example';
 
 import { FlexDemo } from './demo';
+
+The Flex primitive provides a flex container with style `display: flex`. To learn how to use Flexbox CSS properties, see the following documentation:
+
+- [Flex layout - MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox)
+- [A Complete Guide to Flex - CSS Tricks](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
 
 ## Demo
 
@@ -12,164 +17,29 @@ import { FlexDemo } from './demo';
 Import the Flex component and styles.
 
 ```jsx
-import { Flex, Text } from '@aws-amplify/ui-react';
+import { Flex, Button } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
 <Flex>
-  <Text>Hello</Text>
-  <Text>world</Text>
+  <Button backgroundColor="var(--amplify-colors-pink-10)">Button 1</Button>
+  <Button backgroundColor="var(--amplify-colors-pink-20)">Button 2</Button>
+  <Button backgroundColor="var(--amplify-colors-pink-40)">Button 3</Button>
 </Flex>;
 ```
 
 <Flex>
-  <Text>Hello</Text>
-  <Text>world</Text>
+  <Button backgroundColor="var(--amplify-colors-pink-10)">Button 1</Button>
+  <Button backgroundColor="var(--amplify-colors-pink-20)">Button 2</Button>
+  <Button backgroundColor="var(--amplify-colors-pink-40)">Button 3</Button>
 </Flex>
 
-### Direction
+### Mapping CSS Flexbox properties to Flex props
 
-Use the `direction` prop to set how flex items are placed in the flex container defining the main axis (maps to `flex-direction` CSS property).
+#### Flexbox CSS property => Flex prop:
 
-```jsx
-/* example element */
-const NumberBox = ({ number }) => (
-  <Flex
-    justifyContent="center"
-    alignItems="center"
-    width="15rem"
-    height="3rem"
-    borderRadius="5px"
-    fontWeight="bold"
-    color="white"
-    backgroundColor="#805AD5"
-  >
-    {number}
-  </Flex>
-);
-
-<Flex direction="row">
-  <NumberBox number={1} />
-  <NumberBox number={2} />
-  <NumberBox number={3} />
-</Flex>;
-```
-
-<FlexDemo demoType="direction" />
-
-### Gap
-
-Use the `gap` prop to adjust the spacing between child components. `gap` accepts a string representing any unit (e.g., px, rem, %). See [MDN gap documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) for supported values.
-
-```jsx
-<Flex gap="3rem">
-  <NumberBox number={1} />
-  <NumberBox number={2} />
-  <NumberBox number={3} />
-</Flex>
-```
-
-<FlexDemo demoType="gap" />
-
-### Justify Content
-
-Use the `justifyContent` prop to control where the flex items sit on the main axis. You can explore the different options in the demo below:
-
-```jsx
-<Flex justifyContent="flex-start">
-  <NumberBox number={1} />
-  <NumberBox number={2} />
-  <NumberBox number={3} />
-</Flex>
-```
-
-<FlexDemo demoType="justifyContent" />
-
-### Align Items
-
-Use the `alignItems` prop to control where the flex items sit on the cross axis.
-
-```jsx
-<Flex alignItems="stretch">
-  <View backgroundColor="#b794f4" height="100px" padding="2rem" color="white">
-    Wow!
-  </View>
-  <View backgroundColor="#805AD5" padding="10px 2rem 0 2rem" color="white">
-    I love to use
-  </View>
-  <View backgroundColor="#322659" height="70px" padding="2rem" color="white">
-    Flex
-  </View>
-</Flex>
-```
-
-<FlexDemo demoType="alignItems" />
-
-### Wrap
-
-Use the `wrap` prop to control what happens when children overflow the size of the container along the main axis (maps to `flex-wrap` CSS property). By default, children are forced into a single line (`nowrap`), which can shrink elements. If wrapping is allowed (`wrap`), items are wrapped into multiple lines along the main axis if needed.
-
-```jsx
-<Flex wrap="nowrap">
-  <NumberBox number={1} />
-  <NumberBox number={2} />
-  <NumberBox number={3} />
-  <NumberBox number={4} />
-  <NumberBox number={5} />
-  <NumberBox number={6} />
-</Flex>
-```
-
-<FlexDemo demoType="wrap" />
-
-## CSS Styling
-
-### Override Amplify styling using a CSS class
-
-```css
-/* styles.css */
-.my-custom-flex {
-  justify-content: center;
-  gap: 3rem;
-}
-```
-
-```jsx
-import './styles.css';
-
-<Flex className="my-custom-flex">
-  <Text>1</Text>
-  <Text>2</Text>
-  <Text>3</Text>
-</Flex>;
-```
-
-<Flex className="my-custom-flex">
-  <Text>1</Text>
-  <Text>2</Text>
-  <Text>3</Text>
-</Flex>
-
-### Override Amplify styling using the CSS variables
-
-```css
-/* styles.css */
-.styled-flex {
-  --flex-direction: column-reverse;
-}
-```
-
-```jsx
-import './styles.css';
-
-<Flex className="styled-flex">
-  <Text>Adam</Text>
-  <Text>I'm</Text>
-  <Text>Madam</Text>
-</Flex>;
-```
-
-<Flex className="styled-flex">
-  <Text>Adam</Text>
-  <Text>I'm</Text>
-  <Text>Madam</Text>
-</Flex>
+- `flex-direction` => `direction`
+- `justify-content` => `justifyContent`
+- `align-items` => `alignItems`
+- `align-content` => `alignContent`
+- `flex-wrap` => `wrap`
+- `gap` => `gap`

--- a/docs/src/pages/components/flex/useFlexProps.tsx
+++ b/docs/src/pages/components/flex/useFlexProps.tsx
@@ -1,0 +1,39 @@
+import { FlexProps } from '@aws-amplify/ui-react';
+import { useState } from 'react';
+import { FlexPropControlsProps } from './FlexPropControls';
+
+interface UseFlexProps {
+  (initialValues: FlexProps): FlexPropControlsProps;
+}
+
+export const useFlexProps: UseFlexProps = (initialValues) => {
+  const [direction, setDirection] = useState<FlexProps['direction']>(
+    initialValues.direction
+  );
+  const [justifyContent, setJustifyContent] = useState<
+    FlexProps['justifyContent']
+  >(initialValues.justifyContent);
+  const [alignItems, setAlignItems] = useState<FlexProps['alignItems']>(
+    initialValues.alignItems
+  );
+  const [alignContent, setAlignContent] = useState<FlexProps['alignContent']>(
+    initialValues.alignContent
+  );
+  const [wrap, setWrap] = useState<FlexProps['wrap']>(initialValues.wrap);
+  const [gap, setGap] = useState<string>(initialValues.gap as string);
+
+  return {
+    direction,
+    setDirection,
+    justifyContent,
+    setJustifyContent,
+    alignItems,
+    setAlignItems,
+    alignContent,
+    setAlignContent,
+    wrap,
+    setWrap,
+    gap,
+    setGap,
+  };
+};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
![flexgif](https://user-images.githubusercontent.com/48109584/150595483-cc5ef888-d9ba-4a04-abff-20051fbe2735.gif)

I decided to simplify the Flex docs. By showing that the Flex primitive is basically just a Flexbox wrapper, then the props should be fairly intuitive. If the customer wants to learn how to use Flexbox, there are links to great resources on MDN and CSS Tricks. 

I'm wondering if there's a better way to show what the default values are for each prop?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
