### PR TITLE
docs: fixing dark mode example

### DIFF
--- a/docs/src/pages/theming/dark-mode/darkMode.tsx
+++ b/docs/src/pages/theming/dark-mode/darkMode.tsx
@@ -10,8 +10,6 @@ import {
   ToggleButtonGroup,
 } from '@aws-amplify/ui-react';
 
-import { flipPalette } from '../../../theme';
-
 export const DarkModeExample = () => {
   const [colorMode, setColorMode] = React.useState<ColorMode>('system');
   const theme: Theme = {
@@ -21,7 +19,15 @@ export const DarkModeExample = () => {
         colorMode: 'dark',
         tokens: {
           colors: {
-            neutral: flipPalette(defaultTheme.tokens.colors.neutral),
+            neutral: {
+              // flipping the neutral palette
+              10: defaultTheme.tokens.colors.neutral[100],
+              20: defaultTheme.tokens.colors.neutral[90],
+              40: defaultTheme.tokens.colors.neutral[80],
+              80: defaultTheme.tokens.colors.neutral[40],
+              90: defaultTheme.tokens.colors.neutral[20],
+              100: defaultTheme.tokens.colors.neutral[10],
+            },
             black: { value: '#fff' },
             white: { value: '#000' },
             overlay: {


### PR DESCRIPTION
#### Description of changes

Fixing dark mode example on docs site. `flipPalette` is an internal util function which confuses one of our customers. Any examples on docs site should be instructive and not reference any local files.

#### Issue #, if available

#1717 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
