### PR TITLE
fix(angular): remove unneeded parent div 

### DIFF
--- a/.changeset/clean-icons-guess.md
+++ b/.changeset/clean-icons-guess.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-angular": patch
+---
+
+Remove unneeded parent divs on Authenticator screens

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
@@ -1,4 +1,4 @@
-<div data-amplify-container>
+<ng-container>
   <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
     <fieldset
       class="amplify-flex"
@@ -60,4 +60,4 @@
     <amplify-slot name="confirm-reset-password-footer" [context]="context">
     </amplify-slot>
   </form>
-</div>
+</ng-container>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
@@ -1,63 +1,61 @@
-<ng-container>
-  <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
-    <fieldset
-      class="amplify-flex"
-      style="flex-direction: column"
-      data-amplify-fieldset
-      [disabled]="authenticator.isPending"
-    >
-      <amplify-slot name="confirm-reset-password-header" [context]="context">
-        <h3 class="amplify-heading">{{ headerText }}</h3>
-      </amplify-slot>
-      <amplify-form-field
-        name="confirmation_code"
-        type="number"
-        autocomplete="one-time-code"
-        [labelHidden]="grabField('confirmation_code', 'labelHidden', true)"
-        [placeholder]="grabField('confirmation_code', 'placeholder', null)"
-        [required]="grabField('confirmation_code', 'required', true)"
-        [label]="grabField('confirmation_code', 'label', null)"
-      ></amplify-form-field>
-      <amplify-form-field
-        name="password"
-        label="New password"
-        autocomplete="new-password"
-        [labelHidden]="grabField('password', 'labelHidden', true)"
-        [placeholder]="grabField('password', 'placeholder', null)"
-        [required]="grabField('password', 'required', true)"
-        [label]="grabField('password', 'label', 'New password')"
-      ></amplify-form-field>
-      <amplify-form-field
-        name="confirm_password"
-        type="password"
-        autocomplete="new-password"
-        [labelHidden]="grabField('confirm_password', 'labelHidden', true)"
-        [placeholder]="grabField('confirm_password', 'placeholder', null)"
-        [required]="grabField('confirm_password', 'required', true)"
-        [label]="grabField('confirm_password', 'label', 'Confirm Password')"
-      ></amplify-form-field>
-
-      <button amplify-button variation="primary" fullWidth="true" type="submit">
-        {{ sendCodeText }}
-      </button>
-
-      <button
-        amplify-button
-        size="small"
-        variation="link"
-        fontWeight="normal"
-        fullWidth="true"
-        type="button"
-        (click)="authenticator.resendCode()"
-      >
-        {{ resendCodeText }}
-      </button>
-
-      <amplify-error *ngIf="authenticator.error">
-        {{ authenticator.error }}
-      </amplify-error>
-    </fieldset>
-    <amplify-slot name="confirm-reset-password-footer" [context]="context">
+<form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
+  <fieldset
+    class="amplify-flex"
+    style="flex-direction: column"
+    data-amplify-fieldset
+    [disabled]="authenticator.isPending"
+  >
+    <amplify-slot name="confirm-reset-password-header" [context]="context">
+      <h3 class="amplify-heading">{{ headerText }}</h3>
     </amplify-slot>
