### PR TITLE
chore: Add error message for no provider found

### DIFF
--- a/.changeset/fresh-eagles-accept.md
+++ b/.changeset/fresh-eagles-accept.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+chore: Add error message when `useAuthenticator` can't find a parent `Authenticator.Provider`.

--- a/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
@@ -89,6 +89,15 @@ export type Selector = (context: AuthenticatorContext) => Array<any>;
 
 export const useAuthenticator = (selector?: Selector) => {
   const { service } = React.useContext(AuthenticatorContext);
+
+  if (!service) {
+    console.error(
+      'No `Authenticator.Provider` was found above where this hook is being used. ' +
+        'Please ensure you wrap your App with `Authenticator.Provider` like so: ' +
+        'https://ui.docs.amplify.aws/components/authenticator#useauthenticator-hook'
+    );
+  }
+
   const send = service.send;
 
   // send aliases are static and thus can be memoized

--- a/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
@@ -96,6 +96,7 @@ export const useAuthenticator = (selector?: Selector) => {
         'Please ensure you wrap your App with `Authenticator.Provider` like so: ' +
         'https://ui.docs.amplify.aws/components/authenticator#useauthenticator-hook'
     );
+    return null;
   }
 
   const send = service.send;

--- a/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
@@ -92,7 +92,7 @@ export const useAuthenticator = (selector?: Selector) => {
 
   if (!service) {
     console.error(
-      'No `Authenticator.Provider` was found above where this hook is being used. ' +
+      'No `Authenticator.Provider` was found above where `useAuthenticator` hook is. ' +
         'Please ensure you wrap your App with `Authenticator.Provider` like so: ' +
         'https://ui.docs.amplify.aws/components/authenticator#useauthenticator-hook'
     );


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Whenever customer are trying to use `useAuthenticator` without wrapping their App with `Authenticator.Provider`, they'll get the cryptic error message 

```
TypeError: Cannot read properties of undefined (reading 'send')
```

This PR adds a check for that and adds a more dev-friendly message.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#1651: dev confusion with errors when no provider is added/

#### Description of how you validated changes

No runtime behavior changes unless the app is already on faulty configuration. I might have missed edge cases like `Authenticator.Provider` not being ready by the time `useAuthenticator` first runs, but e2e test should catch that.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
