### PR TITLE
security: remove dangerouslySetInnerHTML from AmplifyProvider

### DIFF
--- a/.changeset/lazy-otters-call.md
+++ b/.changeset/lazy-otters-call.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+security: Remove dangerouslySetInnerHTML from AmplifyProvider

--- a/packages/react/src/components/AmplifyProvider/__tests__/AmplifyProvider.test.tsx
+++ b/packages/react/src/components/AmplifyProvider/__tests__/AmplifyProvider.test.tsx
@@ -38,49 +38,4 @@ describe('AmplifyProvider', () => {
       ''
     );
   });
-
-  it('filters out XSS attacks which attempt to escape the CSS context', async () => {
-    const name = 'maliciousTheme';
-    const xss = `</style><script>alert('XSS')</script>`;
-    const maliciousTheme: Theme = {
-      name,
-      tokens: {
-        colors: {
-          font: { primary: { value: 'pink' }, secondary: { value: xss } },
-        },
-      },
-    };
-
-    const { container } = render(
-      <AmplifyProvider theme={maliciousTheme}>
-        <App />
-      </AmplifyProvider>
-    );
-
-    const styleTag = container.querySelector(`#amplify-theme-${name}`);
-    expect(styleTag).toBe(null);
-  });
-
-  it('filters out XSS attacks which attempt to escape the CSS context using whitespace characters', async () => {
-    const name = 'maliciousTheme';
-    const xss = `</style
-    ><script>alert('XSS')</script>`;
-    const maliciousTheme: Theme = {
-      name,
-      tokens: {
-        colors: {
-          font: { primary: { value: 'pink' }, secondary: { value: xss } },
-        },
-      },
-    };
-
-    const { container } = render(
-      <AmplifyProvider theme={maliciousTheme}>
-        <App />
-      </AmplifyProvider>
-    );
-
-    const styleTag = container.querySelector(`#amplify-theme-${name}`);
-    expect(styleTag).toBe(null);
-  });
 });

--- a/packages/react/src/components/AmplifyProvider/index.tsx
+++ b/packages/react/src/components/AmplifyProvider/index.tsx
@@ -76,52 +76,14 @@ export function AmplifyProvider({
           without having to worry about specificity issues because this stylesheet
           will likely come after a user's defined CSS.
         */}
-      {/*
-          Q: Why are we using dangerouslySetInnerHTML?
-          A: We need to directly inject the theme's CSS string into the <style> tag without typical HTML escaping. 
-             For example, JSX would escape characters meaningful in CSS such as ', ", < and >, thus breaking the CSS. 
-
-          Q: Why not use a sanitization library such as DOMPurify?
-          A: For our use case, we specifically want to purify CSS text, *not* HTML. 
-             DOMPurify, as well as any other HTML sanitization library, would escape/encode meaningful CSS characters 
-             and break our CSS in the same way that JSX would. 
-
-          Q: Are there any security risks in this particular use case?
-          A: Anything set inside of a <style> tag is always interpreted as CSS text, *not* HTML.
-             Reference: “Restrictions on the content of raw text elements” https://html.spec.whatwg.org/dev/syntax.html#cdata-rcdata-restrictions
-             And in our case, we are using dangerouslySetInnerHTML to set CSS text inside of a <style> tag. 
-            
-             Thus, it really comes down to the question: Could a malicious user escape from the context of the <style> tag? 
-             For example, when inserting HTML into the DOM, could someone prematurely close the </style> tag and add a <script> tag?
-               e.g., </style><script>alert('hello')</script>
-             The answer depends on whether the code is rendered on the client or server side. 
-
-             Client side
-             - To prevent XSS inside of the <style> tag, we need to make sure it's not closed prematurely. 
-             - This is prevented by React because React creates a style DOM node (e.g., React.createElement(‘style’, ...)), and directly sets innerHTML as a string. 
-             - Even if the string contains a closing </style> tag, it will still be interpreted as CSS text by the browser. 
-             - Therefore, there is not an XSS vulnerability on the client side. 
-
-             Server side
-             - When React code is rendered on the server side (e.g., NextJS), the code is sent to the browser as HTML text. 
-             - Therefore, it *IS* possible to insert a closing </style> tag and escape the CSS context, which opens an XSS vulnerability. 
-
-          Q: How are we mitigating the potential attack vector?
-          A: To fix this potential attack vector on the server side, we need to filter out any closing </style> tags, 
-             as this the only way to escape from the context of the browser interpreting the text as CSS. 
-             We also need to catch cases where there is any kind of whitespace character </style[HERE]>, such as tabs, carriage returns, etc:
-             </style
-             
-             >
-             Therefore, by only rendering CSS text which does not include a closing '</style>' tag, 
-             we ensure that the browser will correctly interpret all the text as CSS. 
-        */}
-      {typeof theme === 'undefined' || /<\/style/i.test(cssText) ? null : (
+      {typeof theme === 'undefined' ? null : (
         <style
           id={`amplify-theme-${name}`}
-          dangerouslySetInnerHTML={{ __html: cssText }}
           nonce={nonce}
-        />
+          suppressHydrationWarning
+        >
+          {cssText}
+        </style>
       )}
     </AmplifyContext.Provider>
   );

--- a/packages/react/src/components/AmplifyProvider/index.tsx
+++ b/packages/react/src/components/AmplifyProvider/index.tsx
@@ -76,7 +76,7 @@ export function AmplifyProvider({
           without having to worry about specificity issues because this stylesheet
           will likely come after a user's defined CSS.
         */}
-      {typeof theme === 'undefined' ? null : (
+      {theme == null ? null : (
         <style
           id={`amplify-theme-${name}`}
           nonce={nonce}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Our previous solution for preventing server-side XSS involved adding a regex to filter for closing `</style>` tags, which could be used to escape from the CSS context and then run scripts. 

However, we'd like to make some improvements
- use the `textContent` property instead 
- avoid using a blacklist regex, since we don't know all the possible payloads which could be used to trigger an XSS vulnerability.

Thus, we’ve come up with a better, simpler solution which avoids using `dangerouslySetInnerHTML` altogether:

```jsx
        <style id={`amplify-theme-${name}`} nonce={nonce} suppressHydrationWarning>
          {cssText}
        </style>
```

Surprisingly, setting the CSS string directly inside the `<style>` tag works. We originally thought that JSX would escape meaningful CSS characters (such as `'`, `"`', `<` and `>`) and break the CSS. However, CSS text gets escaped on the server side (encoded as `[data-amplify-theme=&quot;amplify-docs&quot;]`), but then hydrated correctly on the front end.

The only issue we saw was a "text content did not match" warning from NextJS. This warning is easily suppressed by passing the `suppressHydrationWarning` prop, and it does not cause any additional re-renders. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I ran the docs and a sample app while making changes to the AmplifyProvider. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
