### PR TITLE
Remove sourcemaps from rollup build

### DIFF
--- a/.changeset/wet-ads-yawn.md
+++ b/.changeset/wet-ads-yawn.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+Remove sourcemaps from rollup build

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -11,9 +11,12 @@ const config = defineConfig([
     output: {
       dir: 'dist',
       format: 'cjs',
-      sourcemap: true,
+      sourcemap: false,
     },
-    plugins: [typescript({ declarationDir: 'dist/types' }), terser()],
+    plugins: [
+      typescript({ declarationDir: 'dist/types', sourceMap: false }),
+      terser(),
+    ],
   },
   // ESM config
   {
@@ -23,9 +26,12 @@ const config = defineConfig([
       format: 'es',
       preserveModules: true,
       preserveModulesRoot: 'src',
-      sourcemap: true,
+      sourcemap: false,
     },
-    plugins: [typescript({ outDir: 'dist/esm', declaration: false }), terser()],
+    plugins: [
+      typescript({ outDir: 'dist/esm', declaration: false, sourceMap: false }),
+      terser(),
+    ],
   },
   // CSS config
   {

--- a/packages/ui/rollup.config.js
+++ b/packages/ui/rollup.config.js
@@ -10,10 +10,13 @@ const config = defineConfig([
     output: {
       dir: 'dist',
       format: 'cjs',
-      sourcemap: true,
+      sourcemap: false,
     },
     external: (id) => /style-dictionary/.test(id),
-    plugins: [typescript({ declarationDir: 'dist/types' }), terser()],
+    plugins: [
+      typescript({ declarationDir: 'dist/types', sourceMap: false }),
+      terser(),
+    ],
   },
   // ESM config
   {
@@ -23,13 +26,14 @@ const config = defineConfig([
       format: 'es',
       preserveModules: true,
       preserveModulesRoot: 'src',
-      sourcemap: true,
+      sourcemap: false,
     },
     external: (id) => /style-dictionary/.test(id),
     plugins: [
       typescript({
         outDir: 'dist/esm',
         declaration: false,
+        sourceMap: false,
       }),
       terser(),
     ],


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

In my sample apps using CRA I'm seeing a lot of errors due to our sourcemaps linking to ts files that we don't ship in the package:

![Screen Shot 2022-03-30 at 12 39 37 PM](https://user-images.githubusercontent.com/6165315/161153547-06d40984-3ca4-4217-ad06-b72679eadc76.png)

This PR disables sourcemaps in the rollup config (both prod and dev builds at the moment). I'd like to follow up with a dev version of the rollup config in a separate PR.

#### Description of how you validated changes
- [x] Rebuild `ui-react` and `ui` libraries and pulled into create react app and console warnings go away

![Screen Shot 2022-03-31 at 3 01 32 PM](https://user-images.githubusercontent.com/6165315/161156564-0f3debb0-7ab8-4f5c-9320-d8f22536ce94.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
