### PR TITLE
fix: Resets select option text color to fix windows darkmode bug

### DIFF
--- a/.changeset/chatty-scissors-change.md
+++ b/.changeset/chatty-scissors-change.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix: Resets select option text color to fix windows darkmode bug

--- a/packages/ui/src/theme/css/component/select.scss
+++ b/packages/ui/src/theme/css/component/select.scss
@@ -30,6 +30,11 @@
     }
   }
 
+  // For Chrome on Windows, fixes darkmode text color
+  option {
+    color: initial;
+  }
+
   &[data-size='small'] {
     min-width: var(--amplify-components-select-small-min-width);
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This is essentially setting the text color of our `<option />` elements to the browser default to fix the following issue:  

The SelectField options are not legible in Chrome on Windows in dark mode. While the text color from dark mode cascades down (a very light gray), we do not update the background color.

Alternatively, we could consider theming of the option dropdown for browsers that allow it; Windows on Chrome allows you to style the background color of the options dropdown. That will require some further consideration for creating tokens for the font color as well. The fix in this PR works with our current theming options so seems the better fit for now.

**Before**

![before](https://user-images.githubusercontent.com/376920/164562212-649bcadb-325e-43e4-8586-27e48719d145.png)

**After**

![after](https://user-images.githubusercontent.com/376920/164562219-28dfa990-efce-452a-917a-014c517ba863.png)


#### Issue #, if available

Fixes: https://github.com/aws-amplify/amplify-ui/issues/1738

#### Description of how you validated changes

Checked in a number of other browsers with the change in place in local docs instance:

![dropdowns](https://user-images.githubusercontent.com/376920/164563178-c5640077-9276-444e-92ba-b8e3a4c2e460.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
