### PR TITLE
docs: add section on token definition structure

### DIFF
--- a/docs/src/pages/theming/theming.web.mdx
+++ b/docs/src/pages/theming/theming.web.mdx
@@ -111,12 +111,14 @@ const myTheme = {
 Amplify UI follows a consistent pattern when defining tokens for a component's states and variations. This is helpful for discovering what tokens are available for theming different aspects of a component. Amplify UI uses the following pattern:
 
 ```javascript
-component[variant][_state][child];
+component[modifier][_state][child];
 ```
 
-**Note**: Amplify UI prefixes states with an underscore, `_`, to help distinguish state names from variation names.
+A `modifier` could be a distinct style variation, like the primary or link variant for the Button component. A modifier could also be a variation based on size, such as `small`, `medium`, or `large`.
 
-The [Button](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/theme/tokens/components/button.ts) component is a good example of a token definition that includes multiple states and variations and follows this pattern:
+State typically refers to a change in the component due to an interaction from the user or application itself, such as hover, focus, loading or disabled. **Note**: Amplify UI prefixes states with an underscore, `_`, to help distinguish state names from modifier names.
+
+The [Button](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/theme/tokens/components/button.ts) component is a good example of a token definition that includes multiple states and modifiers and follows this pattern:
 
 ```javascript
 export const button = {
@@ -125,7 +127,6 @@ export const button = {
   // states
   _hover: {},
   _focus: {},
-  _active: {},
   _loading: {},
   _disabled: {},
 
@@ -133,20 +134,29 @@ export const button = {
   primary: {
     _hover: {},
     _focus: {},
-    _active: {},
     _loading: {},
     _disabled: {},
   },
+
+  // size modifiers
+  small: {},
+  large: {},
 };
 ```
 
 Compiled, this would create the following CSS custom properties:
 
 ```css
---amplify-component-child-token: value,
---amplify-component-state-child-token: value,
---amplify-component-variation-child-token: value,
---amplify-component-variation-state-child-token: value,
+--amplify-component-button-hover-token: value,
+--amplify-component-button-focus-token: value,
+--amplify-component-button-hover-loading: value,
+--amplify-component-button-focus-disabled: value,
+--amplify-component-button-primary-hover-token: value,
+--amplify-component-button-primary-focus-token: value,
+--amplify-component-button-primary-hover-loading: value,
+--amplify-component-button-primary-focus-disabled: value,
+--amplify-component-button-small-token: value,
+--amplify-component-button-large-token: value,
 ```
 
 ### Fonts


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

We don't have an explicit structure defined for creating component tokens for the web and there are a couple different patterns used throughout our components, currently. We should have this defined so that contributors know how to structure a component's tokens to be consistent with those already defined, and so that users of the tokens have a consistent way to discover what tokens are available. 

After a brief chat with @dbanksdesign this is the proposal:

```
component[variant][state][child]
```

I included a pseudo-code version of what that looks like in practice in this PR for updating the Theming docs.

This allows us to keep each definition type grouped. This means you could readily find all of a particular state's tokens for a variation without hunting through nested child objects. That is:

```
export const component = {
  childA: { /* tokens */ },
  childB: { /* tokens */ },
  _focus: {
    childA: { /* tokens */ },
    childB: { /* tokens */ }
  },
  large: {
    childA: { /* tokens */ },
    childB: { /* tokens */ },
    _focus: {
      childA: { /* tokens */ },
      childB: { /* tokens */ },
    }
  }
}
```
As opposed to:
```
export const component = {
  childA: {
    /* tokens */
    _focus: { /* tokens */ }
  },
  childB: {
    /* tokens */
    _focus: { /* tokens */}
  },
  large: {
    childA: {
      /* tokens */
      _focus: { /* tokens */ }
    },
    childB: {
      /* tokens */
      _focus: { /* tokens */}
    },
  }
}
```
These are simple examples, but for larger components that have many child elements and tokens, the second version might require a little more sleuthing around the file to find all of the affected, in this example, focus styles for a component.

**Really, the most important part** is aligning on one format so that developers know how to proceed when making new definitions, and so users can have a consistent reading and discoverability experience for the token files.

This also calls out the use of an underscore prefix for defining state tokens, which helps with quickly distinguishing a state from a variation name. That is, we should do:
```
_focus: {},
_hover: {},
_disabled: {},

```
and not
```
focus: {},
hover: {},
disabled: {},
```

#### Open Question ####
- Is this the best place for this to live, on the Theming overview page?  The Theming section in our docs is aimed more at the consumers of the library; while this information is a little more aimed at developers who want to contribute to Amplify UI itself. I could see where  it's useful for consumers, though, as it's nice to know what to look for when learning what tokens are available.

#### Issue #, if available

N/A

#### Description of how you validated changes

Tested in local docs instance.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
