### PR TITLE
Dedupe `aws-amplify` versions

### DIFF
--- a/canary/angular/angularcli/package.json
+++ b/canary/angular/angularcli/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser-dynamic": "~11.2.14",
     "@angular/router": "~11.2.14",
     "@aws-amplify/ui-angular": "^2.0.11",
-    "aws-amplify": "^4.3.13",
+    "aws-amplify": "latest",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.3"

--- a/canary/react/cra-ts/package.json
+++ b/canary/react/cra-ts/package.json
@@ -11,7 +11,7 @@
     "@types/node": "^16.11.22",
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
-    "aws-amplify": "^4.3.13",
+    "aws-amplify": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",

--- a/canary/react/cra/package.json
+++ b/canary/react/cra/package.json
@@ -7,7 +7,7 @@
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
-    "aws-amplify": "^4.3.13",
+    "aws-amplify": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",

--- a/canary/react/next/package.json
+++ b/canary/react/next/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-react": "^2.2.1",
-    "aws-amplify": "^4.3.13",
+    "aws-amplify": "latest",
     "next": "12.0.10",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/canary/vue/vite/package.json
+++ b/canary/vue/vite/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-vue": "^2.0.11",
-    "aws-amplify": "^4.3.13",
+    "aws-amplify": "latest",
     "vue": "^3.2.27"
   },
   "devDependencies": {

--- a/canary/vue/vuecli/package.json
+++ b/canary/vue/vuecli/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-vue": "^2.0.11",
-    "aws-amplify": "^4.3.13",
+    "aws-amplify": "latest",
     "core-js": "^3.6.5",
     "vue": "^3.0.0"
   },

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -13,6 +13,7 @@
   },
   "private": true,
   "dependencies": {
+    "aws-amplify": "latest",
     "@angular/animations": "~11.2.14",
     "@angular/common": "~11.2.14",
     "@angular/compiler": "~11.2.14",
@@ -31,7 +32,6 @@
     "@angular/compiler-cli": "~11.2.14",
     "@types/jasmine": "~3.6.0",
     "@types/node": "^12.11.1",
-    "aws-amplify": "latest",
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.6.0",
     "jasmine-spec-reporter": "~5.0.0",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-vue": "^2.1.1",
-    "aws-amplify": "^4.1.3",
+    "aws-amplify": "latest",
     "vue": "^3.0.5",
     "vue-router": "4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,6 +464,15 @@
   resolved "https://registry.yarnpkg.com/@aws-amplify/ui/-/ui-2.0.3.tgz#7a88a416942aedbc6a6ea9850a2c98693c80340a"
   integrity sha512-LxbmPGD/S4bWzUh2PXMPSt/rXeUVJTsCbMpwH18XilTkXgOSmKH/eyVZNXUBY8C/xwqjzMTC68EtTlsM1DCq1A==
 
+"@aws-amplify/ui@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/ui/-/ui-3.0.3.tgz#8692a5a741c935f2cb5041511fc59edc83f4a314"
+  integrity sha512-IWimjvWcSDq7PPDzEtM6QVeXjP1wGOurHwU2EaOJqeI7x7/d1exd/qhPl/f3PdqXIE6AOxiqGR0EvB8LcWMoWw==
+  dependencies:
+    lodash "^4.17.21"
+    style-dictionary "^3.0.1"
+    xstate "^4.20.1"
+
 "@aws-amplify/xr@3.0.26":
   version "3.0.26"
   resolved "https://registry.yarnpkg.com/@aws-amplify/xr/-/xr-3.0.26.tgz#9f5c3af4a0af68ec52262c9e62bfa1ba14605275"
@@ -7066,7 +7075,7 @@ aws-amplify-react@latest:
     qrcode.react "^0.8.0"
     regenerator-runtime "^0.11.1"
 
-aws-amplify@^4.1.3, aws-amplify@latest:
+aws-amplify@latest:
   version "4.3.8"
   resolved "https://registry.yarnpkg.com/aws-amplify/-/aws-amplify-4.3.8.tgz#8e69bc0dbfb7f8dfe7b01b22a1b7e11037c5e610"
   integrity sha512-Hez6+46IpIiQiFvtk7FOG2zeWU5gKZnoJ6/BZjGKfae0xFiAEQeST0l2n2/9x8lqXZ59kOVvVDUxgEoQ+C5Y9g==
@@ -18497,7 +18506,7 @@ pretty@2.0.0:
     extend-shallow "^2.0.1"
     js-beautify "^1.6.12"
 
-prism-react-renderer@1.2.1:
+prism-react-renderer@1.2.1, prism-react-renderer@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.2.1.tgz#392460acf63540960e5e3caa699d851264e99b89"
   integrity sha512-w23ch4f75V1Tnz8DajsYKvY5lF7H1+WvzvLUcF0paFxkTHSp42RS0H5CttdN2Q8RR3DRGZ9v5xD/h3n8C8kGmg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,15 +464,6 @@
   resolved "https://registry.yarnpkg.com/@aws-amplify/ui/-/ui-2.0.3.tgz#7a88a416942aedbc6a6ea9850a2c98693c80340a"
   integrity sha512-LxbmPGD/S4bWzUh2PXMPSt/rXeUVJTsCbMpwH18XilTkXgOSmKH/eyVZNXUBY8C/xwqjzMTC68EtTlsM1DCq1A==
 
-"@aws-amplify/ui@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/ui/-/ui-3.0.3.tgz#8692a5a741c935f2cb5041511fc59edc83f4a314"
-  integrity sha512-IWimjvWcSDq7PPDzEtM6QVeXjP1wGOurHwU2EaOJqeI7x7/d1exd/qhPl/f3PdqXIE6AOxiqGR0EvB8LcWMoWw==
-  dependencies:
-    lodash "^4.17.21"
-    style-dictionary "^3.0.1"
-    xstate "^4.20.1"
-
 "@aws-amplify/xr@3.0.26":
   version "3.0.26"
   resolved "https://registry.yarnpkg.com/@aws-amplify/xr/-/xr-3.0.26.tgz#9f5c3af4a0af68ec52262c9e62bfa1ba14605275"
@@ -18506,7 +18497,7 @@ pretty@2.0.0:
     extend-shallow "^2.0.1"
     js-beautify "^1.6.12"
 
-prism-react-renderer@1.2.1, prism-react-renderer@^1.1.1:
+prism-react-renderer@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.2.1.tgz#392460acf63540960e5e3caa699d851264e99b89"
   integrity sha512-w23ch4f75V1Tnz8DajsYKvY5lF7H1+WvzvLUcF0paFxkTHSp42RS0H5CttdN2Q8RR3DRGZ9v5xD/h3n8C8kGmg==


### PR DESCRIPTION
*Description of changes:*
This PR fixes an issue where we were pulling in two separate versions of the `aws-amplify` dependencies, 4.3.14 and 4.3.8. Now we will only have the latest version of `aws-amplify` in the node_modules folder.

Note: I found this bug when making an examples app of DataStore hooks. Having multiple versions of `@aws-amplify/datastore` in `node_modules` causes DataStore not to fully initialize, leaving the `DataStore.save` call to throw the following cryptic error message:
```
Cannot read properties of undefined (reading 'version')
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
