### PR TITLE
Update Canaries to run 24 hrs / day

### DIFF
--- a/.github/workflows/run-builds.yml
+++ b/.github/workflows/run-builds.yml
@@ -2,7 +2,7 @@ name: Run Builds
 
 on:
   schedule:
-    - cron: '*/7 17-23,0-4 * * *' # Run every 7 minutes, from 9am to 8pm Pacific Time
+    - cron: '*/7 * * * *' # Run every 7 minutes
 
 jobs:
   build:


### PR DESCRIPTION
Update Canaries to run 24 hrs / day

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
