### PR TITLE
update react authenticator styling, remove inline style tags, add aut…

### DIFF
--- a/docs/src/components/ComponentStyleDisplay.tsx
+++ b/docs/src/components/ComponentStyleDisplay.tsx
@@ -6,6 +6,7 @@ import {
   TabItem,
   Flex,
   View,
+  ScrollView,
   Heading,
   useTheme,
 } from '@aws-amplify/ui-react';
@@ -14,7 +15,7 @@ export const ComponentStyleDisplay = ({ componentName }) => {
   const { tokens } = useTheme();
 
   return (
-    <View className="docs-component-styles">
+    <ScrollView className="docs-component-styles" maxHeight="70vh">
       <Flex
         direction={{
           base: 'column',
@@ -41,6 +42,6 @@ export const ComponentStyleDisplay = ({ componentName }) => {
           </Tabs>
         </Flex>
       </Flex>
-    </View>
+    </ScrollView>
   );
 };

--- a/docs/src/pages/components/authenticator/customization.styling.web.mdx
+++ b/docs/src/pages/components/authenticator/customization.styling.web.mdx
@@ -2,6 +2,7 @@ import { Authenticator } from '@aws-amplify/ui-react';
 
 import { Example } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
+import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 
 ### Styling
 
@@ -91,8 +92,16 @@ For example, if you'd like to hide the sign up tab, you can override the `amplif
 If you'd like to update the primary color of your submit button you can override the `amplify-button` class.
 
 ```css
-.amplify-button[data-variation='primary'] {
+.amplify-authenticator__sign-in-button {
   background: linear-gradient(
+    to right,
+    var(--amplify-colors-green-80),
+    var(--amplify-colors-orange-40)
+  );
+}
+/* OR */
+:root {
+  --amplify-components-authenticator-sign-in-button-background: linear-gradient(
     to right,
     var(--amplify-colors-green-80),
     var(--amplify-colors-orange-40)
@@ -102,15 +111,15 @@ If you'd like to update the primary color of your submit button you can override
 
 <Example>
   <style>{`
-    .customization-button .amplify-button[data-variation="primary"] {
+    .customization-button .amplify-authenticator__sign-in-button {
       background:linear-gradient(to right, var(--amplify-colors-green-80),var(--amplify-colors-orange-40) );
     }
   `}</style>
   <Authenticator className="customization-button" />
 </Example>
 
-### Amplify CSS Variables
+### Authenticator CSS Variables and Target Classes
 
 These variables are used in the theming of the Authenticator. You can override these values to update the look and feel.
 
-<Fragment>{() => import(`./css-variables.mdx`)}</Fragment>
+<ComponentStyleDisplay componentName="Authenticator" />

--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import classNames from 'classnames';
+import { ComponentClassNames } from '../../../primitives/shared';
 
 import {
   AuthChallengeNames,
@@ -32,6 +34,10 @@ export const ConfirmSignIn = (): JSX.Element => {
 
   return (
     <form
+      className={classNames(
+        ComponentClassNames.AuthenticatorConfirmSignIn,
+        ComponentClassNames.AuthenticatorForm
+      )}
       data-amplify-form=""
       data-amplify-authenticator-confirmsignin=""
       method="post"
@@ -39,8 +45,10 @@ export const ConfirmSignIn = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames(
+          'amplify-flex',
+          ComponentClassNames.AuthenticatorFieldSet
+        )}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
+import { ComponentClassNames } from '../../../primitives/shared';
 
 import { Button, Flex, Heading, Text } from '../../..';
 import {
@@ -50,6 +52,10 @@ export function ConfirmSignUp() {
   return (
     // TODO Automatically add these namespaces again from `useAmplify`
     <form
+      className={classNames(
+        ComponentClassNames.AuthenticatorForm,
+        ComponentClassNames.AuthenticatorSignUp
+      )}
       data-amplify-form=""
       data-amplify-authenticator-confirmsignup=""
       method="post"
@@ -57,14 +63,18 @@ export function ConfirmSignUp() {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames(
+          'amplify-flex',
+          ComponentClassNames.AuthenticatorFieldSet
+        )}
         disabled={isPending}
       >
         <Header />
 
         <Flex direction="column">
-          <Text style={{ marginBottom: '1rem' }}>{subtitleText}</Text>
+          <Text className={ComponentClassNames.AuthenticatorConfirmSignuUpText}>
+            {subtitleText}
+          </Text>
 
           <FormFields route="confirmSignUp" />
 
@@ -103,7 +113,10 @@ ConfirmSignUp.Header = () => {
       : translate('We Sent A Code');
 
   return (
-    <Heading level={3} style={{ fontSize: '1.5rem' }}>
+    <Heading
+      level={3}
+      className={ComponentClassNames.AuthenticatorConfirmSignUpHeading}
+    >
       {confirmSignUpHeading}
     </Heading>
   );

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -1,4 +1,6 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
+import { ComponentClassNames } from '../../../primitives/shared';
 
 import { Button, Heading, Text } from '../../..';
 import {
@@ -20,6 +22,10 @@ export const ForceNewPassword = (): JSX.Element => {
 
   return (
     <form
+      className={classNames(
+        ComponentClassNames.AuthenticatorForm,
+        ComponentClassNames.AuthenticatorForceNewPassword
+      )}
       data-amplify-form=""
       data-amplify-authenticator-forcenewpassword=""
       method="post"
@@ -28,8 +34,10 @@ export const ForceNewPassword = (): JSX.Element => {
       onBlur={handleBlur}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames(
+          'amplify-flex',
+          ComponentClassNames.AuthenticatorFieldSet
+        )}
         disabled={isPending}
       >
         <Heading level={3}>{translate('Change Password')}</Heading>

--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
+import { ComponentClassNames } from '../../../primitives/shared';
 
 import { Flex, Heading } from '../../..';
 import {
@@ -25,6 +27,10 @@ export const ConfirmResetPassword = (): JSX.Element => {
 
   return (
     <form
+      className={classNames(
+        ComponentClassNames.AuthenticatorForm,
+        ComponentClassNames.AuthenticatorConfirmResetPassword
+      )}
       data-amplify-form=""
       data-amplify-authenticator-confirmresetpassword=""
       method="post"
@@ -33,8 +39,10 @@ export const ConfirmResetPassword = (): JSX.Element => {
       onBlur={handleBlur}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames(
+          'amplify-flex',
+          ComponentClassNames.AuthenticatorFieldSet
+        )}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import classNames from 'classnames';
+import { ComponentClassNames } from '../../../primitives/shared';
 
 import { translate } from '@aws-amplify/ui';
 
@@ -26,6 +28,10 @@ export const ResetPassword = (): JSX.Element => {
 
   return (
     <form
+      className={classNames(
+        ComponentClassNames.AuthenticatorForm,
+        ComponentClassNames.AuthenticatorResetPassword
+      )}
       data-amplify-form=""
       data-amplify-authenticator-resetpassword=""
       method="post"
@@ -33,8 +39,10 @@ export const ResetPassword = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames(
+          'amplify-flex',
+          ComponentClassNames.AuthenticatorFieldSet
+        )}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/Router/index.tsx
+++ b/packages/react/src/components/Authenticator/Router/index.tsx
@@ -1,4 +1,6 @@
 import { CognitoUserAmplify } from '@aws-amplify/ui';
+import classNames from 'classnames';
+import { ComponentClassNames } from '../../../primitives/shared';
 
 import { useAuthenticator } from '..';
 import { View } from '../../..';
@@ -48,14 +50,22 @@ export function Router({
   return (
     <>
       <View
-        className={className}
+        className={classNames(
+          className,
+          ComponentClassNames.Authenticator,
+          `amplify-authenticator--${variation}`
+        )}
         data-amplify-authenticator=""
         data-variation={variation}
       >
-        <View data-amplify-container="">
+        <View
+          data-amplify-container=""
+          className={ComponentClassNames.AuthenticatorContainer}
+        >
           <Header />
 
           <View
+            className={ComponentClassNames.AuthenticatorRouter}
             data-amplify-router=""
             data-amplify-router-content={hasTabs(route) ? undefined : ''}
           >

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -1,5 +1,7 @@
 import QRCode from 'qrcode';
 import * as React from 'react';
+import classNames from 'classnames';
+import { ComponentClassNames } from '../../../primitives/shared';
 
 import { Auth, Logger } from 'aws-amplify';
 import { getActorState, SignInState, translate } from '@aws-amplify/ui';
@@ -70,6 +72,10 @@ export const SetupTOTP = (): JSX.Element => {
 
   return (
     <form
+      className={classNames(
+        ComponentClassNames.AuthenticatorForm,
+        ComponentClassNames.AuthenticatorSetupTotp
+      )}
       data-amplify-form=""
       data-amplify-authenticator-setup-totp=""
       method="post"
@@ -77,8 +83,10 @@ export const SetupTOTP = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames(
+          'amplify-flex',
+          ComponentClassNames.AuthenticatorFieldSet
+        )}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
 import { translate, hasTranslation } from '@aws-amplify/ui';
+import classNames from 'classnames';
+import { ComponentClassNames } from '../../../primitives/shared';
 
 import { Button, Flex, View, VisuallyHidden } from '../../..';
 import { FederatedSignIn } from '../FederatedSignIn';
@@ -28,6 +30,10 @@ export function SignIn() {
       <Header />
 
       <form
+        className={classNames(
+          ComponentClassNames.AuthenticatorForm,
+          ComponentClassNames.AuthenticatorSignIn
+        )}
         data-amplify-form=""
         data-amplify-authenticator-signin=""
         method="post"
@@ -37,8 +43,10 @@ export function SignIn() {
         <FederatedSignIn />
         <Flex direction="column">
           <fieldset
-            style={{ display: 'flex', flexDirection: 'column' }}
-            className="amplify-flex"
+            className={classNames(
+              'amplify-flex',
+              ComponentClassNames.AuthenticatorFieldSet
+            )}
             disabled={isPending}
           >
             <VisuallyHidden>
@@ -56,6 +64,7 @@ export function SignIn() {
             variation="primary"
             isLoading={isPending}
             loadingText={translate('Signing in')}
+            className={ComponentClassNames.AuthenticatorSignInButton}
           >
             {translate('Sign in')}
           </Button>
@@ -76,7 +85,10 @@ SignIn.Footer = () => {
     : translate('Forgot your password? ');
 
   return (
-    <View data-amplify-footer="">
+    <View
+      data-amplify-footer=""
+      className={ComponentClassNames.AuthenticatorFooter}
+    >
       <Button
         fontWeight="normal"
         onClick={toResetPassword}

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -1,4 +1,6 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
+import { ComponentClassNames } from '../../../primitives/shared';
 
 import { Button, Flex, View } from '../../..';
 import { FederatedSignIn } from '../FederatedSignIn';
@@ -29,6 +31,10 @@ export function SignUp() {
       <Header />
 
       <form
+        className={classNames(
+          ComponentClassNames.AuthenticatorForm,
+          ComponentClassNames.AuthenticatorSignUp
+        )}
         data-amplify-form=""
         data-amplify-authenticator-signup=""
         method="post"
@@ -39,8 +45,10 @@ export function SignUp() {
         <FederatedSignIn />
 
         <fieldset
-          style={{ display: 'flex', flexDirection: 'column' }}
-          className="amplify-flex"
+          className={classNames(
+            'amplify-flex',
+            ComponentClassNames.AuthenticatorFieldSet
+          )}
           disabled={isPending}
         >
           <Flex direction="column">

--- a/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import classNames from 'classnames';
+import { ComponentClassNames } from '../../../primitives/shared';
 
 import { translate } from '@aws-amplify/ui';
 
@@ -26,6 +28,10 @@ export const ConfirmVerifyUser = (): JSX.Element => {
 
   return (
     <form
+      className={classNames(
+        ComponentClassNames.AuthenticatorForm,
+        ComponentClassNames.AuthenticatorConfirmVerifyUser
+      )}
       data-amplify-form=""
       data-amplify-authenticator-confirmverifyuser=""
       method="post"
@@ -33,8 +39,10 @@ export const ConfirmVerifyUser = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames(
+          'amplify-flex',
+          ComponentClassNames.AuthenticatorFieldSet
+        )}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
@@ -7,6 +7,8 @@ import {
   SignInContext,
   translate,
 } from '@aws-amplify/ui';
+import classNames from 'classnames';
+import { ComponentClassNames } from '../../../primitives/shared';
 
 import { Heading, Radio, RadioGroupField } from '../../..';
 import {
@@ -83,6 +85,10 @@ export const VerifyUser = (): JSX.Element => {
 
   return (
     <form
+      className={classNames(
+        ComponentClassNames.AuthenticatorForm,
+        ComponentClassNames.AuthenticatorVerifyUser
+      )}
       data-amplify-form=""
       data-amplify-authenticator-verifyuser=""
       method="post"
@@ -90,8 +96,10 @@ export const VerifyUser = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames(
+          'amplify-flex',
+          ComponentClassNames.AuthenticatorFieldSet
+        )}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/shared/ValidationErrors.tsx
+++ b/packages/react/src/components/Authenticator/shared/ValidationErrors.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import { ComponentClassNames } from '../../../primitives/shared';
 import { View } from '../../../primitives/View';
 import { Text } from '../../../primitives/Text';
 
@@ -9,7 +10,10 @@ export const ValidationErrors = ({ errors }: ValidationErrorsProps) => {
   if (!(errors?.length > 0)) return null;
 
   return (
-    <View data-amplify-sign-up-errors>
+    <View
+      data-amplify-sign-up-errors
+      className={ComponentClassNames.AuthenticatorSignUpErrors}
+    >
       {errors.map((error, idx) => {
         return (
           <Text key={error} role="alert" variation="error">

--- a/packages/react/src/primitives/shared/constants.ts
+++ b/packages/react/src/primitives/shared/constants.ts
@@ -24,6 +24,119 @@ export const ComponentClassObject = {
     components: ['Alert'],
     description: 'Class applied to the close Button',
   },
+  Authenticator: {
+    className: 'amplify-authenticator',
+    components: ['Authenticator'],
+    description: 'Top level element that wraps the Authenticator',
+  },
+  AuthenticatorConfirmSignIn: {
+    className: 'amplify-authenticator__comfirm-sign-in',
+    components: ['Authenticator'],
+    description: 'Element that wraps the authenticator confirm sign in',
+  },
+  AuthenticatorConfirmSignUp: {
+    className: 'amplify-authenticator__confirm-sign-up',
+    components: ['Authenticator'],
+    description: 'Element that wraps the authenticator confirm sign up',
+  },
+  AuthenticatorConfirmSignuUpText: {
+    className: 'amplify-authenticator__confirm-sign-up-text',
+    components: ['Authenticator'],
+    description:
+      'Class targetting the subtitle text within the confirm sign up',
+  },
+  AuthenticatorConfirmSignUpHeading: {
+    className: 'amplify-authenticator__confirm-sign-up-heading',
+    components: ['Authenticator'],
+    description: 'Class targetting the confirm sign up heading',
+  },
+  AuthenticatorContainer: {
+    className: 'amplify-authenticator__container',
+    components: ['Authenticator'],
+    description:
+      'Element within the authentication that wraps all the authenticator states',
+  },
+  AuthenticatorFieldSet: {
+    className: 'amplify-authenticator__fieldset',
+    components: ['Authenticator'],
+    description: 'Fieldset element containing the authenticator fields',
+  },
+  AuthenticatorFooter: {
+    className: 'amplify-authenticator__footer',
+    components: ['Authenticator'],
+    description: 'Class targetting the authenticator footer',
+  },
+  AuthenticatorForm: {
+    className: 'amplify-authenticator__form',
+    components: ['Authenticator'],
+    description:
+      'Class targetting the authenticator form across all authenticator states',
+  },
+  AuthenticatorSignUpErrors: {
+    className: 'amplify-authenticator__sign-up-errors',
+    components: ['Authenticator'],
+    description: 'Element that wraps the authenticator sign up error',
+  },
+  AuthenticatorForceNewPassword: {
+    className: 'amplify-authenticator__force-new-password',
+    components: ['Authenticator'],
+    description: 'Element that wraps the authenticator force new password',
+  },
+  AuthenticatorConfirmResetPassword: {
+    className: 'amplify-authenticator__confirm-reset-password',
+    components: ['Authenticator'],
+    description: 'Element that wraps the authenticator confirm reset password',
+  },
+  AuthenticatorResetPassword: {
+    className: 'amplify-authenticator__reset-password',
+    components: ['Authenticator'],
+    description: 'Element that wraps the authenticator reset password',
+  },
+  AuthenticatorRouter: {
+    className: 'amplify-authenticator__router',
+    components: ['Authenticator'],
+    description: 'Element container wrapping all authenticator routes',
+  },
+  AuthenticatorSetupTotp: {
+    className: 'amplify-authenticator__setup-totp',
+    components: ['Authenticator'],
+    description: 'Element that wraps the authenticator setup totp',
+  },
+  AuthenticatorSignIn: {
+    className: 'amplify-authenticator__sign-in',
+    components: ['Authenticator'],
+    description: 'Element that wraps the authenticator sign in',
+  },
+  AuthenticatorSignInButton: {
+    className: 'amplify-authenticator__sign-in-button',
+    components: ['Authenticator'],
+    description: 'Authenticator sign in button',
+  },
+  AuthenticatorSignUp: {
+    className: 'amplify-authenticator__sign-up',
+    components: ['Authenticator'],
+    description: 'Element that wraps the authenticator sign up',
+  },
+  AuthenticatorConfirmVerifyUser: {
+    className: 'amplify-authenticator__confirm-verify-user',
+    components: ['Authenticator'],
+    description: 'Element that wraps the authenticator confirm verify user',
+  },
+  AuthenticatorVerifyUser: {
+    className: 'amplify-authenticator__verify-user',
+    components: ['Authenticator'],
+    description: 'Element that wraps the authenticator verify user',
+  },
+  AuthenticatorVariationDefault: {
+    className: 'amplify-authenticator--default',
+    components: ['Authenticator'],
+    description: 'Class targetting the default variation of the authenticator',
+  },
+  AuthenticatorVariationModal: {
+    className: 'amplify-authenticator--modal',
+    components: ['Authenticator'],
+    description: 'Class targetting the modal variation of the authenticator',
+  },
   Badge: {
     className: 'amplify-badge',
     components: ['Badge'],

--- a/packages/ui/src/theme/css/component/authenticator.scss
+++ b/packages/ui/src/theme/css/component/authenticator.scss
@@ -56,3 +56,17 @@
     }
   }
 }
+
+.amplify-authenticator__fieldset {
+  flex-direction: var(
+    --amplify-components-authenticator-fieldset-flex-direction
+  );
+}
+
+.amplify-authenticator__confirm-sign-up-text {
+  margin-bottom: var(--amplify-space-relative-medium);
+}
+
+.amplify-authenticator__confirm-sign-up-heading {
+  font-size: var(--amplify-font-sizes-xl);
+}

--- a/packages/ui/src/theme/tokens/components/authenticator.ts
+++ b/packages/ui/src/theme/tokens/components/authenticator.ts
@@ -10,6 +10,9 @@ export const authenticator = {
   container: {
     widthMax: { value: '30rem' },
   },
+  fieldset: {
+    flexDirection: { value: 'column' },
+  },
   router: {
     borderWidth: { value: '{borderWidths.small.value}' },
     borderStyle: { value: 'solid' },
@@ -32,6 +35,15 @@ export const authenticator = {
     color: { value: '{colors.neutral.80.value}' },
     orLine: {
       backgroundColor: { value: '{colors.background.primary.value}' },
+    },
+  },
+  signIn: {
+    button: {
+      fontWeight: { value: '{components.button.fontWeight.value}' },
+      borderColor: { value: '{components.button.primary.borderColor.value}' },
+      background: {
+        value: '{components.button.primary.backgroundColor.value}',
+      },
     },
   },
 };


### PR DESCRIPTION
This pull request has two goals the first is to remove all of the inline style tags from the react Authenticator, the second is to add and document new css classes and design tokens that will specifically target pieces of the Authenticator.  The goal is to provide a more consistent customization experience with Authenticator as with our primitive components.

![authClasses](https://user-images.githubusercontent.com/7351516/161600379-0ed70786-3de8-4b49-aa97-3e3121f06d09.gif)

The styling documentation under the Authenticator page is updated to contain just the classes and css variables that target the Authenticator. The list of all css variables is being removed and might want to be moved to another section (maybe theming or a seperate style guide) to preserve the entire list. 

This allows our customers to customize the Authenticator in a more direct and straightforward manner.
old style rules using data attributes moves to classes `[data-amplify-authenticator]` --> `.amplify-authenticator`

customizing the authenticator by using rules that target primitives within the authenticator move to classes
`[data-amplify-authenticator] .amplify-button[data-variation="primary"]` --> `.amplify-authenticator-sign-in-button`

overriding specific css variables for authenticator at a root level becomes possible
```
:root {
  --amplify-authenticator-sign-in-button-background: red;
}
```

this also opens up the authenticator to being more fully themed through our built in theming system by overriding the newly created authenticator design tokens in the amplify provider
```
const theme = {
  name: 'my-theme',
  tokens: {
    components: {
      authenticator: {
        signIn: { 
          button: {
             background: {
                 value: '{colors.brand.secondary.10.value}'
             }
          }
        },
      },
    },
  },
};
```

This is not a breaking change as the currently used methods for styling the authenticator are going to remain and customers can continue to use them.  Their current rules will only be affected if they are relying on the current specificity of the authenticator rules to override other rules they have specified with lower specificity because the new class rules will be a flat css structure with 010 specificity.  

** This pull request is not ready to be merged as additional classes and design tokens need to be added, this is just to demonstrate the concept and continue the discussion around the topic **