### PR TITLE
Added additional error translation text for SMS MFA

### DIFF
--- a/.changeset/many-bags-explode.md
+++ b/.changeset/many-bags-explode.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Added translations for errors for confirm sign in

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-sms-mfa/sign-in-sms-mfa.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-sms-mfa/sign-in-sms-mfa.component.ts
@@ -1,6 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import { Amplify } from 'aws-amplify';
+import { Amplify, I18n } from 'aws-amplify';
+
+import { translations } from '@aws-amplify/ui';
 
 import awsExports from './aws-exports';
 
@@ -8,8 +10,16 @@ import awsExports from './aws-exports';
   selector: 'sign-in-sms-mfa',
   templateUrl: 'sign-in-sms-mfa.component.html',
 })
-export class SignInSMSMFAComponent {
+export class SignInSMSMFAComponent implements OnInit {
   constructor() {
     Amplify.configure(awsExports);
+  }
+
+  ngOnInit() {
+    I18n.putVocabularies(translations);
+    I18n.setLanguage('en');
+    I18n.putVocabulariesForLanguage('en', {
+      'Invalid code or auth state for the user.': 'translated text',
+    });
   }
 }

--- a/examples/next/pages/ui/components/authenticator/sign-in-sms-mfa/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-sms-mfa/index.page.tsx
@@ -1,10 +1,18 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify, I18n } from 'aws-amplify';
 
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
+import { translations } from '@aws-amplify/ui';
 import awsExports from './aws-exports';
 Amplify.configure(awsExports);
+
+I18n.putVocabularies(translations);
+I18n.setLanguage('en');
+
+I18n.putVocabulariesForLanguage('en', {
+  'Invalid code or auth state for the user.': 'translated text',
+});
 
 export default function AuthenticatorWithSmsMfa() {
   return (

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-sms-mfa/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-sms-mfa/index.vue
@@ -1,10 +1,18 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
+import Amplify, { I18n } from 'aws-amplify';
 import '@aws-amplify/ui-vue/styles.css';
 import { Authenticator } from '@aws-amplify/ui-vue';
+import { translations } from '@aws-amplify/ui';
 import aws_exports from './aws-exports';
 
 Amplify.configure(aws_exports);
+
+I18n.putVocabularies(translations);
+I18n.setLanguage('en');
+
+I18n.putVocabulariesForLanguage('en', {
+  'Invalid code or auth state for the user.': 'translated text',
+});
 </script>
 
 <template>

--- a/packages/e2e/features/ui/components/authenticator/sign-in-sms-mfa.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-sms-mfa.feature
@@ -15,6 +15,7 @@ Feature: Sign In with SMS MFA
     And I click the "Sign in" button
     Then I will be redirected to the confirm sms mfa page
 
+
   @angular @react @vue
   Scenario: Redirect to sign in page
     When I select my country code with status "CONFIRMED"
@@ -25,14 +26,14 @@ Feature: Sign In with SMS MFA
     Then I see "Sign in"
 
   @angular @react @vue
-  Scenario: Incorrect SMS code
+  Scenario: Incorrect SMS code with translated text
     When I select my country code with status "CONFIRMED"
     And I type my "phone number" with status "CONFIRMED"
     And I type my password
     And I click the "Sign in" button
     And I type an invalid SMS code
     And I click the "Confirm" button
-    Then I see "Invalid code or auth state for the user."
+    Then I see "translated text"
     
   @angular @react @vue
   Scenario: Sign in with unknown credentials

--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -28,7 +28,9 @@ export const ConfirmSignIn = (): JSX.Element => {
       break;
     default:
       throw new Error(
-        `Unexpected challengeName encountered in ConfirmSignIn: ${challengeName}`
+        `${translate(
+          'Unexpected challengeName encountered in ConfirmSignIn:'
+        )} ${challengeName}`
       );
   }
   const handleChange = (event: React.FormEvent<HTMLFormElement>) => {
@@ -67,7 +69,7 @@ export const ConfirmSignIn = (): JSX.Element => {
         <Heading level={3}>{headerText}</Heading>
 
         <Flex direction="column">
-          <ConfirmationCodeInput errorText={error} />
+          <ConfirmationCodeInput errorText={translate(error)} />
         </Flex>
 
         <ConfirmSignInFooter />


### PR DESCRIPTION
*Issue #, if available:*
#1200 

*Description of changes:*
Added additional translations of error text for React.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
