### PR TITLE
fix(docs): remove block regarding geo peer dependencies

### DIFF
--- a/docs/src/pages/components/geo/react.mdx
+++ b/docs/src/pages/components/geo/react.mdx
@@ -23,13 +23,6 @@ while using [maplibre-gl-js](https://maplibre.org/maplibre-gl-js-docs/api/) as t
 used as a replacement to `react-map-gl`'s [default map](https://visgl.github.io/react-map-gl/docs/api-reference/map)
 and supports the same functionality.
 
-Install the required peer dependencies using your preferred package manager. Below, we use [Yarn](https://yarnpkg.com/)
-as an example:
-
-```shell
-yarn add maplibre-gl-js@1 react-map-gl
-```
-
 You can import the `MapView` component with related styles and use it in your Amplify application without any
 additional configuration.
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Since we've decided to treat `maplibre-gl` and `react-map-gl` as hard dependencies rather than peer dependencies, we can remove the block of documentation explaining to install those dependencies separately for the Geo components.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated - N/A
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
