### PR TITLE
flutter authenticator: center iframe, remove border, adjust size

### DIFF
--- a/docs/flutter/authenticator/lib/main.dart
+++ b/docs/flutter/authenticator/lib/main.dart
@@ -159,17 +159,14 @@ class _FlutterAuthenticatorPreviewState
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            DeviceFrame(
-              screen: const MyApp(),
-              device: Devices.ios.iPhone13,
-            ),
-          ],
-        ),
+      home: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          DeviceFrame(
+            screen: const MyApp(),
+            device: Devices.ios.iPhone13,
+          ),
+        ],
       ),
     );
   }

--- a/docs/src/components/FlutterAuthenticatorExample.tsx
+++ b/docs/src/components/FlutterAuthenticatorExample.tsx
@@ -8,8 +8,6 @@ export function FlutterAuthenticatorExample({
   includeSocialProviders = false,
   useCustomUI = false,
   useCustomTheme = false,
-  width = '100%',
-  height = '800px',
   // id is passed to the flutter authenticator.
   // it is used by the authenticator to signal when the authenticator has finished loading.
   id = generateId(),
@@ -42,14 +40,17 @@ export function FlutterAuthenticatorExample({
         }
       </Alert>
       <FlutterAuthenticatorLoader id={id} />
-      <View
-        as="iframe"
-        key={id}
-        height={height}
-        width={width}
-        src={src}
-        loading="lazy"
-      />
+      <View width="100%" textAlign="center">
+        <View
+          as="iframe"
+          key={id}
+          height={{ base: '600px', medium: '800px' }}
+          width={{ base: '300px', medium: '400px' }}
+          src={src}
+          loading="lazy"
+          frameborder="0"
+        />
+      </View>
     </>
   );
 }
@@ -78,11 +79,9 @@ function FlutterAuthenticatorLoader({ id }) {
   return (
     <Loader
       style={{
-        bottom: '-14px',
-        padding: '0 6px',
+        padding: '0 4px',
         visibility: hasLoaded ? 'hidden' : 'visible',
       }}
-      position="relative"
       variation="linear"
       size="small"
     />


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Implement small UI changes to the authenticator example
  - Adjust the iframe size to only occupy the required space instead of 100% width
  - Center the iframe
  - Adjust the size of the iframe for smaller screens
  - Remove the iframe border

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
