### PR TITLE
Fix phone number label in reset-password

### DIFF
--- a/.changeset/witty-owls-applaud.md
+++ b/.changeset/witty-owls-applaud.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+Fix phone number label in reset-password

--- a/packages/ui/src/helpers/authenticator/formFields/defaults.ts
+++ b/packages/ui/src/helpers/authenticator/formFields/defaults.ts
@@ -105,11 +105,12 @@ const getConfirmSignUpFormFields = (state: AuthMachineState): FormFields => ({
 
 const getResetPasswordFormFields = (state: AuthMachineState): FormFields => {
   const primaryAlias = getPrimaryAlias(state);
+  const { label } = defaultFormFieldOptions[primaryAlias];
   return {
     username: {
       ...getAliasDefaultFormField(state),
-      label: `Enter your ${primaryAlias.toLowerCase()}`,
-      placeholder: `Enter your ${primaryAlias.toLowerCase()}`,
+      label: `Enter your ${label.toLowerCase()}`,
+      placeholder: `Enter your ${label.toLowerCase()}`,
     },
   };
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This fixes a regression I introduced in #1484, in which phone number field would show up as `Enter your phone_number` instead of `Enter your phone number`. This aligns with previous behaviors.

Before fix:
![image](https://user-images.githubusercontent.com/43682783/158443415-6394c569-f925-4720-a678-00da6287499f.png)

After fix:

![Screen Shot 2022-03-15 at 11 03 35 AM](https://user-images.githubusercontent.com/43682783/158443450-2fad47e8-1c5a-4448-8576-97aa28268025.png)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
