### PR TITLE
set pagination current page default to 1

### DIFF
--- a/.changeset/gentle-turkeys-think.md
+++ b/.changeset/gentle-turkeys-think.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+set pagination current page default to 1

--- a/packages/react/src/primitives/Pagination/Pagination.tsx
+++ b/packages/react/src/primitives/Pagination/Pagination.tsx
@@ -10,7 +10,7 @@ import { View } from '../View';
 const PaginationPrimitive: Primitive<PaginationProps, 'nav'> = (
   {
     className,
-    currentPage,
+    currentPage = 1,
     totalPages,
     siblingCount,
     onNext,

--- a/packages/react/src/primitives/Pagination/PaginationItem.tsx
+++ b/packages/react/src/primitives/Pagination/PaginationItem.tsx
@@ -37,6 +37,7 @@ export const PaginationItem: React.FC<PaginationItemProps> = ({
             <Flex
               as="span"
               className={ComponentClassNames.PaginationItemCurrent}
+              testId="current"
               {...rest}
             >
               {/**

--- a/packages/react/src/primitives/Pagination/PaginationItem.tsx
+++ b/packages/react/src/primitives/Pagination/PaginationItem.tsx
@@ -8,6 +8,9 @@ import { VisuallyHidden } from '../VisuallyHidden';
 import { PaginationItemProps } from '../types/pagination';
 import { ComponentClassNames } from '../shared/constants';
 
+export const PAGINATION_CURRENT_TEST_ID = 'current';
+export const PAGINATION_ELLIPSIS_TEST_ID = 'ellipsis';
+
 export const PaginationItem: React.FC<PaginationItemProps> = ({
   type,
   page,
@@ -37,7 +40,7 @@ export const PaginationItem: React.FC<PaginationItemProps> = ({
             <Flex
               as="span"
               className={ComponentClassNames.PaginationItemCurrent}
-              testId="current"
+              testId={PAGINATION_CURRENT_TEST_ID}
               {...rest}
             >
               {/**
@@ -99,7 +102,7 @@ export const PaginationItem: React.FC<PaginationItemProps> = ({
           <Flex
             as="span"
             className={ComponentClassNames.PaginationItemEllipsis}
-            testId="ellipsis"
+            testId={PAGINATION_ELLIPSIS_TEST_ID}
             {...rest}
           >
             &#8230;

--- a/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
@@ -4,7 +4,11 @@ import userEvent from '@testing-library/user-event';
 
 import { Pagination } from '../Pagination';
 import { ComponentClassNames } from '../../shared';
-import { PaginationItem } from '../PaginationItem';
+import {
+  PaginationItem,
+  PAGINATION_CURRENT_TEST_ID,
+  PAGINATION_ELLIPSIS_TEST_ID,
+} from '../PaginationItem';
 
 describe('Pagination component test suite', () => {
   const id = 'my-pagination';
@@ -219,7 +223,7 @@ describe('Pagination component test suite', () => {
           onPrevious={() => {}}
         />
       );
-      const currentPage = await screen.findByTestId('current');
+      const currentPage = await screen.findByTestId(PAGINATION_CURRENT_TEST_ID);
       expect(currentPage).toHaveTextContent('1');
     });
   });
@@ -281,7 +285,7 @@ describe('Pagination component test suite', () => {
     });
     it('should render ellipsis item with provided porps', async () => {
       render(<PaginationItem type="ellipsis" ariaLabel="ellipsis" />);
-      const ellipsis = await screen.findByTestId('ellipsis');
+      const ellipsis = await screen.findByTestId(PAGINATION_ELLIPSIS_TEST_ID);
       expect(ellipsis.nodeName).toBe('SPAN');
       expect(ellipsis).toHaveClass(ComponentClassNames.PaginationItemEllipsis);
       expect(ellipsis.innerHTML).toBe('\u2026');

--- a/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
@@ -207,6 +207,21 @@ describe('Pagination component test suite', () => {
       expect(pagination).toHaveTextContent('6');
       expect(pagination).toHaveTextContent('7');
     });
+
+    it('should default the current page to 1 if one is not provided', async () => {
+      render(
+        <Pagination
+          id={id}
+          totalPages={10}
+          siblingCount={2}
+          onChange={() => {}}
+          onNext={() => {}}
+          onPrevious={() => {}}
+        />
+      );
+      const currentPage = await screen.findByTestId('current');
+      expect(currentPage).toHaveTextContent('1');
+    });
   });
 
   describe('Test PaginationItem', () => {


### PR DESCRIPTION
#### Description of changes

Set the default currentPage value of the Pagination component to 1

#### Description of how you validated changes

Updated the Pagination component to set the currentPage default value to 1.  This fixes an error that was showing NaN if no currentPage was given.

reproducible with `<Pagination totalPages={20} onNext={()=>{}} onPrevious={()=>{}} onChange={()=>{}} />`
<img width="255" alt="CleanShot 2022-02-15 at 16 37 47@2x" src="https://user-images.githubusercontent.com/7351516/156551260-fb25f1ef-0232-4619-9c2c-41ae7d520629.png">

<img width="358" alt="Screen Shot 2022-03-03 at 3 57 32 AM" src="https://user-images.githubusercontent.com/7351516/156551488-8a0acfc8-2cac-44d5-a1c5-1cd0ead12e8d.png">


#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
