### PR TITLE
fix: Svelte publish config, subpath imports, workspaces usage

### DIFF
--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -30,7 +30,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@aws-amplify/ui-svelte": "^0.0.1",
+    "@aws-amplify/ui-svelte": "./packages/svelte/dist",
     "@sveltejs/adapter-static": "^1.0.0-next.23",
     "aws-amplify": "^4.3.11"
   }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -2,22 +2,16 @@
   "name": "@aws-amplify/ui-svelte",
   "version": "0.0.1",
   "type": "module",
-  "main": "dist/index.js",
-  "svelte": "dist/index.js",
+  "license": "Apache-2.0",
   "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "import": "./dist/index.js"
-    },
-    "./styles.css": "./dist/styles.css"
+    "./styles.css": "./styles.css"
   },
   "browser": {
-    "./styles.css": "./dist/styles.css"
+    "./styles.css": "./styles.css"
   },
-  "files": [
-    "dist",
-    "LICENSE"
-  ],
+  "publishConfig": {
+    "directory": "dist"
+  },
   "scripts": {
     "dev": "svelte-kit dev",
     "build": "svelte-kit build",
@@ -30,8 +24,6 @@
     "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. ."
   },
   "devDependencies": {
-    "@sveltejs/adapter-auto": "next",
-    "@sveltejs/adapter-node": "^1.0.0-next.56",
     "@sveltejs/adapter-static": "^1.0.0-next.23",
     "@sveltejs/kit": "next",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
@@ -50,7 +42,8 @@
     "typescript": "^4.4.3"
   },
   "peerDependencies": {
-    "aws-amplify": "^4.2.2"
+    "aws-amplify": "^4.2.2",
+    "svelte": "^3.44.0"
   },
   "dependencies": {
     "@aws-amplify/ui": "3.0.6",

--- a/packages/svelte/svelte.config.js
+++ b/packages/svelte/svelte.config.js
@@ -9,33 +9,35 @@ const __dirname = dirname(__filename);
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://github.com/sveltejs/svelte-preprocess
-	// for more information about preprocessors
-	preprocess: preprocess(),
+  // Consult https://github.com/sveltejs/svelte-preprocess
+  // for more information about preprocessors
+  preprocess: preprocess(),
 
-	kit: {
-		adapter: adapter(),
-		package: {
-			dir: 'dist'
-		},
+  kit: {
+    adapter: adapter(),
+    package: {
+      dir: 'dist',
+    },
 
-		// hydrate the <div id="svelte"> element in src/app.html
-		target: '#svelte',
-		vite: {
-			ssr: {
-				noExternal:
-					process.env.NODE_ENV !== 'development' ? ['lodash', 'xstate', 'style-dictionary'] : []
-			},
-			resolve: {
-				alias: {
-					'./runtimeConfig': './runtimeConfig.browser',
-					entries: {
-						svelte: path.join(__dirname, '../../node_modules/svelte')
-					}
-				}
-			}
-		}
-	}
+    // hydrate the <div id="svelte"> element in src/app.html
+    target: '#svelte',
+    vite: {
+      ssr: {
+        noExternal:
+          process.env.NODE_ENV !== 'development'
+            ? ['lodash', 'xstate', 'style-dictionary']
+            : [],
+      },
+      resolve: {
+        alias: {
+          './runtimeConfig': './runtimeConfig.browser',
+          entries: {
+            svelte: path.join(__dirname, '../../node_modules/svelte'),
+          },
+        },
+      },
+    },
+  },
 };
 
 export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,6 +480,16 @@
   dependencies:
     "@aws-amplify/ui-components" "1.7.2"
 
+"@aws-amplify/ui-svelte@./packages/svelte/dist":
+  version "0.0.1"
+  dependencies:
+    "@aws-amplify/ui" "3.0.6"
+    "@rollup/plugin-replace" "^3.0.0"
+    nanoid "^3.1.30"
+    qrcode "^1.5.0"
+    svelte2tsx "^0.4.12"
+    xstate "^4.26.1"
+
 "@aws-amplify/ui@2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@aws-amplify/ui/-/ui-2.0.5.tgz#0800938a0bf36ff51922637628b0889017da19f1"
@@ -5047,13 +5057,6 @@
   dependencies:
     "@iarna/toml" "^2.2.5"
     esbuild "^0.13.15"
-    tiny-glob "^0.2.9"
-
-"@sveltejs/adapter-node@^1.0.0-next.56":
-  version "1.0.0-next.60"
-  resolved "https://registry.yarnpkg.com/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.60.tgz#3c9756e336a950e383c1b32a427db22786b3a66a"
-  integrity sha512-aOX0WEoSoy9ANHDbyul83c0F9qxI+vl//kYEhTZURY4NNnRQ4B1+QECDIv70v3SjU/aAT+56ofpvcZA++sfQxw==
-  dependencies:
     tiny-glob "^0.2.9"
 
 "@sveltejs/adapter-static@^1.0.0-next.23":


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- adds `publishConfig.directory` to publish package built by Svelte-Kit
- removes custom subpath imports in favor of Svelte-Kit auto-generated exports (fixes issue with entrypoint file, CSS)
- corrects Svelte example dependency, links directly to svelte `dist/` folder


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
