### PR TITLE
Proposal: input styles

### DIFF
--- a/docs/src/pages/components/textfield/examples/TextFieldStylePropsExample.tsx
+++ b/docs/src/pages/components/textfield/examples/TextFieldStylePropsExample.tsx
@@ -3,21 +3,34 @@ import { Text, TextField, useTheme } from '@aws-amplify/ui-react';
 export const TextFieldStylePropsExample = () => {
   const { tokens } = useTheme();
   return (
-    <TextField
-      direction="row"
-      alignItems="baseline"
-      fontSize={tokens.fontSizes.xl}
-      label={
-        <Text
-          fontWeight={tokens.fontWeights.bold}
-          fontSize={tokens.fontSizes.xl}
-        >
-          Name:
-        </Text>
-      }
-      backgroundColor={tokens.colors.background.primary}
-      color={tokens.colors.black}
-      width="400px"
-    />
+    <>
+      <TextField
+        direction="row"
+        alignItems="bottom"
+        fontSize={tokens.fontSizes.xl}
+        label={
+          <Text
+            fontWeight={tokens.fontWeights.bold}
+            fontSize={tokens.fontSizes.xl}
+          >
+            Name:
+          </Text>
+        }
+        backgroundColor={tokens.colors.background.primary}
+        color={tokens.colors.black}
+        width="400px"
+      />
+      <TextField
+        label="Special Field"
+        inputStyles={{
+          backgroundColor: tokens.colors.brand.primary[10],
+          border: `${tokens.borderWidths.medium} solid ${tokens.colors.brand.primary[80]}`,
+        }}
+        fontSize={tokens.fontSizes.xl}
+        backgroundColor={tokens.colors.background.primary}
+        color={tokens.colors.black}
+        width="400px"
+      />
+    </>
   );
 };

--- a/packages/react/src/primitives/TextField/TextField.tsx
+++ b/packages/react/src/primitives/TextField/TextField.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { splitPrimitiveProps } from '../shared/styleUtils';
 import { FieldDescription, FieldErrorMessage } from '../Field';
 import { FieldGroup } from '../FieldGroup';
 import { Flex } from '../Flex';
@@ -40,13 +39,11 @@ const TextFieldPrimitive = <Multiline extends boolean>(
     type, // remove from rest to prevent passing as DOM attribute to textarea
     size,
     testId,
-    ..._rest
+    inputStyles,
+    ...rest
   } = props;
 
   const fieldId = useStableId(id);
-
-  const { flexContainerStyleProps, baseStyleProps, rest } =
-    splitPrimitiveProps(_rest);
 
   let control: JSX.Element = null;
   if (isTextAreaField(props)) {
@@ -58,8 +55,7 @@ const TextFieldPrimitive = <Multiline extends boolean>(
         ref={isTextAreaRef(props, ref) ? ref : undefined}
         rows={rows ?? DEFAULT_ROW_COUNT}
         size={size}
-        {...baseStyleProps}
-        {...rest}
+        {...inputStyles}
       />
     );
   } else if (isInputField(props)) {
@@ -71,8 +67,7 @@ const TextFieldPrimitive = <Multiline extends boolean>(
         ref={isInputRef(props, ref) ? ref : undefined}
         size={size}
         type={type}
-        {...baseStyleProps}
-        {...rest}
+        {...inputStyles}
       />
     );
   }
@@ -86,7 +81,7 @@ const TextFieldPrimitive = <Multiline extends boolean>(
       )}
       data-size={size}
       testId={testId}
-      {...flexContainerStyleProps}
+      {...rest}
     >
       <Label htmlFor={fieldId} visuallyHidden={labelHidden}>
         {label}

--- a/packages/react/src/primitives/types/field.ts
+++ b/packages/react/src/primitives/types/field.ts
@@ -1,5 +1,6 @@
 import { FieldGroupIconButtonProps } from './fieldGroupIcon';
 import { InputProps } from './input';
+import { BaseStyleProps } from './style';
 
 /**
  * Shared type across all field types
@@ -26,6 +27,8 @@ export interface FieldProps {
    * @default false
    */
   labelHidden?: boolean;
+
+  inputStyles?: BaseStyleProps;
 }
 
 export interface FieldClearButtonProps


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This is a proposal for allowing styles to inner-components, like the input in a Field. Currently we are splitting the style props and applying certain ones to the input and others to the wrapper. This removes that logic and instead ops for an `inputStyles` object prop. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
