### PR TITLE
Split off tests to `test-main` and `test-prs`

### DIFF
--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -1,0 +1,329 @@
+# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Tests
+
+concurrency:
+  group: e2e-${{ github.sha }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [main, ui-svelte/main]
+
+permissions:
+  pull-requests: write # used to remove label
+  # other permissions are defaulted to "none"
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.get-ref.outputs.ref }}
+      commit: ${{ steps.get-ref.outputs.commit }}
+    steps:
+      - name: Get ref and commit
+        id: get-ref
+        run: |
+          echo "::set-output name=ref::${{ github.ref }}"
+          echo "::set-output name=commit::${{ github.sha }}"
+      - name: Checkout Amplify UI
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+          cache: 'yarn'
+      - name: Install packages
+        run: yarn --no-lockfile
+      - name: Build ui package
+        run: yarn ui build
+      - name: Cache cypress runner
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
+      - name: Cache packages/ui/dist
+        uses: actions/cache@v2
+        with:
+          path: ./packages/ui/dist
+          key: ${{ runner.os }}-ui-${{ steps.get-ref.outputs.commit }}
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+          key: ${{ runner.os }}-nodemodules-${{ steps.get-ref.outputs.commit }}
+  unit:
+    needs: setup
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: test
+
+    strategy:
+      matrix:
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        package:
+          - ui
+          - angular
+          - vue
+          - react
+
+    steps:
+      - name: Checkout Amplify UI
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
+
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+          cache: 'yarn'
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v2
+        id: restore-cache
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
+
+      - name: Restore ui/dist cache
+        uses: actions/cache@v2
+        id: restore-ui-cache
+        with:
+          path: ./packages/ui/dist
+          key: ${{ runner.os }}-ui-${{ needs.setup.outputs.commit }}
+
+      - name: Install packages
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: yarn --no-lockfile
+
+      - name: Build ui package
+        if: ${{ steps.restore-ui-cache.outputs.cache-hit != 'true' && matrix.package != 'ui' }}
+        run: yarn ui build
+
+      - name: Build ${{ matrix.package }} package
+        if: ${{ matrix.package != '@aws-amplify/ui' }}
+        run: yarn ${{ matrix.package }} build
+
+      - name: Cache ${{ matrix.package }}/dist
+        uses: actions/cache@v2
+        with:
+          path: ./packages/${{ matrix.package }}/dist
+          key: ${{ runner.os }}-${{ matrix.package }}-${{ needs.setup.outputs.commit }}
+
+      - name: Lint packages
+        run: yarn ${{ matrix.package }} lint
+
+      - name: Run ${{ matrix.package }} tests
+        run: yarn ${{ matrix.package }} test
+
+  e2e:
+    # Only run e2e tests if unit tests pass
+    needs: [setup, unit]
+    runs-on: ubuntu-latest
+    environment: ci
+    env:
+      NODE_ENV: test
+
+    strategy:
+      # Run each examples (e.g. `next-example`) which uses a library (e.g. `@aws-amplify/ui-react`)
+      # BUT, Exclude `@skip` tests in `main` and exclude `@todo-${{ package }}` tests in PRs
+      # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
+      matrix:
+        include:
+          - example: angular
+            package: angular
+            tags: '@angular and not (@skip or @todo-angular)'
+
+          - example: next
+            package: react
+            tags: '@react and not (@skip or @todo-react)'
+
+          - example: vue
+            package: vue
+            tags: '@vue and not (@skip or @todo-vue)'
+
+    steps:
+      - name: Checkout Amplify UI
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Next.js Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+          cache: 'yarn'
+
+      - name: Restore cypress runner Cache
+        uses: actions/cache@v2
+        id: restore-cypress-cache
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v2
+        id: restore-cache
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
+
+      - name: Restore ui/dist cache
+        uses: actions/cache@v2
+        id: restore-ui-cache
+        with:
+          path: ./packages/ui/dist
+          key: ${{ runner.os }}-ui-${{ needs.setup.outputs.commit }}
+
+      - name: Restore ${{ matrix.package }}/dist cache
+        id: restore-package-cache
+        uses: actions/cache@v2
+        with:
+          path: ./packages/${{ matrix.package }}/dist
+          key: ${{ runner.os }}-${{ matrix.package }}-${{ needs.setup.outputs.commit }}
+
+      - name: Install packages
+        if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
+        run: yarn --no-lockfile
+
+      - name: Build @aws-amplify/ui package
+        if: steps.restore-ui-cache.outputs.cache-hit != 'true'
+        run: yarn ui build
+
+      - name: Build ${{ matrix.package }} package
+        if: steps.restore-package-cache.outputs.cache-hit != 'true'
+        run: yarn ${{ matrix.package }} build
+
+      - name: Add Amplify CLI
+        run: yarn global add @aws-amplify/cli
+
+      - name: Get CLI versions
+        id: cli-version
+        run: echo "::set-output name=version::$(amplify --version)"
+
+      - name: Create or restore environments cache
+        id: environments-cache
+        uses: actions/cache@v2
+        with:
+          path: environments/**/aws-exports.js
+          key: ${{ runner.os }}-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('environments/**/amplify/**') }}
+
+      - name: Pull down AWS environments on cache miss
+        if: steps.environments-cache.outputs.cache-hit != 'true'
+        run: yarn environments pull
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Build ${{ matrix.example }} example
+        run: yarn workspace ${{ matrix.example }}-example build
+
+      - name: Start ${{ matrix.example }} example
+        run: yarn workspace ${{ matrix.example }}-example start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000/ui/components/authenticator/sign-in-with-username
+
+      - name: Run E2E tests against ${{ matrix.example }} example
+        run: yarn workspace e2e test:examples
+        env:
+          # Override on the default value in `cypress.json` with framework-specific tag
+          TAGS: '${{ matrix.tags }}'
+
+          # Env values for testing flows
+          DOMAIN: ${{ secrets.DOMAIN }}
+          PHONE_NUMBER: ${{ secrets.PHONE_NUMBER }}
+          USERNAME: ${{ secrets.USERNAME }}
+          NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
+          VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
+  docs:
+    # Only run docs tests if e2e tests pass
+    needs: [setup, unit]
+    runs-on: ubuntu-latest
+    environment: ci
+    env:
+      NODE_ENV: test
+    steps:
+      - name: Checkout Amplify UI
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+          cache: 'yarn'
+
+      - name: Restore cypress runner Cache
+        uses: actions/cache@v2
+        id: restore-cypress-cache
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
+
+      - name: Restore Cache
+        uses: actions/cache@v2
+        id: restore-cache
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
+
+      - name: Install packages
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: yarn --no-lockfile
+
+      - name: Restore ui/dist cache
+        uses: actions/cache@v2
+        id: restore-ui-cache
+        with:
+          path: ./packages/ui/dist
+          key: ${{ runner.os }}-ui-${{ needs.setup.outputs.commit }}
+
+      - name: Restore react/dist cache
+        uses: actions/cache@v2
+        id: restore-react-cache
+        with:
+          path: ./packages/react/dist
+          key: ${{ runner.os }}-@aws-amplify/ui-react-${{ needs.setup.outputs.commit }}
+
+      - name: Build ui package
+        if: steps.restore-ui-cache.outputs.cache-hit != 'true'
+        run: yarn ui build
+
+      - name: Build react package
+        if: steps.restore-react-cache.outputs.cache-hit != 'true'
+        run: yarn react build
+
+      - name: Build docs package
+        run: yarn docs build
+
+      - name: Start docs site
+        run: yarn docs start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000
+
+      - name: Run E2E tests against docs
+        run: yarn workspace e2e test:theme
+        env:
+          # Env values for testing flows
+          DOMAIN: ${{ secrets.DOMAIN }}
+          PHONE_NUMBER: ${{ secrets.PHONE_NUMBER }}
+          USERNAME: ${{ secrets.USERNAME }}
+          NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
+          VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -4,13 +4,10 @@
 name: Tests
 
 concurrency:
