### PR TITLE
Add analytics helper and flag

### DIFF
--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
@@ -32,6 +32,7 @@ export class AuthenticatorComponent
   @Input() loginMechanisms: AuthenticatorMachineOptions['loginMechanisms'];
   @Input() services: AuthenticatorMachineOptions['services'];
   @Input() signUpAttributes: AuthenticatorMachineOptions['signUpAttributes'];
+  @Input() enableAnalytics?: AuthenticatorMachineOptions['enableAnalytics'];
   @Input() socialProviders: SocialProvider[];
   @Input() variation: 'default' | 'modal';
   @Input() hideSignUp: boolean;
@@ -59,6 +60,7 @@ export class AuthenticatorComponent
       signUpAttributes,
       socialProviders,
       formFields,
+      enableAnalytics,
     } = this;
 
     /**
@@ -77,6 +79,7 @@ export class AuthenticatorComponent
             signUpAttributes,
             socialProviders,
             formFields,
+            enableAnalytics,
           },
         });
 

--- a/packages/ui/src/helpers/authenticator/analytics.ts
+++ b/packages/ui/src/helpers/authenticator/analytics.ts
@@ -1,0 +1,19 @@
+import { AuthenticatorMachineOptions } from '../../machines/authenticator';
+import { AnalyticsEventOptions, recordAnalyticsEvent } from '../shared';
+
+/**
+ * Conditionally records a Authenticator analytics event with some default attribute(s)
+ * @param authMachineOptions
+ * @param eventOptions
+ */
+export function recordAuthenticatorAnalyticsEvent(
+  authMachineOptions: AuthenticatorMachineOptions,
+  eventOptions: AnalyticsEventOptions
+) {
+  if (authMachineOptions.enableAnalytics) {
+    recordAnalyticsEvent({
+      // add common Authenticator specific attributes
+      ...eventOptions,
+    });
+  }
+}

--- a/packages/ui/src/helpers/authenticator/index.ts
+++ b/packages/ui/src/helpers/authenticator/index.ts
@@ -5,3 +5,4 @@ export * from './constants';
 export * from './form';
 export * from './utils';
 export * from './formFields';
+export * from './analytics';

--- a/packages/ui/src/helpers/index.ts
+++ b/packages/ui/src/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from './authenticator';
+export * from './shared';

--- a/packages/ui/src/helpers/shared/analytics.ts
+++ b/packages/ui/src/helpers/shared/analytics.ts
@@ -1,0 +1,16 @@
+import { Analytics } from '@aws-amplify/analytics';
+import type { AnalyticsEvent } from '@aws-amplify/analytics/lib/types';
+
+export interface AnalyticsEventOptions extends AnalyticsEvent {
+  // Add more Amplify UI specific options
+}
+
+/**
+ * Record an event with Amplify Analytics
+ * @param event
+ */
+export function recordAnalyticsEvent(event: AnalyticsEventOptions) {
+  Analytics.record(event).catch(() => {
+    // no-op
+  });
+}

--- a/packages/ui/src/helpers/shared/index.ts
+++ b/packages/ui/src/helpers/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './analytics';

--- a/packages/ui/src/types/authenticator/stateMachine/context.ts
+++ b/packages/ui/src/types/authenticator/stateMachine/context.ts
@@ -31,6 +31,17 @@ export interface AuthContext {
     formFields?: AuthFormFields;
     initialState?: 'signIn' | 'signUp' | 'resetPassword';
     passwordSettings?: PasswordSettings;
+
+    /**
+     * Enable analytical events for the component via Amplify Analytics
+     * NOTE: The Amplify Analytics category needs to be configured for this to work
+     * read more here: https://docs.amplify.aws/lib/analytics/getting-started/q/platform/js/
+     *
+     * @experimental Currently under development
+     *
+     * @default false
+     */
+    enableAnalytics?: boolean;
   };
   services?: Partial<typeof defaultServices>;
   user?: CognitoUserAmplify;

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -44,6 +44,7 @@ const {
   socialProviders,
   hideSignUp,
   formFields,
+  enableAnalytics,
 } = withDefaults(
   defineProps<{
     hideSignUp?: boolean;
@@ -51,6 +52,7 @@ const {
     loginMechanisms?: AuthenticatorMachineOptions['loginMechanisms'];
     services?: AuthenticatorMachineOptions['services'];
     signUpAttributes?: AuthenticatorMachineOptions['signUpAttributes'];
+    enableAnalytics?: AuthenticatorMachineOptions['enableAnalytics'];
     variation?: 'default' | 'modal';
     socialProviders?: SocialProvider[];
     formFields?: AuthFormFields;
@@ -98,6 +100,7 @@ unsubscribeMachine = service.subscribe((newState) => {
         signUpAttributes,
         services,
         formFields,
+        enableAnalytics,
       },
     });
     hasInitialized.value = true;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

* This PR adds helpers to collect analytical events and metrics from the cloud connected components. 
* These events would be published to the customer's Pinpoint project in their AWS accounts. 
* The events will only be published if the customers opt-in to it with the `enableAnalytics` flag and also has Amplify's `Analytics` category configured.

As next steps, we can add calls with `recordAuthenticatorAnalyticsEvent` helper method in the Authenticator state machine at various places we want to send events from. For example:

```ts
recordAuthenticatorAnalyticsEvent(authContext, {
  name: 'PASSOWRD_VISIBILE_TOGGLE'
  metrics: { count: 1 }
});
```

The helper can then also be used in the React/Vue/Angular components to send events.

We can update the documentation and remove the `@experimental` flag when we have good set of starter events.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