-  </form>
-</ng-container>
+    <amplify-form-field
+      name="confirmation_code"
+      type="number"
+      autocomplete="one-time-code"
+      [labelHidden]="grabField('confirmation_code', 'labelHidden', true)"
+      [placeholder]="grabField('confirmation_code', 'placeholder', null)"
+      [required]="grabField('confirmation_code', 'required', true)"
+      [label]="grabField('confirmation_code', 'label', null)"
+    ></amplify-form-field>
+    <amplify-form-field
+      name="password"
+      label="New password"
+      autocomplete="new-password"
+      [labelHidden]="grabField('password', 'labelHidden', true)"
+      [placeholder]="grabField('password', 'placeholder', null)"
+      [required]="grabField('password', 'required', true)"
+      [label]="grabField('password', 'label', 'New password')"
+    ></amplify-form-field>
+    <amplify-form-field
+      name="confirm_password"
+      type="password"
+      autocomplete="new-password"
+      [labelHidden]="grabField('confirm_password', 'labelHidden', true)"
+      [placeholder]="grabField('confirm_password', 'placeholder', null)"
+      [required]="grabField('confirm_password', 'required', true)"
+      [label]="grabField('confirm_password', 'label', 'Confirm Password')"
+    ></amplify-form-field>
+
+    <button amplify-button variation="primary" fullWidth="true" type="submit">
+      {{ sendCodeText }}
+    </button>
+
+    <button
+      amplify-button
+      size="small"
+      variation="link"
+      fontWeight="normal"
+      fullWidth="true"
+      type="button"
+      (click)="authenticator.resendCode()"
+    >
+      {{ resendCodeText }}
+    </button>
+
+    <amplify-error *ngIf="authenticator.error">
+      {{ authenticator.error }}
+    </amplify-error>
+  </fieldset>
+  <amplify-slot name="confirm-reset-password-footer" [context]="context">
+  </amplify-slot>
+</form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-in/confirm-sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-in/confirm-sign-in.component.html
@@ -1,45 +1,43 @@
-<div data-amplify-container>
-  <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
-    <fieldset
-      class="amplify-flex"
-      style="flex-direction: column"
-      data-amplify-fieldset
-      [disabled]="authenticator.isPending"
-    >
-      <amplify-slot name="confirm-sign-in-header" [context]="context">
-        <h3 class="amplify-heading">{{ headerText }}</h3>
-      </amplify-slot>
-      <amplify-form-field
-        name="confirmation_code"
-        label="Code *"
-        type="text"
-        autocomplete="one-time-code"
-        [labelHidden]="grabField('confirmation_code', 'labelHidden', true)"
-        [placeholder]="grabField('confirmation_code', 'placeholder', null)"
-        [required]="grabField('confirmation_code', 'required', true)"
-        [label]="grabField('confirmation_code', 'label', 'Code *')"
-      ></amplify-form-field>
+<form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
+  <fieldset
+    class="amplify-flex"
+    style="flex-direction: column"
+    data-amplify-fieldset
+    [disabled]="authenticator.isPending"
+  >
+    <amplify-slot name="confirm-sign-in-header" [context]="context">
+      <h3 class="amplify-heading">{{ headerText }}</h3>
+    </amplify-slot>
+    <amplify-form-field
+      name="confirmation_code"
+      label="Code *"
+      type="text"
+      autocomplete="one-time-code"
+      [labelHidden]="grabField('confirmation_code', 'labelHidden', true)"
+      [placeholder]="grabField('confirmation_code', 'placeholder', null)"
+      [required]="grabField('confirmation_code', 'required', true)"
+      [label]="grabField('confirmation_code', 'label', 'Code *')"
+    ></amplify-form-field>
 
-      <button amplify-button variation="primary" fullWidth="true" type="submit">
-        {{ confirmText }}
-      </button>
-      <button
-        amplify-button
-        size="small"
-        variation="link"
-        fontWeight="normal"
-        fullWidth="true"
-        (click)="authenticator.toSignIn()"
-      >
-        {{ backToSignInText }}
-      </button>
-      <amplify-error *ngIf="authenticator.error">
-        {{ authenticator.error }}
-      </amplify-error>
-    </fieldset>
-    <amplify-slot
-      name="confirm-sign-in-footer"
-      [context]="context"
-    ></amplify-slot>
-  </form>
-</div>
+    <button amplify-button variation="primary" fullWidth="true" type="submit">
+      {{ confirmText }}
+    </button>
+    <button
+      amplify-button
+      size="small"
+      variation="link"
+      fontWeight="normal"
+      fullWidth="true"
+      (click)="authenticator.toSignIn()"
+    >
+      {{ backToSignInText }}
+    </button>
+    <amplify-error *ngIf="authenticator.error">
+      {{ authenticator.error }}
+    </amplify-error>
+  </fieldset>
+  <amplify-slot
+    name="confirm-sign-in-footer"
+    [context]="context"
+  ></amplify-slot>
+</form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-up/confirm-sign-up.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-up/confirm-sign-up.component.html
@@ -1,4 +1,4 @@
-<div data-amplify-container>
+<ng-container>
   <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
     <fieldset
       class="amplify-flex"
@@ -43,4 +43,4 @@
       [context]="context"
     ></amplify-slot>
   </form>
