### PR TITLE
feat: adding equivalent props with value default to false

### DIFF
--- a/.changeset/pretty-gifts-play.md
+++ b/.changeset/pretty-gifts-play.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+1. `isIconHidden` is added on `Alert` with default of `false`
+2. `isHidden` is added on `FieldGroupIcon` with default of `false`
+3. `isLabelShown` is added on `SearchField ` with default of `false`

--- a/packages/react/CONTRIBUTING.md
+++ b/packages/react/CONTRIBUTING.md
@@ -28,7 +28,7 @@ import { Button } from 'primitives/Button';
 import { THIS_ENUM } from 'utils/types';
 ```
 
-Do **NOT** use implicit paths like below,
+Do **NOT** use implicit paths like below. This can lead to circular dependencies unintentionally which is bad for tree shaking.
 
 ```js
 import { Flex, Heading } from '../../..';

--- a/packages/react/CONTRIBUTING.md
+++ b/packages/react/CONTRIBUTING.md
@@ -12,6 +12,40 @@ This will start building `@aws-amplify/ui-react` in watch mode. To test your cha
 
 `@aws-amplify/ui-react` depends on [`@aws-amplify/ui`](../ui) for theming, state management, and translation logic. If you're looking for change in these, please refer to `@aws-amplify/ui` [README](../ui/README.md).
 
+## Code Standards
+
+### Imports
+
+Separate all imports organized, alphabetical blocks of `third_party → internal → local` for easier reading.
+
+```js
+import { isEmpty } from 'lodash/isEmpty';
+import * as React from 'react';
+
+import { Auth } from 'aws-amplify';
+
+import { Button } from 'primitives/Button';
+import { THIS_ENUM } from 'utils/types';
+```
+
+Do **NOT** use implicit paths like below,
+
+```js
+import { Flex, Heading } from '../../..';
+```
+
+Use explicit import paths instead, the more specific the better.
+
+```js
+import { Flex } from '../../../primitives/Flex';
+import { Heading } from '../../../primitives/Heading';
+```
+
+### Variable Naming
+
+1. Component names should be capitalized.
+2. Boolean props should be prefixed with `is` and default to `false`.
+
 ## Testing for Production
 
 After you tested your change, you can run `yarn react build` from monorepo to run build for production.

