### PR TITLE
fix(react): add default TS generic value to TextFieldProps

### DIFF
--- a/packages/react/src/primitives/types/textField.ts
+++ b/packages/react/src/primitives/types/textField.ts
@@ -38,13 +38,14 @@ export interface TextAreaFieldMultilineProps
   extends TextFieldOptions,
     TextAreaProps {}
 
-export type TextFieldProps<Multiline extends boolean> = (Multiline extends true
-  ? TextAreaFieldMultilineProps
-  : TextInputFieldProps) & {
-  /**
-   * @deprecated
-   * Multiline functionality has been moved to TextAreaField and will be removed in next major release.
-   * Please use TextAreaField instead of TextField for multiline text fields.
-   */
-  isMultiline?: Multiline;
-};
+export type TextFieldProps<Multiline extends boolean = false> =
+  (Multiline extends true
+    ? TextAreaFieldMultilineProps
+    : TextInputFieldProps) & {
+    /**
+     * @deprecated
+     * Multiline functionality has been moved to TextAreaField and will be removed in next major release.
+     * Please use TextAreaField instead of TextField for multiline text fields.
+     */
+    isMultiline?: Multiline;
+  };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Add default TS generic value to `TextFieldProps` to prevent TS warnings when used without a generic

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested in docs

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
