### PR TITLE
fix: issue where number unions ignored in primitivesCatalog

### DIFF
--- a/packages/react/scripts/generatePrimitivesCatalog.ts
+++ b/packages/react/scripts/generatePrimitivesCatalog.ts
@@ -34,7 +34,7 @@ const priorityProps = {
   Pagination: ['totalPages', 'currentPage', 'siblingCount'],
   PasswordField: [...fieldProps, 'hideShowPassword', 'labelHidden'],
   PhoneNumberField: [...fieldProps, 'labelHidden'],
-  Radio: ['label', 'value', 'checked', 'isDisabled', 'size', 'labelPosition'],
+  Radio: ['value', 'checked', 'isDisabled', 'size', 'labelPosition'],
   Rating: ['value', 'size', 'maxValue', 'fillColor', 'emptyColor'],
   SearchField: [...fieldProps, 'variation', 'labelHidden'],
   SliderField: [
@@ -65,7 +65,7 @@ const priorityProps = {
     'trackCheckedColor',
   ],
   Text: ['children', 'fontWeight', 'fontSize', 'color'],
-  TextField: [...fieldProps, 'variation', 'isMultiline'],
+  TextField: [...fieldProps, 'variation'],
 };
 
 /**
@@ -115,9 +115,19 @@ const getCatalogComponentProperty = (
   } else if (propType.isNumber() || propType.isNumberLiteral()) {
     return { type: PrimitiveCatalogComponentPropertyType.Number };
   } else if (propType.isUnion()) {
+    const hasNumber = propType
+      .getUnionTypes()
+      .every((prop) => prop.isNumber() || prop.isNumberLiteral());
+
     const hasString = propType
       .getUnionTypes()
       .some((prop) => prop.isStringLiteral() || prop.isString());
+
+    if (hasNumber) {
+      return {
+        type: PrimitiveCatalogComponentPropertyType.Number,
+      };
+    }
 
     if (hasString) {
       return {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fixes an issue where in our `generatePrimitivesCatalog` script  where union types of numbers were being ignored. This made it so that the `Header` primitive's `level` prop was not included in the `primitives.json` or `primitivesCatalog` ESM export. In Studio UI, it get's filtered out for not being a valid prop from the definition.

I also fixed a few other warnings in the script because `Radio` doesn't have a `label` prop, and `TextField` `isMultiline` prop has been deprecated and is no longer used in Studio.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
Diff of the JSON files before and after these changes:

```diff

                      "variation": {
                        "type": "string"
                      },
+                   "level": {
+                     "type": "number",
+                     "priority": true
+                   },
                     "isTruncated": {
                         "type": "boolean"
```

</body></html>
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
