### PR TITLE
Add `nonce` prop to AmplifyProvider

### DIFF
--- a/.changeset/wild-comics-carry.md
+++ b/.changeset/wild-comics-carry.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Add `nonce` prop to AmplifyProvider to allow strict CSP rules

--- a/packages/react/src/components/AmplifyProvider/index.tsx
+++ b/packages/react/src/components/AmplifyProvider/index.tsx
@@ -10,12 +10,14 @@ interface AmplifyProviderProps {
   children: React.ReactNode;
   colorMode?: ColorMode;
   theme?: Theme;
+  nonce?: string;
 }
 
 export function AmplifyProvider({
   children,
   colorMode,
   theme,
+  nonce,
 }: AmplifyProviderProps) {
   const webTheme = createTheme(theme);
   const { name, cssText } = webTheme;
@@ -118,6 +120,7 @@ export function AmplifyProvider({
         <style
           id={`amplify-theme-${name}`}
           dangerouslySetInnerHTML={{ __html: cssText }}
+          nonce={nonce}
         />
       )}
     </AmplifyContext.Provider>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR exposes the capability to add a [nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) to the`<style>` tag rendered by the `AmplifyProvider`:

Example:
`<AmplifyProvider nonce="randomString"/> => <style nonce="randomString">`

This will allow customers to use strict CSP rules while also using a custom theme. See the [example below](https://content-security-policy.com/examples/allow-inline-style/):

![Allow Inline Styles using a Nonce](https://user-images.githubusercontent.com/48109584/162498598-fb56a1b6-67da-4a61-b2dc-5e8e244e2dce.png)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I spent quite a bit of time testing this out on the UI Docs site and NextJS example app, as well as in different browsers. I can confirm that:
- If there is a nonce in headers and it matches the nonce passed to the `<style>` tag, then those styles will get applied to the page. 
- If there is a nonce in headers but it does not match the nonce passed to the `style` tag (or if there is no nonce on the `style` tag), then the browser will log a console error and the styles will not get applied. 
- If there is not a nonce in the headers, then all styles will get applied. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.