### PR TITLE
fix(docs): remove ^ flag from @aws-amplify/ui-react version

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "test": "$_ run build"
   },
   "dependencies": {
-    "@aws-amplify/ui-react": "^2.9.0",
+    "@aws-amplify/ui-react": "2.9.0",
     "@codesandbox/sandpack-react": "0.1.9",
     "@cucumber/gherkin": "^19.0.3",
     "@cucumber/messages": "^16.0.1",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Removes the compatibility flag from the `@aws-amplify/ui-react` version in _docs/package.json_. Usage of this flag leads to false warnings for `@aws-amplify/ui-react` imports and allows for VS Code IntelliSense to work correctly with those imports

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
NA

#### Description of how you validated changes

Warnings cleared uo in editor

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