-</div>
+</ng-container>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.html
@@ -1,42 +1,40 @@
-<div data-amplify-container>
-  <form data-amplify-form (input)="onInput($event)" (submit)="onSubmit($event)">
-    <fieldset
-      class="amplify-flex"
-      style="flex-direction: column"
-      data-amplify-fieldset
-      [disabled]="authenticator.isPending"
-    >
-      <amplify-slot name="confirm-verify-user-header" [context]="context">
-        <h3 class="amplify-heading">{{ this.headerText }}</h3>
-      </amplify-slot>
-      <amplify-form-field
-        name="confirmation_code"
-        type="number"
-        autocomplete="one-time-code"
-        [labelHidden]="grabField('confirmation_code', 'labelHidden', true)"
-        [placeholder]="grabField('confirmation_code', 'placeholder', null)"
-        [required]="grabField('confirmation_code', 'required', true)"
-        [label]="grabField('confirmation_code', 'label', null)"
-      ></amplify-form-field>
-      <button amplify-button variation="primary" fullWidth="true" type="submit">
-        {{ submitText }}
-      </button>
-
-      <button
-        amplify-button
-        size="small"
-        variation="link"
-        fontWeight="normal"
-        fullWidth="true"
-        (click)="authenticator.skipVerification()"
-      >
-        {{ skipText }}
-      </button>
-      <amplify-error *ngIf="authenticator.error">
-        {{ authenticator.error }}
-      </amplify-error>
-    </fieldset>
-    <amplify-slot name="confirm-verify-user-footer" [context]="context">
+<form data-amplify-form (input)="onInput($event)" (submit)="onSubmit($event)">
+  <fieldset
+    class="amplify-flex"
+    style="flex-direction: column"
+    data-amplify-fieldset
+    [disabled]="authenticator.isPending"
+  >
+    <amplify-slot name="confirm-verify-user-header" [context]="context">
+      <h3 class="amplify-heading">{{ this.headerText }}</h3>
     </amplify-slot>
-  </form>
-</div>
+    <amplify-form-field
+      name="confirmation_code"
+      type="number"
+      autocomplete="one-time-code"
+      [labelHidden]="grabField('confirmation_code', 'labelHidden', true)"
+      [placeholder]="grabField('confirmation_code', 'placeholder', null)"
+      [required]="grabField('confirmation_code', 'required', true)"
+      [label]="grabField('confirmation_code', 'label', null)"
+    ></amplify-form-field>
+    <button amplify-button variation="primary" fullWidth="true" type="submit">
+      {{ submitText }}
+    </button>
+
+    <button
+      amplify-button
+      size="small"
+      variation="link"
+      fontWeight="normal"
+      fullWidth="true"
+      (click)="authenticator.skipVerification()"
+    >
+      {{ skipText }}
+    </button>
+    <amplify-error *ngIf="authenticator.error">
+      {{ authenticator.error }}
+    </amplify-error>
+  </fieldset>
+  <amplify-slot name="confirm-verify-user-footer" [context]="context">
+  </amplify-slot>
+</form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/force-new-password/force-new-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/force-new-password/force-new-password.component.html
@@ -1,56 +1,54 @@
-<div data-amplify-container>
-  <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
-    <fieldset
-      class="amplify-flex"
-      style="flex-direction: column"
-      data-amplify-fieldset
-      [disabled]="authenticator.isPending"
-    >
-      <amplify-slot name="force-new-password-header" [context]="context">
-        <h3 class="amplify-heading">{{ this.headerText }}</h3>
-      </amplify-slot>
-      <amplify-form-field
-        [labelHidden]="grabField('password', 'labelHidden', true)"
-        [placeholder]="grabField('password', 'placeholder', null)"
-        [required]="grabField('password', 'required', true)"
-        [label]="grabField('password', 'label', null)"
-        name="password"
-        type="password"
-        autocomplete="new-password"
-      ></amplify-form-field>
-
-      <amplify-form-field
-        name="confirm_password"
-        type="password"
-        autocomplete="new-password"
-        [labelHidden]="grabField('confirm_password', 'labelHidden', true)"
-        [placeholder]="grabField('confirm_password', 'placeholder', null)"
-        [required]="grabField('confirm_password', 'required', true)"
-        [label]="grabField('confirm_password', 'label', 'Confirm Password')"
-      ></amplify-form-field>
-      <amplify-slot name="force-new-form-fields" [context]="context">
-        <amplify-force-new-password-form-fields></amplify-force-new-password-form-fields>
-      </amplify-slot>
-
-      <button amplify-button variation="primary" fullWidth="true" type="submit">
-        {{ changePasswordText }}
-      </button>
-
-      <button
-        amplify-button
-        size="small"
-        variation="link"
-        fontWeight="normal"
-        fullWidth="true"
-        (click)="authenticator.toSignIn()"
-      >
-        {{ backToSignInText }}
-      </button>
-      <amplify-error *ngIf="authenticator.error">
-        {{ authenticator.error }}
-      </amplify-error>
-    </fieldset>
-    <amplify-slot name="force-new-password-footer" [context]="context">
+<form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
+  <fieldset
+    class="amplify-flex"
+    style="flex-direction: column"
+    data-amplify-fieldset
+    [disabled]="authenticator.isPending"
+  >
+    <amplify-slot name="force-new-password-header" [context]="context">
+      <h3 class="amplify-heading">{{ this.headerText }}</h3>
     </amplify-slot>
