### PR TITLE
Adding paths prop to Icon

### DIFF
--- a/.changeset/stupid-rice-nail.md
+++ b/.changeset/stupid-rice-nail.md
@@ -1,0 +1,24 @@
+---
+"@aws-amplify/ui-react": minor
+---
+
+Adding `paths` prop to Icon which is an array of path-like objects that will be mapped to `<path>` elements. 
+
+Example:
+
+```jsx
+<Icon
+  ariaLabel="tag"
+  viewBox={{ width: 23, height: 15 }}
+  paths={[
+    {
+      d: 'M1 0.5C0.723858 0.5 0.5 0.723858 0.5 1V14C0.5 14.2761 0.723858 14.5 1 14.5H14C14.1148 14.5 14.2262 14.4605 14.3153 14.3881L22.3153 7.88806C22.4322 7.79311 22.5 7.65056 22.5 7.5C22.5 7.34944 22.4322 7.20689 22.3153 7.11194L14.3153 0.611943C14.2262 0.539529 14.1148 0.5 14 0.5H1Z',
+      strokeLinejoin: 'bevel',
+      strokeLinecap: 'round',
+      strokeDasharray: '4 4',
+      fill: 'transparent',
+      stroke: 'currentColor',
+    },
+  ]}
+/>
+```

--- a/docs/src/pages/components/icon/examples/CustomIconWithPathsExample.tsx
+++ b/docs/src/pages/components/icon/examples/CustomIconWithPathsExample.tsx
@@ -1,0 +1,20 @@
+import { Icon } from '@aws-amplify/ui-react';
+
+export const CustomIconWithPathsExample = () => {
+  return (
+    <Icon
+      ariaLabel="tag"
+      viewBox={{ width: 23, height: 15 }}
+      paths={[
+        {
+          d: 'M1 0.5C0.723858 0.5 0.5 0.723858 0.5 1V14C0.5 14.2761 0.723858 14.5 1 14.5H14C14.1148 14.5 14.2262 14.4605 14.3153 14.3881L22.3153 7.88806C22.4322 7.79311 22.5 7.65056 22.5 7.5C22.5 7.34944 22.4322 7.20689 22.3153 7.11194L14.3153 0.611943C14.2262 0.539529 14.1148 0.5 14 0.5H1Z',
+          strokeLinejoin: 'bevel',
+          strokeLinecap: 'round',
+          strokeDasharray: '4 4',
+          fill: 'transparent',
+          stroke: 'currentColor',
+        },
+      ]}
+    />
+  );
+};

--- a/docs/src/pages/components/icon/examples/index.tsx
+++ b/docs/src/pages/components/icon/examples/index.tsx
@@ -2,6 +2,7 @@ export { AccessibilityIconExample } from './AccessibilityIconExample';
 export { BuiltInIconExample } from './BuiltInIconExample';
 export { CustomIconExample } from './CustomIconExample';
 export { CustomIconWithLibExample } from './CustomIconWithLibExample';
+export { CustomIconWithPathsExample } from './CustomIconWithPathsExample';
 export { CustomIconWithSvgExample } from './CustomIconWithSvgExample';
 export { DefaultIconExample } from './DefaultIconExample';
 export { IconSizesExample } from './IconSizesExample';

--- a/docs/src/pages/components/icon/react.mdx
+++ b/docs/src/pages/components/icon/react.mdx
@@ -11,6 +11,7 @@ import {
   IconColorExample,
   IconSizesExample,
   CustomIconWithSvgExample,
+  CustomIconWithPathsExample,
   CustomIconWithLibExample,
   ViewboxExample,
 } from './examples';
@@ -97,6 +98,20 @@ You can also pass SVG elements as children to the `Icon` component if you have m
   <ExampleCode>
 
 ```jsx file=./examples/CustomIconWithSvgExample.tsx
+
+```
+
+  </ExampleCode>
+</Example>
+
+You can also optionally use a `paths` array of path-like objects that will be mapped to `<path>` elements.
+
+<Example>
+  <CustomIconWithPathsExample />
+  
+  <ExampleCode>
+
+```jsx file=./examples/CustomIconWithPathsExample.tsx
 
 ```
 

