### PR TITLE
fix: issue where number unions ignored

### DIFF
--- a/packages/react/scripts/generatePrimitivesCatalog.ts
+++ b/packages/react/scripts/generatePrimitivesCatalog.ts
@@ -34,7 +34,7 @@ const priorityProps = {
   Pagination: ['totalPages', 'currentPage', 'siblingCount'],
   PasswordField: [...fieldProps, 'hideShowPassword', 'labelHidden'],
   PhoneNumberField: [...fieldProps, 'labelHidden'],
-  Radio: ['label', 'value', 'checked', 'isDisabled', 'size', 'labelPosition'],
+  Radio: ['value', 'checked', 'isDisabled', 'size', 'labelPosition'],
   Rating: ['value', 'size', 'maxValue', 'fillColor', 'emptyColor'],
   SearchField: [...fieldProps, 'variation', 'labelHidden'],
   SliderField: [
@@ -65,7 +65,7 @@ const priorityProps = {
     'trackCheckedColor',
   ],
   Text: ['children', 'fontWeight', 'fontSize', 'color'],
-  TextField: [...fieldProps, 'variation', 'isMultiline'],
+  TextField: [...fieldProps, 'variation'],
 };
 
 /**
@@ -115,9 +115,19 @@ const getCatalogComponentProperty = (
   } else if (propType.isNumber() || propType.isNumberLiteral()) {
     return { type: PrimitiveCatalogComponentPropertyType.Number };
   } else if (propType.isUnion()) {
+    const hasNumber = propType
+      .getUnionTypes()
+      .every((prop) => prop.isNumber() || prop.isNumberLiteral());
+
     const hasString = propType
       .getUnionTypes()
       .some((prop) => prop.isStringLiteral() || prop.isString());
+
+    if (hasNumber) {
+      return {
+        type: PrimitiveCatalogComponentPropertyType.Number,
+      };
+    }
 
     if (hasString) {
       return {


### PR DESCRIPTION
In our generatePrimitivesCatalog script union types of numbers were being ignored.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
