### PR TITLE
fix: fixing infinite useEffect call in useDataStore hook

### DIFF
--- a/packages/react/src/hooks/useDataStore.tsx
+++ b/packages/react/src/hooks/useDataStore.tsx
@@ -44,7 +44,7 @@ export const useDataStoreCollection = <M extends PersistentModel>({
   };
 
   // Fetch on next render cycle
-  React.useEffect(fetch, [criteria, model, pagination]);
+  React.useEffect(fetch, []);
 
   return result;
 };
@@ -71,7 +71,7 @@ export const useDataStoreItem = <M extends PersistentModel>({
   };
 
   // Fetch on next render cycle
-  React.useEffect(fetch, [id, model]);
+  React.useEffect(fetch, []);
 
   return {
     error,


### PR DESCRIPTION
#### Description of changes

Removing dependencies in `useEffect` enforced by rules of Hook to fix the infinite loop issue in `useDataStore` hook. Not sure exactly why follow the rules will break things there. Removing them to unblock studio side 

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/1396

#### Description of how you validated changes

Manual tested local with a simple app looks like the following:

```jsx
import Amplify from 'aws-amplify';
import awsexports from './aws-exports';
import { Todo } from './models';
import {
  useDataStoreBinding,
  createDataStorePredicate,
} from '@aws-amplify/ui-react/internal';

Amplify.configure(awsexports);

export default function App() {
  const todo = useDataStoreBinding({
    type: 'collection',
    model: Todo,
    criteria: createDataStorePredicate({
      field: 'name',
      operand: 'Working on E2E Tests',
      operator: 'eq',
    }),
  }).items[0];

  return <span>{todo && JSON.stringify(todo)}</span>;
}
```

Verified that the error is gone with the latest build artifacts

<img width="1142" alt="Screen Shot 2022-02-24 at 12 54 03 PM" src="https://user-images.githubusercontent.com/40295569/155605946-8f6882aa-0189-49d9-a748-a991ffd13e51.png">


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