--- a/packages/react/src/primitives/Icon/Icon.tsx
+++ b/packages/react/src/primitives/Icon/Icon.tsx
@@ -16,6 +16,7 @@ const IconPrimitive: Primitive<IconProps, 'svg'> = (
     pathData,
     viewBox = defaultViewBox,
     children,
+    paths,
     ...rest
   },
   ref
@@ -25,9 +26,20 @@ const IconPrimitive: Primitive<IconProps, 'svg'> = (
   const width = viewBox.width ? viewBox.width : defaultViewBox.width;
   const height = viewBox.height ? viewBox.height : defaultViewBox.height;
 
-  // If given children, pass those through. They are expected to be valid
-  // SVG elements. Fall back on rendering a single path with pathData
-  const _children = children ? children : <path d={pathData} fill={fill} />;
+  // An icon can be drawn in 3 ways:
+  // 1. Pass it children which should be valid SVG elements
+  // 2. Pass an array of path-like objects to `paths` prop
+  // 3. Supply `pathData` for a simple icons
+  let _children: React.ReactNode;
+  if (children) {
+    _children = children;
+  }
+  if (paths) {
+    _children = paths.map((path) => <path {...path} />);
+  }
+  if (pathData) {
+    _children = <path d={pathData} fill={fill} />;
+  }
 
   return (
     <View

--- a/packages/react/src/primitives/Icon/__tests__/Icon.test.tsx
+++ b/packages/react/src/primitives/Icon/__tests__/Icon.test.tsx
@@ -102,4 +102,29 @@ describe('Icon component', () => {
     expect(paths.length).toBe(2);
     expect(paths[0].getAttribute('opacity')).toBe('0.5');
   });
+
+  it('can accept an array of path-like objects', async () => {
+    render(
+      <Icon
+        testId={iconTestId}
+        ariaLabel="Search"
+        paths={[
+          {
+            d: 'M1 0.5C0.723858 0.5 0.5 0.723858 0.5 1V14C0.5 14.2761 0.723858 14.5 1 14.5H14C14.1148 14.5 14.2262 14.4605 14.3153 14.3881L22.3153 7.88806C22.4322 7.79311 22.5 7.65056 22.5 7.5C22.5 7.34944 22.4322 7.20689 22.3153 7.11194L14.3153 0.611943C14.2262 0.539529 14.1148 0.5 14 0.5H1Z',
+            strokeLinejoin: 'bevel',
+            strokeLinecap: 'round',
+            strokeDasharray: '4 4',
+            fill: 'transparent',
+            stroke: 'currentColor',
+            role: 'path',
+          },
+        ]}
+      />
+    );
+
+    const icon = await screen.findByTestId(iconTestId);
+    const paths = await within(icon).findAllByRole('path');
+    expect(paths.length).toBe(1);
+    expect(paths[0].getAttribute('stroke-linejoin')).toBe('bevel');
+  });
 });

--- a/packages/react/src/primitives/types/icon.ts
+++ b/packages/react/src/primitives/types/icon.ts
@@ -43,4 +43,10 @@ export interface IconProps extends ViewProps {
    * flexibility and to allow for multiple paths.
    */
   children?: React.ReactNode;
+
+  /**
+   * Optionally pass an array of path-like objects which
+   * the icon will map to <path> elements.
+   */
+  paths?: Array<React.SVGAttributes<SVGPathElement>>;
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adding `paths` prop to Icon primitive that accepts an array of path-like objects.

```jsx
    <Icon
      ariaLabel="tag"
      viewBox={{ width: 23, height: 15 }}
      paths={[
        {
          d: 'M1 0.5C0.723858 0.5 0.5 0.723858 0.5 1V14C0.5 14.2761 0.723858 14.5 1 14.5H14C14.1148 14.5 14.2262 14.4605 14.3153 14.3881L22.3153 7.88806C22.4322 7.79311 22.5 7.65056 22.5 7.5C22.5 7.34944 22.4322 7.20689 22.3153 7.11194L14.3153 0.611943C14.2262 0.539529 14.1148 0.5 14 0.5H1Z',
          strokeLinejoin: 'bevel',
          strokeLinecap: 'round',
          strokeDasharray: '4 4',
          fill: 'transparent',
          stroke: 'currentColor',
        },
      ]}
    />
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
