### PR TITLE
chore: Make glob more specific in canary script

### DIFF
--- a/canary/script/changeCanaryPackageVersion.mjs
+++ b/canary/script/changeCanaryPackageVersion.mjs
@@ -7,7 +7,7 @@ import { globbyStream } from 'globby';
 import fs from 'fs';
 import { pathToFileURL } from 'url';
 
-for await (const path of globbyStream('./apps/**/package.json')) {
+for await (const path of globbyStream('./apps/*/*/package.json')) {
   const pkgJSON = JSON.parse(fs.readFileSync(path));
   const { dependencies } = pkgJSON;
   if (dependencies) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This makes glob more specific in the canary script we have. This will prevent errors in which it'll try to modify `package.json` in child `node_modules` and end up in errors like

```
✅ Updated undefined to "next" for file:///Users/willeea/Documents/spark/amplify-ui/canary/apps/vue/vuecli/node_modules/postcss-selector-parser/package.json
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
