### PR TITLE
fix: datastore hook issue where isLoading is false when fetching data

### DIFF
--- a/packages/react/src/hooks/useDataStore.tsx
+++ b/packages/react/src/hooks/useDataStore.tsx
@@ -21,13 +21,11 @@ export const useDataStoreCollection = <M extends PersistentModel>({
 }: DataStoreCollectionProps<M>): DataStoreCollectionResult<M> => {
   const [result, setResult] = React.useState<DataStoreCollectionResult<M>>({
     items: [],
-    isLoading: false,
+    isLoading: true,
     error: undefined,
   });
 
   const fetch = () => {
-    setResult({ isLoading: true, items: [] });
-
     const subscription = DataStore.observeQuery(
       model,
       criteria,
@@ -61,12 +59,10 @@ export const useDataStoreItem = <M extends PersistentModel>({
   id,
 }: DataStoreItemProps<M>): DataStoreItemResult<M> => {
   const [item, setItem] = React.useState<M>();
-  const [isLoading, setLoading] = React.useState<boolean>(false);
+  const [isLoading, setLoading] = React.useState<boolean>(true);
   const [error, setError] = React.useState<Error>();
 
   const fetch = () => {
-    setLoading(true);
-
     DataStore.query(model, id)
       .then(setItem)
       .catch(setError)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This PR fixes an issue where the `useDataStoreBinding` hook is setting isLoading to false while data is being fetched. This is due to the default isLoading value being false, and the `setResults` / `setLoading` calls not executing before the fetch is executed.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-ui/issues/1729

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- [ ] Tested in Studio app using Collections

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
