### PR TITLE
Make e2e concurrency group unique in `main`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@
 name: Tests
 
 concurrency:
-  group: e2e-${{ github.event.pull_request.id || github.ref }}
+  group: e2e-${{ github.event.pull_request.id || github.sha }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Makes concurrency group unique for all commits to `main`, so that a new commit does not cancel previous one. 

This does not affect concurrency on pull requests, in which we will still cancel previous old workflows for the sake of efficiency.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Same logic from https://github.com/aws-amplify/amplify-ui/blob/b8675d1b007e5a3bb4cfd8b0ad675e876ee1e836/.github/workflows/tests.yml#L51.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
