### PR TITLE
Add how to default export with `AmplifyProvider` on Next.js

### DIFF
--- a/docs/src/pages/getting-started/installation/dependencies.react.mdx
+++ b/docs/src/pages/getting-started/installation/dependencies.react.mdx
@@ -21,6 +21,8 @@ yarn add aws-amplify @aws-amplify/ui-react
 
 Wrap your application in `<AmplifyProvider/>` and include default styling:
 
+<Tabs>
+<TabItem title="React" >
 ```jsx
 import { AmplifyProvider } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css'; // default theme
@@ -31,3 +33,19 @@ export default () => (
   </AmplifyProvider>
 );
 ```
+</TabItem>
+<TabItem title="Next.js" >
+```jsx
+import { AmplifyProvider } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css'; // default theme
+
+export default function App(props) {
+  return (
+    <Authenticator.Provider>
+      <MyApp {...props} />
+    </Authenticator.Provider>
+  );
+};
+```
+</TabItem>
+</Tabs>

--- a/docs/src/pages/getting-started/installation/dependencies.react.mdx
+++ b/docs/src/pages/getting-started/installation/dependencies.react.mdx
@@ -22,7 +22,7 @@ yarn add aws-amplify @aws-amplify/ui-react
 Wrap your application in `<AmplifyProvider/>` and include default styling:
 
 <Tabs>
-<TabItem title="React" >
+<TabItem title="React">
 ```jsx
 import { AmplifyProvider } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css'; // default theme
@@ -33,7 +33,7 @@ export default function App() {
       <App />
     </AmplifyProvider>
   );
-}
+};
 ```
 </TabItem>
 <TabItem title="Next.js" >

--- a/docs/src/pages/getting-started/installation/dependencies.react.mdx
+++ b/docs/src/pages/getting-started/installation/dependencies.react.mdx
@@ -22,7 +22,7 @@ yarn add aws-amplify @aws-amplify/ui-react
 Wrap your application in `<AmplifyProvider/>` and include default styling:
 
 <Tabs>
-<TabItem title="React">
+<TabItem title="Create React App">
 ```jsx
 import { AmplifyProvider } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css'; // default theme

--- a/docs/src/pages/getting-started/installation/dependencies.react.mdx
+++ b/docs/src/pages/getting-started/installation/dependencies.react.mdx
@@ -27,11 +27,13 @@ Wrap your application in `<AmplifyProvider/>` and include default styling:
 import { AmplifyProvider } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css'; // default theme
 
-export default () => (
-  <AmplifyProvider>
-    <App />
-  </AmplifyProvider>
-);
+export default function App() {
+  return (
+    <AmplifyProvider>
+      <App />
+    </AmplifyProvider>
+  );
+}
 ```
 </TabItem>
 <TabItem title="Next.js" >
@@ -41,9 +43,9 @@ import '@aws-amplify/ui-react/styles.css'; // default theme
 
 export default function App(props) {
   return (
-    <Authenticator.Provider>
+    <AmplifyProvider>
       <MyApp {...props} />
-    </Authenticator.Provider>
+    </AmplifyProvider>
   );
 };
 ```


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Trying to wrap your application in <AmplifyProvider/> on `Next.js` with the code snippet on https://ui.docs.amplify.aws/getting-started/installation#packages will fail, with the error described in #1345.

This is because the `default export` on `Next.js` requires `{ Component, pageProps }` as props, while that of CRA does not take any props.

This PR adds a tab for `Next.js` to resolve this. Also changed arrow function to named constant here, to satisfy `react/display-name` eslint rule: [link](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md#rule-details).
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
Resolves #1345, resolves #1367.

#### Description of how you validated changes


https://user-images.githubusercontent.com/43682783/159073863-07ce2110-20a6-48a5-8f8d-ce6c1bd64bde.mp4

Also checked with a new `create-next-app` [codesandbox](https://codesandbox.io/s/nextjs12-authenticator-p39p18?file=/pages/_app.js). 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
