### PR TITLE
docs: add links to legacy v1 version

### DIFF
--- a/docs/src/pages/components/authenticator/quick-start.angular.mdx
+++ b/docs/src/pages/components/authenticator/quick-start.angular.mdx
@@ -1,3 +1,5 @@
+import { Alert } from '@aws-amplify/ui-react';
+
 For Angular,
 
 1. Register and configure Amplify inside `app.module.ts`
@@ -41,3 +43,9 @@ export class AppModule {}
   </ng-template>
 </amplify-authenticator>
 ```
+
+<Alert variation="info" heading="Angular Authenticator v1">
+  Looking for an previous version of Authenticator? Checkout the [Authenticator
+  v1
+  documentation](https://github.com/aws-amplify/amplify-ui/tree/legacy/legacy/amplify-ui-angular).
+</Alert>

--- a/docs/src/pages/components/authenticator/quick-start.angular.mdx
+++ b/docs/src/pages/components/authenticator/quick-start.angular.mdx
@@ -45,7 +45,7 @@ export class AppModule {}
 ```
 
 <Alert variation="info" heading="Angular Authenticator v1">
-  Looking for an previous version of Authenticator? Checkout the [Authenticator
+  Looking for a previous version of Authenticator? Checkout the [Authenticator
   v1
   documentation](https://github.com/aws-amplify/amplify-ui/tree/legacy/legacy/amplify-ui-angular).
 </Alert>

--- a/docs/src/pages/components/authenticator/quick-start.react.mdx
+++ b/docs/src/pages/components/authenticator/quick-start.react.mdx
@@ -23,7 +23,7 @@ The `withAuthenticator` automatically sets the [`variation`](#variation) to `mod
 </Tabs>
 
 <Alert variation="info" heading="React Authenticator v1">
-  Looking for an previous version of Authenticator? Checkout the [Authenticator
+  Looking for a previous version of Authenticator? Checkout the [Authenticator
   v1
   documentation](https://github.com/aws-amplify/amplify-ui/tree/legacy/legacy/amplify-ui-react).
 </Alert>

--- a/docs/src/pages/components/authenticator/quick-start.react.mdx
+++ b/docs/src/pages/components/authenticator/quick-start.react.mdx
@@ -1,4 +1,4 @@
-import { Tabs, TabItem } from '@aws-amplify/ui-react';
+import { Alert, Tabs, TabItem } from '@aws-amplify/ui-react';
 
 For React, you can use the `Authenticator` component directly, or wrap your app in `withAuthenticator`
 [Higher-Order Component](https://reactjs.org/docs/higher-order-components.html):
@@ -21,3 +21,9 @@ The `withAuthenticator` automatically sets the [`variation`](#variation) to `mod
 
   </TabItem>
 </Tabs>
+
+<Alert variation="info" heading="React Authenticator v1">
+  Looking for an previous version of Authenticator? Checkout the [Authenticator
+  v1
+  documentation](https://github.com/aws-amplify/amplify-ui/tree/legacy/legacy/amplify-ui-react).
+</Alert>


### PR DESCRIPTION
#### Description of changes
Adds docs link from current React and Angular Authenticator docs to the v1 docs.

React:
![Screen Shot 2022-02-18 at 1 48 03 PM](https://user-images.githubusercontent.com/6165315/154759608-49da4e91-c781-48ad-9588-4663ee4777b2.png)


Angular:
![Screen Shot 2022-02-18 at 1 48 16 PM](https://user-images.githubusercontent.com/6165315/154759590-9cf10f62-eaa0-4c46-9f24-1301b05008d9.png)




#### Issue #, if available
https://github.com/aws-amplify/amplify-ui/issues/1128

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran docs site and clicked links

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
