### PR TITLE
Pin xstate versions

### DIFF
--- a/.changeset/gold-beers-tell.md
+++ b/.changeset/gold-beers-tell.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-vue": patch
+"@aws-amplify/ui-angular": patch
+---
+
+Pin xstate versions

--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -19,7 +19,7 @@
     "nanoid": "^3.1.31",
     "qrcode": "^1.4.4",
     "tslib": "^2.0.0",
-    "xstate": "^4.20.1"
+    "xstate": "4.26.1"
   },
   "publishConfig": {
     "directory": "../../dist/ui-angular"

--- a/packages/e2e/cypress/plugins/index.js
+++ b/packages/e2e/cypress/plugins/index.js
@@ -8,7 +8,7 @@
 // ***********************************************************
 
 const cucumber = require('cypress-cucumber-preprocessor').default;
-const resolve = require('resolve');
+const path = require('path');
 require('dotenv-safe').config({
   allowEmptyValues: true,
 });
@@ -21,7 +21,7 @@ require('dotenv-safe').config({
  */
 module.exports = (on, config) => {
   const options = {
-    typescript: resolve.sync('typescript', { baseDir: config.projectRoot }),
+    typescript: path.join(path.resolve('../..'), 'node_modules/typescript'),
   };
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "style-dictionary": "^3.0.1",
-    "xstate": "^4.20.1"
+    "xstate": "4.26.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@aws-amplify/ui": "3.0.10",
     "@vueuse/core": "^7.4.1",
-    "@xstate/vue": "^0.8.0",
+    "@xstate/vue": "0.8.1",
     "qrcode": "^1.4.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6320,7 +6320,7 @@
     use-isomorphic-layout-effect "^1.0.0"
     use-subscription "^1.3.0"
 
-"@xstate/vue@^0.8.0":
+"@xstate/vue@0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@xstate/vue/-/vue-0.8.1.tgz#96a144fe72eb6bccb8be98c7192bbed1b26ed3ff"
   integrity sha512-m4Ejd08eUHzlTD7P6aGscwpjeHRXVZQ5iVyv5RxYi5WKoFqOMeurO2dxvI8QDfTxF27NqODj30LWYsMzZZ9lsg==
@@ -22965,7 +22965,7 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xstate@^4.20.1:
+xstate@4.26.1, xstate@^4.20.1:
   version "4.26.1"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.26.1.tgz#4fc1afd153f88cf302a9ee2b758f6629e6a829b6"
   integrity sha512-JLofAEnN26l/1vbODgsDa+Phqa61PwDlxWu8+2pK+YbXf+y9pQSDLRvcYH2H1kkeUBA5fGp+xFL/zfE8jNMw4g==


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This pins all `xstate` version to last known working version in `yarn.lock`. This fixes Typescript error found in https://github.com/aws-amplify/amplify-ui/issues/1223, which actually happened to React/Vue as well as Angular. 

Not sure why this wasn't caught in `no-lock` test we have, we shoudl look into it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