-  </form>
-</div>
+    <amplify-form-field
+      [labelHidden]="grabField('password', 'labelHidden', true)"
+      [placeholder]="grabField('password', 'placeholder', null)"
+      [required]="grabField('password', 'required', true)"
+      [label]="grabField('password', 'label', null)"
+      name="password"
+      type="password"
+      autocomplete="new-password"
+    ></amplify-form-field>
+
+    <amplify-form-field
+      name="confirm_password"
+      type="password"
+      autocomplete="new-password"
+      [labelHidden]="grabField('confirm_password', 'labelHidden', true)"
+      [placeholder]="grabField('confirm_password', 'placeholder', null)"
+      [required]="grabField('confirm_password', 'required', true)"
+      [label]="grabField('confirm_password', 'label', 'Confirm Password')"
+    ></amplify-form-field>
+    <amplify-slot name="force-new-form-fields" [context]="context">
+      <amplify-force-new-password-form-fields></amplify-force-new-password-form-fields>
+    </amplify-slot>
+
+    <button amplify-button variation="primary" fullWidth="true" type="submit">
+      {{ changePasswordText }}
+    </button>
+
+    <button
+      amplify-button
+      size="small"
+      variation="link"
+      fontWeight="normal"
+      fullWidth="true"
+      (click)="authenticator.toSignIn()"
+    >
+      {{ backToSignInText }}
+    </button>
+    <amplify-error *ngIf="authenticator.error">
+      {{ authenticator.error }}
+    </amplify-error>
+  </fieldset>
+  <amplify-slot name="force-new-password-footer" [context]="context">
+  </amplify-slot>
+</form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/reset-password/reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/reset-password/reset-password.component.html
@@ -1,47 +1,45 @@
-<div data-amplify-container>
-  <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
-    <fieldset
+<form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
+  <fieldset
+    class="amplify-flex"
+    style="flex-direction: column"
+    data-amplify-fieldset
+    [disabled]="authenticator.isPending"
+  >
+    <amplify-slot
       class="amplify-flex"
-      style="flex-direction: column"
-      data-amplify-fieldset
-      [disabled]="authenticator.isPending"
+      name="reset-password-header"
+      [context]="context"
     >
-      <amplify-slot
-        class="amplify-flex"
-        name="reset-password-header"
-        [context]="context"
-      >
-        <h3 class="amplify-heading">{{ this.headerText }}</h3>
-      </amplify-slot>
-
-      <amplify-form-field
-        name="username"
-        type="username"
-        autocomplete="username"
-        [labelHidden]="grabField('username', 'labelHidden', true)"
-        [required]="grabField('username', 'required', true)"
-        [label]="grabField('username', 'label', labelText)"
-        [placeholder]="grabField('username', 'placeholder', labelText)"
-      ></amplify-form-field>
-      <button amplify-button variation="primary" fullWidth="true" type="submit">
-        {{ sendCodeText }}
-      </button>
-      <button
-        amplify-button
-        size="small"
-        variation="link"
-        fontWeight="normal"
-        fullWidth="true"
-        (click)="authenticator.toSignIn()"
-      >
-        {{ backToSignInText }}
-      </button>
-      <amplify-error *ngIf="authenticator.error">
-        {{ authenticator.error }}
-      </amplify-error>
-    </fieldset>
-
-    <amplify-slot name="reset-password-footer" [context]="context">
+      <h3 class="amplify-heading">{{ this.headerText }}</h3>
     </amplify-slot>
