### PR TITLE
docs/fix: valid table DOM nesting for docs css styling tables

### DIFF
--- a/docs/src/components/ComponentClassTable.tsx
+++ b/docs/src/components/ComponentClassTable.tsx
@@ -4,6 +4,8 @@ import {
   ComponentClassObject,
   View,
   TableRow,
+  TableBody,
+  TableHead,
   TableCell,
 } from '@aws-amplify/ui-react';
 
@@ -30,11 +32,13 @@ export const ComponentClassTable = ({ componentName }) => {
   return (
     <View className="docs-css-classes">
       <Table variation="bordered">
-        <TableRow>
-          <TableCell as="th">Class</TableCell>
-          <TableCell as="th">Description</TableCell>
-        </TableRow>
-        {targetClasses}
+        <TableHead>
+          <TableRow>
+            <TableCell as="th">Class</TableCell>
+            <TableCell as="th">Description</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>{targetClasses}</TableBody>
       </Table>
     </View>
   );

--- a/docs/src/components/ComponentVariableTable.tsx
+++ b/docs/src/components/ComponentVariableTable.tsx
@@ -4,6 +4,7 @@ import {
   View,
   TableRow,
   TableCell,
+  TableBody,
   useTheme,
 } from '@aws-amplify/ui-react';
 
@@ -51,7 +52,9 @@ export const ComponentVariableTable = ({ componentName }) => {
 
   return (
     <View className="docs-css-variables">
-      <Table variation="bordered">{variableNames}</Table>
+      <Table variation="bordered">
+        <TableBody>{variableNames}</TableBody>
+      </Table>
     </View>
   );
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

No visual changes, just addresses the validateDomNesting warnings for the styling tables in docs. Adds `<tbody />` and `<thead />` where applicable.

**Console warning**
<img width="1056" alt="Screen Shot 2022-04-11 at 12 06 04 PM" src="https://user-images.githubusercontent.com/376920/162788721-6914a6b3-4633-46bc-a280-4e5b92da83ae.png">

**Before DOM**
<img width="513" alt="Screen Shot 2022-04-11 at 12 40 05 PM" src="https://user-images.githubusercontent.com/376920/162788944-1796d081-6cba-4d3e-af8f-029d98f05545.png">

**After DOM**

<img width="527" alt="Screen Shot 2022-04-11 at 12 24 57 PM" src="https://user-images.githubusercontent.com/376920/162788970-cb35ff15-c9b9-4c8b-84ac-582d65aecfb6.png">

#### Issue #, if available

N/A

#### Description of how you validated changes

Tested docs instance locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
