### PR TITLE
fix(examples,e2e): Add examples and tests for #1580

### DIFF
--- a/examples/angular/src/app/app-routing.module.ts
+++ b/examples/angular/src/app/app-routing.module.ts
@@ -19,6 +19,7 @@ import { SignUpWithEmailLambdaComponent } from 'src/pages/ui/components/authenti
 import { SignUpWithPhoneComponent } from 'src/pages/ui/components/authenticator/sign-up-with-phone/sign-up-with-phone.component';
 import { SignUpWithUsernameComponent } from 'src/pages/ui/components/authenticator/sign-up-with-username/sign-up-with-username.component';
 import { UseAuthenticatorComponent } from 'src/pages/ui/components/authenticator/useAuthenticator/useAuthenticator.component';
+import { UseAuthenticatorHomeComponent } from 'src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component';
 
 const routes: Routes = [
   {
@@ -100,6 +101,10 @@ const routes: Routes = [
   {
     path: 'ui/components/authenticator/useAuthenticator',
     component: UseAuthenticatorComponent,
+  },
+  {
+    path: 'ui/components/authenticator/useAuthenticator/home',
+    component: UseAuthenticatorHomeComponent,
   },
 ];
 

--- a/examples/angular/src/app/app.module.ts
+++ b/examples/angular/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { SignUpWithEmailLambdaComponent } from 'src/pages/ui/components/authenti
 import { SignUpWithPhoneComponent } from 'src/pages/ui/components/authenticator/sign-up-with-phone/sign-up-with-phone.component';
 import { SignUpWithUsernameComponent } from 'src/pages/ui/components/authenticator/sign-up-with-username/sign-up-with-username.component';
 import { UseAuthenticatorComponent } from 'src/pages/ui/components/authenticator/useAuthenticator/useAuthenticator.component';
+import { UseAuthenticatorHomeComponent } from 'src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component';
 
 @NgModule({
   declarations: [
@@ -49,6 +50,7 @@ import { UseAuthenticatorComponent } from 'src/pages/ui/components/authenticator
     SignUpWithPhoneComponent,
     SignUpWithUsernameComponent,
     UseAuthenticatorComponent,
+    UseAuthenticatorHomeComponent,
   ],
   imports: [
     BrowserModule,

--- a/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.html
@@ -1,0 +1,1 @@
+<div>Welcome, {{ authenticator.user?.username }}!</div>

--- a/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.html
@@ -1,1 +1,2 @@
 <div>Welcome, {{ authenticator.user?.username }}!</div>
+<button (click)="handleClick($event)">Sign Out</button>

--- a/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.html
@@ -1,2 +1,2 @@
-<div>Welcome, {{ authenticator.user?.username }}!</div>
+<div>Hello, {{ authenticator.user?.username }}!</div>
 <button (click)="handleClick($event)">Sign Out</button>

--- a/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { Amplify } from 'aws-amplify';
+import { AuthenticatorService } from '@aws-amplify/ui-angular';
+
+import awsExports from '../aws-exports';
+
+@Component({
+  selector: 'use-authenticator',
+  templateUrl: 'useAuthenticatorHome.component.html',
+})
+export class UseAuthenticatorHomeComponent {
+  constructor(public authenticator: AuthenticatorService) {
+    Amplify.configure(awsExports);
+  }
+}

--- a/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
 import { Amplify } from 'aws-amplify';
 import { AuthenticatorService } from '@aws-amplify/ui-angular';
 
@@ -9,7 +10,16 @@ import awsExports from '../aws-exports';
   templateUrl: 'useAuthenticatorHome.component.html',
 })
 export class UseAuthenticatorHomeComponent {
-  constructor(public authenticator: AuthenticatorService) {
+  constructor(
+    public authenticator: AuthenticatorService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {
     Amplify.configure(awsExports);
+  }
+
+  public handleClick(event: Event) {
+    event.preventDefault();
+    this.router.navigate(['../'], { relativeTo: this.route });
   }
 }

--- a/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/home/useAuthenticatorHome.component.ts
@@ -20,6 +20,7 @@ export class UseAuthenticatorHomeComponent {
 
   public handleClick(event: Event) {
     event.preventDefault();
+    this.authenticator.signOut();
     this.router.navigate(['../'], { relativeTo: this.route });
   }
 }

--- a/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/useAuthenticator.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/useAuthenticator.component.html
@@ -1,8 +1,5 @@
-<ng-container *ngIf="authenticator.route === 'authenticated'">
-  <h2>Welcome, {{ authenticator.user.username }}!</h2>
-  <button (click)="authenticator.signOut()">Sign Out</button>
-</ng-container>
-
-<ng-container *ngIf="authenticator.route !== 'authenticated'">
-  <amplify-authenticator></amplify-authenticator>
-</ng-container>
+<amplify-authenticator>
+  <ng-template amplifySlot="authenticated">
+    <button (click)="navigateHome($event)">Navigate to Home</button>
+  </ng-template>
+</amplify-authenticator>

--- a/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/useAuthenticator.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/useAuthenticator/useAuthenticator.component.ts
@@ -1,15 +1,25 @@
-import { Component } from '@angular/core';
-import { Amplify } from 'aws-amplify';
+import { Component, OnInit } from '@angular/core';
+import { Amplify, Auth } from 'aws-amplify';
 import { AuthenticatorService } from '@aws-amplify/ui-angular';
 
 import awsExports from './aws-exports';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'use-authenticator',
   templateUrl: 'useAuthenticator.component.html',
 })
 export class UseAuthenticatorComponent {
-  constructor(public authenticator: AuthenticatorService) {
+  constructor(
+    public authenticator: AuthenticatorService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {
     Amplify.configure(awsExports);
+  }
+
+  public navigateHome(event: Event) {
+    event.preventDefault();
+    this.router.navigate(['home'], { relativeTo: this.route });
   }
 }

--- a/examples/next/pages/_app.page.tsx
+++ b/examples/next/pages/_app.page.tsx
@@ -3,9 +3,18 @@
 // https://nextjs.org/docs/advanced-features/custom-app
 import App from 'next/app';
 import { Amplify } from 'aws-amplify';
+import { Authenticator, AmplifyProvider } from '@aws-amplify/ui-react';
 
 if (typeof window !== 'undefined') {
   window['Amplify'] = Amplify;
 }
 
-export default App;
+export default function MyApp(props) {
+  return (
+    <AmplifyProvider>
+      <Authenticator.Provider>
+        <App {...props} />
+      </Authenticator.Provider>
+    </AmplifyProvider>
+  );
+}

--- a/examples/next/pages/ui/components/authenticator/useAuthenticator/home/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/useAuthenticator/home/index.page.tsx
@@ -1,4 +1,8 @@
+import { Amplify } from 'aws-amplify';
 import { useAuthenticator } from '@aws-amplify/ui-react';
+import awsExports from '../aws-exports';
+
+Amplify.configure(awsExports);
 
 export default function App() {
   const { user } = useAuthenticator();

--- a/examples/next/pages/ui/components/authenticator/useAuthenticator/home/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/useAuthenticator/home/index.page.tsx
@@ -1,0 +1,11 @@
+import { useAuthenticator } from '@aws-amplify/ui-react';
+
+export default function App() {
+  const { user } = useAuthenticator();
+
+  return (
+    <>
+      <div>Welcome, {user?.username}</div>
+    </>
+  );
+}

--- a/examples/next/pages/ui/components/authenticator/useAuthenticator/home/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/useAuthenticator/home/index.page.tsx
@@ -1,15 +1,24 @@
 import { Amplify } from 'aws-amplify';
 import { useAuthenticator } from '@aws-amplify/ui-react';
+import * as React from 'react';
 import awsExports from '../aws-exports';
+import router from 'next/router';
 
 Amplify.configure(awsExports);
 
 export default function App() {
-  const { user } = useAuthenticator();
+  const { user, signOut } = useAuthenticator();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    signOut();
+    router.push('../useAuthenticator');
+  };
 
   return (
     <>
       <div>Welcome, {user?.username}</div>
+      <button onClick={handleClick}>Sign Out</button>
     </>
   );
 }

--- a/examples/next/pages/ui/components/authenticator/useAuthenticator/home/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/useAuthenticator/home/index.page.tsx
@@ -17,7 +17,7 @@ export default function App() {
 
   return (
     <>
-      <div>Welcome, {user?.username}</div>
+      <div>Hello, {user?.username}!</div>
       <button onClick={handleClick}>Sign Out</button>
     </>
   );

--- a/examples/next/pages/ui/components/authenticator/useAuthenticator/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/useAuthenticator/index.page.tsx
@@ -1,34 +1,19 @@
-import { Amplify } from 'aws-amplify';
+import router from 'next/router';
 
-import { Authenticator, useAuthenticator } from '@aws-amplify/ui-react';
+import { Amplify } from 'aws-amplify';
 import '@aws-amplify/ui-react/styles.css';
 
 import awsExports from './aws-exports';
+import { Authenticator } from '@aws-amplify/ui-react';
 
 Amplify.configure(awsExports);
 
-const Home = () => {
-  const { user, signOut } = useAuthenticator((context) => [context.user]);
+export default function App() {
+  const navigateHome = () => router.push('useAuthenticator/home');
 
   return (
-    <>
-      <h2>Welcome, {user.username}!</h2>
-      <button onClick={signOut}>Sign Out</button>
-    </>
-  );
-};
-
-const Login = () => <Authenticator />;
-
-function App() {
-  const { route } = useAuthenticator((context) => [context.route]);
-  return route === 'authenticated' ? <Home /> : <Login />;
-}
-
-export default function AppWithProvider() {
-  return (
-    <Authenticator.Provider>
-      <App></App>
-    </Authenticator.Provider>
+    <Authenticator>
+      {() => <button onClick={navigateHome}>Navigate to Home</button>}
+    </Authenticator>
   );
 }

--- a/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { toRefs } from 'vue';
+import Amplify from 'aws-amplify';
+import { useAuthenticator } from '@aws-amplify/ui-vue';
+import '@aws-amplify/ui-vue/styles.css';
+import aws_exports from '../aws-exports';
+
+Amplify.configure(aws_exports);
+
+const { user } = toRefs(useAuthenticator());
+</script>
+
+<template>
+  <div>Hello, {{ user?.username }}</div>
+</template>

--- a/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
@@ -3,7 +3,7 @@ import { toRefs } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { Amplify } from 'aws-amplify';
-import { useAuthenticator } from '@aws-amplify/ui-vue';
+import { Authenticator, useAuthenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '../aws-exports';
 
@@ -19,6 +19,8 @@ const handleClick = (event: Event) => {
 </script>
 
 <template>
+  <!-- TODO: this authenticator shouldn't be needed -->
+  <authenticator></authenticator>
   <div>Hello, {{ user?.username }}!</div>
   <button @click="handleClick">Sign Out</button>
 </template>

--- a/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
@@ -13,7 +13,7 @@ const router = useRouter();
 const { user, signOut } = toRefs(useAuthenticator());
 const handleClick = (event: Event) => {
   event.preventDefault();
-  signOut();
+  signOut.value();
   router.push('../useAuthenticator');
 };
 </script>

--- a/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
@@ -11,5 +11,5 @@ const { user } = toRefs(useAuthenticator());
 </script>
 
 <template>
-  <div>Hello, {{ user?.username }}</div>
+  <div>Hello, {{ user?.username }}!</div>
 </template>

--- a/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
@@ -11,7 +11,7 @@ Amplify.configure(aws_exports);
 
 const router = useRouter();
 const { user, signOut } = toRefs(useAuthenticator());
-const handleClick = (event: Event) => {
+const handleClick = (event) => {
   event.preventDefault();
   signOut.value();
   router.push('../useAuthenticator');

--- a/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/home/index.vue
@@ -1,15 +1,24 @@
 <script setup lang="ts">
 import { toRefs } from 'vue';
-import Amplify from 'aws-amplify';
+import { useRouter } from 'vue-router';
+
+import { Amplify } from 'aws-amplify';
 import { useAuthenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from '../aws-exports';
 
 Amplify.configure(aws_exports);
 
-const { user } = toRefs(useAuthenticator());
+const router = useRouter();
+const { user, signOut } = toRefs(useAuthenticator());
+const handleClick = (event: Event) => {
+  event.preventDefault();
+  signOut();
+  router.push('../useAuthenticator');
+};
 </script>
 
 <template>
   <div>Hello, {{ user?.username }}!</div>
+  <button @click="handleClick">Sign Out</button>
 </template>

--- a/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/index.vue
@@ -12,10 +12,11 @@ const props = useAuthenticator();
 </script>
 
 <template>
-  <authenticator> </authenticator>
-  <template v-if="route === 'authenticated'">
-    <router-link to="useAuthenticator/home">
-      <button>Navigate to Home</button>
-    </router-link>
-  </template>
+  <authenticator>
+    <template v-slot>
+      <router-link to="useAuthenticator/home">
+        <button>Navigate to Home</button>
+      </router-link>
+    </template>
+  </authenticator>
 </template>

--- a/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/useAuthenticator/index.vue
@@ -7,14 +7,15 @@ import aws_exports from './aws-exports';
 
 Amplify.configure(aws_exports);
 
-const { route, user, signOut } = toRefs(useAuthenticator());
+const { route } = toRefs(useAuthenticator());
 const props = useAuthenticator();
 </script>
 
 <template>
   <authenticator> </authenticator>
   <template v-if="route === 'authenticated'">
-    <h1>Hello {{ user?.username }}!</h1>
-    <button @click="signOut">Sign out</button>
+    <router-link to="useAuthenticator/home">
+      <button>Navigate to Home</button>
+    </router-link>
   </template>
 </template>

--- a/packages/e2e/cypress/integration/ui/components/authenticator/useAuthenticator/useAuthenticator.ts
+++ b/packages/e2e/cypress/integration/ui/components/authenticator/useAuthenticator/useAuthenticator.ts
@@ -1,0 +1,7 @@
+import { Then, When } from 'cypress-cucumber-preprocessor/steps';
+
+Then('I see a valid greetings message', () => {
+  cy.findByRole('document')
+    .contains(new RegExp('^Hello, .+!$', 'i'))
+    .should('exist');
+});

--- a/packages/e2e/features/ui/components/authenticator/useAuthenticator.feature
+++ b/packages/e2e/features/ui/components/authenticator/useAuthenticator.feature
@@ -19,9 +19,9 @@ Feature: Headless Usage
     When I type my "username" with status "CONFIRMED"
     And I type my password
     And I click the "Sign in" button
-    Then I see "Sign out"
-    When I reload the page
-    Then I see "Sign out"
-    And I click the "Sign out" button
-    Then I see "Sign in"
+    Then I see "Navigate to Home"
+    And I click the "Navigate to Home" button
+    Then I see a valid greetings message
+    And I reload the page
+    Then I see a valid greetings message
 

--- a/packages/e2e/features/ui/components/authenticator/useAuthenticator.feature
+++ b/packages/e2e/features/ui/components/authenticator/useAuthenticator.feature
@@ -24,4 +24,6 @@ Feature: Headless Usage
     Then I see a valid greetings message
     And I reload the page
     Then I see a valid greetings message
+    And I click the "Sign Out" button
+    Then I see "Sign In"
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This updates the `useAuthenticator` examples and their e2e test to match #1580.

**Details**

Our current `useAuthenticator` examples are really SPA and do not sufficiently test router use cases.

There are many `useAuthenticator` bugs, especially with refresh, so we plan to update examples and tests incrementally as we add more `router` support. For now, this PR adds additional route `useAuthenticator/home`. 

This PR adds:

1. Test starts at `/useAuthenticater` route. This has the authenticator for user to sign in.
1. User signs in with Authenticator.
2. Once user signs in, they'll see a "Navigate to Home" button. (This can be something like "Manage your account" irl)
3. Clicking that button redirects user to /useAuthenticator/home`. This will have basic greetings with a sign out button.
4. Refreshing sustains auth contexts.

**Future Goals**
This example needs to be extended to better resemble customer use cases:

- [ ] Have a separate `/sign-in` route
- [ ] Automatically redirect users without buttons
- [ ] Add current user check in `/home` and make it actually protected.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Related to #1332, #1497, accompanies #1580

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