-  </form>
-</div>
+
+    <amplify-form-field
+      name="username"
+      type="username"
+      autocomplete="username"
+      [labelHidden]="grabField('username', 'labelHidden', true)"
+      [required]="grabField('username', 'required', true)"
+      [label]="grabField('username', 'label', labelText)"
+      [placeholder]="grabField('username', 'placeholder', labelText)"
+    ></amplify-form-field>
+    <button amplify-button variation="primary" fullWidth="true" type="submit">
+      {{ sendCodeText }}
+    </button>
+    <button
+      amplify-button
+      size="small"
+      variation="link"
+      fontWeight="normal"
+      fullWidth="true"
+      (click)="authenticator.toSignIn()"
+    >
+      {{ backToSignInText }}
+    </button>
+    <amplify-error *ngIf="authenticator.error">
+      {{ authenticator.error }}
+    </amplify-error>
+  </fieldset>
+
+  <amplify-slot name="reset-password-footer" [context]="context">
+  </amplify-slot>
+</form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/setup-totp/setup-totp.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/setup-totp/setup-totp.component.html
@@ -1,68 +1,66 @@
-<div data-amplify-container>
-  <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
-    <fieldset
-      class="amplify-flex"
-      style="flex-direction: column"
-      data-amplify-fieldset
-      [disabled]="authenticator.isPending"
-    >
-      <amplify-slot name="setup-totp-header" [context]="context">
-        <h3 class="amplify-heading">{{ this.headerText }}</h3>
-      </amplify-slot>
-      <p *ngIf="!qrCodeSource">Loading...</p>
-      <img
-        *ngIf="qrCodeSource"
-        [src]="qrCodeSource"
-        alt="qr code"
-        data-amplify-qrcode
-        width="228"
-        height="228"
-      />
-      <div class="amplify-flex" data-amplify-copy>
-        <div>{{ secretKey }}</div>
-        <div data-amplify-copy-svg (click)="copyText()">
-          <div data-amplify-copy-tooltip>{{ copyTextLabel }}</div>
-          <svg
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M16 1H4C2.9 1 2 1.9 2 3V17H4V3H16V1ZM15 5H8C6.9 5 6.01 5.9 6.01 7L6 21C6 22.1 6.89 23 7.99 23H19C20.1 23 21 22.1 21 21V11L15 5ZM8 21V7H14V12H19V21H8Z"
-              fill="black"
-            />
-          </svg>
-        </div>
+<form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
+  <fieldset
+    class="amplify-flex"
+    style="flex-direction: column"
+    data-amplify-fieldset
+    [disabled]="authenticator.isPending"
+  >
+    <amplify-slot name="setup-totp-header" [context]="context">
+      <h3 class="amplify-heading">{{ this.headerText }}</h3>
+    </amplify-slot>
+    <p *ngIf="!qrCodeSource">Loading...</p>
+    <img
+      *ngIf="qrCodeSource"
+      [src]="qrCodeSource"
+      alt="qr code"
+      data-amplify-qrcode
+      width="228"
+      height="228"
+    />
+    <div class="amplify-flex" data-amplify-copy>
+      <div>{{ secretKey }}</div>
+      <div data-amplify-copy-svg (click)="copyText()">
+        <div data-amplify-copy-tooltip>{{ copyTextLabel }}</div>
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16 1H4C2.9 1 2 1.9 2 3V17H4V3H16V1ZM15 5H8C6.9 5 6.01 5.9 6.01 7L6 21C6 22.1 6.89 23 7.99 23H19C20.1 23 21 22.1 21 21V11L15 5ZM8 21V7H14V12H19V21H8Z"
+            fill="black"
+          />
+        </svg>
       </div>
+    </div>
 
