### PR TITLE
Add workflow for publishing to geo tag

### DIFF
--- a/.github/changeset-presets/bump-react.md
+++ b/.github/changeset-presets/bump-react.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui': patch
+'@aws-amplify/ui-react': patch
+---
+
+Version bump for ui and ui-react packages

--- a/.github/workflows/publish-geo.yml
+++ b/.github/workflows/publish-geo.yml
@@ -47,4 +47,4 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish to geo tag
-        run: yarn changeset publish --tag next
+        run: yarn changeset publish --tag geo

--- a/.github/workflows/publish-geo.yml
+++ b/.github/workflows/publish-geo.yml
@@ -1,0 +1,50 @@
+name: Publish to @geo
+
+on:
+  workflow_run:
+    workflows: ['Tests']
+    types:
+      - completed
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: deployment
+    # We only publish if the previous workflow run (Tests) was successful
+    # and the previous workflow was called from main branch.
+    #
+    # Note that we check against workflow_run.head_branch instead of github.ref
+    # because workflow_run is always run on main, even if it's triggered from
+    # another branch.
+    #
+    # https://github.community/t/workflow-run-not-working-as-expected/139342
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      (
+        github.event.workflow_run.head_branch == 'main' ||
+        github.event.workflow_run.head_branch == 'ui-geo/main'
+      )
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+          cache: 'yarn'
+      - name: Install and build packages
+        run: yarn --frozen-lockfile && yarn build
+      - name: Bump ui and ui-react packages
+        run: cp .github/changeset-presets/bump-react.md .changeset
+      - name: Run changeset version to geo tag
+        run: yarn changeset version --snapshot geo-$(git rev-parse --short=7 HEAD) && yarn angular build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create .npmrc
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to geo tag
+        run: yarn changeset publish --tag next

--- a/.github/workflows/publish-geo.yml
+++ b/.github/workflows/publish-geo.yml
@@ -20,10 +20,7 @@ jobs:
     # https://github.community/t/workflow-run-not-working-as-expected/139342
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      (
-        github.event.workflow_run.head_branch == 'main' ||
-        github.event.workflow_run.head_branch == 'ui-geo/main'
-      )
+      github.event.workflow_run.head_branch == 'ui-geo/main'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This workflow will publish the Map components to the `@geo` npm tag. It triggers on merges to the `ui-geo/main` branch, which includes e2e tests which must pass prior publishing.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

N/A
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Publishing workflow is based upon the `.github/workflows/publish-next.yml` workflow.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes - N/A
- [x] Tests are updated - N/A
- [x] Relevant documentation is changed or added (and PR referenced) - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
