### PR TITLE
fix(docs): Fix anchor tags between pages

### DIFF
--- a/docs/src/components/Layout/index.tsx
+++ b/docs/src/components/Layout/index.tsx
@@ -60,6 +60,20 @@ export default function Page({
 
     return () => observer.disconnect();
   }, [children]);
+
+  React.useEffect(() => {
+    const scrollToHash = () => {
+      const { hash } = window.location;
+
+      if (hash) {
+        document.querySelector(hash)?.scrollIntoView({ behavior: 'smooth' });
+      }
+    };
+    window.addEventListener('load', scrollToHash);
+
+    return () => window.removeEventListener('load', scrollToHash);
+  }, []);
+
   return (
     <div className="docs-main">
       <Sidebar />


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR ensures docs to scroll to the anchor tag on load. 

This doesn't work on our live docs. For example, click on https://ui.docs.amplify.aws/components/authenticator?platform=react#headers--footers and you'll see you're not scrolled to the content.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Validated manually: 

https://user-images.githubusercontent.com/43682783/163648868-87885c26-d19d-4c65-bb8c-4c3767220257.mp4



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
