### PR TITLE
Add Concurrency for CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@
 name: Tests
 
 concurrency:
-  group: ${{ github.event.pull_request.id || github.ref }}
+  group: e2e-${{ github.event.pull_request.id || github.ref }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Adds [concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) condition for our CI workflows. This change will define a group based on the pull request ID and whenever a new CI job is triggered for that group (e.g. a new commit on the PR) any in-progress workflows in that group will be canceled.

This should help alleviate some pressure on the number of concurrent GitHub Action runners we utilize.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated - N/A
- [x] Relevant documentation is changed or added (and PR referenced) - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
