### PR TITLE
chore: updating docs build to respect yarn.lock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -319,7 +319,7 @@ jobs:
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: yarn --no-lockfile
+        run: yarn install
 
       - name: Restore ui/dist cache
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -308,39 +308,13 @@ jobs:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
 
-      - name: Restore Cache
-        uses: actions/cache@v2
-        id: restore-cache
-        with:
-          path: |
-            ./node_modules
-            **/node_modules
-          key: ${{ runner.os }}-nodemodules-${{ needs.setup.outputs.commit }}
-
       - name: Install packages
-        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: yarn install
 
-      - name: Restore ui/dist cache
-        uses: actions/cache@v2
-        id: restore-ui-cache
-        with:
-          path: ./packages/ui/dist
-          key: ${{ runner.os }}-ui-${{ needs.setup.outputs.commit }}
-
-      - name: Restore react/dist cache
-        uses: actions/cache@v2
-        id: restore-react-cache
-        with:
-          path: ./packages/react/dist
-          key: ${{ runner.os }}-@aws-amplify/ui-react-${{ needs.setup.outputs.commit }}
-
       - name: Build ui package
-        if: steps.restore-ui-cache.outputs.cache-hit != 'true'
         run: yarn ui build
 
       - name: Build react package
-        if: steps.restore-react-cache.outputs.cache-hit != 'true'
         run: yarn react build
 
       - name: Build docs package

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "trim": "^0.0.3",
     "ts-jest": "^26.5.6",
     "vscode-vue-languageservice": "0.27.26",
-    "ws": "^7.4.6"
+    "ws": "^7.4.6",
+    "micromark-util-events-to-acorn": "1.0.4"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "trim": "^0.0.3",
     "ts-jest": "^26.5.6",
     "vscode-vue-languageservice": "0.27.26",
-    "ws": "^7.4.6",
-    "micromark-util-events-to-acorn": "1.0.4"
+    "ws": "^7.4.6"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.1",


### PR DESCRIPTION
#### Description of changes

Having docs site build respect `yarn.lock` since this is not a canary build and it doesn't have to be acting like a new customer.

#### Issue #, if available

Minor release of `micromark-util-events-to-acorn` from `1.0.4` to `1.0.5` this morning is breaking our docs build.

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
