### PR TITLE
TextField/TextAreafield - width and height style props

### DIFF
--- a/.changeset/sixty-teachers-ring.md
+++ b/.changeset/sixty-teachers-ring.md
@@ -1,0 +1,8 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+`TextField` and `TextAreaField` - Apply `width` and `height` style props to 
+`Flex` container element rather than `input` field to match `SelectField` behavior. 
+This will also apply to `PasswordField`, `PhoneNumberField` and `SearchField`
+which use the `TextField`.

--- a/packages/react/src/primitives/TextAreaField/TextAreaField.tsx
+++ b/packages/react/src/primitives/TextAreaField/TextAreaField.tsx
@@ -22,12 +22,14 @@ const TextAreaFieldPrimitive: Primitive<TextAreaFieldProps, 'textarea'> = (
     descriptiveText,
     errorMessage,
     hasError = false,
+    height,
     id,
     label,
     labelHidden = false,
     rows,
     size,
     testId,
+    width,
     ..._rest
   } = props;
 
@@ -45,7 +47,9 @@ const TextAreaFieldPrimitive: Primitive<TextAreaFieldProps, 'textarea'> = (
         className
       )}
       data-size={size}
+      height={height}
       testId={testId}
+      width={width}
       {...flexContainerStyleProps}
     >
       <Label htmlFor={fieldId} visuallyHidden={labelHidden}>

--- a/packages/react/src/primitives/TextField/TextField.tsx
+++ b/packages/react/src/primitives/TextField/TextField.tsx
@@ -30,6 +30,7 @@ const TextFieldPrimitive = <Multiline extends boolean>(
     descriptiveText,
     errorMessage,
     hasError = false,
+    height, // @TODO: remove custom destructuring for 3.0 release
     id,
     label,
     labelHidden = false,
@@ -41,6 +42,7 @@ const TextFieldPrimitive = <Multiline extends boolean>(
     type, // remove from rest to prevent passing as DOM attribute to textarea
     size,
     testId,
+    width, // @TODO: remove custom destructuring for 3.0 release
     ..._rest
   } = props;
 
@@ -95,7 +97,9 @@ const TextFieldPrimitive = <Multiline extends boolean>(
         className
       )}
       data-size={size}
+      height={height}
       testId={testId}
+      width={width}
       {...flexContainerStyleProps}
     >
       <Label htmlFor={fieldId} visuallyHidden={labelHidden}>


### PR DESCRIPTION
#### Description of changes
This PR moves the `width` and `height` style props to the parent container to be consistent with the `SelectField` styling. This fixes an issue where the TextField `height` prop is applied to the input field, whereas the `SelectField` `height` prop is applied to the parent Flex container.
![Screen Shot 2022-03-07 at 3 49 09 PM](https://user-images.githubusercontent.com/6165315/157132233-35b1e13a-22cd-4b21-b8c4-5d0f962fbeb9.png)

#### Description of how you validated changes
* Ran unit tests
* Manually tested setting height and width on SelectField and TextField on same line:
![Screen Shot 2022-03-07 at 4 01 36 PM](https://user-images.githubusercontent.com/6165315/157136047-03ed9a4c-9d45-4332-831b-06dc11806b0d.png)



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
