### PR TITLE
Add `options` prop to <SelectField>

### DIFF
--- a/.changeset/silent-queens-guess.md
+++ b/.changeset/silent-queens-guess.md
@@ -1,0 +1,6 @@
+---
+"docs": patch
+"@aws-amplify/ui-react": patch
+---
+
+Add `options` prop to <SelectField>

--- a/.changeset/silent-queens-guess.md
+++ b/.changeset/silent-queens-guess.md
@@ -1,5 +1,5 @@
 ---
-"@aws-amplify/ui-react": patch
+"@aws-amplify/ui-react": minor
 ---
 
 Add `options` prop to <SelectField>

--- a/.github/workflows/run-builds.yml
+++ b/.github/workflows/run-builds.yml
@@ -17,7 +17,7 @@ jobs:
           - react/cra-ts
           - react/next
           - vue/vite
-          # - vue/vuecli
+          - vue/vuecli
     steps:
       - name: Checkout Amplify UI
         uses: actions/checkout@v2

--- a/docs/src/pages/components/selectfield/examples/SelectFieldOptionsExample.tsx
+++ b/docs/src/pages/components/selectfield/examples/SelectFieldOptionsExample.tsx
@@ -1,0 +1,22 @@
+import { SelectField, Flex } from '@aws-amplify/ui-react';
+
+export const SelectFieldOptionsExample = () => (
+  <Flex direction="column">
+    <SelectField
+      label="Animals"
+      options={['lions', 'tigers', 'bears']}
+    ></SelectField>
+
+    <SelectField label="This is the same as the example above">
+      <option value="lions" label="lions">
+        lions
+      </option>
+      <option value="tigers" label="tigers">
+        tigers
+      </option>
+      <option value="bears" label="bears">
+        bears
+      </option>
+    </SelectField>
+  </Flex>
+);

--- a/docs/src/pages/components/selectfield/examples/index.ts
+++ b/docs/src/pages/components/selectfield/examples/index.ts
@@ -7,3 +7,4 @@ export { SelectFieldIconExample } from './SelectFieldIconExample';
 export { SelectFieldDisabledStateExample } from './SelectFieldDisabledStateExample';
 export { SelectFieldValidationErrorExample } from './SelectFieldValidationErrorExample';
 export { SelectFieldControlledExample } from './SelectFieldControlledExample';
+export { SelectFieldOptionsExample } from './SelectFieldOptionsExample';

--- a/docs/src/pages/components/selectfield/react.mdx
+++ b/docs/src/pages/components/selectfield/react.mdx
@@ -58,7 +58,7 @@ To manually control the SelectField state, you can use the `value` and `onChange
 
 ### Options
 
-To create a simple SelectField in which each `<option>` has matching `value`, `label` and `children`, pass a `string[]` to the `options` prop.
+Create a simple `SelectField` by passing a list to the `options` prop.
 
 <Example>
   <SelectFieldOptionsExample />

--- a/docs/src/pages/components/selectfield/react.mdx
+++ b/docs/src/pages/components/selectfield/react.mdx
@@ -13,6 +13,7 @@ import {
   SelectFieldDisabledStateExample,
   SelectFieldValidationErrorExample,
   SelectFieldControlledExample,
+  SelectFieldOptionsExample,
 } from './examples';
 
 ## Demo
@@ -49,6 +50,22 @@ To manually control the SelectField state, you can use the `value` and `onChange
   <ExampleCode>
 
 ```jsx file=./examples/SelectFieldControlledExample.tsx
+
+```
+
+  </ExampleCode>
+</Example>
+
+### Options
+
+To create a simple SelectField in which each `<option>` has matching `value`, `label` and `children`, pass a `string[]` to the `options` prop.
+
+<Example>
+  <SelectFieldOptionsExample />
+  
+  <ExampleCode>
+
+```jsx file=./examples/SelectFieldOptionsExample.tsx
 
 ```
 

