### PR TITLE
fix(authenticator): Ensure setup has ran after refresh

### DIFF
--- a/.changeset/tender-parents-sniff.md
+++ b/.changeset/tender-parents-sniff.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(authenticator): Ensure machine setup runs after user signs in, refreshes, then signs out.

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-username.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-username.feature
@@ -43,6 +43,10 @@ Feature: Sign In with Username
     Then I see "Sign out"
     And I click the "Sign out" button
     Then I see "Sign in"
+    And I type my "username" with status "CONFIRMED"
+    And I type my password
+    And I click the "Sign in" button
+    Then I see "Sign out"
 
   # FORCE_CHANGE_PASSWORD tests are skipped as the temporary passwords used for these
   # test accounts will expire in Cognito.

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-username.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-username.feature
@@ -34,12 +34,25 @@ Feature: Sign In with Username
     Then I see "Sign out"
 
   @angular @react @vue
-  Scenario: Sign in with confirmed credentials then sign out
+  Scenario: Sign in with confirmed credentials, reload, sign out, then sign in again
     When I type my "username" with status "CONFIRMED"
     And I type my password
     And I click the "Sign in" button
     Then I see "Sign out"
     When I reload the page
+    Then I see "Sign out"
+    And I click the "Sign out" button
+    Then I see "Sign in"
+    And I type my "username" with status "CONFIRMED"
+    And I type my password
+    And I click the "Sign in" button
+    Then I see "Sign out"
+
+  @angular @react @vue
+  Scenario: Sign in with confirmed credentials, sign out, then sign in again
+    When I type my "username" with status "CONFIRMED"
+    And I type my password
+    And I click the "Sign in" button
     Then I see "Sign out"
     And I click the "Sign out" button
     Then I see "Sign in"

--- a/packages/ui/src/types/authenticator/stateMachine/context.ts
+++ b/packages/ui/src/types/authenticator/stateMachine/context.ts
@@ -39,6 +39,7 @@ export interface AuthContext {
   code?: string;
   mfaType?: AuthChallengeNames.SMS_MFA | AuthChallengeNames.SOFTWARE_TOKEN_MFA;
   actorDoneData?: Omit<ActorDoneData, 'user'>; // data returned from actors when they finish and reach their final state
+  hasSetup?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This resolves issues when users try to sign in or sign up after they refresh in signed in state.

This happened because `setup` state was skipped when user has refreshed, and hence Authenticator would not send `INIT` event. This PR resolves it by ensuring setup has run after refresh + signing out.
 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Resolves #1623, Resolves #1676, Resolves #1659

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Added new tests. Note how they fail on my first two commits but pass later after I add the fix.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
