### PR TITLE
chore: updating all React imports from default to namespace

### DIFF
--- a/.changeset/afraid-days-poke.md
+++ b/.changeset/afraid-days-poke.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+chore: updating all React imports from default to namespace

--- a/canary/react/cra-ts/src/App.test.tsx
+++ b/canary/react/cra-ts/src/App.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
+
 import App from './App';
 
 test('renders learn react link', () => {

--- a/canary/react/cra-ts/src/index.tsx
+++ b/canary/react/cra-ts/src/index.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
+
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';

--- a/canary/react/cra/src/index.js
+++ b/canary/react/cra/src/index.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
+
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';

--- a/docs/src/components/DemoBox.tsx
+++ b/docs/src/components/DemoBox.tsx
@@ -4,7 +4,7 @@ import {
   IconKeyboardArrowUp,
 } from '@aws-amplify/ui-react';
 import classNames from 'classnames';
-import React from 'react';
+import * as React from 'react';
 
 interface DemoBoxProps {
   primitiveName: string;

--- a/docs/src/components/Feature.tsx
+++ b/docs/src/components/Feature.tsx
@@ -12,7 +12,6 @@ import {
 } from '@heroicons/react/solid';
 import { useRouter } from 'next/router';
 import * as React from 'react';
-import { useEffect } from 'react';
 import * as runtime from 'react/jsx-runtime';
 import remarkGfm from 'remark-gfm';
 import { evaluateSync } from 'xdm';
@@ -61,7 +60,7 @@ export function Feature({ name = required('Missing feature name') }) {
 
   const port = getPortForPlatform(platform);
 
-  useEffect(() => {
+  React.useEffect(() => {
     import(`../../../packages/e2e/features${pathname}/${name}.feature`).then(
       (exports) => setSource(exports.default)
     );

--- a/docs/src/components/FieldLabeler.tsx
+++ b/docs/src/components/FieldLabeler.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export const FieldLabeler: React.FC<{
   alignItems?: string;

--- a/docs/src/components/LinkPropControls.tsx
+++ b/docs/src/components/LinkPropControls.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import * as React from 'react';
 import { LinkProps, BaseStyleProps } from '@aws-amplify/ui-react';
+
 import { FieldLabeler } from './FieldLabeler';
 import { DemoBox } from './DemoBox';
 

--- a/docs/src/components/RadioGroupFieldPropControls.tsx
+++ b/docs/src/components/RadioGroupFieldPropControls.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import * as React from 'react';
 import { RadioGroupFieldProps, SelectField } from '@aws-amplify/ui-react';
+
 import { FieldLabeler } from './FieldLabeler';
 import { DemoBox } from './DemoBox';
 

--- a/docs/src/components/TableOfContents.tsx
+++ b/docs/src/components/TableOfContents.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react';
+import * as React from 'react';
 import debounce from 'lodash/debounce';
 import { Text, ScrollView } from '@aws-amplify/ui-react';
 
 export const TableOfContents = ({ title, headings }) => {
-  const [activeHeading, setActiveHeading] = useState(-1);
+  const [activeHeading, setActiveHeading] = React.useState(-1);
 
   let offsets = [...headings].map((heading) => {
     return heading.top;
@@ -23,7 +23,7 @@ export const TableOfContents = ({ title, headings }) => {
     setActiveHeading(index);
   });
 
-  useEffect(() => {
+  React.useEffect(() => {
     // if the URL has a hash, set the active heading
     // so the right ToC link is active on page load
     if (document.location.hash) {
@@ -36,7 +36,7 @@ export const TableOfContents = ({ title, headings }) => {
     return function cleanup() {
       document.removeEventListener('scroll', scrollHandler);
     };
-  }, [headings]);
+  }, [headings, scrollHandler]);
 
   return (
     <aside className="docs-toc" id="toc">

--- a/docs/src/components/TabsPropControls.tsx
+++ b/docs/src/components/TabsPropControls.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import * as React from 'react';
 import { TabsProps } from '@aws-amplify/ui-react';
+
 import { FieldLabeler } from './FieldLabeler';
 import { DemoBox } from './DemoBox';
 

--- a/docs/src/components/ToggleButtonPropControls.tsx
+++ b/docs/src/components/ToggleButtonPropControls.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-
+import * as React from 'react';
 import {
   CheckboxField,
   ToggleButtonProps,
   SelectField,
 } from '@aws-amplify/ui-react';
-import { FieldLabeler } from './FieldLabeler';
+
 import { DemoBox } from './DemoBox';
 
 export interface ToggleButtonPropControlsProps extends ToggleButtonProps {

--- a/docs/src/components/useGridContainerProps.tsx
+++ b/docs/src/components/useGridContainerProps.tsx
@@ -1,5 +1,5 @@
 import { GridContainerStyleProps } from '@aws-amplify/ui-react';
-import { useState } from 'react';
+import * as React from 'react';
 
 import { GridContainerPropControlsProps } from './GridContainerPropControls';
 
@@ -8,22 +8,28 @@ interface UseGridContainerProps {
 }
 
 export const useGridContainerProps: UseGridContainerProps = (initialValues) => {
-  const [autoColumns, setAutoColumns] = useState(initialValues.autoColumns);
-  const [autoFlow, setAutoFlow] = useState(initialValues.autoFlow);
-  const [autoRows, setAutoRows] = useState(initialValues.autoRows);
-  const [columnGap, setColumnGap] = useState(initialValues.columnGap);
-  const [gap, setGap] = useState(initialValues.gap);
-  const [rowGap, setRowGap] = useState(initialValues.rowGap);
-  const [templateAreas, setTemplateAreas] = useState(
+  const [autoColumns, setAutoColumns] = React.useState(
+    initialValues.autoColumns
+  );
+  const [autoFlow, setAutoFlow] = React.useState(initialValues.autoFlow);
+  const [autoRows, setAutoRows] = React.useState(initialValues.autoRows);
+  const [columnGap, setColumnGap] = React.useState(initialValues.columnGap);
+  const [gap, setGap] = React.useState(initialValues.gap);
+  const [rowGap, setRowGap] = React.useState(initialValues.rowGap);
+  const [templateAreas, setTemplateAreas] = React.useState(
     initialValues.templateAreas
   );
-  const [templateColumns, setTemplateColumns] = useState(
+  const [templateColumns, setTemplateColumns] = React.useState(
     initialValues.templateColumns
   );
-  const [templateRows, setTemplateRows] = useState(initialValues.templateRows);
-  const [alignItems, setAlignItems] = useState(initialValues.alignItems);
-  const [alignContent, setAlignContent] = useState(initialValues.alignContent);
-  const [justifyContent, setJustifyContent] = useState(
+  const [templateRows, setTemplateRows] = React.useState(
+    initialValues.templateRows
+  );
+  const [alignItems, setAlignItems] = React.useState(initialValues.alignItems);
+  const [alignContent, setAlignContent] = React.useState(
+    initialValues.alignContent
+  );
+  const [justifyContent, setJustifyContent] = React.useState(
     initialValues.justifyContent
   );
 

--- a/docs/src/components/useGridItemProps.tsx
+++ b/docs/src/components/useGridItemProps.tsx
@@ -1,5 +1,6 @@
 import { GridItemStyleProps } from '@aws-amplify/ui-react';
-import { useState } from 'react';
+import * as React from 'react';
+
 import { GridItemPropControlsProps } from './GridItemPropControls';
 
 interface UseGridItemProps {
@@ -7,15 +8,17 @@ interface UseGridItemProps {
 }
 
 export const useGridItemProps: UseGridItemProps = (initialValues) => {
-  const [area, setArea] = useState(initialValues.area);
-  const [column, setColumn] = useState(initialValues.column);
-  const [columnEnd, setColumnEnd] = useState(initialValues.columnEnd);
-  const [columnSpan, setColumnSpan] = useState(initialValues.columnSpan);
-  const [columnStart, setColumnStart] = useState(initialValues.columnStart);
-  const [row, setRow] = useState(initialValues.row);
-  const [rowEnd, setRowEnd] = useState(initialValues.rowEnd);
-  const [rowSpan, setRowSpan] = useState(initialValues.rowSpan);
-  const [rowStart, setRowStart] = useState(initialValues.rowStart);
+  const [area, setArea] = React.useState(initialValues.area);
+  const [column, setColumn] = React.useState(initialValues.column);
+  const [columnEnd, setColumnEnd] = React.useState(initialValues.columnEnd);
+  const [columnSpan, setColumnSpan] = React.useState(initialValues.columnSpan);
+  const [columnStart, setColumnStart] = React.useState(
+    initialValues.columnStart
+  );
+  const [row, setRow] = React.useState(initialValues.row);
+  const [rowEnd, setRowEnd] = React.useState(initialValues.rowEnd);
+  const [rowSpan, setRowSpan] = React.useState(initialValues.rowSpan);
+  const [rowStart, setRowStart] = React.useState(initialValues.rowStart);
 
   return {
     area,

--- a/docs/src/components/useLinkProps.tsx
+++ b/docs/src/components/useLinkProps.tsx
@@ -1,5 +1,6 @@
 import { LinkProps } from '@aws-amplify/ui-react';
-import { useState } from 'react';
+import * as React from 'react';
+
 import { LinkPropControlsProps } from './LinkPropControls';
 
 interface UseLinkProps {
@@ -7,11 +8,13 @@ interface UseLinkProps {
 }
 
 export const useLinkProps: UseLinkProps = (initialValues) => {
-  const [isExternal, setIsExternal] = useState<LinkProps['isExternal']>(
+  const [isExternal, setIsExternal] = React.useState<LinkProps['isExternal']>(
     initialValues.isExternal
   );
-  const [color, setColor] = useState<LinkProps['color']>(initialValues.color);
-  const [textDecoration, setTextDecoration] = useState<
+  const [color, setColor] = React.useState<LinkProps['color']>(
+    initialValues.color
+  );
+  const [textDecoration, setTextDecoration] = React.useState<
     LinkProps['textDecoration']
   >(initialValues.textDecoration);
 

--- a/docs/src/components/useMenuProps.tsx
+++ b/docs/src/components/useMenuProps.tsx
@@ -1,5 +1,6 @@
 import { MenuProps } from '@aws-amplify/ui-react';
-import { useState } from 'react';
+import * as React from 'react';
+
 import { MenuPropControlsProps } from './MenuPropControls';
 
 interface UseMenuProps {
@@ -7,10 +8,10 @@ interface UseMenuProps {
 }
 
 export const useMenuProps: UseMenuProps = (initialValues) => {
-  const [menuAlign, setMenuAlign] = useState<MenuProps['menuAlign']>(
+  const [menuAlign, setMenuAlign] = React.useState<MenuProps['menuAlign']>(
     initialValues.align
   );
-  const [size, setSize] = useState<MenuProps['size']>(initialValues.size);
+  const [size, setSize] = React.useState<MenuProps['size']>(initialValues.size);
 
   return {
     ...initialValues,

--- a/docs/src/components/useRadioGroupFieldProps.tsx
+++ b/docs/src/components/useRadioGroupFieldProps.tsx
@@ -1,5 +1,5 @@
 import { RadioGroupFieldProps } from '@aws-amplify/ui-react';
-import { useState } from 'react';
+import * as React from 'react';
 
 import { RadioGroupFieldPropControlsProps } from './RadioGroupFieldPropControls';
 
@@ -10,19 +10,19 @@ interface UseRadioGroupFieldProps {
 export const useRadioGroupFieldProps: UseRadioGroupFieldProps = (
   initialValues
 ) => {
-  const [direction, setDirection] = useState<RadioGroupFieldProps['direction']>(
-    initialValues.direction
-  );
-  const [isDisabled, setIsDisabled] = useState<
+  const [direction, setDirection] = React.useState<
+    RadioGroupFieldProps['direction']
+  >(initialValues.direction);
+  const [isDisabled, setIsDisabled] = React.useState<
     RadioGroupFieldProps['isDisabled']
   >(initialValues.isDisabled);
-  const [label, setLabel] = useState<RadioGroupFieldProps['label']>(
+  const [label, setLabel] = React.useState<RadioGroupFieldProps['label']>(
     initialValues.label
   );
-  const [name, setName] = useState<RadioGroupFieldProps['name']>(
+  const [name, setName] = React.useState<RadioGroupFieldProps['name']>(
     initialValues.name
   );
-  const [size, setSize] = useState<RadioGroupFieldProps['size']>(
+  const [size, setSize] = React.useState<RadioGroupFieldProps['size']>(
     initialValues.size
   );
 

--- a/docs/src/components/useTableProps.tsx
+++ b/docs/src/components/useTableProps.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import * as React from 'react';
 
 import { TableProps } from '@aws-amplify/ui-react';
 
@@ -9,17 +9,19 @@ interface UseTableProps {
 }
 
 export const useTableProps: UseTableProps = (initialValues) => {
-  const [caption, setCaption] = useState<TableProps['caption']>(
+  const [caption, setCaption] = React.useState<TableProps['caption']>(
     initialValues.caption
   );
 
-  const [highlightOnHover, setHighlightOnHover] = useState<
+  const [highlightOnHover, setHighlightOnHover] = React.useState<
     TableProps['highlightOnHover']
   >(initialValues.highlightOnHover);
 
-  const [size, setSize] = useState<TableProps['size']>(initialValues.size);
+  const [size, setSize] = React.useState<TableProps['size']>(
+    initialValues.size
+  );
 
-  const [variation, setVariation] = useState<TableProps['variation']>(
+  const [variation, setVariation] = React.useState<TableProps['variation']>(
     initialValues.variation
   );
 

--- a/docs/src/components/useTabsProps.tsx
+++ b/docs/src/components/useTabsProps.tsx
@@ -1,5 +1,6 @@
-import { TabsProps, TabItem, Button } from '@aws-amplify/ui-react';
-import { useState } from 'react';
+import { TabsProps } from '@aws-amplify/ui-react';
+import * as React from 'react';
+
 import { TabsPropControlsProps } from './TabsPropControls';
 
 interface UseTabsProps {
@@ -7,16 +8,16 @@ interface UseTabsProps {
 }
 
 export const useTabsProps: UseTabsProps = (initialValues) => {
-  const [currentIndex, setCurrentIndex] = useState<TabsProps['currentIndex']>(
-    initialValues.currentIndex
-  );
-  const [spacing, setSpacing] = useState<TabsProps['spacing']>(
+  const [currentIndex, setCurrentIndex] = React.useState<
+    TabsProps['currentIndex']
+  >(initialValues.currentIndex);
+  const [spacing, setSpacing] = React.useState<TabsProps['spacing']>(
     initialValues.spacing
   );
-  const [justifyContent, setJustifyContent] = useState<
+  const [justifyContent, setJustifyContent] = React.useState<
     TabsProps['justifyContent']
   >(initialValues.justifyContent);
-  const [indicatorPosition, setIndicatorPosition] = useState<
+  const [indicatorPosition, setIndicatorPosition] = React.useState<
     TabsProps['indicatorPosition']
   >(initialValues.indicatorPosition);
   const children = initialValues.children;

--- a/docs/src/components/useToggleButtonProps.ts
+++ b/docs/src/components/useToggleButtonProps.ts
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-
+import * as React from 'react';
 import { ToggleButtonProps } from '@aws-amplify/ui-react';
 
 import { ToggleButtonPropControlsProps } from './ToggleButtonPropControls';
@@ -9,15 +8,15 @@ interface UseToggleButtonProps {
 }
 
 export const useToggleButtonProps: UseToggleButtonProps = (initialValues) => {
-  const [isDisabled, setIsDisabled] = useState<ToggleButtonProps['isDisabled']>(
-    initialValues.isDisabled
-  );
-  const [size, setSize] = useState<ToggleButtonProps['size']>(
+  const [isDisabled, setIsDisabled] = React.useState<
+    ToggleButtonProps['isDisabled']
+  >(initialValues.isDisabled);
+  const [size, setSize] = React.useState<ToggleButtonProps['size']>(
     initialValues.size
   );
-  const [variation, setVariation] = useState<ToggleButtonProps['variation']>(
-    initialValues.variation
-  );
+  const [variation, setVariation] = React.useState<
+    ToggleButtonProps['variation']
+  >(initialValues.variation);
 
   return {
     isDisabled,

--- a/docs/src/pages/components/badge/BadgePropControls.tsx
+++ b/docs/src/pages/components/badge/BadgePropControls.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   BadgeProps,
   SelectField,

--- a/docs/src/pages/components/badge/useBadgeProps.tsx
+++ b/docs/src/pages/components/badge/useBadgeProps.tsx
@@ -1,5 +1,6 @@
 import { BadgeProps } from '@aws-amplify/ui-react';
-import { useState } from 'react';
+import * as React from 'react';
+
 import { BadgePropControlsProps } from './BadgePropControls';
 
 interface UseBadgeProps {
@@ -7,11 +8,13 @@ interface UseBadgeProps {
 }
 
 export const useBadgeProps: UseBadgeProps = (initialValues) => {
-  const [variation, setVariation] = useState<BadgeProps['variation']>(
+  const [variation, setVariation] = React.useState<BadgeProps['variation']>(
     initialValues.variation
   );
-  const [size, setSize] = useState<BadgeProps['size']>(initialValues.size);
-  const [body, setBody] = useState<string>(initialValues.body);
+  const [size, setSize] = React.useState<BadgeProps['size']>(
+    initialValues.size
+  );
+  const [body, setBody] = React.useState<string>(initialValues.body);
 
   return {
     variation,

--- a/docs/src/pages/components/chatbot/usage.react.mdx
+++ b/docs/src/pages/components/chatbot/usage.react.mdx
@@ -1,5 +1,5 @@
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import Amplify from 'aws-amplify';
 import { AmplifyChatbot } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';

--- a/docs/src/pages/components/collection/demo.tsx
+++ b/docs/src/pages/components/collection/demo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   Card,
   Text,

--- a/docs/src/pages/components/divider/useDividerProps.tsx
+++ b/docs/src/pages/components/divider/useDividerProps.tsx
@@ -1,5 +1,6 @@
 import { DividerOptions } from '@aws-amplify/ui-react';
-import { useState } from 'react';
+import * as React from 'react';
+
 import { DividerPropControlsProps } from './DividerPropControls';
 
 interface UseDividerProps {
@@ -7,10 +8,12 @@ interface UseDividerProps {
 }
 
 export const useDividerProps: UseDividerProps = (initialValues) => {
-  const [size, setSize] = useState<DividerOptions['size']>(initialValues.size);
-  const [orientation, setOrientation] = useState<DividerOptions['orientation']>(
-    initialValues.orientation
+  const [size, setSize] = React.useState<DividerOptions['size']>(
+    initialValues.size
   );
+  const [orientation, setOrientation] = React.useState<
+    DividerOptions['orientation']
+  >(initialValues.orientation);
 
   return {
     size,

--- a/docs/src/pages/components/link/demo.tsx
+++ b/docs/src/pages/components/link/demo.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import * as React from 'react';
 import { Link, Text, View } from '@aws-amplify/ui-react';
+
 import { LinkPropControls } from '@/components/LinkPropControls';
 import { useLinkProps } from '@/components/useLinkProps';
 import { Example } from '@/components/Example';

--- a/docs/src/pages/components/radiogroupfield/demo.tsx
+++ b/docs/src/pages/components/radiogroupfield/demo.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-
+import * as React from 'react';
 import { Radio, RadioGroupField, View } from '@aws-amplify/ui-react';
 
 import { RadioGroupFieldPropControls } from '@/components/RadioGroupFieldPropControls';
@@ -24,7 +23,7 @@ export const Demo = () => {
 };
 
 export const ControlledRadioGroupField = () => {
-  const [value, setValue] = useState('html');
+  const [value, setValue] = React.useState('html');
   return (
     <RadioGroupField
       label="Language"

--- a/docs/src/pages/components/radiogroupfield/react.mdx
+++ b/docs/src/pages/components/radiogroupfield/react.mdx
@@ -41,11 +41,11 @@ import '@aws-amplify/ui-react/styles.css';
 ### Controlled component
 
 ```jsx
-import { useState } from 'react';
+import * as React from 'react';
 import { RadioGroupField, Radio } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
-const [value, setValue] = useState('html');
+const [value, setValue] = React.useState('html');
 
 <RadioGroupField
   label="Language"

--- a/docs/src/pages/components/selectfield/useSelectFieldProps.tsx
+++ b/docs/src/pages/components/selectfield/useSelectFieldProps.tsx
@@ -1,5 +1,6 @@
 import { SelectFieldProps } from '@aws-amplify/ui-react';
-import { useState } from 'react';
+import * as React from 'react';
+
 import { SelectFieldPropControlsProps } from './SelectFieldPropControls';
 
 interface UseSelectFieldProps {
@@ -7,30 +8,30 @@ interface UseSelectFieldProps {
 }
 
 export const useSelectFieldProps: UseSelectFieldProps = (initialValues) => {
-  const [descriptiveText, setDescriptiveText] = useState<
+  const [descriptiveText, setDescriptiveText] = React.useState<
     SelectFieldProps['descriptiveText']
   >(initialValues.descriptiveText);
-  const [errorMessage, setErrorMessage] = useState<
+  const [errorMessage, setErrorMessage] = React.useState<
     SelectFieldProps['errorMessage']
   >(initialValues.errorMessage);
-  const [hasError, setHasError] = useState<SelectFieldProps['hasError']>(
+  const [hasError, setHasError] = React.useState<SelectFieldProps['hasError']>(
     initialValues.hasError
   );
-  const [isDisabled, setIsDisabled] = useState<SelectFieldProps['isDisabled']>(
-    initialValues.isDisabled
-  );
-  const [label, setLabel] = useState<SelectFieldProps['label']>(
+  const [isDisabled, setIsDisabled] = React.useState<
+    SelectFieldProps['isDisabled']
+  >(initialValues.isDisabled);
+  const [label, setLabel] = React.useState<SelectFieldProps['label']>(
     initialValues.label
   );
-  const [labelHidden, setLabelHidden] = useState<
+  const [labelHidden, setLabelHidden] = React.useState<
     SelectFieldProps['labelHidden']
   >(initialValues.labelHidden);
-  const [size, setSize] = useState<SelectFieldProps['size']>(
+  const [size, setSize] = React.useState<SelectFieldProps['size']>(
     initialValues.size
   );
-  const [variation, setVariation] = useState<SelectFieldProps['variation']>(
-    initialValues.variation
-  );
+  const [variation, setVariation] = React.useState<
+    SelectFieldProps['variation']
+  >(initialValues.variation);
 
   return {
     descriptiveText,

--- a/docs/src/pages/components/shared/useFlexContainerStyleProps.tsx
+++ b/docs/src/pages/components/shared/useFlexContainerStyleProps.tsx
@@ -1,5 +1,6 @@
 import { FlexContainerStyleProps } from '@aws-amplify/ui-react';
-import { useState } from 'react';
+import * as React from 'react';
+
 import { FieldControl } from './GetFieldControls';
 
 interface UseFlexContainerStyleProps {
@@ -11,30 +12,36 @@ export const useFlexContainerStyleProps: UseFlexContainerStyleProps = (
 ) => {
   return [
     [
-      ...useState<FlexContainerStyleProps['alignItems']>(
+      ...React.useState<FlexContainerStyleProps['alignItems']>(
         initialValues.alignItems
       ),
       'alignItems',
     ],
     [
-      ...useState<FlexContainerStyleProps['alignContent']>(
+      ...React.useState<FlexContainerStyleProps['alignContent']>(
         initialValues.alignContent
       ),
       'alignContent',
     ],
     [
-      ...useState<FlexContainerStyleProps['direction']>(
+      ...React.useState<FlexContainerStyleProps['direction']>(
         initialValues.direction
       ),
       'direction',
     ],
-    [...useState<FlexContainerStyleProps['gap']>(initialValues.gap), 'gap'],
     [
-      ...useState<FlexContainerStyleProps['justifyContent']>(
+      ...React.useState<FlexContainerStyleProps['gap']>(initialValues.gap),
+      'gap',
+    ],
+    [
+      ...React.useState<FlexContainerStyleProps['justifyContent']>(
         initialValues.justifyContent
       ),
       'justifyContent',
     ],
-    [...useState<FlexContainerStyleProps['wrap']>(initialValues.wrap), 'wrap'],
+    [
+      ...React.useState<FlexContainerStyleProps['wrap']>(initialValues.wrap),
+      'wrap',
+    ],
   ];
 };

--- a/docs/src/pages/components/storage/s3album/usage.react.mdx
+++ b/docs/src/pages/components/storage/s3album/usage.react.mdx
@@ -1,5 +1,5 @@
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import Amplify from 'aws-amplify';
 import { AmplifyS3Album } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';

--- a/docs/src/pages/components/storage/s3image/usage.react.mdx
+++ b/docs/src/pages/components/storage/s3image/usage.react.mdx
@@ -1,5 +1,5 @@
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import Amplify from 'aws-amplify';
 import { AmplifyS3Image } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';

--- a/docs/src/pages/components/storage/s3imagepicker/usage.react.mdx
+++ b/docs/src/pages/components/storage/s3imagepicker/usage.react.mdx
@@ -1,5 +1,5 @@
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import Amplify from 'aws-amplify';
 import { AmplifyS3ImagePicker } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';

--- a/docs/src/pages/components/storage/s3text/usage.react.mdx
+++ b/docs/src/pages/components/storage/s3text/usage.react.mdx
@@ -1,5 +1,5 @@
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import Amplify from 'aws-amplify';
 import { AmplifyS3Text } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';

--- a/docs/src/pages/components/storage/s3textpicker/usage.react.mdx
+++ b/docs/src/pages/components/storage/s3textpicker/usage.react.mdx
@@ -1,5 +1,5 @@
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import Amplify from 'aws-amplify';
 import { AmplifyS3TextPicker } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';

--- a/docs/src/pages/components/tabs/demo.tsx
+++ b/docs/src/pages/components/tabs/demo.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { Tabs, TabItem, Flex, Button, Text, View } from '@aws-amplify/ui-react';
+import * as React from 'react';
+import { Tabs, TabItem, Flex, Button, View } from '@aws-amplify/ui-react';
+
 import { TabsPropControls } from '@/components/TabsPropControls';
 import { useTabsProps } from '@/components/useTabsProps';
 import { Example } from '@/components/Example';

--- a/docs/src/pages/components/text/demo.tsx
+++ b/docs/src/pages/components/text/demo.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import * as React from 'react';
 import { Text, useTheme } from '@aws-amplify/ui-react';
+
 import { Example } from '@/components/Example';
 
 export const TextDemo = ({ children }) => {

--- a/docs/src/pages/components/togglebutton/react.mdx
+++ b/docs/src/pages/components/togglebutton/react.mdx
@@ -131,12 +131,12 @@ You can group related Toggle buttons easily with a `ToggleButtonGroup` out of bo
 _Exclusive Selection_
 
 ```jsx
-import { useState } from 'react';
+import * as React from 'react';
 import { ToggleButton, ToggleButtonGroup } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
 const ExclusiveSelectionGroup = () => {
-  const [exclusiveValue, setExclusiveValue] = useState('align-left');
+  const [exclusiveValue, setExclusiveValue] = React.useState('align-left');
   return (
     <ToggleButtonGroup
       value={exclusiveValue}
@@ -167,12 +167,12 @@ const ExclusiveSelectionGroup = () => {
 _Multiple Selection_
 
 ```jsx
-import { useState } from 'react';
+import * as React from 'react';
 import { ToggleButton, ToggleButtonGroup } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
 const MultipleSelectionGroup = () => {
-  const [multipleValue, setMultipleValue] = useState(['bold']);
+  const [multipleValue, setMultipleValue] = React.useState(['bold']);
   return (
     <ToggleButtonGroup
       value={multipleValue}

--- a/docs/src/pages/components/view/demo.tsx
+++ b/docs/src/pages/components/view/demo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { View, ViewProps } from '@aws-amplify/ui-react';
 
 const FieldSet: React.FC<{

--- a/docs/src/pages/theming/alternative-styling/index.page.mdx
+++ b/docs/src/pages/theming/alternative-styling/index.page.mdx
@@ -17,7 +17,7 @@ There are many CSS In JS libraries out there that give a number of benefits. Amp
 #### Usage
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import styled from 'styled-components';
 import { View } from '@aws-amplify/ui-react';
 
@@ -41,7 +41,7 @@ There are various ways to customize an Amplify component and Styled Components w
 These are styling props that can be used directly on an Amplify component which will affect a single style property. Examples of styling props are `color` or `fontWeight`. These Amplify styling props will take precedence over Styled Component styling.
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import styled from 'styled-components';
 import { View } from '@aws-amplify/ui-react';
 
@@ -59,7 +59,7 @@ In the example above, the color of the view will be set to `red` because of the 
 These props change the look and/or behavior of certain Amplify components. Examples include `size` and `variation`.
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import styled from "styled-components";
 import { Button } from '@aws-amplify/ui-react';
 
@@ -77,7 +77,7 @@ In the example above, the color of the button will be set to `white`, because th
 These are custom classnames added onto Amplify components and can be used with CSS styling rules to modify the look of an Amplify component.
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import styled from 'styled-components';
 import { View } from '@aws-amplify/ui-react';
 
@@ -102,7 +102,7 @@ In the example above, the color of the view will be `blue` because the styled co
 Amplify theming provides many CSS variables to customize the look and feel of the entire application. These CSS variables can be used with the `:root` CSS psuedo-class to override all instances of component styling.
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import styled from 'styled-components';
 import { Button } from '@aws-amplify/ui-react';
 
@@ -130,7 +130,7 @@ In the example above, the button color will be set to `blue` because the Styled 
 #### Usage
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import { createUseStyles } from 'react-jss';
 import { View } from '@aws-amplify/ui-react';
 
@@ -155,7 +155,7 @@ There are various ways to customize an Amplify component and JSS will interact w
 These are styling props that can be used directly on an Amplify component which will affect a single style property. Examples of styling props are `color` or `fontWeight`. These Amplify styling props will take precedence over JSS styling.
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import { createUseStyles } from 'react-jss';
 import { View } from '@aws-amplify/ui-react';
 
@@ -179,7 +179,7 @@ In the example above, the color of the view will be set to `red` because of the 
 These props change the look and/or behavior of certain Amplify components. Examples include `size` and `variation`.
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import { createUseStyles } from 'react-jss';
 import { Button } from '@aws-amplify/ui-react';
 
@@ -203,7 +203,7 @@ In the example above, the color of the button will be set to `white`, because th
 These are custom classnames added onto Amplify components and can be used with CSS styling rules to modify the look of an Amplify component.
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import { createUseStyles } from 'react-jss';
 import { View } from '@aws-amplify/ui-react';
 
@@ -233,7 +233,7 @@ In the example above, the color of the text will be `blue` because the JSS styli
 Amplify theming provides many CSS variables to customize the look and feel of the entire application. These CSS variables can be used at a root level to override all instances of component styling.
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import { createUseStyles } from 'react-jss';
 import { Button } from '@aws-amplify/ui-react';
 

--- a/examples/next/pages/examples/listings/App.tsx
+++ b/examples/next/pages/examples/listings/App.tsx
@@ -7,7 +7,7 @@ import {
   IconTonality,
   ColorMode,
 } from '@aws-amplify/ui-react';
-import { useState } from 'react';
+import * as React from 'react';
 
 import { theme } from '../../../theme';
 import { Logo } from './Logo';
@@ -16,7 +16,7 @@ import '@aws-amplify/ui-react/styles.css';
 import './styles.scss';
 
 export const App = ({ children }) => {
-  const [colorMode, setColorMode] = useState<ColorMode>('system');
+  const [colorMode, setColorMode] = React.useState<ColorMode>('system');
   return (
     <AmplifyProvider theme={theme} colorMode={colorMode}>
       <header className="listing-app-header">

--- a/examples/next/pages/ui/hooks/actions/index.page.tsx
+++ b/examples/next/pages/ui/hooks/actions/index.page.tsx
@@ -1,20 +1,20 @@
 import { Amplify, Hub } from 'aws-amplify';
 import { Authenticator } from '@aws-amplify/ui-react';
+import * as React from 'react';
 import '@aws-amplify/ui-react/styles.css';
 
 import { NavigateActions } from './NavigateActions';
 import { AuthSignOutButton } from './AuthActions';
-
 import awsExports from './aws-exports';
-import { useEffect } from 'react';
 import { DataStoreTodoForm } from './DataStoreActions';
+
 Amplify.configure({
   ...awsExports,
   aws_appsync_graphqlEndpoint: 'https://fake-appsync-endpoint/graphql',
 });
 
 export default function App() {
-  useEffect(() => {
+  React.useEffect(() => {
     (window as any).LOG_LEVEL = 'DEBUG';
     Hub.listen('ui', (data) => {
       console.log(data);

--- a/packages/react/_templates/primitives/new/component.t
+++ b/packages/react/_templates/primitives/new/component.t
@@ -1,7 +1,7 @@
 ---
 to: src/primitives/<%= name %>/<%= name %>.tsx
 ---
-import React from 'react';
+import * as React from 'react';
 import { <%= name %>Props } from "../types";
 
 export const <%= name %>: React.FC<<%= name %>Props> = ({ children }) => {

--- a/packages/react/src/components/Authenticator/Authenticator.tsx
+++ b/packages/react/src/components/Authenticator/Authenticator.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from 'react';
+import * as React from 'react';
 import { AuthenticatorMachineOptions } from '@aws-amplify/ui';
+
 import { Provider, useAuthenticator } from './hooks/useAuthenticator';
 import { ResetPassword } from './ResetPassword';
 import { Router, RouterProps } from './Router';
@@ -43,7 +44,7 @@ export function Authenticator({
   // Helper component that sends init event to the parent provider
   function InitMachine({ children, ...machineProps }) {
     const { _send, route } = useAuthenticator();
-    useEffect(() => {
+    React.useEffect(() => {
       if (route === 'idle') {
         _send({
           type: 'INIT',

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -1,11 +1,11 @@
+import QRCode from 'qrcode';
+import * as React from 'react';
+
 import { Auth, Logger } from 'aws-amplify';
 import { getActorState, SignInState, translate } from '@aws-amplify/ui';
 
-import QRCode from 'qrcode';
-import { useEffect, useState } from 'react';
-
 import { useAuthenticator } from '..';
-import { Flex, Heading, Image } from '../../..';
+import { Flex, Heading } from '../../..';
 import { isInputOrSelectElement, isInputElement } from '../../../helpers/utils';
 
 import {
@@ -17,10 +17,10 @@ import {
 const logger = new Logger('SetupTOTP-logger');
 
 export const SetupTOTP = (): JSX.Element => {
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [qrCode, setQrCode] = useState<string>();
-  const [copyTextLabel, setCopyTextLabel] = useState<string>('COPY');
-  const [secretKey, setSecretKey] = useState<string>('');
+  const [isLoading, setIsLoading] = React.useState<boolean>(true);
+  const [qrCode, setQrCode] = React.useState<string>();
+  const [copyTextLabel, setCopyTextLabel] = React.useState<string>('COPY');
+  const [secretKey, setSecretKey] = React.useState<string>('');
   const { _state, submitForm, updateForm, isPending } = useAuthenticator();
 
   // `user` hasn't been set on the top-level state yet, so it's only available from the signIn actor
@@ -43,7 +43,7 @@ export const SetupTOTP = (): JSX.Element => {
     }
   };
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (!user) return;
 
     generateQRCode(user);

--- a/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   createAuthenticatorMachine,
   getServiceFacade,
@@ -11,6 +11,7 @@ import {
 } from '@aws-amplify/ui';
 import { useSelector, useInterpret } from '@xstate/react';
 import isEmpty from 'lodash/isEmpty';
+
 import { areArraysEqual } from '../../../../helpers';
 
 export type AuthenticatorContextValue = {

--- a/packages/react/src/components/Authenticator/hooks/useCustomComponents/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useCustomComponents/index.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import * as React from 'react';
+
 import { PartialDeep } from 'src/types';
 import { defaultComponents } from './defaultComponents';
 

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
+import * as React from 'react';
+
 import Auth, { CognitoUser } from '@aws-amplify/auth';
 import { Hub } from '@aws-amplify/core';
-import { useEffect, useState } from 'react';
 
 // Exposes relevant CognitoUser properties
 interface AuthUser extends CognitoUser {
@@ -20,7 +21,7 @@ export interface UseAuthResult {
  * @internal
  */
 export const useAuth = (): UseAuthResult => {
-  const [result, setResult] = useState<UseAuthResult>({
+  const [result, setResult] = React.useState<UseAuthResult>({
     error: undefined,
     isLoading: true,
     user: undefined,
@@ -51,7 +52,7 @@ export const useAuth = (): UseAuthResult => {
     return () => Hub.remove('auth', handleAuth);
   };
 
-  useEffect(fetch, []);
+  React.useEffect(fetch, []);
 
   return { ...result, fetch };
 };

--- a/packages/react/src/hooks/useDataStore.tsx
+++ b/packages/react/src/hooks/useDataStore.tsx
@@ -1,5 +1,7 @@
+import * as React from 'react';
+
 import { DataStore, PersistentModel } from '@aws-amplify/datastore';
-import { useEffect, useState } from 'react';
+
 import {
   DataStoreBindingProps,
   DataStoreCollectionProps,
@@ -17,7 +19,7 @@ export const useDataStoreCollection = <M extends PersistentModel>({
   criteria,
   pagination,
 }: DataStoreCollectionProps<M>): DataStoreCollectionResult<M> => {
-  const [result, setResult] = useState<DataStoreCollectionResult<M>>({
+  const [result, setResult] = React.useState<DataStoreCollectionResult<M>>({
     items: [],
     isLoading: false,
     error: undefined,
@@ -42,7 +44,7 @@ export const useDataStoreCollection = <M extends PersistentModel>({
   };
 
   // Fetch on next render cycle
-  useEffect(fetch, []);
+  React.useEffect(fetch, [criteria, model, pagination]);
 
   return result;
 };
@@ -55,9 +57,9 @@ export const useDataStoreItem = <M extends PersistentModel>({
   model,
   id,
 }: DataStoreItemProps<M>): DataStoreItemResult<M> => {
-  const [item, setItem] = useState<M>();
-  const [isLoading, setLoading] = useState<boolean>(false);
-  const [error, setError] = useState<Error>();
+  const [item, setItem] = React.useState<M>();
+  const [isLoading, setLoading] = React.useState<boolean>(false);
+  const [error, setError] = React.useState<Error>();
 
   const fetch = () => {
     setLoading(true);
@@ -69,7 +71,7 @@ export const useDataStoreItem = <M extends PersistentModel>({
   };
 
   // Fetch on next render cycle
-  useEffect(fetch, []);
+  React.useEffect(fetch, [id, model]);
 
   return {
     error,

--- a/packages/react/src/hooks/useStorageURL.ts
+++ b/packages/react/src/hooks/useStorageURL.ts
@@ -1,5 +1,6 @@
+import * as React from 'react';
+
 import { S3ProviderGetConfig, Storage } from '@aws-amplify/storage';
-import { useEffect, useState } from 'react';
 
 export interface UseStorageURLResult {
   url?: string;
@@ -12,7 +13,7 @@ export interface UseStorageURLResult {
  * @internal
  */
 export const useStorageURL = (key: string, options?: S3ProviderGetConfig) => {
-  const [result, setResult] = useState<UseStorageURLResult>({
+  const [result, setResult] = React.useState<UseStorageURLResult>({
     isLoading: true,
   });
 
@@ -34,7 +35,7 @@ export const useStorageURL = (key: string, options?: S3ProviderGetConfig) => {
     return () => Storage.cancel(promise);
   };
 
-  useEffect(fetch, [key, serializedOptions]);
+  React.useEffect(fetch, [key, options, serializedOptions]);
 
   return { ...result, fetch };
 };

--- a/packages/react/src/primitives/Collection/Collection.tsx
+++ b/packages/react/src/primitives/Collection/Collection.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import debounce from 'lodash/debounce';
-import { useCallback, useState } from 'react';
+import * as React from 'react';
+
 import { Flex } from '../Flex';
 import { Grid } from '../Grid';
 import { Pagination, usePagination } from '../Pagination';
@@ -49,12 +50,13 @@ export const Collection = <Item,>({
   testId,
   ...rest
 }: CollectionProps<Item>): JSX.Element => {
-  const [searchText, setSearchText] = useState<string>();
+  const [searchText, setSearchText] = React.useState<string>();
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const onSearch = useCallback(debounce(setSearchText, TYPEAHEAD_DELAY_MS), [
-    setSearchText,
-  ]);
+  const onSearch = React.useCallback(
+    debounce(setSearchText, TYPEAHEAD_DELAY_MS),
+    [setSearchText]
+  );
 
   // Make sure that items are iterable
   items = Array.isArray(items) ? items : [];

--- a/packages/react/src/primitives/Pagination/usePagination.ts
+++ b/packages/react/src/primitives/Pagination/usePagination.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import * as React from 'react';
 
 import { UsePaginationProps, UsePaginationResult } from '../types/pagination';
 
@@ -13,24 +13,24 @@ export const usePagination = (
   siblingCount = Math.max(siblingCount, 1);
   // The total pages should be always greater than current page
   totalPages = Math.max(initialPage, totalPages);
-  const [currentPage, setCurrentPage] = useState(initialPage);
+  const [currentPage, setCurrentPage] = React.useState(initialPage);
 
   // Reset current page if initialPage or totalPages changes
-  useEffect(() => setCurrentPage(initialPage), [initialPage, totalPages]);
+  React.useEffect(() => setCurrentPage(initialPage), [initialPage, totalPages]);
 
-  const onNext = useCallback(() => {
+  const onNext = React.useCallback(() => {
     if (currentPage < totalPages) {
       setCurrentPage(currentPage + 1);
     }
   }, [currentPage, totalPages]);
 
-  const onPrevious = useCallback(() => {
+  const onPrevious = React.useCallback(() => {
     if (currentPage > 1) {
       setCurrentPage(currentPage - 1);
     }
   }, [currentPage]);
 
-  const onChange = useCallback((newPage: number, prevPage: number) => {
+  const onChange = React.useCallback((newPage: number, prevPage: number) => {
     setCurrentPage(newPage);
   }, []);
 

--- a/packages/react/src/primitives/Pagination/useRange.ts
+++ b/packages/react/src/primitives/Pagination/useRange.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import * as React from 'react';
 
 import { getConsecutiveIntArray } from '../shared/utils';
 
@@ -17,7 +17,7 @@ export const useRange = (
   totalPagesParam: number,
   siblingCountParam = 1
 ): (string | number)[] => {
-  const range = useMemo(() => {
+  const range = React.useMemo(() => {
     // The current page should not be less than 1
     const currentPage = Math.max(currentPageParam, 1);
     // The sibling count should not be less than 1

--- a/packages/react/src/primitives/ToggleButtonGroup/useToggleButtonGroup.tsx
+++ b/packages/react/src/primitives/ToggleButtonGroup/useToggleButtonGroup.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import * as React from 'react';
 
 import { isFunction } from '../shared/utils';
 import { ToggleButtonProps, ToggleButtonGroupProps } from '../types';
@@ -8,7 +8,7 @@ export const useToggleButtonGroup = (
   isExclusive = false
 ) => {
   // Multiple selection
-  const handleChange: ToggleButtonProps['onChange'] = useCallback(
+  const handleChange: ToggleButtonProps['onChange'] = React.useCallback(
     (buttonValue) => {
       if (!isFunction(onChange) || !Array.isArray(value)) {
         return;
@@ -33,16 +33,17 @@ export const useToggleButtonGroup = (
   );
 
   // Exclusive selection
-  const handleExclusiveChange: ToggleButtonProps['onChange'] = useCallback(
-    (buttonValue) => {
-      if (!onChange) {
-        return;
-      }
+  const handleExclusiveChange: ToggleButtonProps['onChange'] =
+    React.useCallback(
+      (buttonValue) => {
+        if (!onChange) {
+          return;
+        }
 
-      onChange(value === buttonValue ? null : buttonValue);
-    },
-    [onChange, value]
-  );
+        onChange(value === buttonValue ? null : buttonValue);
+      },
+      [onChange, value]
+    );
 
   return isExclusive ? handleExclusiveChange : handleChange;
 };

--- a/packages/react/src/primitives/types/searchField.ts
+++ b/packages/react/src/primitives/types/searchField.ts
@@ -1,4 +1,5 @@
-import React from 'react';
+import * as React from 'react';
+
 import { FieldGroupIconButtonProps } from './fieldGroupIcon';
 import { TextInputFieldProps } from './textField';
 

--- a/packages/react/src/primitives/utils/testUtils.ts
+++ b/packages/react/src/primitives/utils/testUtils.ts
@@ -1,6 +1,6 @@
-import { useMemo } from 'react';
+import * as React from 'react';
 export const useTestId = (testId: string, component: string) => {
-  const newTestId = useMemo(
+  const newTestId = React.useMemo(
     () => (testId && component ? `${testId}-${component}` : undefined),
     [testId, component]
   );


### PR DESCRIPTION
#### Description of changes

Updating all React imports from default to namespace

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
