### PR TITLE
Fixed setting secret key value when generating TOTP QR code

### DIFF
--- a/.changeset/clever-donkeys-own.md
+++ b/.changeset/clever-donkeys-own.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-vue': patch
+---
+
+fixed setting secret key value when generating TOTP QR code

--- a/packages/vue/src/components/setup-totp.vue
+++ b/packages/vue/src/components/setup-totp.vue
@@ -38,7 +38,7 @@ onMounted(async () => {
   try {
     secretKey.value = await Auth.setupTOTP(user);
     const issuer = 'AWSCognito';
-    const totpCode = `otpauth://totp/${issuer}:${user.username}?secret=${secretKey}&issuer=${issuer}`;
+    const totpCode = `otpauth://totp/${issuer}:${user.username}?secret=${secretKey.value}&issuer=${issuer}`;
     qrCode.qrCodeImageSource = await QRCode.toDataURL(totpCode);
   } catch (error) {
     logger.error(error);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The value for the secret key was incorrectly set when generating the QR code for the TOTP, thus resulting in an invalid QR being produced.

It seems that this bug was introduced by #1083  and currently, the link looks like this:

```
otpauth://totp/AWSCognito:test@google.com?secret=[object Object]&issuer=AWSCognito
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
