### PR TITLE
fix: update complex field components to allow absolute positioning

### DIFF
--- a/.changeset/thick-pumas-guess.md
+++ b/.changeset/thick-pumas-guess.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix: update complex field components (TextField, TextAreaField, etc) to apply absolute positioning from Figma
+
+Figma to Studio integration will absolutely position components when autolayout is not enabled in Figma. This causes an issue for field components that were passing position, top, and left, and padding down to the input element, causing the layout not to match Figma. This is fixed by moving the absolute position props and padding up to the container Flex element.

--- a/packages/react/src/primitives/Radio/Radio.tsx
+++ b/packages/react/src/primitives/Radio/Radio.tsx
@@ -17,6 +17,13 @@ export const RadioPrimitive: Primitive<RadioProps, 'input'> = (
     testId,
     value,
     labelPosition: radioLabelPosition,
+    width, // @TODO: remove custom destructuring for 3.0 release
+    bottom, // @TODO: remove custom destructuring for 3.0 release
+    left, // @TODO: remove custom destructuring for 3.0 release
+    position, // @TODO: remove custom destructuring for 3.0 release
+    padding, // @TODO: remove custom destructuring for 3.0 release
+    right, // @TODO: remove custom destructuring for 3.0 release
+    top, // @TODO: remove custom destructuring for 3.0 release
     ...rest
   },
   ref
