### PR TITLE
chore: moving useNavigateAction test to action test folder

### DIFF
--- a/packages/react/src/hooks/actions/__tests__/useNavigateAction.test.ts
+++ b/packages/react/src/hooks/actions/__tests__/useNavigateAction.test.ts
@@ -1,4 +1,4 @@
-import { Hub } from '@aws-amplify/core';
+import { Hub } from 'aws-amplify';
 import { renderHook } from '@testing-library/react-hooks';
 
 import {
@@ -12,7 +12,7 @@ import {
   UseNavigateActionOptions,
 } from '../useNavigateAction';
 
-jest.mock('@aws-amplify/core');
+jest.mock('aws-amplify');
 
 describe('useNavigateHook: ', () => {
   let windowSpy: jest.SpyInstance;

--- a/packages/react/src/hooks/actions/__tests__/useNavigateAction.test.ts
+++ b/packages/react/src/hooks/actions/__tests__/useNavigateAction.test.ts
@@ -1,16 +1,16 @@
 import { Hub } from '@aws-amplify/core';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks';
 
 import {
   ACTIONS_CHANNEL,
   ACTION_NAVIGATE_FINISHED,
   ACTION_NAVIGATE_STARTED,
-} from '../actions/constants';
+} from '../constants';
 import {
   defaultTarget,
   useNavigateAction,
   UseNavigateActionOptions,
-} from '../actions/useNavigateAction';
+} from '../useNavigateAction';
 
 jest.mock('@aws-amplify/core');
 

--- a/packages/react/src/hooks/actions/useNavigateAction.ts
+++ b/packages/react/src/hooks/actions/useNavigateAction.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Hub } from '@aws-amplify/core';
+import { Hub } from 'aws-amplify';
 
 import {
   ACTIONS_CHANNEL,


### PR DESCRIPTION
*Description of changes:*

Moving `useNavigateAction` test file to the correct folder under `hooks/actions/__tests__`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
