### PR TITLE
update docs to reflect native html properties can be used with input

### DIFF
--- a/docs/src/pages/components/button/react.mdx
+++ b/docs/src/pages/components/button/react.mdx
@@ -10,7 +10,7 @@ import { IconButtonExample, ButtonThemeExample } from './examples';
 
 ## Usage
 
-Import the Button primitive and styles.
+Import the `Button` component. The `Button` component will also accept any of the native HTML properties that are accepted by a `button` tag.
 
 <Example>
   <View>
@@ -21,7 +21,6 @@ Import the Button primitive and styles.
 
 ```jsx
 import { Button } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
 
 <Button>Hello world</Button>;
 ```

--- a/docs/src/pages/components/checkboxfield/react.mdx
+++ b/docs/src/pages/components/checkboxfield/react.mdx
@@ -14,7 +14,7 @@ CheckboxField is used to mark an individual item as selected, or to select multi
 
 ## Usage
 
-Import the CheckboxField primitive.
+Import the `CheckboxField` component. The `CheckboxField` component will also accept any of the native HTML properties that are accepted by an `input` tag.
 
 ```jsx
 import { CheckboxField } from '@aws-amplify/ui-react';

--- a/docs/src/pages/components/icon/react.mdx
+++ b/docs/src/pages/components/icon/react.mdx
@@ -24,7 +24,7 @@ Icons should be thought of as plain text; they inherit the size and color of the
 
 ## Usage
 
-Import the Icon component and styles.
+Import the `Icon` component. The `Icon` component will also accept any of the native HTML properties that are accepted by an `svg` tag.
 
 <Example>
 <DefaultIconExample />

--- a/docs/src/pages/components/image/react.mdx
+++ b/docs/src/pages/components/image/react.mdx
@@ -15,6 +15,7 @@ import {
 ## Usage
 
 Import the `Image` component. Images are responsive by default (if you're on desktop, try resizing your browser window).
+The `Image` component will also accept any of the native HTML properties that are accepted by an `img` tag.
 
 <Example>
   <DefaultImageExample />

--- a/docs/src/pages/components/link/react.mdx
+++ b/docs/src/pages/components/link/react.mdx
@@ -10,6 +10,8 @@ Links are customizable and themable elements used for Navigation. By default Lin
 
 ## Usage
 
+Import the `Link` component. The `Link` component will also accept any of the native HTML properties that are accepted by a `link` tag.
+
 ```jsx
 import { Link } from '@aws-amplify/ui-react';
 

--- a/docs/src/pages/components/passwordfield/react.mdx
+++ b/docs/src/pages/components/passwordfield/react.mdx
@@ -26,11 +26,11 @@ The PasswordField primitive allows users to input passwords. It also features fu
 
 ## Usage
 
-Import the `PasswordField` component and styles and provide a `label` for accessibility/usability.
+Import the `PasswordField` component and provide a `label` for accessibility/usability.
+The `PasswordField` component will also accept any of the native HTML properties that are accepted by an `input` tag.
 
 ```jsx
 import { PasswordField } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
 
 <PasswordField label="Password" name="password" />;
 ```

--- a/docs/src/pages/components/phonenumberfield/react.mdx
+++ b/docs/src/pages/components/phonenumberfield/react.mdx
@@ -25,12 +25,12 @@ The `PhoneNumberField` form primitive can be used allow users to input a phone n
 
 ## Usage
 
-Import the `PhoneNumberField` component and styles and provide a `label` for accessibility/usability as well as a `defaultCountryCode`
+Import the `PhoneNumberField` component and provide a `label` for accessibility/usability as well as a `defaultCountryCode`
 which will auto-populate the country or region code select field.
+The `PhoneNumberField` component will also accept any of the native HTML properties that are accepted by an `input` tag.
 
 ```jsx
 import { PhoneNumberField } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
 
 <PhoneNumberField defaultCountryCode="+1" label="Phone Number" />;
 ```