--- a/packages/react/src/primitives/SelectField/SelectField.tsx
+++ b/packages/react/src/primitives/SelectField/SelectField.tsx
@@ -10,6 +10,27 @@ import { SelectFieldProps, Primitive } from '../types';
 import { splitPrimitiveProps } from '../shared/styleUtils';
 import { useStableId } from '../shared/utils';
 
+const selectFieldChildren = (
+  children?: React.ReactNode,
+  options?: string[]
+) => {
+  if (options?.length) {
+    if (children) {
+      console.warn(
+        'Amplify UI: <SelectField> component defaults to rendering children over `options`. When using the `options` prop, do not also pass children.'
+      );
+    } else {
+      return options.map((option, index) => (
+        <option label={option} value={option} key={index}>
+          {option}
+        </option>
+      ));
+    }
+  }
+
+  return children;
+};
+
 const SelectFieldPrimitive: Primitive<SelectFieldProps, 'select'> = (
   props,
   ref
@@ -23,6 +44,7 @@ const SelectFieldPrimitive: Primitive<SelectFieldProps, 'select'> = (
     id,
     label,
     labelHidden = false,
+    options,
     size,
     testId,
     ..._rest
@@ -62,7 +84,7 @@ const SelectFieldPrimitive: Primitive<SelectFieldProps, 'select'> = (
         size={size}
         {...rest}
       >
-        {children}
+        {selectFieldChildren(children, options)}
       </Select>
       <FieldErrorMessage hasError={hasError} errorMessage={errorMessage} />
     </Flex>

--- a/packages/react/src/primitives/SelectField/SelectField.tsx
+++ b/packages/react/src/primitives/SelectField/SelectField.tsx
@@ -10,25 +10,29 @@ import { SelectFieldProps, Primitive } from '../types';
 import { splitPrimitiveProps } from '../shared/styleUtils';
 import { useStableId } from '../shared/utils';
 
-const selectFieldChildren = (
-  children?: React.ReactNode,
-  options?: string[]
-) => {
-  if (options?.length) {
-    if (children) {
+interface SelectFieldChildrenProps {
+  children?: React.ReactNode;
+  options?: SelectFieldProps['options'];
+}
+
+const selectFieldChildren = ({
+  children,
+  options,
+}: SelectFieldChildrenProps) => {
+  if (children) {
+    if (options?.length) {
       console.warn(
-        'Amplify UI: <SelectField> component defaults to rendering children over `options`. When using the `options` prop, do not also pass children.'
+        'Amplify UI: <SelectField> component  defaults to rendering children over `options`. When using the `options` prop, omit children.'
       );
-    } else {
-      return options.map((option, index) => (
-        <option label={option} value={option} key={index}>
-          {option}
-        </option>
-      ));
     }
+    return children;
   }
 
-  return children;
+  return options?.map((option, index) => (
+    <option label={option} value={option} key={`${option}-${index}`}>
+      {option}
+    </option>
+  ));
 };
 
 const SelectFieldPrimitive: Primitive<SelectFieldProps, 'select'> = (
@@ -84,7 +88,7 @@ const SelectFieldPrimitive: Primitive<SelectFieldProps, 'select'> = (
         size={size}
         {...rest}
       >
-        {selectFieldChildren(children, options)}
+        {selectFieldChildren({ children, options })}
       </Select>
       <FieldErrorMessage hasError={hasError} errorMessage={errorMessage} />
     </Flex>

--- a/packages/react/src/primitives/SelectField/__tests__/SelectField.test.tsx
+++ b/packages/react/src/primitives/SelectField/__tests__/SelectField.test.tsx
@@ -286,5 +286,24 @@ describe('SelectField test suite', () => {
         expect(option.innerHTML).toBe(optionString);
       });
     });
+
+    it('logs a warning to the console if the customer passes both children and options', async () => {
+      const warningMessage =
+        'Amplify UI: <SelectField> component  defaults to rendering children over `options`. When using the `options` prop, omit children.';
+      const spy = jest.spyOn(console, 'warn');
+
+      const optionStrings = ['lions', 'tigers', 'bears'];
+      render(
+        <SelectField label={label} options={optionStrings}>
+          <option value="lions">lions</option>
+          <option value="tigers">tigers</option>
+          <option value="bears">bears</option>
+        </SelectField>
+      );
+
+      expect(console.warn).toHaveBeenCalledWith(warningMessage);
+
+      spy.mockClear();
+    });
   });
 });

--- a/packages/react/src/primitives/SelectField/__tests__/SelectField.test.tsx
+++ b/packages/react/src/primitives/SelectField/__tests__/SelectField.test.tsx
@@ -269,4 +269,22 @@ describe('SelectField test suite', () => {
       expect(errorText.innerHTML).toContain(errorMessage);
     });
   });
