### PR TITLE
Revert "Test GitHub action to release docs"

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -49,9 +49,3 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish to next tag
         run: yarn publish:next
-      - name: Merge main into docs-release branch
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          git checkout docs-release
-          git merge main
-          git push


### PR DESCRIPTION
Reverting #1493. This was for POC purposes only and should no longer be in our workflows. 