### PR TITLE
Set default prettier configs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 .next
 .husky
 .changeset
+dist
+.d.ts

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,21 @@
 {
-  "trailingComma": "es5",
+  "arrowParens": "always",
+  "bracketSameLine": false,
+  "bracketSpacing": true,
+  "cursorOffset": -1,
+  "embeddedLanguageFormatting": "auto",
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxSingleQuote": false,
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
   "singleQuote": true,
-  "arrowParens": "always"
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "vueIndentScriptAndStyle": false
 }

--- a/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
@@ -6,32 +6,30 @@ import { ComponentClassNames } from '../shared/constants';
 import { CountryCodeSelectProps, Primitive } from '../types';
 import { SelectField } from '../SelectField';
 
-const CountryCodeSelectPrimitive: Primitive<
-  CountryCodeSelectProps,
-  'select'
-> = ({ className, ...props }, ref) => {
-  const countryCodeOptions = React.useMemo(
-    () =>
-      countryDialCodes.map((dialCode) => (
-        <option key={dialCode} value={dialCode}>
-          {dialCode}
-        </option>
-      )),
-    []
-  );
+const CountryCodeSelectPrimitive: Primitive<CountryCodeSelectProps, 'select'> =
+  ({ className, ...props }, ref) => {
+    const countryCodeOptions = React.useMemo(
+      () =>
+        countryDialCodes.map((dialCode) => (
+          <option key={dialCode} value={dialCode}>
+            {dialCode}
+          </option>
+        )),
+      []
+    );
 
-  return (
-    <SelectField
-      autoComplete="tel-country-code"
-      className={classNames(ComponentClassNames.CountryCodeSelect, className)}
-      labelHidden={true}
-      ref={ref}
-      {...props}
-    >
-      {countryCodeOptions}
-    </SelectField>
-  );
-};
+    return (
+      <SelectField
+        autoComplete="tel-country-code"
+        className={classNames(ComponentClassNames.CountryCodeSelect, className)}
+        labelHidden={true}
+        ref={ref}
+        {...props}
+      >
+        {countryCodeOptions}
+      </SelectField>
+    );
+  };
 
 export const CountryCodeSelect = React.forwardRef(CountryCodeSelectPrimitive);
 

--- a/packages/ui/src/i18n/dictionaries/authenticator/de.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/de.ts
@@ -16,7 +16,7 @@ export const deDict = {
   'Confirmation Code': 'Bestätigungs-Code',
   'Create a new account': 'Einen neuen Account erstellen',
   'Create account': 'Hier registrieren',
-  'Create Account': 'Account erstellen',  
+  'Create Account': 'Account erstellen',
   'Creating Account': 'Account wird erstellt',
   Email: 'Email',
   'Enter your code': 'Geben Sie Ihren Code ein',

--- a/packages/ui/src/i18n/dictionaries/authenticator/en.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/en.ts
@@ -1,5 +1,5 @@
 export const enDict = {
-  'Account recovery requires verified contact information': 
+  'Account recovery requires verified contact information':
     'Account recovery requires verified contact information',
   'Back to Sign In': 'Back to Sign In',
   'Change Password': 'Change Password',

--- a/packages/ui/src/i18n/dictionaries/authenticator/it.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/it.ts
@@ -1,15 +1,15 @@
 export const itDict = {
   'Account recovery requires verified contact information':
-    'Il ripristino dell\'account richiede informazioni di contatto verificate',
+    "Il ripristino dell'account richiede informazioni di contatto verificate",
   'An account with the given email already exists.':
-    'Questa email è già utilizzata da un\'altro account.',
+    "Questa email è già utilizzata da un'altro account.",
   'Back to Sign In': 'Torna alla schermata di accesso',
   'Change Password': 'Cambia la password',
   Code: 'Codice',
   Confirm: 'Conferma',
   'Confirm a Code': 'Conferma un codice',
   'Confirm Password': 'Conferma la password',
-  'Confirm Sign In': 'Conferma l\'accesso',
+  'Confirm Sign In': "Conferma l'accesso",
   'Confirm Sign Up': 'Conferma registrazione',
   'Confirmation Code': 'Codice di verifica',
   'Create a new account': 'Crea un nuovo account',
@@ -23,8 +23,7 @@ export const itDict = {
   'Have an account? ': 'Già registrato?',
   'Incorrect username or password': 'Nome utente o password errati',
   'Invalid password format': 'Formato della password non valido',
-  'Invalid phone number format':
-    'Formato del numero di telefono non valido',
+  'Invalid phone number format': 'Formato del numero di telefono non valido',
   'Lost your code?': 'Codice smarrito?',
   'New Password': 'Nuova password',
   or: 'o',

--- a/packages/vue/src/types/index.ts
+++ b/packages/vue/src/types/index.ts
@@ -54,6 +54,5 @@ export type InterpretService = Interpreter<
   }
 >;
 
-export const InterpretServiceInjectionKeyTypes: InjectionKey<InterpretService> = Symbol(
-  'interpret.service'
-);
+export const InterpretServiceInjectionKeyTypes: InjectionKey<InterpretService> =
+  Symbol('interpret.service');


### PR DESCRIPTION
#### Description of changes

This PR adds all the available prettier config keys with their default values. This is to attempt to ensure that we always run prettier with the same settings.

This following the recommendation here: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode#configuration

>  It is recommended that you always include a prettier configuration file in your project specifying all settings for your project

After that I ran prettier on all files and it only had a few changes, which I've added to this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
