### PR TITLE
Pin xstate to `4.28.0`

### DIFF
--- a/.changeset/purple-apples-crash.md
+++ b/.changeset/purple-apples-crash.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-angular": patch
+---
+
+Pin xstate to `4.28.0`

--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -19,7 +19,7 @@
     "nanoid": "^3.1.31",
     "qrcode": "^1.4.4",
     "tslib": "^2.0.0",
-    "xstate": "4.26.1"
+    "xstate": "4.28.0"
   },
   "publishConfig": {
     "directory": "../../dist/ui-angular"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "style-dictionary": "^3.0.1",
-    "xstate": "4.26.1"
+    "xstate": "4.28.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22965,7 +22965,12 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xstate@4.26.1, xstate@^4.20.1:
+xstate@4.28.0:
+  version "4.28.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.28.0.tgz#e5802638120951793ef7ea5a91e975f86244a73c"
+  integrity sha512-qavuFNzejRZVR75Pmbc7zOuUvVOWoABn6sucHr9M5oWjP3LeJ8A5T9lYfADiaY0o9E6q1T63f6JIhCBgt4XTdw==
+
+xstate@^4.20.1:
   version "4.26.1"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.26.1.tgz#4fc1afd153f88cf302a9ee2b758f6629e6a829b6"
   integrity sha512-JLofAEnN26l/1vbODgsDa+Phqa61PwDlxWu8+2pK+YbXf+y9pQSDLRvcYH2H1kkeUBA5fGp+xFL/zfE8jNMw4g==


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Resolves #1226.

Bumping xstate to `4.28.0`, which is the last version before `xstate` brought major TypeScript updates. We should look into updating to `4.29.0` eventually, but we should unblock customers first.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
