### PR TITLE
Fix Dependabot ANSI-HTML version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   ],
   "resolutions": {
     "ansi-regex": "5.0.1",
+    "ansi-html": "0.0.8",
     "fs-extra": "^10.0.0",
     "jest": "^26.6.3",
     "json-schema": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6661,10 +6661,10 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-html@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
-  integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
+ansi-html@0.0.7, ansi-html@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.8.tgz#e969db193b12bcdfa6727b29ffd8882dc13cc501"
+  integrity sha512-QROYz1I1Kj+8bTYgx0IlMBpRSCIU+7GjbE0oH+KF7QKc+qSF8YAlIutN59Db17tXN70Ono9upT9Ht0iG93W7ug==
 
 ansi-regex@5.0.1, ansi-regex@^2.0.0, ansi-regex@^3.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1, ansi-regex@^6.0.1:
   version "5.0.1"


### PR DESCRIPTION
#### Description of changes
This will fix a security issue with `ansi-html` found by dependabot. This will make sure we are using the earliest fixed version.

<img width="952" alt="image" src="https://user-images.githubusercontent.com/65630/157524858-642eaa56-2b86-4e0b-a93b-3272c5a7a838.png">



#### Issue #, if available

Dependabot

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
