### PR TITLE
React test for setting default region code

### DIFF
--- a/examples/next/pages/ui/components/authenticator/default-region-code/aws-exports.js
+++ b/examples/next/pages/ui/components/authenticator/default-region-code/aws-exports.js
@@ -1,0 +1,2 @@
+import awsExports from '@environments/auth-with-phone-number/src/aws-exports';
+export default awsExports;

--- a/examples/next/pages/ui/components/authenticator/default-region-code/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/default-region-code/index.page.tsx
@@ -1,0 +1,86 @@
+import { Amplify } from 'aws-amplify';
+
+import {
+  PasswordField,
+  PhoneNumberField,
+  TextField,
+  Text,
+  useAuthenticator,
+  Authenticator,
+} from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+import awsExports from './aws-exports';
+Amplify.configure(awsExports);
+
+/**
+ * TODO: Introduce and use new API for setting default region code.
+ * For now, we're using Slots to mock default region code manually.
+ */
+const components = {
+  SignUp: {
+    FormFields() {
+      const { updateBlur, validationErrors } = useAuthenticator();
+      return (
+        <>
+          <PhoneNumberField
+            autoComplete="username"
+            countryCodeName="country_code"
+            defaultCountryCode="+44"
+            onCountryCodeChange={(e) => console.log(e.target.value)}
+            isRequired
+            label={'Phone Number'}
+            name="phone_number"
+            labelHidden={true}
+            placeholder={'Phone Number'}
+          />
+          <PasswordField
+            autoComplete="new-password"
+            data-amplify-password
+            hasError={!!validationErrors['confirm-password']}
+            isRequired
+            name="password"
+            label={'Password'}
+            labelHidden={true}
+            placeholder={'Password'}
+          />
+          <PasswordField
+            autoComplete="new-password"
+            data-amplify-confirmpassword
+            hasError={!!validationErrors['confirm-password']}
+            isRequired
+            name="confirm_password"
+            label={'Confirm Password'}
+            labelHidden={true}
+            placeholder={'Confirm Password'}
+          />
+
+          {validationErrors.confirm_password && (
+            <Text role="alert" variation="error">
+              {validationErrors.confirm_password}
+            </Text>
+          )}
+          <TextField
+            label="Email"
+            labelHidden={true}
+            name={'email'}
+            required
+            placeholder={'Email'}
+            isRequired
+            type={'email'}
+          />
+        </>
+      );
+    },
+  },
+};
+
+function App({ signOut }) {
+  return <button onClick={signOut}>Sign out</button>;
+}
+
+export default () => (
+  <Authenticator initialState="signUp" components={components}>
+    {({ signOut }) => <button onClick={signOut}>Sign out</button>}
+  </Authenticator>
+);

--- a/examples/next/pages/ui/components/authenticator/default-region-code/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/default-region-code/index.page.tsx
@@ -20,7 +20,7 @@ Amplify.configure(awsExports);
 const components = {
   SignUp: {
     FormFields() {
-      const { updateBlur, validationErrors } = useAuthenticator();
+      const { validationErrors } = useAuthenticator();
       return (
         <>
           <PhoneNumberField
@@ -75,12 +75,10 @@ const components = {
   },
 };
 
-function App({ signOut }) {
-  return <button onClick={signOut}>Sign out</button>;
+export default function App() {
+  return (
+    <Authenticator initialState="signUp" components={components}>
+      {({ signOut }) => <button onClick={signOut}>Sign out</button>}
+    </Authenticator>
+  );
 }
-
-export default () => (
-  <Authenticator initialState="signUp" components={components}>
-    {({ signOut }) => <button onClick={signOut}>Sign out</button>}
-  </Authenticator>
-);

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -51,6 +51,12 @@ Given('I verify the body has {string} included', (value: string) => {
   cy.wait('@route').its('request.body.Username').should('include', value);
 });
 
+Given('I verify the body starts with {string}', (value: string) => {
+  cy.wait('@route')
+    .its('request.body.Username')
+    .should('match', new RegExp(`^${escapeRegExp(value)}`));
+});
+
 Given(
   'I intercept {string} with error fixture {string}',
   (json: string, fixture: string) => {

--- a/packages/e2e/features/ui/components/authenticator/default-region-code.feature
+++ b/packages/e2e/features/ui/components/authenticator/default-region-code.feature
@@ -1,0 +1,18 @@
+Feature: Default Phone Number Field
+
+  WIP: Currently, you can set default region code through sign-up-form-fields slot. 
+  Eventually, we will provide an explicit API for providing default region code across
+  all forms.
+
+  Background:
+    Given I'm running the example "ui/components/authenticator/default-region-code"
+
+  @angular @react @vue  
+  Scenario: Sign up with a new email & password and lowercase the email 
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-phone"
+    And I type my "phone number" with status "UNCONFIRMED"
+    And I type my password
+    And I confirm my password
+    And I type my "email" with status "UNCONFIRMED"
+    And I click the "Create Account" button
+    Then I verify the body starts with "+44"

--- a/packages/e2e/features/ui/components/authenticator/default-region-code.feature
+++ b/packages/e2e/features/ui/components/authenticator/default-region-code.feature
@@ -7,7 +7,7 @@ Feature: Default Phone Number Field
   Background:
     Given I'm running the example "ui/components/authenticator/default-region-code"
 
-  @angular @react @vue  
+  @react
   Scenario: Sign up with a new email & password and lowercase the email 
     Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-phone"
     And I type my "phone number" with status "UNCONFIRMED"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This adds a React test for setting default region code through slots. For now, I used Slots to mock default region code manually. Eventually, we should look to introduce explicit API for setting default region code without having to region code.

I only added test for React as Vue/Angular do not have primitives to mock `PhoneNumberField` through slots. Since we'll be adding an explicit API for setting default form values, let's update the examples after then. This will at least verify the fix for #1324.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

#1324, accompanies #1366.

#### Description of how you validated changes

New e2e test!

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