-      <amplify-form-field
-        name="confirmation_code"
-        type="text"
-        autocomplete="one-time-code"
-        [labelHidden]="grabField('confirmation_code', 'labelHidden', true)"
-        [placeholder]="grabField('confirmation_code', 'placeholder', null)"
-        [required]="grabField('confirmation_code', 'required', true)"
-        [label]="grabField('confirmation_code', 'label', 'Code *')"
-      ></amplify-form-field>
-      <button amplify-button variation="primary" fullWidth="true" type="submit">
-        {{ confirmText }}
-      </button>
-      <button
-        amplify-button
-        size="small"
-        variation="link"
-        fontWeight="normal"
-        fullWidth="true"
-        (click)="authenticator.toSignIn()"
-      >
-        {{ backToSignInText }}
-      </button>
-      <amplify-error *ngIf="authenticator.error">
-        {{ authenticator.error }}
-      </amplify-error>
-    </fieldset>
-    <amplify-slot name="setup-totp-footer" [context]="context"> </amplify-slot>
-  </form>
-</div>
+    <amplify-form-field
+      name="confirmation_code"
+      type="text"
+      autocomplete="one-time-code"
+      [labelHidden]="grabField('confirmation_code', 'labelHidden', true)"
+      [placeholder]="grabField('confirmation_code', 'placeholder', null)"
+      [required]="grabField('confirmation_code', 'required', true)"
+      [label]="grabField('confirmation_code', 'label', 'Code *')"
+    ></amplify-form-field>
+    <button amplify-button variation="primary" fullWidth="true" type="submit">
+      {{ confirmText }}
+    </button>
+    <button
+      amplify-button
+      size="small"
+      variation="link"
+      fontWeight="normal"
+      fullWidth="true"
+      (click)="authenticator.toSignIn()"
+    >
+      {{ backToSignInText }}
+    </button>
+    <amplify-error *ngIf="authenticator.error">
+      {{ authenticator.error }}
+    </amplify-error>
+  </fieldset>
+  <amplify-slot name="setup-totp-footer" [context]="context"> </amplify-slot>
+</form>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.html
@@ -1,54 +1,52 @@
-<ng-container>
-  <amplify-slot name="sign-in-header" [context]="context"></amplify-slot>
+<amplify-slot name="sign-in-header" [context]="context"></amplify-slot>
 
-  <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
-    <amplify-federated-sign-in></amplify-federated-sign-in>
-    <fieldset
-      class="amplify-flex"
-      style="flex-direction: column"
-      data-amplify-fieldset
-      [disabled]="authenticator.isPending"
+<form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
+  <amplify-federated-sign-in></amplify-federated-sign-in>
+  <fieldset
+    class="amplify-flex"
+    style="flex-direction: column"
+    data-amplify-fieldset
+    [disabled]="authenticator.isPending"
+  >
+    <amplify-user-name-alias
+      [labelHidden]="labelHidden('username')"
+      [placeholder]="userOverrides?.placeholder"
+      [required]="required('username')"
+      [label]="userOverrides?.label"
+      [dialCode]="userOverrides?.dialCode"
+      [dialCodeList]="userOverrides?.dialCodeList"
+    ></amplify-user-name-alias>
+    <amplify-form-field
+      [labelHidden]="labelHidden('password')"
+      [placeholder]="passwordOR?.placeholder"
+      [required]="required('password')"
+      [label]="passwordOR?.label"
+      data-amplify-password
+      name="password"
+      type="password"
+      autocomplete="current-password"
+    ></amplify-form-field>
+    <button amplify-button variation="primary" fullWidth="true" type="submit">
+      {{ signInButtonText }}
+    </button>
+
+    <amplify-error *ngIf="authenticator.error">
+      {{ authenticator.error }}
+    </amplify-error>
+  </fieldset>
+</form>
+
+<amplify-slot name="sign-in-footer" [context]="context">
+  <div data-amplify-footer>
+    <button
+      amplify-button
+      fontWeight="normal"
+      size="small"
+      variation="link"
+      fullWidth="true"
+      (click)="authenticator.toResetPassword()"
     >
-      <amplify-user-name-alias
-        [labelHidden]="labelHidden('username')"
-        [placeholder]="userOverrides?.placeholder"
-        [required]="required('username')"
-        [label]="userOverrides?.label"
-        [dialCode]="userOverrides?.dialCode"
-        [dialCodeList]="userOverrides?.dialCodeList"
-      ></amplify-user-name-alias>
-      <amplify-form-field
-        [labelHidden]="labelHidden('password')"
-        [placeholder]="passwordOR?.placeholder"
-        [required]="required('password')"
-        [label]="passwordOR?.label"
-        data-amplify-password
-        name="password"
-        type="password"
-        autocomplete="current-password"
-      ></amplify-form-field>
-      <button amplify-button variation="primary" fullWidth="true" type="submit">
-        {{ signInButtonText }}
-      </button>
-
-      <amplify-error *ngIf="authenticator.error">
-        {{ authenticator.error }}
-      </amplify-error>
-    </fieldset>
-  </form>
-
-  <amplify-slot name="sign-in-footer" [context]="context">
-    <div data-amplify-footer>
-      <button
-        amplify-button
-        fontWeight="normal"
-        size="small"
-        variation="link"
-        fullWidth="true"
-        (click)="authenticator.toResetPassword()"
-      >
-        {{ forgotPasswordText }}
-      </button>
-    </div>
-  </amplify-slot>
-</ng-container>
+      {{ forgotPasswordText }}
+    </button>
+  </div>
+</amplify-slot>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.html
@@ -1,4 +1,4 @@
-<div data-amplify-container>
+<ng-container>
   <amplify-slot name="sign-in-header" [context]="context"></amplify-slot>
 
   <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
