### PR TITLE
fix: make shouldWarn required prop on useDeprecationWarning

### DIFF
--- a/.changeset/unlucky-ducks-melt.md
+++ b/.changeset/unlucky-ducks-melt.md
@@ -2,7 +2,7 @@
 "@aws-amplify/ui-react": patch
 ---
 
-fix: supress erroneous isMultiline deprecation warnings on TextField component
+fix: suppress erroneous isMultiline deprecation warnings on TextField component
 
 Deprecation warning messages are showing for users of TextField for the isMultiline prop even though
 they are not using the prop. This issue is fixed by making the shouldWarn prop required on the internal

--- a/.changeset/unlucky-ducks-melt.md
+++ b/.changeset/unlucky-ducks-melt.md
@@ -1,0 +1,9 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix: supress erroneous isMultiline deprecation warnings on TextField component
+
+Deprecation warning messages are showing for users of TextField for the isMultiline prop even though
+they are not using the prop. This issue is fixed by making the shouldWarn prop required on the internal
+useDeprecationWarning hook.

--- a/packages/react/src/hooks/__tests__/useDeprecationWarning.test.tsx
+++ b/packages/react/src/hooks/__tests__/useDeprecationWarning.test.tsx
@@ -17,7 +17,7 @@ describe('useDeprecationWarning', () => {
   it('should render message (shouldWarn true)', async () => {
     const message = 'This component is deprecated, use X instead';
 
-    renderHook(() => useDeprecationWarning({ message }));
+    renderHook(() => useDeprecationWarning({ shouldWarn: true, message }));
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(message);
   });
@@ -30,13 +30,21 @@ describe('useDeprecationWarning', () => {
     expect(console.warn).not.toHaveBeenCalledWith(message);
   });
 
+  it('should not render message if shouldWarn is undefined', async () => {
+    const message = 'This component is deprecated, use X instead';
+
+    renderHook(() => useDeprecationWarning({ message, shouldWarn: undefined }));
+    expect(console.warn).toHaveBeenCalledTimes(0);
+    expect(console.warn).not.toHaveBeenCalledWith(message);
+  });
+
   it('should not throw reference error if process is not defined', async () => {
     const message = 'This component is deprecated, use X instead';
 
     const originalProcess = global.process;
     delete global.process;
 
-    renderHook(() => useDeprecationWarning({ message }));
+    renderHook(() => useDeprecationWarning({ shouldWarn: true, message }));
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(message);
 

--- a/packages/react/src/hooks/useDeprecationWarning.ts
+++ b/packages/react/src/hooks/useDeprecationWarning.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 interface UseDeprecationWarning {
-  shouldWarn?: boolean;
+  shouldWarn: boolean;
   message: string;
 }
 
 export const useDeprecationWarning = ({
-  shouldWarn = true,
+  shouldWarn,
   message,
 }: UseDeprecationWarning) => {
   React.useEffect(() => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This fixes an issue where when isMultiline is undefined (which is usually true), shouldWarn will default to true and trigger the warning. This causes the TextField component to always complain about the use of isMultiline for fields where it's not set to `true`. Now setting `isMultiline` to any falsy value should not trigger the deprecation warning. I added a unit test to ensure passing `undefined` to `shouldWarn` doesn't trigger a console warning.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

* Ran docs site and verified that Multline deprecation message is no longer shown

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