--- a/docs/src/pages/components/searchfield/react.mdx
+++ b/docs/src/pages/components/searchfield/react.mdx
@@ -21,7 +21,8 @@ clear button. When users hit `Enter` key or click the search icon, the `onSubmit
 
 ## Usage
 
-Import the `SearchField` primitive, and provide a `label` for accessibility/usability.
+Import the `SearchField` component, and provide a `label` for accessibility/usability.
+The `SearchField` component will also accept any of the native HTML properties that are accepted by an `input` tag.
 
 <Example>
   <View>

--- a/docs/src/pages/components/selectfield/react.mdx
+++ b/docs/src/pages/components/selectfield/react.mdx
@@ -23,7 +23,7 @@ import {
 ## Usage
 
 Import the `SelectField` component, and provide a `label` for accessibility. The `<option>` tags nested inside the component define the available options in the drop-down list.
-The `SelectField` component will also accept any of the native HTML properties that are accepted by an `select` tag.
+The `SelectField` component will also accept any of the native HTML properties that are accepted by a `select` tag.
 
 <Example>
   <DefaultSelectFieldExample />

--- a/docs/src/pages/components/selectfield/react.mdx
+++ b/docs/src/pages/components/selectfield/react.mdx
@@ -22,7 +22,8 @@ import {
 
 ## Usage
 
-Import the SelectField primitive, and provide a `label` for accessibility. The `<option>` tags nested inside the component define the available options in the drop-down list.
+Import the `SelectField` component, and provide a `label` for accessibility. The `<option>` tags nested inside the component define the available options in the drop-down list.
+The `SelectField` component will also accept any of the native HTML properties that are accepted by an `select` tag.
 
 <Example>
   <DefaultSelectFieldExample />

--- a/docs/src/pages/components/stepperfield/react.mdx
+++ b/docs/src/pages/components/stepperfield/react.mdx
@@ -19,7 +19,8 @@ import { Fragment } from '@/components/Fragment';
 
 ## Usage
 
-Import StepperField and styles. You could edit the stepping value directly but it will be validated and rounded to a valid one when the field loses focus.
+Import the `StepperField` component. You could edit the stepping value directly but it will be validated and rounded to a valid one when the field loses focus.
+The `StepperField` component will also accept any of the native HTML properties that are accepted by an `input` tag.
 
 <Example>
   <DefaultStepperFieldExample />

--- a/docs/src/pages/components/table/react.mdx
+++ b/docs/src/pages/components/table/react.mdx
@@ -25,8 +25,9 @@ The `Table` primitive provides users with a styled and customizable table elemen
 
 ## Usage
 
-The `Table` primitive and its various components can be used similiarly to how the
+The `Table` component and its various components can be used similiarly to how the
 HTML `table`, `tbody`, `td`, `tfoot`, `th`, `thead`, and `tr` elements are used.
+The `Table` component will also accept any of the native HTML properties that are accepted by a `table` tag.
 
 ```tsx file=./examples/basicExample.tsx
 

--- a/docs/src/pages/components/textfield/react.mdx
+++ b/docs/src/pages/components/textfield/react.mdx
@@ -30,7 +30,8 @@ import { Fragment } from '@/components/Fragment';
 
 ## Usage
 
-Import the `TextField` component and styles and provide a `label` for accessibility/usability.
+Import the `TextField` component and provide a `label` for accessibility/usability.
+The `TextField` component will also accept any of the native HTML properties that are accepted by an `input` tag.
 
 <Example>
   <DefaultTextFieldExample />

--- a/docs/src/pages/components/togglebutton/react.mdx
+++ b/docs/src/pages/components/togglebutton/react.mdx
@@ -16,11 +16,10 @@ A toggle button represents an on/off state for some configuration, for example s
 
 ## Usage
 
-Import the ToggleButton primitive and styles.
+Import the `ToggleButton` component. The `ToggleButton` component will also accept any of the native HTML properties that are accepted by a `button` tag.
 
 ```jsx
 import { ToggleButton } from '@aws-amplify/ui-react';
-import '@aws-amplify/ui-react/styles.css';
 
 <ToggleButton>Press me!</ToggleButton>;
 ```


### PR DESCRIPTION
#### Description of changes

Update Documentation pages to reflect that native HTML tag properties can be used with Amplify UI components.

#### Issue #1131

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