@@ -54,6 +61,13 @@ export const RadioPrimitive: Primitive<RadioProps, 'input'> = (
       className={classNames(ComponentClassNames.Radio, className)}
       data-disabled={shouldBeDisabled}
       data-label-position={labelPosition}
+      width={width}
+      bottom={bottom}
+      top={top}
+      right={right}
+      left={left}
+      position={position}
+      padding={padding}
     >
       {children && (
         <Text

--- a/packages/react/src/primitives/Radio/Radio.tsx
+++ b/packages/react/src/primitives/Radio/Radio.tsx
@@ -17,6 +17,7 @@ export const RadioPrimitive: Primitive<RadioProps, 'input'> = (
     testId,
     value,
     labelPosition: radioLabelPosition,
+    height, // @TODO: remove custom destructuring for 3.0 release
     width, // @TODO: remove custom destructuring for 3.0 release
     bottom, // @TODO: remove custom destructuring for 3.0 release
     left, // @TODO: remove custom destructuring for 3.0 release

--- a/packages/react/src/primitives/SliderField/SliderField.tsx
+++ b/packages/react/src/primitives/SliderField/SliderField.tsx
@@ -53,7 +53,8 @@ const SliderFieldPrimitive: Primitive<SliderFieldProps, typeof Root> = (
   const descriptionId = useStableId();
   const ariaDescribedBy = descriptiveText ? descriptionId : undefined;
 
-  const { flexContainerStyleProps, rest } = splitPrimitiveProps(_rest);
+  const { flexContainerStyleProps, baseStyleProps, rest } =
+    splitPrimitiveProps(_rest);
 
   const isControlled = value !== undefined;
 
@@ -86,6 +87,7 @@ const SliderFieldPrimitive: Primitive<SliderFieldProps, typeof Root> = (
       )}
       testId={testId}
       data-size={size}
+      {...baseStyleProps}
       {...flexContainerStyleProps}
     >
       <Label

--- a/packages/react/src/primitives/StepperField/StepperField.tsx
+++ b/packages/react/src/primitives/StepperField/StepperField.tsx
@@ -40,6 +40,16 @@ const StepperFieldPrimitive: Primitive<StepperFieldProps, 'input'> = (
     size,
     variation,
     testId,
+
+    bottom, // @TODO: remove custom destructuring for 3.0 release
+    height, // @TODO: remove custom destructuring for 3.0 release
+    left, // @TODO: remove custom destructuring for 3.0 release
+    padding, // @TODO: remove custom destructuring for 3.0 release
+    position, // @TODO: remove custom destructuring for 3.0 release
+    right, // @TODO: remove custom destructuring for 3.0 release
+    top, // @TODO: remove custom destructuring for 3.0 release
+    width, // @TODO: remove custom destructuring for 3.0 release
+
     // this is only required in useStepper hook but deconstruct here to remove its existence in rest
     value: controlledValue,
     ..._rest
@@ -83,6 +93,14 @@ const StepperFieldPrimitive: Primitive<StepperFieldProps, 'input'> = (
       data-size={size}
       data-variation={variation}
       testId={testId}
+      width={width}
+      height={height}
+      position={position}
+      padding={padding}
+      top={top}
+      right={right}
+      left={left}
+      bottom={bottom}
       {...flexContainerStyleProps}
     >
       <Label htmlFor={fieldId} visuallyHidden={labelHidden}>

--- a/packages/react/src/primitives/TextAreaField/TextAreaField.tsx
+++ b/packages/react/src/primitives/TextAreaField/TextAreaField.tsx
@@ -22,14 +22,22 @@ const TextAreaFieldPrimitive: Primitive<TextAreaFieldProps, 'textarea'> = (
     descriptiveText,
     errorMessage,
     hasError = false,
-    height,
     id,
     label,
     labelHidden = false,
     rows,
     size,
     testId,
-    width,
+
+    bottom, // @TODO: remove custom destructuring for 3.0 release
+    height, // @TODO: remove custom destructuring for 3.0 release
+    left, // @TODO: remove custom destructuring for 3.0 release
+    padding, // @TODO: remove custom destructuring for 3.0 release
+    position, // @TODO: remove custom destructuring for 3.0 release
+    right, // @TODO: remove custom destructuring for 3.0 release
+    top, // @TODO: remove custom destructuring for 3.0 release
+    width, // @TODO: remove custom destructuring for 3.0 release
+
     ..._rest
   } = props;
 
@@ -51,6 +59,12 @@ const TextAreaFieldPrimitive: Primitive<TextAreaFieldProps, 'textarea'> = (
       height={height}
       testId={testId}
       width={width}
+      bottom={bottom}
+      left={left}
+      right={right}
+      top={top}
+      position={position}
+      padding={padding}
       {...flexContainerStyleProps}
     >
       <Label htmlFor={fieldId} visuallyHidden={labelHidden}>

--- a/packages/react/src/primitives/TextField/TextField.tsx
+++ b/packages/react/src/primitives/TextField/TextField.tsx
@@ -43,6 +43,12 @@ const TextFieldPrimitive = <Multiline extends boolean>(
     size,
     testId,
     width, // @TODO: remove custom destructuring for 3.0 release
+    left, // @TODO: remove custom destructuring for 3.0 release
+    bottom, // @TODO: remove custom destructuring for 3.0 release
+    position, // @TODO: remove custom destructuring for 3.0 release
+    padding, // @TODO: remove custom destructuring for 3.0 release
+    right, // @TODO: remove custom destructuring for 3.0 release
+    top, // @TODO: remove custom destructuring for 3.0 release
     ..._rest
   } = props;
 
@@ -97,9 +103,15 @@ const TextFieldPrimitive = <Multiline extends boolean>(
         ComponentClassNames.TextField,
         className
       )}
+      bottom={bottom}
       data-size={size}
       height={height}
+      left={right}
+      padding={padding}
+      position={position}
+      right={right}
       testId={testId}
+      top={top}
       width={width}
       {...flexContainerStyleProps}
     >

--- a/packages/react/src/primitives/TextField/TextField.tsx
+++ b/packages/react/src/primitives/TextField/TextField.tsx
@@ -30,7 +30,6 @@ const TextFieldPrimitive = <Multiline extends boolean>(
     descriptiveText,
     errorMessage,
     hasError = false,
-    height, // @TODO: remove custom destructuring for 3.0 release
     id,
     label,
     labelHidden = false,
@@ -42,13 +41,16 @@ const TextFieldPrimitive = <Multiline extends boolean>(
     type, // remove from rest to prevent passing as DOM attribute to textarea
     size,
     testId,
-    width, // @TODO: remove custom destructuring for 3.0 release
-    left, // @TODO: remove custom destructuring for 3.0 release
+
     bottom, // @TODO: remove custom destructuring for 3.0 release
-    position, // @TODO: remove custom destructuring for 3.0 release
+    height, // @TODO: remove custom destructuring for 3.0 release
+    left, // @TODO: remove custom destructuring for 3.0 release
     padding, // @TODO: remove custom destructuring for 3.0 release
+    position, // @TODO: remove custom destructuring for 3.0 release
     right, // @TODO: remove custom destructuring for 3.0 release
     top, // @TODO: remove custom destructuring for 3.0 release
+    width, // @TODO: remove custom destructuring for 3.0 release
+
     ..._rest
   } = props;
 


### PR DESCRIPTION
#### Description of changes
Figma to Studio integration will absolutely position components when autolayout is not enabled in Figma. This causes an issue for field components that were passing `position`, `top`, and `left`, and `padding` down to the input element, causing the layout not to match Figma. This is fixed by moving the absolute position props and `padding` up to the container Flex element.

![Screen Shot 2022-03-16 at 6 37 34 PM](https://user-images.githubusercontent.com/6165315/158719876-75fab4d7-bba6-494d-af7a-b31f36a5c2bc.png)

#### Description of how you validated changes
* Manually published packaged to local Verdaccio and installed in in sample app
* Checked that sample app using code generated from Amplify Studio matches Figma


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
