### PR TITLE
Fix Angular README 'anuglar' typo

### DIFF
--- a/.changeset/wet-plums-type.md
+++ b/.changeset/wet-plums-type.md
@@ -1,0 +1,6 @@
+---
+"amplify-ui-angular-mono": patch
+"@aws-amplify/ui-angular": patch
+---
+
+Fix Angular README 'anuglar' typo

--- a/packages/angular/projects/ui-angular/README.md
+++ b/packages/angular/projects/ui-angular/README.md
@@ -1,4 +1,4 @@
-# @aws-amplify/ui-anuglar
+# @aws-amplify/ui-angular
 
 ## Getting Started
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Fix a typo in the Angular package readme - `angular` was misspelled as `anuglar`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
