### PR TITLE
fix: update nth-check dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "jest": "^26.6.3",
     "json-schema": "^0.4.0",
     "node-forge": "1.3.0",
+    "nth-check": "^2.0.1",
     "prismjs": "^1.25.0",
     "prism-react-renderer": "1.2.1",
     "trim": "^0.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7506,7 +7506,7 @@ bonjour@^3.5.0:
     multicast-dns "^6.0.1"
     multicast-dns-service-types "^1.1.0"
 
-boolbase@^1.0.0, boolbase@~1.0.0:
+boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
@@ -16914,14 +16914,7 @@ npmlog@^4.1.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
-  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
-  dependencies:
-    boolbase "~1.0.0"
-
-nth-check@^2.0.1:
+nth-check@^1.0.2, nth-check@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
   integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==


### PR DESCRIPTION
#### Description of changes

Updates nth-check to 2.0.1 to fix a security vulnerability raised by dependabot.

#### Issue #, if available
See dependabot

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
```
$ yarn why nth-check
yarn why v1.22.17
[1/4] 🤔  Why do we have the module "nth-check"...?
[2/4] 🚚  Initialising dependency graph...
warning Resolution field "ansi-regex@5.0.1" is incompatible with requested version "ansi-regex@^6.0.1"
warning Resolution field "node-forge@1.3.0" is incompatible with requested version "node-forge@^0.10.0"
warning Resolution field "ansi-regex@5.0.1" is incompatible with requested version "ansi-regex@^2.0.0"
warning Resolution field "ansi-regex@5.0.1" is incompatible with requested version "ansi-regex@^2.0.0"
warning Resolution field "ansi-regex@5.0.1" is incompatible with requested version "ansi-regex@^3.0.0"
warning Resolution field "ansi-regex@5.0.1" is incompatible with requested version "ansi-regex@^4.1.0"
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "nth-check@2.0.1"
info Reasons this module exists
   - "_project_#css-select" depends on it
   - Hoisted from "_project_#css-select#nth-check"
=> Found "ng-packagr#nth-check@1.0.2"
info Reasons this module exists
   - "_project_#amplify-ui-angular-mono#ng-packagr#cssnano#cssnano-preset-default#postcss-svgo#svgo#css-select" depends on it
   - Hoisted from "_project_#amplify-ui-angular-mono#ng-packagr#cssnano#cssnano-preset-default#postcss-svgo#svgo#css-select#nth-check"
✨  Done in 0.93s.
```
Ran yarn build and saw no errors

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
