### PR TITLE
fix: remove extra title and description from geo page

### DIFF
--- a/docs/src/pages/components/geo/react.mdx
+++ b/docs/src/pages/components/geo/react.mdx
@@ -1,14 +1,9 @@
----
-title: Geo
-description: Amplify UI Geo provides UI components for maps and location search for popular front-end frameworks.
----
-
 import { Example } from '@/components/Example';
 import { Feature } from '@/components/Feature';
 import { Fragment } from '@/components/Fragment';
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 
-Amplify UI Geo provides UI components for maps and location search for popular front-end frameworks, powered by
+Amplify UI Geo is powered by
 [Amplify Geo APIs](https://docs.amplify.aws/lib/geo/getting-started/q/platform/js/) and
 [Amazon Location Service](https://aws.amazon.com/location/).
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

PR fixes an issue where the geo title showed twice after the page content was moved to a react specific page (introduced in https://github.com/aws-amplify/amplify-ui/pull/1636).

Before (present on dev.ui.docs.amplify.aws, but not prod docs site)

![Screen Shot 2022-04-06 at 4 52 03 PM](https://user-images.githubusercontent.com/6165315/162092883-172fe7ab-59e8-4f31-84f0-cc9845717863.png)

After:
![Screen Shot 2022-04-06 at 4 48 36 PM](https://user-images.githubusercontent.com/6165315/162092814-689bcb84-c553-435e-8ecc-d118cded1fe4.png)

#### Description of how you validated changes
Ran docs site, validated changes above.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
