### PR TITLE
fix: accessibly hide label text for CheckboxField when labelHidden is…

### DIFF
--- a/.changeset/lucky-cooks-shave.md
+++ b/.changeset/lucky-cooks-shave.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix: accessibly hide label text for CheckboxField when labelHidden is…

--- a/packages/react/src/primitives/Checkbox/Checkbox.tsx
+++ b/packages/react/src/primitives/Checkbox/Checkbox.tsx
@@ -74,10 +74,12 @@ const CheckboxPrimitive: Primitive<CheckboxProps, 'input'> = (
           {...rest}
         />
       </VisuallyHidden>
-      {label && !labelHidden && (
+      {label && (
         <Text
           as="span"
-          className={ComponentClassNames.CheckboxLabel}
+          className={classNames(ComponentClassNames.CheckboxLabel, {
+            [ComponentClassNames.VisuallyHidden]: labelHidden,
+          })}
           data-disabled={isDisabled}
           testId={labelTestId}
         >


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This updates the Checkbox label to use the visuallyHidden class (ComponentClassNames.VisuallyHidden) to hide the label Text when the labelHidden prop = true. Currently, when true, it removes the label text from the DOM completely making it inaccessible.

Using the docs example, we can compare the DOM before and after.
```
<CheckboxField label="Subscribe" name="subscribe" value="yes" labelHidden={true} />
```

**Before**

<img width="716" alt="Screen Shot 2022-04-08 at 2 13 06 PM" src="https://user-images.githubusercontent.com/376920/162498811-64333502-044e-406c-9708-46b3f12893a3.png">

**After**
<img width="664" alt="Screen Shot 2022-04-08 at 2 16 00 PM" src="https://user-images.githubusercontent.com/376920/162498866-0cc3f9cd-5a0e-45f9-b4b9-281c3b85f2e0.png">

[VoiceOver video](https://user-images.githubusercontent.com/376920/162500869-9a2013bb-5292-4295-a8cf-ee4110a7d620.mp4)




#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
