### PR TITLE
chore: Bump maplibre-gl-js-amplify dependency version

### DIFF
--- a/.changeset/spicy-weeks-smoke.md
+++ b/.changeset/spicy-weeks-smoke.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Bump maplibre-gl-js-amplify dependency version

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,7 +69,7 @@
     "lodash": "4.17.21",
     "mapbox-gl": "npm:empty-npm-package@1.0.0",
     "maplibre-gl": "1.15.2",
-    "maplibre-gl-js-amplify": "1.2.3",
+    "maplibre-gl-js-amplify": "1.5.0",
     "qrcode": "1.5.0",
     "react-generate-context": "1.0.1",
     "react-map-gl": "7.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4424,7 +4424,7 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@maplibre/maplibre-gl-geocoder@^1.1.0":
+"@maplibre/maplibre-gl-geocoder@^1.3.0":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-geocoder/-/maplibre-gl-geocoder-1.3.1.tgz#d7c8dd27f4e574ef6f556e31dc8ec5e570adec31"
   integrity sha512-u9ue09xt70ajEZh9+k8aD7AplfObMxBrsO1WWb5ZPXiwyGdfEsW6/BMk8OF7lvtG8r23wm2sp7GTQ8DhGGSVpQ==
@@ -15197,12 +15197,12 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/empty-npm-package/-/empty-npm-package-1.0.0.tgz#fda29eb6de5efa391f73d578697853af55f6793a"
   integrity sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA==
 
-maplibre-gl-js-amplify@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/maplibre-gl-js-amplify/-/maplibre-gl-js-amplify-1.2.3.tgz#5ac644c663986e287237677074687b797c8e55c2"
-  integrity sha512-dBntciMcerEIG7+Ky9MNj2nBXhIgPB5+qmqaHKV6mrmvujR1GF7fGf5S9H+6T1DBXZVeVU2+YIZNEpamaTWvbQ==
+maplibre-gl-js-amplify@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/maplibre-gl-js-amplify/-/maplibre-gl-js-amplify-1.5.0.tgz#49dc0ac3034bef5bec1da3f1b1abdedd3dd9393d"
+  integrity sha512-4Um06lfGJ45Rw9jlZr3hXxHSUdQQ5sRJJKTgpk14kEZRBuVV3uqvv5odTNn/Wf8wFJpZbZ6aDT3/eSltckpHlA==
   dependencies:
-    "@maplibre/maplibre-gl-geocoder" "^1.1.0"
+    "@maplibre/maplibre-gl-geocoder" "^1.3.0"
 
 maplibre-gl@1.15.2:
   version "1.15.2"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This pull request updates the dependency `maplibre-gl-js-amplify` to the latest version, v1.5.0. This version of the dependency fixes source map warnings received when using the library in a Create React App v5 application (see [Issue #147](https://github.com/aws-amplify/maplibre-gl-js-amplify/issues/147)). These warnings are reported by users of the Amplify UI library (see [this comment](https://github.com/aws-amplify/amplify-ui/issues/1647#issuecomment-1100232282)).
<img width="1022" alt="warnings" src="https://user-images.githubusercontent.com/26472139/164089079-b8987e1f-51bf-4274-b853-4e56677d69f5.png">

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#1647 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Building the canary CRA package can verify whether these source map warnings appear after updating the `maplibre-gl-js-amplify` package.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated - N/A
- [x] Relevant documentation is changed or added (and PR referenced) - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
