### PR TITLE
Fix I18n demo screen bugs

### DIFF
--- a/docs/src/pages/components/authenticator/LabelsAndTextDemo.tsx
+++ b/docs/src/pages/components/authenticator/LabelsAndTextDemo.tsx
@@ -76,7 +76,12 @@ export function LabelsAndTextDemo({ Component }: ScreenProps) {
      * This waits for Authenticator machine to init before its inner components
      * start consuming machine context.
      */
-    const { route } = useAuthenticator();
+    const { route, _send } = useAuthenticator();
+    React.useEffect(() => {
+      if (route === 'idle') {
+        _send('INIT', { data: {} });
+      }
+    }, []);
     if (!route || route === 'idle' || route === 'setup') return null;
 
     return <>{children}</>;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This fixes https://ui.docs.amplify.aws/components/authenticator#labels--text that I broke again with #1168. Not a runtime error this time, but screens weren't rendering because its state machine was not initiated.

This PR ensures that `LabelsAndTextDemo` starts the state machine by explicitly sending INIT event.


https://user-images.githubusercontent.com/43682783/151238207-0f12533a-bf64-4105-b5e0-32a3e5d8ccb9.mp4


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
