### PR TITLE
Update required permissions for publish-latest

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write # Used to commit to "Version Packages" PR
+  pull-requests: write # Used to create "Version Packages" PR
+  # Other permissions are defaulted to none
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

We recently defaulted all `GITHUB_TOKEN` access to read. `release-@latest` in particular though needs write token to create and commit to "Version Packages" PR, so adding those permissions in with some comments.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Tested on my POC repo https://github.com/wlee221/changeset-poc/blob/main/.github/workflows/release-main.yml

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
