### PR TITLE
Removing base docs theme overrides and fixing theme switcher on docs site

### DIFF
--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -20,11 +20,18 @@ function MyApp({ Component, pageProps }) {
   const [colorMode, setColorMode] = React.useState<ColorMode>('system');
   const [themeOverride, setThemeOverride] = React.useState('');
 
+  React.useEffect(() => {
+    document.documentElement.setAttribute(
+      'data-amplify-theme-override',
+      themeOverride
+    );
+  }, [themeOverride]);
+
   configure();
   trackPageVisit();
 
   return (
-    <div className={themeOverride}>
+    <>
       <Head>
         <title>Amplify UI</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -44,7 +51,7 @@ function MyApp({ Component, pageProps }) {
       </AmplifyProvider>
       <Script src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js" />
       <Script src="/scripts/shortbreadv2.js" />
-    </div>
+    </>
   );
 }
 

--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -31,31 +31,6 @@ const usePalette = (str) => {
 
 export const theme: Theme = {
   name: 'amplify-docs',
-  tokens: {
-    components: {
-      sliderfield: {
-        thumb: {
-          boxShadow: { value: '{shadows.small.value}' },
-        },
-      },
-      badge: {
-        borderRadius: { value: '{radii.large.value}' },
-      },
-      switchfield: {
-        track: {
-          checked: {
-            background: { value: '{colors.brand.primary.80.value}' },
-          },
-        },
-      },
-      togglebutton: {
-        borderColor: { value: '{colors.border.primary.value}' },
-        pressed: {
-          color: { value: '{colors.font.primary.value}' },
-        },
-      },
-    },
-  },
   overrides: [
     {
       colorMode: 'dark',
@@ -94,17 +69,12 @@ export const theme: Theme = {
       },
     },
     {
-      selector: '.classic [data-amplify-theme="amplify-docs"]',
+      selector: '[data-amplify-theme-override="classic"]',
       tokens: {
         colors: {
           brand: {
             primary: usePalette('blue'),
             secondary: usePalette('neutral'),
-          },
-          radii: {
-            small: { value: '0' },
-            medium: { value: '2px' },
-            large: { value: '4px' },
           },
           border: {
             primary: { value: '{colors.neutral.40.value}' },
@@ -112,10 +82,16 @@ export const theme: Theme = {
             tertiary: { value: '{colors.neutral.10.value}' },
           },
         },
+        radii: {
+          small: { value: '2px' },
+          medium: { value: '2px' },
+          large: { value: '4px' },
+          xl: { value: '6px' },
+        },
       },
     },
     {
-      selector: '.terminal [data-amplify-theme="amplify-docs"]',
+      selector: '[data-amplify-theme-override="terminal"]',
       tokens: {
         colors: {
           green: {
@@ -163,6 +139,17 @@ export const theme: Theme = {
           },
         },
         components: {
+          card: {
+            boxShadow: { value: '{shadows.medium.value}' },
+          },
+          heading: {
+            1: { fontWeight: { value: '{fontWeights.extrabold.value}' } },
+            2: { fontWeight: { value: '{fontWeights.extrabold.value}' } },
+            3: { fontWeight: { value: '{fontWeights.extrabold.value}' } },
+            4: { fontWeight: { value: '{fontWeights.extrabold.value}' } },
+            5: { fontWeight: { value: '{fontWeights.extrabold.value}' } },
+            6: { fontWeight: { value: '{fontWeights.extrabold.value}' } },
+          },
           button: {
             primary: {
               backgroundColor: { value: '{colors.brand.primary.40.value}' },

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -147,6 +147,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-card-outlined-border-width: var(--amplify-border-widths-small);
         --amplify-components-card-outlined-border-style: solid;
         --amplify-components-card-outlined-border-color: var(--amplify-colors-border-primary);
+        --amplify-components-card-outlined-box-shadow: var(--amplify-components-card-box-shadow);
         --amplify-components-card-elevated-background-color: var(--amplify-components-card-background-color);
         --amplify-components-card-elevated-border-radius: var(--amplify-radii-xs);
         --amplify-components-card-elevated-border-width: 0;
@@ -456,7 +457,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-sliderfield-thumb-width: 1.25rem;
         --amplify-components-sliderfield-thumb-height: 1.25rem;
         --amplify-components-sliderfield-thumb-background-color: var(--amplify-colors-background-primary);
-        --amplify-components-sliderfield-thumb-box-shadow: var(--amplify-shadows-medium);
+        --amplify-components-sliderfield-thumb-box-shadow: var(--amplify-shadows-small);
         --amplify-components-sliderfield-thumb-border-radius: 50%;
         --amplify-components-sliderfield-thumb-border-width: var(--amplify-border-widths-small);
         --amplify-components-sliderfield-thumb-border-color: var(--amplify-colors-border-primary);
@@ -477,9 +478,9 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-stepperfield-input-text-align: center;
         --amplify-components-switchfield-disabled-opacity: var(--amplify-opacities-60);
         --amplify-components-switchfield-focused-shadow: var(--amplify-shadows-small);
-        --amplify-components-switchfield-label-padding: var(--amplify-space-xs);
         --amplify-components-switchfield-large-font-size: var(--amplify-font-sizes-large);
         --amplify-components-switchfield-small-font-size: var(--amplify-font-sizes-small);
+        --amplify-components-switchfield-label-padding: var(--amplify-space-xs);
         --amplify-components-switchfield-thumb-background-color: var(--amplify-colors-background-primary);
         --amplify-components-switchfield-thumb-border-color: var(--amplify-colors-border-tertiary);
         --amplify-components-switchfield-thumb-border-radius: var(--amplify-radii-xxxl);
@@ -581,7 +582,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-togglebutton-disabled-background-color: var(--amplify-colors-transparent);
         --amplify-components-togglebutton-disabled-border-color: var(--amplify-colors-border-secondary);
         --amplify-components-togglebutton-disabled-color: var(--amplify-colors-font-disabled);
-        --amplify-components-togglebutton-pressed-color: var(--amplify-colors-overlay-90);
+        --amplify-components-togglebutton-pressed-color: var(--amplify-colors-font-primary);
         --amplify-components-togglebutton-pressed-background-color: var(--amplify-colors-overlay-20);
         --amplify-components-togglebutton-pressed-hover-background-color: var(--amplify-colors-overlay-30);
         --amplify-components-togglebutton-primary-background-color: var(--amplify-colors-transparent);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -197,6 +197,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-card-outlined-border-width: var(--amplify-border-widths-small);
         --amplify-components-card-outlined-border-style: solid;
         --amplify-components-card-outlined-border-color: var(--amplify-colors-border-primary);
+        --amplify-components-card-outlined-box-shadow: var(--amplify-components-card-box-shadow);
         --amplify-components-card-elevated-background-color: var(--amplify-components-card-background-color);
         --amplify-components-card-elevated-border-radius: var(--amplify-radii-xs);
         --amplify-components-card-elevated-border-width: 0;
@@ -506,7 +507,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-sliderfield-thumb-width: 1.25rem;
         --amplify-components-sliderfield-thumb-height: 1.25rem;
         --amplify-components-sliderfield-thumb-background-color: var(--amplify-colors-background-primary);
-        --amplify-components-sliderfield-thumb-box-shadow: var(--amplify-shadows-medium);
+        --amplify-components-sliderfield-thumb-box-shadow: var(--amplify-shadows-small);
         --amplify-components-sliderfield-thumb-border-radius: 50%;
         --amplify-components-sliderfield-thumb-border-width: var(--amplify-border-widths-small);
         --amplify-components-sliderfield-thumb-border-color: var(--amplify-colors-border-primary);
@@ -527,9 +528,9 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-stepperfield-input-text-align: center;
         --amplify-components-switchfield-disabled-opacity: var(--amplify-opacities-60);
         --amplify-components-switchfield-focused-shadow: var(--amplify-shadows-small);
-        --amplify-components-switchfield-label-padding: var(--amplify-space-xs);
         --amplify-components-switchfield-large-font-size: var(--amplify-font-sizes-large);
         --amplify-components-switchfield-small-font-size: var(--amplify-font-sizes-small);
+        --amplify-components-switchfield-label-padding: var(--amplify-space-xs);
         --amplify-components-switchfield-thumb-background-color: var(--amplify-colors-background-primary);
         --amplify-components-switchfield-thumb-border-color: var(--amplify-colors-border-tertiary);
         --amplify-components-switchfield-thumb-border-radius: var(--amplify-radii-xxxl);
@@ -631,7 +632,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-togglebutton-disabled-background-color: var(--amplify-colors-transparent);
         --amplify-components-togglebutton-disabled-border-color: var(--amplify-colors-border-secondary);
         --amplify-components-togglebutton-disabled-color: var(--amplify-colors-font-disabled);
-        --amplify-components-togglebutton-pressed-color: var(--amplify-colors-overlay-90);
+        --amplify-components-togglebutton-pressed-color: var(--amplify-colors-font-primary);
         --amplify-components-togglebutton-pressed-background-color: var(--amplify-colors-overlay-20);
         --amplify-components-togglebutton-pressed-hover-background-color: var(--amplify-colors-overlay-30);
         --amplify-components-togglebutton-primary-background-color: var(--amplify-colors-transparent);

--- a/packages/ui/src/theme/tokens/components/card.js
+++ b/packages/ui/src/theme/tokens/components/card.js
@@ -13,6 +13,7 @@ module.exports = {
     borderWidth: { value: '{borderWidths.small.value}' },
     borderStyle: { value: 'solid' },
     borderColor: { value: '{colors.border.primary.value}' },
+    boxShadow: { value: '{components.card.boxShadow.value}' },
   },
 
   elevated: {

--- a/packages/ui/src/theme/tokens/components/sliderField.js
+++ b/packages/ui/src/theme/tokens/components/sliderField.js
@@ -23,7 +23,7 @@ module.exports = {
     width: { value: '1.25rem' },
     height: { value: '1.25rem' },
     backgroundColor: { value: '{colors.background.primary.value}' },
-    boxShadow: { value: '{shadows.medium.value}' },
+    boxShadow: { value: '{shadows.small.value}' },
     borderRadius: { value: '50%' },
     borderWidth: { value: '{borderWidths.small.value}' },
     borderColor: { value: '{colors.border.primary.value}' },

--- a/packages/ui/src/theme/tokens/components/switchField.js
+++ b/packages/ui/src/theme/tokens/components/switchField.js
@@ -1,23 +1,25 @@
 module.exports = {
+  // States
   disabled: {
     opacity: { value: '{opacities.60.value}' },
   },
   focused: {
     shadow: { value: '{shadows.small.value}' },
   },
+
+  // Sizes
+  large: {
+    fontSize: { value: '{fontSizes.large.value}' },
+  },
+  small: {
+    fontSize: { value: '{fontSizes.small.value}' },
+  },
+
+  // Child elements
   label: {
     padding: { value: '{space.xs.value}' },
   },
-  large: {
-    font: {
-      size: { value: '{fontSizes.large.value}' },
-    },
-  },
-  small: {
-    font: {
-      size: { value: '{fontSizes.small.value}' },
-    },
-  },
+
   thumb: {
     backgroundColor: { value: '{colors.background.primary.value}' },
     borderColor: { value: '{colors.border.tertiary.value}' },
@@ -30,6 +32,7 @@ module.exports = {
     },
     width: { value: '{space.relative.medium.value}' },
   },
+
   track: {
     backgroundColor: { value: '{colors.background.tertiary.value}' },
     borderRadius: { value: '{radii.xxxl.value}' },

--- a/packages/ui/src/theme/tokens/components/toggleButton.js
+++ b/packages/ui/src/theme/tokens/components/toggleButton.js
@@ -17,7 +17,7 @@ module.exports = {
     color: { value: '{colors.font.disabled.value}' },
   },
   _pressed: {
-    color: { value: '{colors.overlay.90.value}' },
+    color: { value: '{colors.font.primary.value}' },
     backgroundColor: { value: '{colors.overlay.20.value}' },
     _hover: {
       backgroundColor: { value: '{colors.overlay.30.value}' },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Removed default theme overrides in the docs site so the primitives match exactly what we show in the docs. 
* Fixed a few tokens in the default theme
* Fixed the theme switcher on the docs homepage

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

| before | after |
| ----- | ----- |
| ![CleanShot 2022-02-14 at 22 50 52](https://user-images.githubusercontent.com/321279/154009432-73deaf44-35c1-46bd-8e4c-d7191d984f47.gif) | ![CleanShot 2022-02-14 at 22 50 19](https://user-images.githubusercontent.com/321279/154009452-563b2846-70a2-4ca7-b295-e9b35baab9c0.gif) |


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
