### PR TITLE
Fix language typo

### DIFF
--- a/docs/src/pages/components/authenticator/index.page.mdx
+++ b/docs/src/pages/components/authenticator/index.page.mdx
@@ -424,7 +424,7 @@ The `Authenticator` ships with [translations](https://github.com/aws-amplify/amp
 - `fr` – French
 - `de` – German
 - `it` – Italian
-- `ja` – Japenese
+- `ja` – Japanese
 - `kr` - Korean
 - `pl` - Polish
 - `pt` – Portuguese


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes a typo on https://ui.docs.amplify.aws/components/authenticator#internationalization-i18n


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
