### PR TITLE
fix shadow tokens

### DIFF
--- a/.changeset/five-shrimps-attend.md
+++ b/.changeset/five-shrimps-attend.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-react": patch
+---
+
+Fixing shadow and outline CSS variables in the default styles.

--- a/packages/ui/sd.config.ts
+++ b/packages/ui/sd.config.ts
@@ -4,7 +4,11 @@
 
 import StyleDictionary from 'style-dictionary';
 import { defaultTheme } from './src/theme';
-import { CSS_VARIABLE_PREFIX, cssNameTransform } from './src/theme/utils';
+import {
+  CSS_VARIABLE_PREFIX,
+  cssNameTransform,
+  cssValue,
+} from './src/theme/utils';
 
 const CSS_VARIABLE_SCOPE = ':root, [data-amplify-theme]';
 
@@ -15,10 +19,15 @@ StyleDictionary.extend({
       type: 'name',
       transformer: cssNameTransform,
     },
+    cssValue: {
+      type: 'value',
+      transitive: true,
+      transformer: cssValue,
+    },
   },
   platforms: {
     css: {
-      transforms: ['attribute/cti', 'cssNameTransform'],
+      transforms: ['attribute/cti', 'cssNameTransform', 'cssValue'],
       prefix: CSS_VARIABLE_PREFIX,
       files: [
         {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Transforming the shadow tokens in style dictionary for the default CSS Amplify UI generates. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Before:
![CleanShot 2022-04-08 at 10 08 27](https://user-images.githubusercontent.com/321279/162489721-a13c660a-9534-4366-9db9-3b153daaa298.png)

After:
![CleanShot 2022-04-08 at 10 08 00](https://user-images.githubusercontent.com/321279/162489734-801041d9-aba5-4391-b8ac-310a2e7b8e9e.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