-  group: e2e-${{ github.event.pull_request.id || github.sha }}
+  group: e2e-${{ github.event.pull_request.id }}
   cancel-in-progress: true
 
 on:
-  push:
-    branches: [main, ui-svelte/main]
-
   pull_request_target:
     branches: [main, ui-svelte/main]
     types: [opened, synchronize, labeled]
@@ -23,11 +20,9 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     # We run tests only if it's:
-    #   1) push to main, or
-    #   2) pull request not from a fork (ie. internal PR), or
-    #   3) pull request from a fork (ie. external PR) that was added "run-tests" label
+    #   1) pull request not from a fork (ie. internal PR), or
+    #   2) pull request from a fork (ie. external PR) that was added "run-tests" label
     if: |
-      github.event_name == 'push' ||
       (github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event.action == 'labeled' && github.event.label.name == 'run-tests')
     outputs:
@@ -47,13 +42,13 @@ jobs:
       - name: Get ref and commit
         id: get-ref
         run: |
-          echo "::set-output name=ref::${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}"
-          echo "::set-output name=commit::${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}"
+          echo "::set-output name=ref::${{ github.event.pull_request.head.ref }}"
+          echo "::set-output name=commit::${{ github.event.pull_request.head.sha }}"
       - name: Checkout Amplify UI
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.get-ref.outputs.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
       - name: Setup Node.js LTS
         uses: actions/setup-node@v2
@@ -100,8 +95,8 @@ jobs:
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
 
       - name: Setup Node.js LTS
@@ -183,7 +178,7 @@ jobs:
           # For `pull_request_target`, we want ref to point to `pull_request.head.ref` because `github.ref`
           # always points to the target branch.
           # See: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
-          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
@@ -291,8 +286,8 @@ jobs:
       - name: Checkout Amplify UI
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
 
       - name: Setup Node.js LTS


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This is round 1 of our CI/CD improvments. This will split off our monolithic `tests.yml` to `test-main.yml` and `test-prs.yml`.

#### Goals

This will enable us to extend testing workflow per-use case. For example, we would want to more extensive testing once a PR hits main like build testing. This was very hard in previous setup because everything was in one place. 

This will also resolve some spaghetti code we had in our `tests.yml` by breaking per use cases.

#### Duplciated Code
An obvious downside of this PR is that now testing codes are duplicated. We'll look to reuse duplicated code with [Reusable Workflows](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows?learn=getting_started&learnProduct=actions). Meanwhile, I'm good with having some duplicated code for the sake of operational improvements we can get.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
