### PR TITLE
docs(fix): remove Theme tab from demos

### DIFF
--- a/docs/src/components/Demo.tsx
+++ b/docs/src/components/Demo.tsx
@@ -48,7 +48,10 @@ export const Demo = ({
             <TabItem title="Props">
               <View padding={`${tokens.space.medium} 0`}>{propControls}</View>
             </TabItem>
-            {themeControls ?? <TabItem title="Theme">{themeControls}</TabItem>}
+            {/* Temporarily removing the Theme tab until we figure out a way 
+                to let customers dynamically edit a theme object in the demos 
+            */}
+            {/* {themeControls ?? <TabItem title="Theme">{themeControls}</TabItem>} */}
           </Tabs>
         </Flex>
         <View

--- a/docs/src/components/Demo.tsx
+++ b/docs/src/components/Demo.tsx
@@ -51,7 +51,7 @@ export const Demo = ({
             {/* Temporarily removing the Theme tab until we figure out a way 
                 to let customers dynamically edit a theme object in the demos 
             */}
-            {/* {themeControls ? <TabItem title="Theme">{themeControls}</TabItem>} : null */}
+            {/* {themeControls ? <TabItem title="Theme">{themeControls}</TabItem> : null} */}
           </Tabs>
         </Flex>
         <View

--- a/docs/src/components/Demo.tsx
+++ b/docs/src/components/Demo.tsx
@@ -51,7 +51,7 @@ export const Demo = ({
             {/* Temporarily removing the Theme tab until we figure out a way 
                 to let customers dynamically edit a theme object in the demos 
             */}
-            {/* {themeControls ?? <TabItem title="Theme">{themeControls}</TabItem>} */}
+            {/* {themeControls ? <TabItem title="Theme">{themeControls}</TabItem>} : null */}
           </Tabs>
         </Flex>
         <View


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR temporary removes the Theme tab from the Docs demos until we figure out a way to let customers dynamically edit a theme object in the demos.

![Screen Shot 2022-04-19 at 5 29 14 PM](https://user-images.githubusercontent.com/48109584/164111949-97b83839-28fd-4bd2-a2ac-627e5cb4011a.png)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
