### PR TITLE
Cache canary environments

### DIFF
--- a/.github/workflows/run-and-test-builds.yml
+++ b/.github/workflows/run-and-test-builds.yml
@@ -1,8 +1,8 @@
 name: Run and Test Builds
 
 on:
-  schedule:
-    - cron: '*/15 * * * *' # Run every  minutes
+  pull_request:
+    branches: [canary-test-cypress, main]
 
 jobs:
   build:

--- a/.github/workflows/run-and-test-builds.yml
+++ b/.github/workflows/run-and-test-builds.yml
@@ -37,6 +37,15 @@ jobs:
         working-directory: ./canary/apps/${{ matrix.path }}
       - name: Add Amplify CLI
         run: yarn global add @aws-amplify/cli
+      - name: Get CLI versions
+        id: cli-version
+        run: echo "::set-output name=version::$(amplify --version)"
+      - name: Create or restore environments cache
+        id: environments-cache
+        uses: actions/cache@v2
+        with:
+          path: canary/environments/**/aws-exports.js
+          key: ${{ runner.os }}-canary-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('canary/environments/**/amplify/**') }}
       - name: Pull down AWS environments
         run: yarn pull
         env:

--- a/.github/workflows/run-and-test-builds.yml
+++ b/.github/workflows/run-and-test-builds.yml
@@ -47,6 +47,7 @@ jobs:
           path: canary/environments/**/aws-exports.js
           key: ${{ runner.os }}-canary-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('canary/environments/**/amplify/**') }}
       - name: Pull down AWS environments
+        if: steps.environments-cache.outputs.cache-hit != 'true'
         run: yarn pull
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/run-and-test-builds.yml
+++ b/.github/workflows/run-and-test-builds.yml
@@ -1,8 +1,8 @@
 name: Run and Test Builds
 
 on:
-  pull_request:
-    branches: [canary-test-cypress, main]
+  schedule:
+    - cron: '*/15 * * * *' # Run every  minutes
 
 jobs:
   build:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This caches the environment we use for canary runtime tests. Not significant time improvement, but this will help as we build on our canary tests.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

To be add on to #1450

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

https://github.com/aws-amplify/amplify-ui/runs/5415010995?check_suite_focus=true!

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
