### PR TITLE
fix(docs): Fix docs theme toggle button

### DIFF
--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -69,7 +69,7 @@ export const theme: Theme = {
       },
     },
     {
-      selector: '[data-amplify-theme-override="classic"]',
+      selector: '[data-amplify-theme-override="classic"] [data-amplify-theme]',
       tokens: {
         colors: {
           brand: {
@@ -91,7 +91,7 @@ export const theme: Theme = {
       },
     },
     {
-      selector: '[data-amplify-theme-override="terminal"]',
+      selector: '[data-amplify-theme-override="terminal"] [data-amplify-theme]',
       tokens: {
         colors: {
           green: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

## Description of changes

This fixes the docs theme toggle button by targeting `[data-amplify-theme]` to override the theme css variables.

| Before | After |
| ------------- | ------------- |
|  ![toggle-fix-before](https://user-images.githubusercontent.com/43682783/158651851-042c0d4b-e635-4980-b8d7-0071b2d1f889.gif) | ![toggle-fix-after](https://user-images.githubusercontent.com/43682783/158652011-f9e462c6-90d5-495e-9585-d44c7464138d.gif)  |



## Details
This is a regression from #1447, which puts the `[data-amplify-theme]` attribute inside a div in `<AmplifyProvider />`, in addition to the top level `<html />`. But `[data-amplify-theme-override] from the theme toggle buttons is still placed in the top-level `html` like so:

```html
(1) <html data-amplify-theme="amplify-docs" data-amplify-theme-override="classic">
(2)   <body>
(3)     <AmplifyProvider>
(4)       <div data-amplify-theme="amplify-docs">
              ...
```

CSS variables set from `[data-amplify-theme-override]` on (1) gets overridden by css variables set from `[data-amplify-theme]` on (4).

## Fix

This PR fixes this issue by changing the override selector 

```diff
- [data-amplify-theme-override="classic"]
+ - [data-amplify-theme-override="classic"] [data-amplify-theme="amplify-docs"]
```

Overrides within nested providers in docs should not be affected because they have different theme name.


## Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
Fixes #1526.

## Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
