### PR TITLE
Bump @aws-sdk/client-location from 3.22.0 to 3.48.0

### DIFF
--- a/.changeset/lemon-falcons-care.md
+++ b/.changeset/lemon-falcons-care.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Bumps @aws-sdk/client-location from 3.22.0 to 3.48.0

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "packages/angular/projects/ui-angular"
   ],
   "resolutions": {
-    "@aws-sdk/client-location": "3.22.0",
+    "@aws-sdk/client-location": "3.48.0",
     "ansi-regex": "5.0.1",
     "fs-extra": "^10.0.0",
     "jest": "^26.6.3",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I talked with @TreTuna and @ErikCH , and we figured out that the resolutions were overriding the `@aws-sdk/client-location` version that Geo uses to an older version that is missing the needed API. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
