### PR TITLE
chore: fixing workflow not publishing to next tag

### DIFF
--- a/.github/workflows/publish-geo.yml
+++ b/.github/workflows/publish-geo.yml
@@ -18,7 +18,9 @@ jobs:
     # another branch.
     #
     # https://github.community/t/workflow-run-not-working-as-expected/139342
-    if: github.event.workflow_run.conclusion == 'success'
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'ui-geo/main'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/publish-geo.yml
+++ b/.github/workflows/publish-geo.yml
@@ -2,7 +2,7 @@ name: Publish to @geo
 
 on:
   workflow_run:
-    workflows: ['Test / PRs']
+    workflows: ['Test / main']
     types:
       - completed
 

--- a/.github/workflows/publish-geo.yml
+++ b/.github/workflows/publish-geo.yml
@@ -2,7 +2,7 @@ name: Publish to @geo
 
 on:
   workflow_run:
-    workflows: ['Tests']
+    workflows: ['Test / PRs']
     types:
       - completed
 
@@ -18,9 +18,7 @@ jobs:
     # another branch.
     #
     # https://github.community/t/workflow-run-not-working-as-expected/139342
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'ui-geo/main'
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -18,7 +18,12 @@ jobs:
     # another branch.
     #
     # https://github.community/t/workflow-run-not-working-as-expected/139342
-    if: github.event.workflow_run.conclusion == 'success'
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      (
+        github.event.workflow_run.head_branch == 'main' ||
+        github.event.workflow_run.head_branch == 'ui-svelte/main'
+      )
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -2,7 +2,7 @@ name: Publish to @next
 
 on:
   workflow_run:
-    workflows: ['Tests']
+    workflows: ['Test / main']
     types:
       - completed
 
@@ -18,12 +18,7 @@ jobs:
     # another branch.
     #
     # https://github.community/t/workflow-run-not-working-as-expected/139342
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      (
-        github.event.workflow_run.head_branch == 'main' ||
-        github.event.workflow_run.head_branch == 'ui-svelte/main'
-      )
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -8,7 +8,7 @@ concurrency:
 
 on:
   push:
-    branches: [main, ui-svelte/main]
+    branches: [main, ui-svelte/main, ui-geo/main]
 
 permissions:
   pull-requests: write # used to remove label

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -8,7 +8,7 @@ concurrency:
 
 on:
   pull_request_target:
-    branches: [main, ui-svelte/main]
+    branches: [main, ui-svelte/main, ui-geo/main]
     types: [opened, synchronize, labeled]
 
 permissions:


### PR DESCRIPTION
#### Description of changes

Fixing workflow stop publishing to next

#### Issue #, if available

Workflow stops publishing to next after splitting

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
