### PR TITLE
fix: remove double border on TextField outer components

### DIFF
--- a/.changeset/kind-badgers-marry.md
+++ b/.changeset/kind-badgers-marry.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix: remove double border on TextField outer components

--- a/docs/src/styles/primitives/passwordFieldStyles.css
+++ b/docs/src/styles/primitives/passwordFieldStyles.css
@@ -5,7 +5,3 @@
 .custom-passwordfield-class .amplify-button {
   border-radius: 0;
 }
-
-.amplify-passwordfield .amplify-button:not(:focus) {
-  border-left: none; /* Remove double-border between the password field & reveal button */
-}

--- a/packages/ui/src/theme/css/component/fieldGroup.scss
+++ b/packages/ui/src/theme/css/component/fieldGroup.scss
@@ -57,6 +57,13 @@
   .amplify-field-group__control {
     @extend %remove-end-radii;
 
+    &:not(:focus) {
+      border-inline-end: none;
+    }
+    &:focus {
+      z-index: 1;
+    }
+
     // This targets non first-child controls
     // when there are multiple controls
     &:not(:first-child) {
@@ -78,6 +85,13 @@
 .amplify-field-group__outer-end {
   .amplify-field-group__control {
     @extend %remove-start-radii;
+
+    &:not(:focus) {
+      border-inline-start: none;
+    }
+    &:focus {
+      z-index: 1;
+    }
 
     // This targets non last-child controls
     // where there are multiple controls


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR addresses the issue of a double border appearing on the Authenticator component password field, and the underlying primitive. It updates the appearance of the outer controls on the [TextField](https://ui.docs.amplify.aws/components/textfield#outer-components) component when using outerStartComponent and outerEndComponent props

**Note**: This currently shows with a single border on the Authenticator in the docs site because there is some docs specific css added to fix it. This PR also removes that CSS since it will no longer be needed.
### Before

<img width="507" alt="BeforeAuthenticatorCRA" src="https://user-images.githubusercontent.com/376920/161619888-88572f91-24d9-46ef-bb8e-6601931e41b4.png">


<img width="1026" alt="BeforeDocs" src="https://user-images.githubusercontent.com/376920/161618025-040829da-2044-48fe-8362-ae076a026b5e.png">

### After

<img width="513" alt="Screen Shot 2022-04-04 at 3 49 36 PM" src="https://user-images.githubusercontent.com/376920/161620857-3e82570c-b060-4853-a7dd-2f8afa36e35e.png">

<img width="1026" alt="After" src="https://user-images.githubusercontent.com/376920/161618719-c5544fca-fac2-4f4a-9e97-5110e8365c99.png">

### Cut off focus style fixed:
**Before**
<img width="175" alt="Screen Shot 2022-04-04 at 3 39 48 PM" src="https://user-images.githubusercontent.com/376920/161619560-50226b9d-091c-4045-b773-7e011710365a.png">
**After**
<img width="170" alt="Screen Shot 2022-04-04 at 3 40 22 PM" src="https://user-images.githubusercontent.com/376920/161619578-f3281c81-929f-414d-91cf-7c18683ef5c9.png">

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/1468

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Tested changes in docs instance as well as the Next example instance.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
