### PR TITLE
fix(geo): Add position option to GeocoderControl

### DIFF
--- a/.changeset/cuddly-buses-walk.md
+++ b/.changeset/cuddly-buses-walk.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Fix Geocoder position bug

--- a/packages/react/src/components/Geo/Geocoder/index.tsx
+++ b/packages/react/src/components/Geo/Geocoder/index.tsx
@@ -44,13 +44,13 @@ export const Geocoder = (props: GeocoderProps) => {
    * This logic determines whether the Geocoder exists as part of a Map component or if it is a standalone component.
    * The `useControl` hook inside `GeocoderControl` from `react-map-gl` makes it easy to add a control to a map,
    * but throws an error if that map doesn't exist. If the map doesn't exist, the Geocoder is mounted to a container
-   * upon rendering inside the `StandaloneGeocoder`.
+   * upon rendering inside the `GeocoderStandalone`.
    */
   if (map) {
     return <GeocoderControl {...GEOCODER_OPTIONS} {...props} />;
   }
 
-  return <StandaloneGeocoder {...GEOCODER_OPTIONS} {...props} />;
+  return <GeocoderStandalone {...GEOCODER_OPTIONS} {...props} />;
 };
 
 const GeocoderControl = ({
@@ -64,7 +64,7 @@ const GeocoderControl = ({
   return null;
 };
 
-const StandaloneGeocoder = (props: GeocoderProps) => {
+const GeocoderStandalone = (props: GeocoderProps) => {
   const hasMounted = useRef(false);
 
   useEffect(() => {

--- a/packages/react/src/components/Geo/Geocoder/index.tsx
+++ b/packages/react/src/components/Geo/Geocoder/index.tsx
@@ -14,7 +14,7 @@ const GEOCODER_OPTIONS = {
 
 const GEOCODER_CONTAINER = 'geocoder-container';
 
-type GeocoderControl = IControl & {
+type AmplifyGeocoder = IControl & {
   addTo: (container: string) => void;
 };
 
@@ -57,7 +57,7 @@ const GeocoderControl = ({
   position = 'top-right',
   ...props
 }: GeocoderProps) => {
-  useControl(() => createAmplifyGeocoder(props) as unknown as GeocoderControl, {
+  useControl(() => createAmplifyGeocoder(props) as unknown as AmplifyGeocoder, {
     position,
   });
 
@@ -69,7 +69,7 @@ const GeocoderStandalone = (props: GeocoderProps) => {
 
   useEffect(() => {
     if (!hasMounted.current) {
-      (createAmplifyGeocoder(props) as unknown as GeocoderControl).addTo(
+      (createAmplifyGeocoder(props) as unknown as AmplifyGeocoder).addTo(
         `#${GEOCODER_CONTAINER}`
       );
 

--- a/packages/react/src/components/Geo/Geocoder/index.tsx
+++ b/packages/react/src/components/Geo/Geocoder/index.tsx
@@ -37,27 +37,26 @@ type GeocoderControl = IControl & {
  *   return <Geocoder />;
  * }
  */
-export const Geocoder = ({
-  position = 'top-right',
-  ...props
-}: GeocoderProps) => {
+export const Geocoder = (props: GeocoderProps) => {
   const { current: map } = useMap();
 
   /**
    * This logic determines whether the Geocoder exists as part of a Map component or if it is a standalone component.
-   * The `useControl` hook inside `ControlledGeocoder` from `react-map-gl` makes it easy to add a control to a map,
+   * The `useControl` hook inside `GeocoderControl` from `react-map-gl` makes it easy to add a control to a map,
    * but throws an error if that map doesn't exist. If the map doesn't exist, the Geocoder is mounted to a container
    * upon rendering inside the `StandaloneGeocoder`.
    */
   if (map) {
-    return <ControlledGeocoder {...GEOCODER_OPTIONS} {...props} />;
+    return <GeocoderControl {...GEOCODER_OPTIONS} {...props} />;
   }
 
   return <StandaloneGeocoder {...GEOCODER_OPTIONS} {...props} />;
 };
 
-const ControlledGeocoder = (props: GeocoderProps) => {
-  useControl(() => createAmplifyGeocoder(props) as unknown as GeocoderControl);
+const GeocoderControl = ({ position, ...props }: GeocoderProps) => {
+  useControl(() => createAmplifyGeocoder(props) as unknown as GeocoderControl, {
+    position,
+  });
 
   return null;
 };

--- a/packages/react/src/components/Geo/Geocoder/index.tsx
+++ b/packages/react/src/components/Geo/Geocoder/index.tsx
@@ -53,7 +53,10 @@ export const Geocoder = (props: GeocoderProps) => {
   return <StandaloneGeocoder {...GEOCODER_OPTIONS} {...props} />;
 };
 
-const GeocoderControl = ({ position, ...props }: GeocoderProps) => {
+const GeocoderControl = ({
+  position = 'top-right',
+  ...props
+}: GeocoderProps) => {
   useControl(() => createAmplifyGeocoder(props) as unknown as GeocoderControl, {
     position,
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
The `position` property for the `Geocoder` component needs to be passed as the second argument to the `useControl` hook when `Geocoder` is used as a map control.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Passing a `position` property to the `Geocoder` component in the `map-with-geocoder` example is reflected in the map.
```jsx
import { MapView, Geocoder } from '@aws-amplify/ui-react';
import { Amplify } from 'aws-amplify';

import '@aws-amplify/ui-react/styles.css';

import awsExports from './aws-exports';

Amplify.configure(awsExports);

export default function MapWithGeocoder() {
  return (
    <MapView>
      <Geocoder position="top-left" />
    </MapView>
  );
}
```
![Screen Shot 2022-04-21 at 09 14 47](https://user-images.githubusercontent.com/26472139/164505156-a5cc65c0-0606-4e75-813a-5176421a4887.png)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated - N/A
- [x] Relevant documentation is changed or added (and PR referenced) - docs are up to date

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
