### PR TITLE
add overflow styling to authenticator modal

### DIFF
--- a/.changeset/tame-seas-grin.md
+++ b/.changeset/tame-seas-grin.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+add overflow styling to authenticator modal

--- a/packages/ui/src/theme/css/component/authenticator.scss
+++ b/packages/ui/src/theme/css/component/authenticator.scss
@@ -1,6 +1,7 @@
 /* Center by default */
 [data-amplify-authenticator] {
   &[data-variation='modal'] {
+    overflow-y: auto;
     display: grid;
     width: var(--amplify-components-authenticator-modal-width);
     height: var(--amplify-components-authenticator-modal-height);


### PR DESCRIPTION
#### Description of changes
add overflow so that long authenticator modals will cause page scroll instead of just being cut off.

#### Issue #1665 

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