+
+  describe('Options', () => {
+    it('correctly maps the options prop to corresponding option tags with matching value, label and children', async () => {
+      const optionStrings = ['lions', 'tigers', 'bears'];
+
+      render(<SelectField label={label} options={optionStrings}></SelectField>);
+
+      const selectFieldOptions = await screen.findAllByRole('option');
+      expect(selectFieldOptions.length).toBe(optionStrings.length);
+
+      selectFieldOptions.forEach((option, index) => {
+        const optionString = optionStrings[index];
+        expect(option).toHaveAttribute('value', optionString);
+        expect(option).toHaveAttribute('label', optionString);
+        expect(option.innerHTML).toBe(optionString);
+      });
+    });
+  });
 });

--- a/packages/react/src/primitives/SelectField/__tests__/SelectField.test.tsx
+++ b/packages/react/src/primitives/SelectField/__tests__/SelectField.test.tsx
@@ -290,7 +290,8 @@ describe('SelectField test suite', () => {
     it('logs a warning to the console if the customer passes both children and options', async () => {
       const warningMessage =
         'Amplify UI: <SelectField> component  defaults to rendering children over `options`. When using the `options` prop, omit children.';
-      const spy = jest.spyOn(console, 'warn');
+      const originalWarn = console.warn;
+      console.warn = jest.fn();
 
       const optionStrings = ['lions', 'tigers', 'bears'];
       render(
@@ -303,7 +304,7 @@ describe('SelectField test suite', () => {
 
       expect(console.warn).toHaveBeenCalledWith(warningMessage);
 
-      spy.mockClear();
+      console.warn = originalWarn;
     });
   });
 });

--- a/packages/react/src/primitives/types/selectField.ts
+++ b/packages/react/src/primitives/types/selectField.ts
@@ -7,7 +7,7 @@ export interface SelectFieldProps
     FlexContainerStyleProps,
     SelectProps {
   /**
-   * Accepts an array of strings which maps to the value, label and children of each option tag in the SelectField
+   * List of option values for select dropdown
    */
   options?: string[];
 }

--- a/packages/react/src/primitives/types/selectField.ts
+++ b/packages/react/src/primitives/types/selectField.ts
@@ -5,4 +5,9 @@ import { FieldProps } from './field';
 export interface SelectFieldProps
   extends FieldProps,
     FlexContainerStyleProps,
-    SelectProps {}
+    SelectProps {
+  /**
+   * Accepts an array of strings which maps to the value, label and children of each option tag in the SelectField
+   */
+  options?: string[];
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

The added `options` prop accepts an array of strings which maps to the value, label and children of each `<option>` in a SelectField. 

If there are children and an `options` prop is set, then the children will win but there will be a warning in the console. 

This requirement will help Amplify Studio's Codegen team create a SelectField easier, plus it has a nice DX if the customer just wants a simple SelectField. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Added a test and confirmed that a new `options` example in the docs works correctly. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are updated
- [X] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
