### PR TITLE
Allow Content-less TabItem

### DIFF
--- a/.changeset/famous-tigers-visit.md
+++ b/.changeset/famous-tigers-visit.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Allow Content-less TabItem

--- a/packages/react/src/primitives/Tabs/Tabs.tsx
+++ b/packages/react/src/primitives/Tabs/Tabs.tsx
@@ -17,8 +17,7 @@ const isTabsType = (child: any): child is React.Component<TabItemProps> => {
     child !== null &&
     typeof child === 'object' &&
     child.hasOwnProperty('props') &&
-    child.props.title != null &&
-    child.props.children != null
+    child.props.title != null
   );
 };
 
@@ -38,6 +37,12 @@ const TabsPrimitive: Primitive<TabsProps, typeof Flex> = (
 ) => {
   const tabs = React.Children.map(children, (child) => {
     if (child === null) return {};
+
+    // checking if the child is a whitespace character
+    if (typeof child === 'string' && /\s/.test(child)) {
+      return {};
+    }
+
     if (!isTabsType(child)) {
       console.warn(
         'Amplify UI: <Tabs> component only accepts <TabItem> as children.'

--- a/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
@@ -68,11 +68,10 @@ describe('Tabs: ', () => {
     expect(console.warn).not.toHaveBeenCalledWith(warningMessage);
   });
 
-  it('should log a warning for children not matching the tabItem structure', async () => {
+  it('should log a warning for children not matching the TabItem structure', async () => {
     const invalidChildren = [
       123,
       'test',
-      <div title="someTitle"></div>,
       <div>
         <span></span>
       </div>,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR allows the `<TabItem />` primitive to not have `children`, giving customers more flexibility. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/1282

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Created a sample `<Tabs />` example with no `children` in the `<TabItems />`, then confirmed that there were no `console.warning`'s getting thrown. 

Also caught a tiny bug with newline characters causing the `console.warning`: `'Amplify UI: <Tabs> component only accepts <TabItem> as children.'` This is because React considers newline characters (`\n`) to be children. I added a conditional to ignore whitespace characters as children.  

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