--- a/packages/react/src/primitives/Alert/Alert.tsx
+++ b/packages/react/src/primitives/Alert/Alert.tsx
@@ -18,6 +18,7 @@ const AlertPrimitive: Primitive<AlertProps, typeof Flex> = (
     hasIcon = true,
     heading,
     isDismissible = false,
+    isIconHidden = false,
     onDismiss,
     variation,
     ...rest
@@ -42,7 +43,7 @@ const AlertPrimitive: Primitive<AlertProps, typeof Flex> = (
         ref={ref}
         {...rest}
       >
-        {hasIcon && <AlertIcon variation={variation} />}
+        {hasIcon && !isIconHidden && <AlertIcon variation={variation} />}
         <View role="alert" flex="1">
           {heading && (
             <View className={ComponentClassNames.AlertHeading}>{heading}</View>

--- a/packages/react/src/primitives/Alert/__tests__/Alert.test.tsx
+++ b/packages/react/src/primitives/Alert/__tests__/Alert.test.tsx
@@ -86,6 +86,20 @@ describe('Alert: ', () => {
     ).toBe(false);
   });
 
+  it('should have isIconHidden default to false', async () => {
+    render(<Alert variation="info" testId="testIcon" />);
+    const alert = await screen.findByTestId('testIcon');
+    expect(alert.childElementCount).toBe(2);
+    expect(alert.firstElementChild).toHaveClass(ComponentClassNames.Icon);
+  });
+
+  it('should not render icon if isIconHidden is set to true', async () => {
+    render(<Alert variation="info" testId="testIcon" isIconHidden />);
+    const alert = await screen.findByTestId('testIcon');
+    expect(alert.childElementCount).toBe(1);
+    expect(alert.firstElementChild).not.toHaveClass(ComponentClassNames.Icon);
+  });
+
   it('can be dismissible', async () => {
     render(
       <div>
@@ -135,7 +149,7 @@ describe('Alert: ', () => {
     expect(alert.dataset['demo']).toBe('true');
   });
 
-  describe.only('Forward ref: ', () => {
+  describe('Forward ref: ', () => {
     it('should forward ref to container DOM element', async () => {
       const testId = 'alert';
       const ref = React.createRef<HTMLDivElement>();

--- a/packages/react/src/primitives/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/primitives/Button/__tests__/Button.test.tsx
@@ -49,6 +49,13 @@ describe('Button test suite', () => {
     expect(button).toBeDisabled();
   });
 
+  it('should have isFullWidth default to false', async () => {
+    render(<Button />);
+
+    const button = await screen.findByRole('button');
+    expect(button).toHaveAttribute('data-fullwidth', 'false');
+  });
+
   it('should set loading state correctly if isLoading is set to true', async () => {
     render(<Button loadingText="loading" isLoading />);
 

--- a/packages/react/src/primitives/FieldGroupIcon/FieldGroupIcon.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/FieldGroupIcon.tsx
@@ -13,12 +13,13 @@ const FieldGroupIconPrimitive: Primitive<
     className,
     children,
     isVisible = true,
+    isHidden = false,
     excludeFromTabOrder = false,
     ...rest
   },
   ref
 ) => {
-  return isVisible ? (
+  return isVisible && !isHidden ? (
     <View
       className={classNames(ComponentClassNames.FieldGroupIcon, className)}
       ref={ref}

--- a/packages/react/src/primitives/FieldGroupIcon/__tests__/FieldGroupIcon.test.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/__tests__/FieldGroupIcon.test.tsx
@@ -16,6 +16,13 @@ describe('FieldGroupIcon component', () => {
     expect(fieldGroup).toHaveClass(ComponentClassNames.FieldGroupIcon);
   });
 
+  it('should render icon with isHidden default to false', async () => {
+    render(<FieldGroupIcon testId={testId} />);
+
+    const fieldGroupIcon = await screen.findByTestId(testId);
+    expect(fieldGroupIcon).toBeInTheDocument();
+  });
+
   it('should forward ref to DOM element', async () => {
     const ref = React.createRef<HTMLDivElement>();
     render(

--- a/packages/react/src/primitives/SearchField/SearchField.tsx
+++ b/packages/react/src/primitives/SearchField/SearchField.tsx
@@ -14,6 +14,7 @@ const SearchFieldPrimitive: Primitive<SearchFieldProps, 'input'> = (
     autoComplete = 'off',
     className,
     labelHidden = true,
+    isLabelShown = false,
     name = 'q',
     onSubmit,
     onClear,
@@ -30,7 +31,7 @@ const SearchFieldPrimitive: Primitive<SearchFieldProps, 'input'> = (
     <TextField
       autoComplete={autoComplete}
       className={classNames(ComponentClassNames.SearchField, className)}
-      labelHidden={labelHidden}
+      labelHidden={labelHidden && !isLabelShown}
       innerEndComponent={
         <FieldClearButton
           excludeFromTabOrder={true}

--- a/packages/react/src/primitives/SearchField/__tests__/SearchField.test.tsx
+++ b/packages/react/src/primitives/SearchField/__tests__/SearchField.test.tsx
@@ -141,6 +141,13 @@ describe('SearchField component', () => {
     expect(searchField).toHaveValue('');
   });
 
+  it('should not visually show label with isLabelShown default to false', async () => {
+    render(<SearchField label={label} />);
+
+    const searchFieldLabel = await screen.findByText(label);
+    expect(searchFieldLabel).toHaveClass(ComponentClassNames.VisuallyHidden);
+  });
+
   describe(' - search button', () => {
     it('should call onSubmit handler when clicked', async () => {
       const onSubmit = jest.fn();

--- a/packages/react/src/primitives/types/alert.ts
+++ b/packages/react/src/primitives/types/alert.ts
@@ -21,9 +21,16 @@ export interface AlertProps extends FlexProps {
   onDismiss?: () => void;
 
   /**
-   * The hasIcon property will determine whether or not an icon is displayed on the Alert. Defaults to true (icon displayed).
+   * @deprecated
+   * hasIcon property will be removed in the next major release in favor of isIconHidden. Please use isIconHidden instead.
    */
   hasIcon?: boolean;
+
+  /**
+   * @default false
+   * Determines whether or not an icon is hidden on the Alert.
+   */
+  isIconHidden?: boolean;
 
   /**
    * The heading property will affect the content of the Alert heading.

--- a/packages/react/src/primitives/types/fieldGroupIcon.ts
+++ b/packages/react/src/primitives/types/fieldGroupIcon.ts
@@ -3,9 +3,16 @@ import { ButtonProps } from './button';
 
 export interface FieldGroupIconProps extends ViewProps {
   /**
-   * Determines whether Icon should be visible
+   * @deprecated
+   * isVisible will be removed in the next major release in favor of isHidden. Please use isHidden instead.
    */
   isVisible?: boolean;
+
+  /**
+   * @default false
+   * Determines whether Icon should be hidden.
+   */
+  isHidden?: boolean;
 
   /**
    * Determines whether element should be focusable.

--- a/packages/react/src/primitives/types/searchField.ts
+++ b/packages/react/src/primitives/types/searchField.ts
@@ -15,10 +15,16 @@ export interface SearchFieldProps extends TextInputFieldProps {
   onClear?: () => void;
 
   /**
-   * Visually hide label
-   * @default true
+   * @deprecated
+   * labelHidden will be removed in the next major release in favor of isLabelShown. Please use isLabelShown instead.
    */
   labelHidden?: boolean;
+
+  /**
+   * @default false
+   * Visually display label
+   */
+  isLabelShown?: boolean;
 
   /**
    * Provides ref access to search button DOM element


### PR DESCRIPTION
#### Description of changes

To simplify code generation process, we would like to have all boolean props default to `false`.

1. Alert `isIconHidden` is added with default of `false`
2. FieldGroupIcon `isHidden` is added with default of `false`
3. SearchField `isLabelShown` is added with default of `false`
4. Updating `CONTRIBUTING.md` for `@aws-amplify/ui-react`

#### Description of how you validated changes

Added unit tests to cover new changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
