### PR TITLE
scoped theme PoC

### DIFF
--- a/docs/src/pages/components/button/examples/ButtonThemeExample.tsx
+++ b/docs/src/pages/components/button/examples/ButtonThemeExample.tsx
@@ -17,7 +17,7 @@ const theme = {
         primary: {
           backgroundColor: { value: 'rebeccapurple' },
           _hover: {
-            backgroundColor: { value: 'hotpink' },
+            backgroundColor: { value: 'teal' },
           },
         },
       },
@@ -26,7 +26,7 @@ const theme = {
 };
 
 export const ButtonThemeExample = () => (
-  <AmplifyProvider theme={theme}>
+  <AmplifyProvider theme={theme} scoped>
     <Flex direction="row">
       <Button>Default</Button>
       <Button variation="primary">Primary</Button>

--- a/packages/react/src/components/AmplifyProvider/index.tsx
+++ b/packages/react/src/components/AmplifyProvider/index.tsx
@@ -12,24 +12,38 @@ interface AmplifyProviderProps {
   children: React.ReactNode;
   colorMode?: ColorMode;
   theme?: Theme;
+  // Should this theme be scoped to its part of the DOM
+  // This is useful if you just want part of an application to get a different theme
+  scoped?: boolean;
 }
 
 export function AmplifyProvider({
   children,
   colorMode,
   theme = defaultTheme,
+  scoped = false,
 }: AmplifyProviderProps) {
   const webTheme = createTheme(theme);
   const { name, cssText } = webTheme;
-  React.useEffect(() => {
-    if (document && document.documentElement) {
-      document.documentElement.setAttribute('data-amplify-theme', name);
-      document.documentElement.setAttribute(
-        'data-amplify-color-mode',
-        colorMode
-      );
-    }
-  }, [theme, colorMode]);
+  let props = {};
+
+  if (scoped) {
+    props = {
+      'data-amplify-theme': name,
+      'data-amplify-color-mode': colorMode,
+    };
+  } else {
+    React.useEffect(() => {
+      if (document && document.documentElement) {
+        document.documentElement.setAttribute('data-amplify-theme', name);
+        document.documentElement.setAttribute(
+          'data-amplify-color-mode',
+          colorMode
+        );
+      }
+    }, [theme, colorMode]);
+  }
+
   return (
     <AmplifyContext.Provider
       value={{
@@ -37,7 +51,7 @@ export function AmplifyProvider({
       }}
     >
       <IdProvider>
-        <div>{children}</div>
+        <div {...props}>{children}</div>
         <style
           id={`amplify-theme-${name}`}
           dangerouslySetInnerHTML={{ __html: cssText }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This is a PoC so feedback welcome. This adds a `scoped` prop to the AmplifyProvider to allow for scoped theming, where a them only applies to a particular part of the DOM. The reason this might be needed is we do use scoped themes in the docs site to show theming examples. We don't want to put a provider with a custom theme somewhere and have it override the entire site. You can see this in action by going to the [buttons](https://ui.docs.amplify.aws/components/button) page which does this. Another thing is because the provider is only on part of a page, navigating around when the example provider is no longer present, the data attributes it set on the document are still there. 

Caveats: this won't work if you use a Portal'd component like the Menu inside a scoped theme area, but I think that might be a fine compromise. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Live docs site (notice the non-default color buttons because of the second Provider):
<img width="1439" alt="CleanShot 2022-02-10 at 22 51 40@2x" src="https://user-images.githubusercontent.com/321279/153549238-89e8c4f8-b89e-44ad-b8c1-2504b7801abf.png">


Docs site with these changes:
<img width="1439" alt="CleanShot 2022-02-10 at 22 51 14@2x" src="https://user-images.githubusercontent.com/321279/153549248-8f75b52a-5a64-45b3-b661-1b485e0bd93d.png">



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
