### PR TITLE
fix(docs Authenticator): Update style authenticator

### DIFF
--- a/docs/src/pages/components/authenticator/AuthStyle.tsx
+++ b/docs/src/pages/components/authenticator/AuthStyle.tsx
@@ -1,0 +1,64 @@
+import {
+  Authenticator,
+  AmplifyProvider,
+  Theme,
+  useTheme,
+} from '@aws-amplify/ui-react';
+export function AuthStyle() {
+  const { tokens } = useTheme();
+  const theme: Theme = {
+    name: 'Auth Example Theme',
+    tokens: {
+      colors: {
+        background: {
+          primary: {
+            value: tokens.colors.neutral['90'].value,
+          },
+          secondary: {
+            value: tokens.colors.neutral['100'].value,
+          },
+        },
+        font: {
+          interactive: {
+            value: tokens.colors.white.value,
+          },
+        },
+        brand: {
+          primary: {
+            '10': tokens.colors.teal['100'],
+            '80': tokens.colors.teal['40'],
+            '90': tokens.colors.teal['20'],
+            '100': tokens.colors.teal['10'],
+          },
+        },
+      },
+      components: {
+        tabs: {
+          item: {
+            _focus: {
+              color: {
+                value: tokens.colors.white.value,
+              },
+            },
+            _hover: {
+              color: {
+                value: tokens.colors.yellow['80'].value,
+              },
+            },
+            _active: {
+              color: {
+                value: tokens.colors.white.value,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  return (
+    <AmplifyProvider theme={theme}>
+      <Authenticator></Authenticator>
+    </AmplifyProvider>
+  );
+}

--- a/docs/src/pages/components/authenticator/customization.styling.react.mdx
+++ b/docs/src/pages/components/authenticator/customization.styling.react.mdx
@@ -1,0 +1,21 @@
+import { AuthStyle } from './AuthStyle';
+import { Example } from '@/components/Example';
+
+#### Amplify Provider Theme
+
+You can update the style of the Authenticator by using the [AmplifyProvider](/theming?platform=react) [theme object](/theming?platform=react#theme-object). To do this, you must surround the `Authenticator` in the `AmplifyProvider`.
+
+Then create a [theme object](/theming?platform=react#theme-object), with all your font and color updates. Feel free to use [design tokens](/theming?platform=react#design-tokens), as a way of desiging your theme further.
+
+Below is an example of changing the default colors to a dark theme.
+
+```jsx file=./AuthStyle.tsx
+
+```
+
+<Example>
+<AuthStyle />
+
+</Example>
+
+> If you have TypeScript enabled, all the object keys will be present when creating the [theme object](/theming?platform=react#theme-object). This will help speed up your development time while creating themes.

--- a/docs/src/pages/components/authenticator/customization.styling.web.mdx
+++ b/docs/src/pages/components/authenticator/customization.styling.web.mdx
@@ -1,71 +1,55 @@
-import { Authenticator } from '@aws-amplify/ui-react';
+import { Authenticator, AmplifyProvider } from '@aws-amplify/ui-react';
+import { AuthStyle } from './AuthStyle';
 
 import { Example } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
 
 ### Styling
 
-You can customize the Authenticator's default [theme](/theming) with [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
+You can customize the Authenticator's default style by using [CSS variables](/components/authenticator?platform=react#amplify-css-variables) or by using the [Amplify Provider](/theming?platform=react) with a [theme object](/theming?platform=react#theme-object).
+
+#### CSS style
+
 The example below uses a `<style>` tag to change the default colors to a dark theme:
 
 ```css
 [data-amplify-authenticator] {
   --amplify-colors-background-primary: var(--amplify-colors-neutral-90);
   --amplify-colors-background-secondary: var(--amplify-colors-neutral-100);
-  --amplify-colors-background-tertiary: var(--amplify-colors-black);
-  --amplify-colors-border-primary: var(--amplify-colors-neutral-20);
-  --amplify-colors-border-secondary: var(--amplify-colors-neutral-40);
-  --amplify-colors-border-tertiary: var(--amplify-colors-neutral-60);
   --amplify-colors-brand-primary-10: var(--amplify-colors-teal-100);
-  --amplify-colors-brand-primary-20: var(--amplify-colors-teal-90);
-  --amplify-colors-brand-primary-40: var(--amplify-colors-teal-80);
-  --amplify-colors-brand-primary-60: var(--amplify-colors-teal-60);
   --amplify-colors-brand-primary-80: var(--amplify-colors-teal-40);
   --amplify-colors-brand-primary-90: var(--amplify-colors-teal-20);
   --amplify-colors-brand-primary-100: var(--amplify-colors-teal-10);
   --amplify-colors-font-interactive: var(--amplify-colors-white);
-  --amplify-components-heading-color: var(--amplify-colors-neutral-20);
-  --amplify-components-tabs-item-active-border-color: var(
-    --amplify-colors-white
-  );
   --amplify-components-tabs-item-active-color: var(--amplify-colors-white);
-  --amplify-components-tabs-item-color: var(--amplify-colors-white);
   --amplify-components-tabs-item-focus-color: var(--amplify-colors-white);
-  --amplify-components-text-color: var(--amplify-colors-font-interactive);
+  --amplify-components-tabs-item-hover-color: var(--amplify-colors-orange);
 }
 ```
 
-<Example className="customization-styles">
-  <style>{`
-    .example.customization-styles {
-      background-color: #1a1a1a !important;
-      color: #eee !important;
-    }
-    .example.customization-styles [data-amplify-authenticator] {
-      --amplify-colors-background-primary: var(--amplify-colors-neutral-90);
-      --amplify-colors-background-secondary: var(--amplify-colors-neutral-100);
-      --amplify-colors-background-tertiary: var(--amplify-colors-black);
-      --amplify-colors-border-primary: var(--amplify-colors-neutral-20);
-      --amplify-colors-border-secondary: var(--amplify-colors-neutral-40);
-      --amplify-colors-border-tertiary: var(--amplify-colors-neutral-60);
-      --amplify-colors-brand-primary-10: var(--amplify-colors-teal-100);
-      --amplify-colors-brand-primary-20: var(--amplify-colors-teal-90);
-      --amplify-colors-brand-primary-40: var(--amplify-colors-teal-80);
-      --amplify-colors-brand-primary-60: var(--amplify-colors-teal-60);
-      --amplify-colors-brand-primary-80: var(--amplify-colors-teal-40);
-      --amplify-colors-brand-primary-90: var(--amplify-colors-teal-20);
-      --amplify-colors-brand-primary-100: var(--amplify-colors-teal-10);
-      --amplify-colors-font-interactive: var(--amplify-colors-white);
-      --amplify-components-heading-color: var(--amplify-colors-neutral-20);
-      --amplify-components-tabs-item-active-border-color: var(--amplify-colors-white);
-      --amplify-components-tabs-item-active-color: var(--amplify-colors-white);
-      --amplify-components-tabs-item-color: var(--amplify-colors-white);
-      --amplify-components-tabs-item-focus-color: var(--amplify-colors-white);
-      --amplify-components-text-color: var(--amplify-colors-font-interactive);
-    }
-  `}</style>
-  <Authenticator />
+<Example>
+<AuthStyle />
+
 </Example>
+
+#### Amplify Provider Theme
+
+You can update the style of the Authenticator by using the [AmplifyProvider](/theming?platform=react) [theme object](/theming?platform=react#theme-object). To do this, you must surround the `Authenticator` in the `AmplifyProvider`.
+
+Then create a [theme object](/theming?platform=react#theme-object), with all your font and color updates. Feel free to use [design tokens](/theming?platform=react#design-tokens), as a way of desiging your theme further.
+
+Below is an example of changing the default colors to a dark theme.
+
+```jsx file=./AuthStyle.tsx
+
+```
+
+<Example>
+<AuthStyle />
+
+</Example>
+
+> If you have TypeScript enabled, all the object keys will be present when creating the [theme object](/theming?platform=react#theme-object). This will help speed up your development time while creating themes.
 
 ### Additional CSS Styling
 

--- a/docs/src/pages/components/authenticator/customization.styling.web.mdx
+++ b/docs/src/pages/components/authenticator/customization.styling.web.mdx
@@ -6,7 +6,7 @@ import { Fragment } from '@/components/Fragment';
 
 ### Styling
 
-You can customize the Authenticator's default style by using [CSS variables](/components/authenticator?platform=react#amplify-css-variables) or by using the [Amplify Provider](/theming?platform=react) with a [theme object](/theming?platform=react#theme-object).
+You can customize the Authenticator's default style by using [CSS variables](/components/authenticator?platform=react#amplify-css-variables).
 
 #### CSS style
 
@@ -32,24 +32,9 @@ The example below uses a `<style>` tag to change the default colors to a dark th
 
 </Example>
 
-#### Amplify Provider Theme
-
-You can update the style of the Authenticator by using the [AmplifyProvider](/theming?platform=react) [theme object](/theming?platform=react#theme-object). To do this, you must surround the `Authenticator` in the `AmplifyProvider`.
-
-Then create a [theme object](/theming?platform=react#theme-object), with all your font and color updates. Feel free to use [design tokens](/theming?platform=react#design-tokens), as a way of desiging your theme further.
-
-Below is an example of changing the default colors to a dark theme.
-
-```jsx file=./AuthStyle.tsx
-
-```
-
-<Example>
-<AuthStyle />
-
-</Example>
-
-> If you have TypeScript enabled, all the object keys will be present when creating the [theme object](/theming?platform=react#theme-object). This will help speed up your development time while creating themes.
+<Fragment platforms={['react']}>
+  {({ platform }) => import(`./customization.styling.${platform}.mdx`)}
+</Fragment>
 
 ### Additional CSS Styling
 


### PR DESCRIPTION
#### Description of changes
Updated docs so the Authenticator style example works correctly. Also added example of using `AmplifyProvider` with a `theme` object.

#### Issue #, if available
#1694

<img width="1234" alt="image" src="https://user-images.githubusercontent.com/65630/163650070-93a1e77f-76ff-4600-8b52-1744c49de5a4.png">

<img width="1248" alt="image" src="https://user-images.githubusercontent.com/65630/163650095-6741b4e4-7bd2-445a-b501-93d6a916c5cd.png">


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