@@ -51,4 +51,4 @@
       </button>
     </div>
   </amplify-slot>
-</div>
+</ng-container>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/verify-user/verify-user.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/verify-user/verify-user.component.html
@@ -1,46 +1,44 @@
-<div data-amplify-container>
-  <form data-amplify-form (input)="onInput($event)" (submit)="onSubmit($event)">
-    <fieldset
-      class="amplify-flex"
-      style="flex-direction: column"
-      data-amplify-fieldset
-      [disabled]="authenticator.isPending"
+<form data-amplify-form (input)="onInput($event)" (submit)="onSubmit($event)">
+  <fieldset
+    class="amplify-flex"
+    style="flex-direction: column"
+    data-amplify-fieldset
+    [disabled]="authenticator.isPending"
+  >
+    <amplify-slot name="verify-user-header" [context]="context">
+      <h3 class="amplify-heading">{{ this.headerText }}</h3>
+    </amplify-slot>
+
+    <div *ngFor="let unverifiedAttribute of unverifiedAttributes | keyvalue">
+      <input
+        name="unverifiedAttr"
+        type="radio"
+        [value]="unverifiedAttribute.key"
+        [id]="labelId"
+      />
+      <label [for]="labelId">{{
+        getLabelForAttr(unverifiedAttribute.key)
+      }}</label>
+    </div>
+
+    <button amplify-button variation="primary" fullWidth="true" type="submit">
+      {{ verifyText }}
+    </button>
+
+    <button
+      amplify-button
+      size="small"
+      variation="link"
+      fontWeight="normal"
+      fullWidth="true"
+      (click)="authenticator.skipVerification()"
     >
-      <amplify-slot name="verify-user-header" [context]="context">
-        <h3 class="amplify-heading">{{ this.headerText }}</h3>
-      </amplify-slot>
+      {{ skipText }}
+    </button>
 
-      <div *ngFor="let unverifiedAttribute of unverifiedAttributes | keyvalue">
-        <input
-          name="unverifiedAttr"
-          type="radio"
-          [value]="unverifiedAttribute.key"
-          [id]="labelId"
-        />
-        <label [for]="labelId">{{
-          getLabelForAttr(unverifiedAttribute.key)
-        }}</label>
-      </div>
-
-      <button amplify-button variation="primary" fullWidth="true" type="submit">
-        {{ verifyText }}
-      </button>
-
-      <button
-        amplify-button
-        size="small"
-        variation="link"
-        fontWeight="normal"
-        fullWidth="true"
-        (click)="authenticator.skipVerification()"
-      >
-        {{ skipText }}
-      </button>
-
-      <amplify-error *ngIf="authenticator.error">
-        {{ authenticator.error }}
-      </amplify-error>
-    </fieldset>
-    <amplify-slot name="verify-user-footer" [context]="context"> </amplify-slot>
-  </form>
-</div>
+    <amplify-error *ngIf="authenticator.error">
+      {{ authenticator.error }}
+    </amplify-error>
+  </fieldset>
+  <amplify-slot name="verify-user-footer" [context]="context"> </amplify-slot>
+</form>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This fixes Angular Authenticator screens being too narrow. This was due to an unneeded `data-amplify-container` underneath. 

I removed the parent `div` for these screens, because they are unneeded and react/vue do not have one.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#1454

#### Description of how you validated changes

Tested manually.

Before: 

![image](https://user-images.githubusercontent.com/43682783/156490175-3211a654-13ea-4d20-b4eb-084739937d57.png)

After: 

![Screen Shot 2022-03-02 at 7 23 47 PM](https://user-images.githubusercontent.com/43682783/156490194-45e12c28-6413-48ac-ad4d-e7859dc79005.png)

Also confirmed other screens take the full with as exected by running through cypress mocks.


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
