### PR TITLE
fix(react): Keep a local copy of previous facade value 

### DIFF
--- a/.changeset/proud-trainers-collect.md
+++ b/.changeset/proud-trainers-collect.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(react): Keep a local copy of previous facade value

--- a/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
@@ -97,14 +97,9 @@ export const useAuthenticator = (selector?: Selector) => {
     [service]
   );
 
-  const getFacade = (state: AuthMachineState) => ({
-    ...sendAliases,
-    ...getServiceContextFacade(state),
-    /** @deprecated For internal use only */
-    _state: state,
-    /** @deprecated For internal use only */
-    _send: send,
-  });
+  const getFacade = (state: AuthMachineState) => {
+    return { ...sendAliases, ...getServiceContextFacade(state) };
+  };
 
   /**
    * For `useSelector`'s selector argument, we just return back the `state`.
@@ -167,5 +162,11 @@ export const useAuthenticator = (selector?: Selector) => {
 
   const state = useSelector(service, xstateSelector, comparator);
 
-  return getFacade(state);
+  return {
+    ...getFacade(state),
+    /** @deprecated For internal use only */
+    _state: state,
+    /** @deprecated For internal use only */
+    _send: send,
+  };
 };

--- a/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
@@ -106,8 +106,6 @@ export const useAuthenticator = (selector?: Selector) => {
     _send: send,
   });
 
-  const prevFacadeRef = React.useRef<ReturnType<typeof getFacade>>();
-
   /**
    * For `useSelector`'s selector argument, we just return back the `state`.
    * The reason is that whenever you select a specific value of the state, the
@@ -119,10 +117,22 @@ export const useAuthenticator = (selector?: Selector) => {
   const xstateSelector = (state: AuthMachineState) => state;
 
   /**
+   * Holds a snapshot copy of last previous facade values. Will be used
+   * on state changes to see if any of facade values have changed.
+   */
+  const prevFacadeRef = React.useRef<ReturnType<typeof getFacade>>();
+
+  /**
    * comparator decides whether or not the new authState should trigger a
    * re-render. Does a deep equality check.
    */
   const comparator = (
+    /**
+     * We do not use `_prevState`, because it holds a *reference* to actor
+     * object, of which value could easily mutate between compare calls.
+     *
+     * Instead, we'll use prevFacadeRef for comparison.
+     */
     _prevState: AuthMachineState,
     nextState: AuthMachineState
   ) => {
@@ -136,7 +146,7 @@ export const useAuthenticator = (selector?: Selector) => {
     const nextFacade = getFacade(nextState);
 
     /**
-     * prevFacadeRef can now be updated  with new facade values
+     * prevFacadeRef can now be updated with new facade values
      */
     prevFacadeRef.current = nextFacade;
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

`useAuthenticator` did not optimize re-renders as expected when it selects an actor context. For example,

```tsx
const { error } = useAuthenticator((context) => [context.error])
```

would always re-render, even if `error` hasn't changed. This was because `prevState` and `nextState` we use in comparators holds a *reference* to actor contexts, which could easily change between each compare calls. 

This PR resolves it by explicitly holding onto actor snapshot values that wouldn't change between compares. More details on code comments.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Related to #1602

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

E2e test, + some manual validation on `examples/next`.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
