### PR TITLE
fix: add useCreateDataStorePredicate that uses hooks to prevent infinite useEffect loop

### DIFF
--- a/packages/react/src/primitives/shared/__tests__/datastore.test.ts
+++ b/packages/react/src/primitives/shared/__tests__/datastore.test.ts
@@ -1,19 +1,22 @@
+import { renderHook } from '@testing-library/react-hooks';
 import { DataStorePredicateObject } from '../../types/datastore';
-import { createDataStorePredicate } from '../datastore';
+import {
+  createDataStorePredicate,
+  useCreateDataStorePredicate,
+} from '../datastore';
 
 type Post = {
   id: string;
   name: string;
   age: string;
 };
+const namePredicateObject = {
+  field: 'name',
+  operator: 'startsWith',
+  operand: 'John',
+};
 
 describe('createDataStorePredicate', () => {
-  const namePredicateObject = {
-    field: 'name',
-    operator: 'startsWith',
-    operand: 'John',
-  };
-
   const agePredicateObject = {
     field: 'age',
     operator: 'gt',
@@ -154,6 +157,34 @@ describe('createDataStorePredicate', () => {
     expect(agePredicate).toHaveBeenCalledWith(
       agePredicateObject.operator,
       agePredicateObject.operand
+    );
+  });
+});
+
+describe('useCreateDataStorePredicate', () => {
+  test('should give same result as createDataStorePredicate', () => {
+    const namePredicate = jest.fn();
+
+    createDataStorePredicate<Post>(namePredicateObject)({
+      name: namePredicate,
+    } as any);
+
+    expect(namePredicate).toHaveBeenCalledWith(
+      namePredicateObject.operator,
+      namePredicateObject.operand
+    );
+
+    namePredicate.mockClear();
+
+    renderHook(() =>
+      useCreateDataStorePredicate<Post>(namePredicateObject)({
+        name: namePredicate,
+      } as any)
+    );
+
+    expect(namePredicate).toHaveBeenCalledWith(
+      namePredicateObject.operator,
+      namePredicateObject.operand
     );
   });
 });

--- a/packages/react/src/primitives/shared/datastore.ts
+++ b/packages/react/src/primitives/shared/datastore.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   ModelPredicate,
   PersistentModel,
@@ -53,4 +54,22 @@ export const createDataStorePredicate = <Model extends PersistentModel>(
 
     return predicate;
   };
+};
+
+/**
+ * Creates a DataStore compatible predicate function from an object representation using useCallback
+ * @internal
+ */
+export const useCreateDataStorePredicate = <Model extends PersistentModel>(
+  predicateObject: DataStorePredicateObject
+): ProducerModelPredicate<Model> => {
+  const serializedPredicateObject = JSON.stringify(predicateObject);
+
+  return React.useCallback(
+    (predicate: ModelPredicate<Model>) =>
+      createDataStorePredicate<Model>(JSON.parse(serializedPredicateObject))(
+        predicate
+      ),
+    [serializedPredicateObject]
+  );
 };


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Add `useCreateDataStorePredicate` that wraps `createDataStorePredicate` with `useCallback` so that the same function is used on each render.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Resolves #1396

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I changed all occurrences of `createDataStorePredicate` with `useCreateDataStorePredicate`.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
