### PR TITLE
add script to update canary package for release step and fix the clean script

### DIFF
--- a/canary/package.json
+++ b/canary/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "test": "echo \"Future\" && exit 1",
+    "clean": "rimraf ./**/yarn.lock && rimraf ./**/node_modules",
     "build": "yarn react && yarn vue && yarn angular",
     "install": "yarn react:install && yarn vue:install && yarn angular:install",
     "react": "yarn cra && yarn cra-ts && yarn next",
@@ -25,5 +26,8 @@
     "vuecli:install": "yarn --cwd vue/vuecli install"
   },
   "author": "",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "rimraf": "^3.0.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "turbo run build --include-dependencies --no-deps --scope=*@aws-amplify/*",
-    "clean": "turbo run clean && rm -rf node_modules",
+    "clean": "turbo run clean && rimraf node_modules",
     "setup": "yarn install && yarn build",
     "refresh": "yarn clean && yarn setup",
     "angular": "yarn workspace @aws-amplify/ui-angular",
@@ -24,7 +25,10 @@
     "version:latest": "yarn changeset version && yarn angular build",
     "publish:latest": "yarn changeset publish",
     "canary:build": "yarn --cwd canary/ build",
-    "canary:install": "yarn --cwd canary/ install "
+    "canary:install": "yarn --cwd canary/ install ",
+    "canary:clean": "yarn --cwd canary clean ",
+    "canary:updatePackage": "node script/changeCanaryPackageVersion.js",
+    "release:canary": "yarn install && yarn canary:updatePackage && rm postcss.config.js && yarn canary:install && yarn canary:build"
   },
   "turbo": {
     "baseBranch": "origin/main",
@@ -67,9 +71,11 @@
   "devDependencies": {
     "@changesets/changelog-github": "0.4.1",
     "@changesets/cli": "^2.16.0",
+    "globby": "^13.1.1",
     "husky": ">=6",
     "lint-staged": ">=10",
     "prettier": "2.4.1",
+    "rimraf": "^3.0.2",
     "tsup": "^5.11.9",
     "turbo": "^1.0.23",
     "wait-on": "^6.0.0"

--- a/script/changeCanaryPackageVersion.js
+++ b/script/changeCanaryPackageVersion.js
@@ -1,0 +1,26 @@
+/*
+ * This Script change all package.json fils under canary/ .
+ * It changes `@aws-amplify/ui-{framework}` version to `next`.
+ */
+
+import { globbyStream } from 'globby';
+import fs from 'fs';
+import { pathToFileURL } from 'url';
+
+for await (const path of globbyStream('canary/**/package.json')) {
+  const pkgJSON = JSON.parse(fs.readFileSync(path));
+  const { dependencies } = pkgJSON;
+  if (dependencies) {
+    let pkgToUpdate;
+    Object.keys(dependencies)
+      .filter((dependency) => dependency.includes('@aws-amplify'))
+      .forEach((key) => {
+        dependencies[key] = 'next';
+        pkgToUpdate = key;
+      });
+    fs.writeFileSync(path, JSON.stringify(pkgJSON, null, 2) + '\n');
+    console.log(
+      `✅ Updated ${pkgToUpdate} to "next" for ${pathToFileURL(path)}`
+    );
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11619,6 +11619,17 @@ fast-glob@^3.1.1, fast-glob@^3.2.4, fast-glob@^3.2.7:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.2.11:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@2.1.0, fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -12261,6 +12272,17 @@ globby@^11.0.0, globby@^11.0.1, globby@^11.0.3, globby@^11.0.4:
     ignore "^5.1.4"
     merge2 "^1.3.0"
     slash "^3.0.0"
+
+globby@^13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.1.tgz#7c44a93869b0b7612e38f22ed532bfe37b25ea6f"
+  integrity sha512-XMzoDZbGZ37tufiv7g0N4F/zp3zkwdFtVbV3EHsVl1KQr4RPLfNoT068/97RPshz2J5xYNEjLKKBKaGHifBd3Q==
+  dependencies:
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.11"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -12955,6 +12977,11 @@ ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.9"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
   integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
+
+ignore@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 image-size@1.0.0:
   version "1.0.0"
@@ -15769,7 +15796,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0:
+merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -20273,6 +20300,11 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
+  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
 slice-ansi@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**Issue:** During the release pre-flight process, to run canary, we have to manually change the package version to `next` for each `package.json`

**Fix:** this PR adds a script to do it automatically

**Code Change**:
- add `script/changeCanaryPackageVersion.js`
- fix the `clean` script
- add `clean` script for canary/

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->


#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
