### PR TITLE
Test GitHub action to release docs

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -49,3 +49,9 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish to next tag
         run: yarn publish:next
+      - name: Merge main into docs-release branch
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          git checkout docs-release
+          git merge main
+          git push


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

The goal of this PR is to test a GitHub action that will release the Amplify UI Docs site after successfully publishing to npm. 

I confirmed that manually merging `main` into `docs-release` and pushing my changes triggers a redeployment of the docs site (or rather, a test version of the docs site). The next step is to automate that process whenever we release our library. 

Instead of creating a separate workflow to test this action, I'm appending it to the end of the `publish-next` workflow for two reasons. 

1. We need access to the `published` output from the [changeset release action](https://github.com/changesets/action#outputs). 
2. This workflow runs more frequently than `publish-latest`, so we'll be able to test it and make sure it works. 

Once we confirm that the GitHub action works as expected, we can append it to the end of the `publish-latest` workflow. I'm still researching if we'll need to change the `fetch-depth` from 0. 

I am open to a better way of testing this GitHub action if you have any suggestions 👍

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
