### PR TITLE
fix: Authenticator issue where InitMachine useEffect runs every render

### DIFF
--- a/.changeset/nine-camels-cover.md
+++ b/.changeset/nine-camels-cover.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix: Authenticator issue where InitMachine useEffect runs every render, causing `children` of 
+`Authenticator` to be unmounted and remounted on every render.

--- a/.changeset/nine-camels-cover.md
+++ b/.changeset/nine-camels-cover.md
@@ -2,5 +2,4 @@
 "@aws-amplify/ui-react": patch
 ---
 
-fix: Authenticator issue where InitMachine useEffect runs every render, causing `children` of 
-`Authenticator` to be unmounted and remounted on every render.
+fix: Authenticator issue where InitMachine useEffect runs every render, causing `children` of `Authenticator` to be unmounted and remounted on every render.

--- a/packages/react/src/components/Authenticator/Authenticator.tsx
+++ b/packages/react/src/components/Authenticator/Authenticator.tsx
@@ -21,18 +21,20 @@ export type AuthenticatorProps = AuthenticatorMachineOptions &
   ComponentsProviderProps;
 
 // Helper component that sends init event to the parent provider
-function InitMachine({ children, ...machineProps }) {
+function InitMachine({ children, ...data }) {
   const { _send, route } = useAuthenticator();
+
+  const hasInitialized = React.useRef(false);
+
   React.useEffect(() => {
-    if (route === 'idle') {
+    if (!hasInitialized.current && route === 'idle') {
       _send({
         type: 'INIT',
-        data: machineProps,
+        data,
       });
+      hasInitialized.current = true;
     }
-    // Disabling exhaustive hooks rule here because we only want to run a single time
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [_send, route, data]);
   return <>{children}</>;
 }
 

--- a/packages/react/src/components/Authenticator/Authenticator.tsx
+++ b/packages/react/src/components/Authenticator/Authenticator.tsx
@@ -20,6 +20,22 @@ export type AuthenticatorProps = AuthenticatorMachineOptions &
   RouterProps &
   ComponentsProviderProps;
 
+// Helper component that sends init event to the parent provider
+function InitMachine({ children, ...machineProps }) {
+  const { _send, route } = useAuthenticator();
+  React.useEffect(() => {
+    if (route === 'idle') {
+      _send({
+        type: 'INIT',
+        data: machineProps,
+      });
+    }
+    // Disabling exhaustive hooks rule here because we only want to run a single time
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return <>{children}</>;
+}
+
 export function Authenticator({
   children,
   className,
@@ -42,20 +58,6 @@ export function Authenticator({
     socialProviders,
     formFields,
   };
-
-  // Helper component that sends init event to the parent provider
-  function InitMachine({ children, ...machineProps }) {
-    const { _send, route } = useAuthenticator();
-    React.useEffect(() => {
-      if (route === 'idle') {
-        _send({
-          type: 'INIT',
-          data: machineProps,
-        });
-      }
-    }, []);
-    return <>{children}</>;
-  }
 
   return (
     <Provider>


### PR DESCRIPTION
#### Description of changes
This PR fixes an issue where the `InitMachine` component is defined on each render. This caused the `useEffect` inside `InitMachine` to also run on each render, which finally caused the `children` of `InitMachine` to be unmounted and remounted. I also found that on initial render, the `useEffect` hook inside `InitMachine` was called many times. This PR fixes all of this by moving `InitMachine` outside of the `Authenticator` function. 

#### Issue #, if available

Fixes: https://github.com/aws-amplify/amplify-ui/issues/1451
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Using the app from https://github.com/aws-amplify/amplify-ui/issues/1451 I validated the following:
* useEffect was only called a single time on initial render
![2022-03-07 18 33 32](https://user-images.githubusercontent.com/6165315/157149650-5f915646-3d55-425e-970c-495bbf272064.gif)

* useEffect is not called when typing in the input field, and focus is not lost
![2022-03-07 18 32 41](https://user-images.githubusercontent.com/6165315/157149704-6264cf83-7623-4603-9ade-5e6853d8737b.gif)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
