### PR TITLE
Turn on Building for VueCLI

### DIFF
--- a/.github/workflows/run-builds.yml
+++ b/.github/workflows/run-builds.yml
@@ -17,7 +17,7 @@ jobs:
           - react/cra-ts
           - react/next
           - vue/vite
-          # - vue/vuecli
+          - vue/vuecli
     steps:
       - name: Checkout Amplify UI
         uses: actions/checkout@v2


### PR DESCRIPTION
#### Description of changes

We temporarily turned off the building of Vue CLI. This was a downstream issue with babel and is now fixed. https://github.com/vuejs/vue-cli/issues/6994


#### Description of how you validated changes
Ran manually

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
