### PR TITLE
Pin prism-react-renderer to 1.2.1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -32,7 +32,7 @@
     "next": "11.1.4",
     "next-plugin-preval": "^1.2.1",
     "next-sitemap": "^1.6.203",
-    "prism-react-renderer": "^1.2.1",
+    "prism-react-renderer": "1.2.1",
     "prism-theme-night-owl": "^1.4.0",
     "raw-loader": "^4.0.2",
     "react": "latest",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "json-schema": "^0.4.0",
     "node-forge": "1.0.0",
     "prismjs": "^1.25.0",
+    "prism-react-renderer": "1.2.1",
     "trim": "^0.0.3",
     "ts-jest": "^26.5.6",
     "vscode-vue-languageservice": "0.27.26",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding `prism-react-renderer` to `resolutions` because it is currently breaking the build ([see issue](https://github.com/FormidableLabs/prism-react-renderer/issues/142)), and it also has transitive dependencies. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
