### PR TITLE
make pagination change functions optional

### DIFF
--- a/packages/react/src/primitives/types/pagination.ts
+++ b/packages/react/src/primitives/types/pagination.ts
@@ -24,17 +24,17 @@ interface BasePaginationProps {
   /**
    * Callback function triggered when the next-page button is pressed
    */
-  onNext: () => void;
+  onNext?: () => void;
 
   /**
    * Callback function triggered when the prev-page button is pressed
    */
-  onPrevious: () => void;
+  onPrevious?: () => void;
 
   /**
    * Callback function triggered every time the page changes
    */
-  onChange: (newPageIndex: number, prevPageIndex: number) => void;
+  onChange?: (newPageIndex: number, prevPageIndex: number) => void;
 }
 
 export interface PaginationProps extends BasePaginationProps, ViewProps {}


### PR DESCRIPTION
#### Description of changes

This is a simple pull request that updates the pagination props type to make the change functions optional. This is to alleviate the awkwardness of all 3 being required when onChange and onNext/onPrevious are redundant.

#### Checklist

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
