### PR TITLE
remove inline styling from authenticator component

### DIFF
--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
@@ -1,7 +1,6 @@
 <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
   <fieldset
-    class="amplify-flex"
-    style="flex-direction: column"
+    class="amplify-flex amplify-authenticator__column"
     data-amplify-fieldset
     [disabled]="authenticator.isPending"
   >

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-in/confirm-sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-in/confirm-sign-in.component.html
@@ -1,7 +1,6 @@
 <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
   <fieldset
-    class="amplify-flex"
-    style="flex-direction: column"
+    class="amplify-flex amplify-authenticator__column"
     data-amplify-fieldset
     [disabled]="authenticator.isPending"
   >

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-up/confirm-sign-up.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-up/confirm-sign-up.component.html
@@ -1,17 +1,16 @@
 <ng-container>
   <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
     <fieldset
-      class="amplify-flex"
-      style="flex-direction: column"
+      class="amplify-flex amplify-authenticator__column"
       data-amplify-fieldset
       [disabled]="context.isPending"
     >
       <amplify-slot name="confirm-sign-up-header" [context]="context">
-        <h3 class="amplify-heading" style="font-size: 1.5rem">
+        <h3 class="amplify-heading amplify-authenticator__heading">
           {{ confirmSignUpHeading }}
         </h3>
       </amplify-slot>
-      <span style="margin-bottom: 1rem">
+      <span class="amplify-authenticator__subtitle">
         {{ subtitleText }}
       </span>
       <amplify-base-form-fields

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.html
@@ -1,7 +1,6 @@
 <form data-amplify-form (input)="onInput($event)" (submit)="onSubmit($event)">
   <fieldset
-    class="amplify-flex"
-    style="flex-direction: column"
+    class="amplify-flex amplify-authenticator__column"
     data-amplify-fieldset
     [disabled]="authenticator.isPending"
   >

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/federated-sign-in-button/federated-sign-in-button.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/federated-sign-in-button/federated-sign-in-button.component.html
@@ -3,13 +3,9 @@
   class="amplify-field-group__control federated-sign-in-button"
   fullWidth="true"
   fontWeight="normal"
-  style="display: block"
   (click)="onClick()"
 >
-  <div
-    class="amplify-flex federated-sign-in-button-row"
-    style="flex-direction: row; justify-content: center; align-items: center"
-  >
+  <div class="amplify-flex federated-sign-in-button-row">
     <ng-content></ng-content>
   </div>
 </button>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/federated-sign-in/federated-sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/federated-sign-in/federated-sign-in.component.html
@@ -1,6 +1,5 @@
 <div
   class="amplify-flex federated-sign-in-container"
-  style="flex-direction: column; padding: 0 0 1rem 0"
   *ngIf="shouldShowFederatedSignIn"
   data-orientation="horizontal"
   data-size="small"
@@ -21,7 +20,7 @@
       ></path>
     </svg>
 
-    <p class="amplify-text" style="align-self: center">
+    <p class="amplify-text amplify-authenticator__federated-text">
       {{ signInAmazonText }}
     </p>
   </amplify-federated-sign-in-button>
@@ -44,7 +43,7 @@
         d="M747.4 535.7c-.4-68.2 30.5-119.6 92.9-157.5-34.9-50-87.7-77.5-157.3-82.8-65.9-5.2-138 38.4-164.4 38.4-27.9 0-91.7-36.6-141.9-36.6C273.1 298.8 163 379.8 163 544.6c0 48.7 8.9 99 26.7 150.8 23.8 68.2 109.6 235.3 199.1 232.6 46.8-1.1 79.9-33.2 140.8-33.2 59.1 0 89.7 33.2 141.9 33.2 90.3-1.3 167.9-153.2 190.5-221.6-121.1-57.1-114.6-167.2-114.6-170.7zm-105.1-305c50.7-60.2 46.1-115 44.6-134.7-44.8 2.6-96.6 30.5-126.1 64.8-32.5 36.8-51.6 82.3-47.5 133.6 48.4 3.7 92.6-21.2 129-63.7z"
       ></path>
     </svg>
-    <p class="amplify-text" style="align-self: center">
+    <p class="amplify-text amplify-authenticator__federated-text">
       {{ signInAppleText }}
     </p>
   </amplify-federated-sign-in-button>
@@ -64,7 +63,7 @@
         fill="#1877F2"
       ></path>
     </svg>
-    <p class="amplify-text" style="align-self: center">
+    <p class="amplify-text amplify-authenticator__federated-text">
       {{ signInFacebookText }}
     </p>
   </amplify-federated-sign-in-button>
@@ -97,11 +96,10 @@
         fill="#EB4335"
       ></path>
     </svg>
-    <p class="amplify-text" style="align-self: center">
+    <p class="amplify-text amplify-authenticator__federated-text">
       {{ signInGoogleText }}
     </p>
   </amplify-federated-sign-in-button>
-
 
   <hr
     class="amplify-divider amplify-divider--label"

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/force-new-password/force-new-password-form-fields/force-new-password-form-fields.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/force-new-password/force-new-password-form-fields/force-new-password-form-fields.component.html
@@ -1,3 +1,3 @@
-<div class="amplify-flex" style="flex-direction: column" data-amplify-fieldset>
+<div class="amplify-flex amplify-authenticator__column" data-amplify-fieldset>
   <amplify-base-form-fields route="forceNewPassword"></amplify-base-form-fields>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/force-new-password/force-new-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/force-new-password/force-new-password.component.html
@@ -1,7 +1,6 @@
 <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
   <fieldset
-    class="amplify-flex"
-    style="flex-direction: column"
+    class="amplify-flex amplify-authenticator__column"
     data-amplify-fieldset
     [disabled]="authenticator.isPending"
   >

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.html
@@ -1,4 +1,4 @@
-<div class="amplify-flex amplify-field" style="flex-direction: column">
+<div class="amplify-flex amplify-field amplify-authenticator__column">
   <!-- Country code field -->
   <amplify-phone-number-field
     *ngIf="isPhoneField()"

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/reset-password/reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/reset-password/reset-password.component.html
@@ -1,7 +1,6 @@
 <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
   <fieldset
-    class="amplify-flex"
-    style="flex-direction: column"
+    class="amplify-flex amplify-authenticator__column"
     data-amplify-fieldset
     [disabled]="authenticator.isPending"
   >

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/setup-totp/setup-totp.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/setup-totp/setup-totp.component.html
@@ -1,7 +1,6 @@
 <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
   <fieldset
-    class="amplify-flex"
-    style="flex-direction: column"
+    class="amplify-flex amplify-authenticator__column"
     data-amplify-fieldset
     [disabled]="authenticator.isPending"
   >

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.html
@@ -2,8 +2,11 @@
 
 <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
   <amplify-federated-sign-in></amplify-federated-sign-in>
-  <fieldset class="amplify-flex" style="flex-direction: column" data-amplify-fieldset
-    [disabled]="authenticator.isPending">
+  <fieldset
+    class="amplify-flex amplify-authenticator__column"
+    data-amplify-fieldset
+    [disabled]="authenticator.isPending"
+  >
     <legend class="amplify-visually-hidden">Sign in</legend>
     <amplify-base-form-fields route="signIn"></amplify-base-form-fields>
     <button amplify-button variation="primary" fullWidth="true" type="submit">
@@ -18,8 +21,14 @@
 
 <amplify-slot name="sign-in-footer" [context]="context">
   <div data-amplify-footer>
-    <button amplify-button fontWeight="normal" size="small" variation="link" fullWidth="true"
-      (click)="authenticator.toResetPassword()">
+    <button
+      amplify-button
+      fontWeight="normal"
+      size="small"
+      variation="link"
+      fullWidth="true"
+      (click)="authenticator.toResetPassword()"
+    >
       {{ forgotPasswordText }}
     </button>
   </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-up/sign-up-form-fields/sign-up-form-fields.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-up/sign-up-form-fields/sign-up-form-fields.component.html
@@ -1,3 +1,3 @@
-<div class="amplify-flex" style="flex-direction: column" data-amplify-fieldset>
+<div class="amplify-flex amplify-authenticator__column" data-amplify-fieldset>
   <amplify-base-form-fields route="signUp"></amplify-base-form-fields>
 </div>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-up/sign-up.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-up/sign-up.component.html
@@ -2,8 +2,8 @@
 
 <form data-amplify-form (submit)="onSubmit($event)" (input)="onInput($event)">
   <amplify-federated-sign-in></amplify-federated-sign-in>
-  <div class="amplify-flex" style="flex-direction: column">
-    <div class="amplify-flex" style="flex-direction: column">
+  <div class="amplify-flex amplify-authenticator__column">
+    <div class="amplify-flex amplify-authenticator__column">
       <amplify-slot name="sign-up-form-fields" [context]="context">
         <amplify-sign-up-form-fields></amplify-sign-up-form-fields>
       </amplify-slot>

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/verify-user/verify-user.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/verify-user/verify-user.component.html
@@ -1,7 +1,6 @@
 <form data-amplify-form (input)="onInput($event)" (submit)="onSubmit($event)">
   <fieldset
-    class="amplify-flex"
-    style="flex-direction: column"
+    class="amplify-flex amplify-authenticator__column"
     data-amplify-fieldset
     [disabled]="authenticator.isPending"
   >

--- a/packages/angular/projects/ui-angular/theme.css
+++ b/packages/angular/projects/ui-angular/theme.css
@@ -11,3 +11,18 @@ html {
     font-family: var(--amplify-fonts-default-variable);
   }
 }
+
+.federated-sign-in-container {
+  flex-direction: column;
+  padding: 0 0 1rem 0;
+}
+
+.federated-sign-in-button {
+  display: block;
+}
+
+.federated-sign-in-button-row {
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}

--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -5,6 +5,7 @@ import {
   SignInState,
   translate,
 } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -37,8 +38,7 @@ export const ConfirmSignIn = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
@@ -60,14 +61,15 @@ export function ConfirmSignUp() {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />
 
         <Flex direction="column">
-          <Text style={{ marginBottom: '1rem' }}>{subtitleText}</Text>
+          <Text className="amplify-authenticator__subtitle">
+            {subtitleText}
+          </Text>
 
           <FormFields route="confirmSignUp" />
 
@@ -107,7 +109,7 @@ const DefaultHeader = () => {
       : translate('We Sent A Code');
 
   return (
-    <Heading level={3} style={{ fontSize: '1.5rem' }}>
+    <Heading level={3} className="amplify-authenticator__heading">
       {confirmSignUpHeading}
     </Heading>
   );

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
 import { Heading } from '../../../primitives/Heading';
@@ -32,8 +33,7 @@ export const ForceNewPassword = (): JSX.Element => {
       onBlur={handleBlur}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Heading level={3}>{translate('Change Password')}</Heading>

--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -32,8 +33,7 @@ export const ConfirmResetPassword = (): JSX.Element => {
       onBlur={handleBlur}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -31,8 +32,7 @@ export const ResetPassword = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -1,5 +1,6 @@
 import QRCode from 'qrcode';
 import * as React from 'react';
+import classNames from 'classnames';
 
 import { Auth, Logger } from 'aws-amplify';
 import {
@@ -83,8 +84,7 @@ export const SetupTOTP = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -1,4 +1,5 @@
 import { translate, hasTranslation } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
@@ -35,8 +36,10 @@ export function SignIn() {
         <FederatedSignIn />
         <Flex direction="column">
           <fieldset
-            style={{ display: 'flex', flexDirection: 'column' }}
-            className="amplify-flex"
+            className={classNames(
+              'amplify-flex',
+              'amplify-authenticator__column'
+            )}
             disabled={isPending}
           >
             <VisuallyHidden>

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
@@ -42,8 +43,10 @@ export function SignUp() {
         <FederatedSignIn />
 
         <fieldset
-          style={{ display: 'flex', flexDirection: 'column' }}
-          className="amplify-flex"
+          className={classNames(
+            'amplify-flex',
+            'amplify-authenticator__column'
+          )}
           disabled={isPending}
         >
           <Flex direction="column">

--- a/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -31,8 +32,7 @@ export const ConfirmVerifyUser = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
@@ -7,6 +7,7 @@ import {
   SignInContext,
   translate,
 } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Heading } from '../../../primitives/Heading';
 import { Radio } from '../../../primitives/Radio';
@@ -94,8 +95,7 @@ export const VerifyUser = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/ui/src/theme/css/component/authenticator.scss
+++ b/packages/ui/src/theme/css/component/authenticator.scss
@@ -57,3 +57,20 @@
     }
   }
 }
+
+.amplify-authenticator__column {
+  display: flex;
+  flex-direction: column;
+}
+
+.amplify-authenticator__subtitle {
+  margin-bottom: var(--amplify-space-medium);
+}
+
+.amplify-authenticator__heading {
+  font-size: var(--amplify-font-sizes-xl);
+}
+
+.amplify-authenticator__federated-text {
+  align-self: center;
+}

--- a/packages/vue/src/components/alias-control.vue
+++ b/packages/vue/src/components/alias-control.vue
@@ -37,8 +37,8 @@ const randomPhone = Math.floor(Math.random() * 999999);
   <base-wrapper
     class="
       amplify-flex amplify-field amplify-textfield amplify-phonenumberfield
+      amplify-authenticator__column
     "
-    style="flex-direction: column"
   >
     <base-label
       :for="'amplify-field-' + random"
@@ -57,8 +57,8 @@ const randomPhone = Math.floor(Math.random() * 999999);
             amplify-field
             amplify-selectfield
             amplify-countrycodeselect
+            amplify-authenticator__column
           "
-          style="flex-direction: column"
           v-if="type === 'tel'"
         >
           <base-label
@@ -80,8 +80,11 @@ const randomPhone = Math.floor(Math.random() * 999999);
             >
             </base-select>
             <base-wrapper
-              class="amplify-flex amplify-select__icon-wrapper"
-              style="align-items: center; justify-content: center"
+              class="
+                amplify-flex
+                amplify-select__icon-wrapper
+                amplify-authenticator__icon-wrapper
+              "
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/vue/src/components/confirm-reset-password.vue
+++ b/packages/vue/src/components/confirm-reset-password.vue
@@ -80,8 +80,7 @@ function onBlur(e: Event) {
         @submit.prevent="onConfirmResetPasswordSubmit"
       >
         <base-field-set
-          class="amplify-flex"
-          style="flex-direction: column"
+          class="amplify-flex amplify-authenticator__column"
           :disabled="actorState.matches('confirmResetPassword.pending')"
         >
           <slot name="header">
@@ -90,30 +89,28 @@ function onBlur(e: Event) {
             </base-heading>
           </slot>
 
-          <base-wrapper class="amplify-flex" style="flex-direction: column">
+          <base-wrapper class="amplify-flex amplify-authenticator__column">
             <base-form-fields route="confirmResetPassword"></base-form-fields>
           </base-wrapper>
-          <base-footer class="amplify-flex" style="flex-direction: column">
+          <base-footer class="amplify-flex amplify-authenticator__column">
             <base-alert v-if="actorState?.context?.remoteError">
               {{ translate(actorState?.context?.remoteError) }}
             </base-alert>
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-variation="primary"
               type="submit"
-              style="font-weight: normal"
               :disabled="actorState.matches('confirmResetPassword.pending')"
               >{{ confirmResetPasswordText }}</amplify-button
             >
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-size="small"
               data-variation="link"
               type="button"
               @click.prevent="onLostYourCodeClicked"
-              style="font-weight: normal"
             >
               {{ resendCodeText }}
             </amplify-button>

--- a/packages/vue/src/components/confirm-sign-in.vue
+++ b/packages/vue/src/components/confirm-sign-in.vue
@@ -78,8 +78,7 @@ const onBackToSignInClicked = (): void => {
         @submit.prevent="onConfirmSignInSubmit"
       >
         <base-field-set
-          class="amplify-flex"
-          style="flex-direction: column"
+          class="amplify-flex amplify-authenticator__column"
           :disabled="actorState.matches('confirmSignIn.pending')"
         >
           <slot name="header">
@@ -87,28 +86,26 @@ const onBackToSignInClicked = (): void => {
               {{ confirmSignInHeading }}
             </base-heading>
           </slot>
-          <base-wrapper class="amplify-flex" style="flex-direction: column">
+          <base-wrapper class="amplify-flex amplify-authenticator__column">
             <base-form-fields route="confirmSignIn"></base-form-fields>
           </base-wrapper>
-          <base-footer class="amplify-flex" style="flex-direction: column">
+          <base-footer class="amplify-flex amplify-authenticator__column">
             <base-alert v-if="actorState?.context?.remoteError">
               {{ translate(actorState?.context?.remoteError) }}
             </base-alert>
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-loading="false"
               data-variation="primary"
-              style="font-weight: normal"
               :disabled="actorState.matches('confirmSignIn.pending')"
               >{{ confirmText }}</amplify-button
             >
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-size="small"
               data-variation="link"
-              style="font-weight: normal"
               type="button"
               @click.prevent="onBackToSignInClicked"
             >

--- a/packages/vue/src/components/confirm-sign-up.vue
+++ b/packages/vue/src/components/confirm-sign-up.vue
@@ -74,50 +74,48 @@ const onLostCodeClicked = (): void => {
   <slot v-bind="$attrs" name="confirmSignUpSlotI">
     <base-wrapper v-bind="$attrs">
       <base-form @input="onInput" @submit.prevent="onConfirmSignUpSubmit">
-        <base-wrapper class="amplify-flex" style="flex-direction: column">
+        <base-wrapper class="amplify-flex amplify-authenticator__column">
           <slot name="header">
             <base-heading
-              class="amplify-heading"
-              style="font-size: 1.5rem"
+              class="amplify-heading amplify-authenticator__heading"
               :level="3"
             >
               {{ confirmSignUpHeading }}
             </base-heading>
           </slot>
-          <base-text style="margin-bottom: 1rem">
+          <base-text class="amplify-authenticator__subtitle">
             {{ subtitleText }}
           </base-text>
           <base-field-set
-            class="amplify-flex"
-            style="flex-direction: column"
+            class="amplify-flex amplify-authenticator__column"
             :disabled="isPending"
           >
             <base-form-fields route="confirmSignUp"></base-form-fields>
           </base-field-set>
 
           <base-footer
-            class="amplify-flex"
-            style="flex-direction: column; align-items: unset"
+            class="
+              amplify-flex
+              amplify-authenticator__column amplify-authenticator__footer
+            "
           >
             <base-alert v-if="error">
               {{ translate(error) }}
             </base-alert>
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-loading="false"
               data-variation="primary"
               type="submit"
-              style="font-weight: normal"
               :disabled="isPending"
             >
               {{ confirmText }}
             </amplify-button>
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-variation="default"
-              style="font-weight: normal"
               type="button"
               @click.prevent="onLostCodeClicked"
             >

--- a/packages/vue/src/components/confirm-verify-user.vue
+++ b/packages/vue/src/components/confirm-verify-user.vue
@@ -69,8 +69,7 @@ const onSkipClicked = (): void => {
     <base-wrapper v-bind="$attrs">
       <base-form @input="onInput" @submit.prevent="onConfirmVerifyUserSubmit">
         <base-field-set
-          class="amplify-flex"
-          style="flex-direction: column"
+          class="amplify-flex amplify-authenticator__column"
           :disabled="actorState.matches('confirmVerifyUser.pending')"
         >
           <slot name="header">
@@ -78,29 +77,27 @@ const onSkipClicked = (): void => {
               {{ verifyHeading }}
             </base-heading>
           </slot>
-          <base-wrapper class="amplify-flex" style="flex-direction: column">
+          <base-wrapper class="amplify-flex amplify-authenticator__column">
             <base-form-fields route="confirmVerifyUser"></base-form-fields>
           </base-wrapper>
 
-          <base-footer class="amplify-flex" style="flex-direction: column">
+          <base-footer class="amplify-flex amplify-authenticator__column">
             <base-alert v-if="actorState?.context?.remoteError">
               {{ translate(actorState?.context.remoteError) }}
             </base-alert>
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-variation="primary"
               type="submit"
-              style="font-weight: normal"
               :disabled="actorState.matches('confirmVerifyUser.pending')"
               >{{ submitText }}</amplify-button
             >
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-size="small"
               data-variation="link"
-              style="font-weight: normal"
               type="button"
               @click.prevent="onSkipClicked"
             >

--- a/packages/vue/src/components/federated-sign-in-button.vue
+++ b/packages/vue/src/components/federated-sign-in-button.vue
@@ -1,14 +1,20 @@
 <template>
   <amplify-button
-    class="amplify-field-group__control federated-sign-in-button"
+    class="
+      amplify-field-group__control
+      federated-sign-in-button
+      amplify-authenticator__font
+    "
     data-fullwidth="false"
-    style="font-weight: normal"
     type="button"
     @click="onClick"
   >
     <base-wrapper
-      class="amplify-flex federated-sign-in-button-row"
-      style="flex-direction: row; justify-content: center; align-items: center"
+      class="
+        amplify-flex
+        federated-sign-in-button-row
+        amplify-authenticator__sign-in-button-wrapper
+      "
     >
       <slot></slot>
     </base-wrapper>

--- a/packages/vue/src/components/federated-sign-in.vue
+++ b/packages/vue/src/components/federated-sign-in.vue
@@ -44,8 +44,11 @@ const signInWithGoogle = computed(() =>
 
 <template>
   <base-wrapper
-    class="amplify-flex federated-sign-in-container"
-    style="flex-direction: column; padding: 0 0 1rem 0"
+    class="
+      amplify-flex
+      federated-sign-in-container
+      amplify-authenticator__column amplify-authenticator__sign-in-base
+    "
     v-if="shouldShowFederatedSignIn"
   >
     <federated-sign-in-button v-if="includeAmazon" :provider="fp.Amazon">
@@ -60,7 +63,7 @@ const signInWithGoogle = computed(() =>
         ></path>
       </svg>
 
-      <p class="amplify-text" style="align-self: center">
+      <p class="amplify-text amplify-authenticator__federated-text">
         {{ signInWithAmazon }}
       </p>
     </federated-sign-in-button>
@@ -80,7 +83,7 @@ const signInWithGoogle = computed(() =>
           d="M747.4 535.7c-.4-68.2 30.5-119.6 92.9-157.5-34.9-50-87.7-77.5-157.3-82.8-65.9-5.2-138 38.4-164.4 38.4-27.9 0-91.7-36.6-141.9-36.6C273.1 298.8 163 379.8 163 544.6c0 48.7 8.9 99 26.7 150.8 23.8 68.2 109.6 235.3 199.1 232.6 46.8-1.1 79.9-33.2 140.8-33.2 59.1 0 89.7 33.2 141.9 33.2 90.3-1.3 167.9-153.2 190.5-221.6-121.1-57.1-114.6-167.2-114.6-170.7zm-105.1-305c50.7-60.2 46.1-115 44.6-134.7-44.8 2.6-96.6 30.5-126.1 64.8-32.5 36.8-51.6 82.3-47.5 133.6 48.4 3.7 92.6-21.2 129-63.7z"
         ></path>
       </svg>
-      <p class="amplify-text" style="align-self: center">
+      <p class="amplify-text amplify-authenticator__federated-text">
         {{ signInWithApple }}
       </p>
     </federated-sign-in-button>
@@ -97,7 +100,7 @@ const signInWithGoogle = computed(() =>
         ></path>
       </svg>
 
-      <p class="amplify-text" style="align-self: center">
+      <p class="amplify-text amplify-authenticator__federated-text">
         {{ signInWithFacebook }}
       </p>
     </federated-sign-in-button>
@@ -127,7 +130,7 @@ const signInWithGoogle = computed(() =>
           fill="#EB4335"
         ></path>
       </svg>
-      <p class="amplify-text" style="align-self: center">
+      <p class="amplify-text amplify-authenticator__federated-text">
         {{ signInWithGoogle }}
       </p>
     </federated-sign-in-button>

--- a/packages/vue/src/components/force-new-password.vue
+++ b/packages/vue/src/components/force-new-password.vue
@@ -76,8 +76,7 @@ function onBlur(e: Event) {
         @submit.prevent="onForceNewPasswordSubmit"
       >
         <base-field-set
-          class="amplify-flex"
-          style="flex-direction: column"
+          class="amplify-flex amplify-authenticator__column"
           :disabled="actorState.matches('forceNewPassword.pending')"
         >
           <slot name="header">
@@ -85,22 +84,21 @@ function onBlur(e: Event) {
               {{ changePasswordLabel }}
             </base-heading>
           </slot>
-          <base-wrapper class="amplify-flex" style="flex-direction: column">
+          <base-wrapper class="amplify-flex amplify-authenticator__column">
             <slot name="force-new-password-form-fields">
               <authenticator-force-new-password-form-fields />
             </slot>
           </base-wrapper>
 
-          <base-footer class="amplify-flex" style="flex-direction: column">
+          <base-footer class="amplify-flex amplify-authenticator__column">
             <base-alert data-ui-error v-if="actorState.context.remoteError">
               {{ translate(actorState.context.remoteError) }}
             </base-alert>
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-loading="false"
               data-variation="primary"
-              style="font-weight: normal"
               :disabled="actorState.matches('signUp.submit')"
               >{{
                 actorState.matches('forceNewPassword.pending')
@@ -109,11 +107,10 @@ function onBlur(e: Event) {
               }}</amplify-button
             >
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-size="small"
               data-variation="link"
-              style="font-weight: normal"
               type="button"
               @click.prevent="onHaveAccountClicked"
             >

--- a/packages/vue/src/components/password-control.vue
+++ b/packages/vue/src/components/password-control.vue
@@ -53,8 +53,10 @@ export default {
 
 <template>
   <base-wrapper
-    class="amplify-flex amplify-field amplify-textfield amplify-passwordfield"
-    style="flex-direction: column"
+    class="
+      amplify-flex amplify-field amplify-textfield amplify-passwordfield
+      amplify-authenticator__column
+    "
   >
     <base-label
       class="amplify-label"

--- a/packages/vue/src/components/primitives/base-alert.vue
+++ b/packages/vue/src/components/primitives/base-alert.vue
@@ -10,12 +10,11 @@ function close() {
 <template>
   <div
     v-if="show"
-    class="amplify-flex amplify-alert"
+    class="amplify-flex amplify-alert amplify-authenticator__base"
     data-variation="error"
-    style="align-items: center; justify-content: space-between"
     role="alert"
   >
-    <div class="amplify-flex" style="align-items: center">
+    <div class="amplify-flex amplify-authenticator__icon-wrapper">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="amplify-icon"

--- a/packages/vue/src/components/primitives/base-two-tabs.vue
+++ b/packages/vue/src/components/primitives/base-two-tabs.vue
@@ -5,13 +5,12 @@
     tabindex="0"
     aria-orientation="horizontal"
     data-orientation="horizontal"
+    class="amplify-authenticator__tabs"
     role="tablist"
-    style="outline: none"
   >
     <base-wrapper
-      class="amplify-flex amplify-tabs"
+      class="amplify-flex amplify-tabs amplify-authenticator__tabs-wrapper"
       data-indicator-position="top"
-      style="gap: 0px; justify-content: center"
     >
       <slot></slot>
     </base-wrapper>

--- a/packages/vue/src/components/reset-password.vue
+++ b/packages/vue/src/components/reset-password.vue
@@ -58,42 +58,41 @@ const onBackToSignInClicked = (): void => {
       @input="onInput"
       @submit.prevent="onResetPasswordSubmit"
     >
-      <base-wrapper class="amplify-flex" style="flex-direction: column">
+      <base-wrapper class="amplify-flex amplify-authenticator__column">
         <slot name="header">
           <base-heading class="amplify-heading" :level="3">
             {{ resetPasswordHeading }}
           </base-heading>
         </slot>
         <base-field-set
-          class="amplify-flex"
-          style="flex-direction: column"
+          class="amplify-flex amplify-authenticator__column"
           :disabled="isPending"
         >
           <base-form-fields route="resetPassword"></base-form-fields>
         </base-field-set>
 
         <base-footer
-          class="amplify-flex"
-          style="flex-direction: column; align-items: unset"
+          class="
+            amplify-flex
+            amplify-authenticator__column amplify-authenticator__footer
+          "
         >
           <base-alert v-if="error">
             {{ translate(error) }}
           </base-alert>
           <amplify-button
-            class="amplify-field-group__control"
+            class="amplify-field-group__control amplify-authenticator__font"
             data-fullwidth="false"
             data-variation="primary"
             type="submit"
-            style="font-weight: normal"
             :disabled="isPending"
             >{{ resetPasswordText }}</amplify-button
           >
           <amplify-button
-            class="amplify-field-group__control"
+            class="amplify-field-group__control amplify-authenticator__font"
             data-fullwidth="false"
             data-size="small"
             data-variation="link"
-            style="font-weight: normal"
             type="button"
             @click.prevent="onBackToSignInClicked"
           >

--- a/packages/vue/src/components/setup-totp.vue
+++ b/packages/vue/src/components/setup-totp.vue
@@ -116,22 +116,21 @@ const onBackToSignInClicked = (): void => {
         @submit.prevent="onSetupTOTPSubmit"
       >
         <base-field-set
-          class="amplify-flex"
-          style="flex-direction: column"
+          class="amplify-flex amplify-authenticator__column"
           :disabled="actorState.matches('confirmSignIn.pending')"
         >
           <template v-if="qrCode.isLoading">
             <p>Loading...</p>
           </template>
           <template v-else>
-            <base-wrapper class="amplify-flex" style="flex-direction: column">
+            <base-wrapper class="amplify-flex amplify-authenticator__column">
               <slot name="header">
                 <base-heading class="amplify-heading" :level="3">
                   Setup TOTP
                 </base-heading>
               </slot>
 
-              <base-wrapper class="amplify-flex" style="flex-direction: column">
+              <base-wrapper class="amplify-flex amplify-authenticator__column">
                 <img
                   class="amplify-image"
                   data-amplify-qrcode
@@ -158,27 +157,31 @@ const onBackToSignInClicked = (): void => {
                 </base-wrapper>
                 <base-form-fields route="setupTOTP"></base-form-fields>
               </base-wrapper>
-              <base-footer class="amplify-flex" style="flex-direction: column">
+              <base-footer class="amplify-flex amplify-authenticator__column">
                 <base-alert v-if="actorState.context?.remoteError">
                   {{ translate(actorState.context.remoteError) }}
                 </base-alert>
                 <amplify-button
-                  class="amplify-field-group__control"
+                  class="
+                    amplify-field-group__control
+                    amplify-authenticator__font
+                  "
                   data-fullwidth="false"
                   data-loading="false"
                   data-variation="primary"
                   type="submit"
-                  style="font-weight: normal"
                   :disabled="actorState.matches('confirmSignIn.pending')"
                 >
                   {{ confirmText }}
                 </amplify-button>
                 <amplify-button
-                  class="amplify-field-group__control"
+                  class="
+                    amplify-field-group__control
+                    amplify-authenticator__font
+                  "
                   data-fullwidth="false"
                   data-size="small"
                   data-variation="link"
-                  style="font-weight: normal"
                   type="button"
                   @click.prevent="onBackToSignInClicked"
                 >

--- a/packages/vue/src/components/sign-in.vue
+++ b/packages/vue/src/components/sign-in.vue
@@ -95,11 +95,10 @@ const onForgotPasswordClicked = (): void => {
           </slot>
         </template>
         <federated-sign-in></federated-sign-in>
-        <base-wrapper class="amplify-flex" style="flex-direction: column">
+        <base-wrapper class="amplify-flex amplify-authenticator__column">
           <base-field-set
             :disabled="actorState.matches('signIn.submit')"
-            class="amplify-flex"
-            style="flex-direction: column"
+            class="amplify-flex amplify-authenticator__column"
           >
             <template #fieldSetI="{ slotData }">
               <slot name="signin-fields" :info="slotData"> </slot>
@@ -113,11 +112,13 @@ const onForgotPasswordClicked = (): void => {
 
           <amplify-button
             :disabled="actorState.matches('signIn.submit')"
-            class="amplify-field-group__control"
+            class="
+              amplify-field-group__control
+              amplify-authenticator__font amplify-authenticator__sign-in-button
+            "
             :fullwidth="true"
             data-loading="false"
             :variation="'primary'"
-            style="border-radius: 0x; font-weight: normal"
           >
             {{
               actorState.matches('signIn.submit')
@@ -134,11 +135,10 @@ const onForgotPasswordClicked = (): void => {
         <div data-amplify-footer>
           <amplify-button
             @click="onForgotPasswordClicked"
-            class="amplify-field-group__control"
+            class="amplify-field-group__control amplify-authenticator__font"
             data-fullwidth="true"
             data-size="small"
             data-variation="link"
-            style="font-weight: normal"
             type="button"
           >
             {{ forgotYourPasswordLink }}

--- a/packages/vue/src/components/sign-up.vue
+++ b/packages/vue/src/components/sign-up.vue
@@ -60,10 +60,9 @@ const submit = (e: Event): void => {
       >
         <federated-sign-in></federated-sign-in>
 
-        <base-wrapper class="amplify-flex" style="flex-direction: column">
+        <base-wrapper class="amplify-flex amplify-authenticator__column">
           <base-field-set
-            class="amplify-flex"
-            style="flex-direction: column"
+            class="amplify-flex amplify-authenticator__column"
             :disabled="isPending"
           >
             <template #fieldSetI="{ slotData }">
@@ -75,11 +74,13 @@ const submit = (e: Event): void => {
             {{ translate(error) }}
           </base-alert>
           <amplify-button
-            class="amplify-field-group__control"
+            class="
+              amplify-field-group__control
+              amplify-authenticator__font amplify-authenticator__sign-in-button
+            "
             data-fullwidth="true"
             data-loading="false"
             data-variation="primary"
-            style="border-radius: 0px; font-weight: normal"
             :disabled="isPending || hasValidationErrors"
             >{{ createAccountLabel }}</amplify-button
           >

--- a/packages/vue/src/components/verify-user.vue
+++ b/packages/vue/src/components/verify-user.vue
@@ -72,8 +72,7 @@ const onSkipClicked = (): void => {
       <base-form @input="onInput" @submit.prevent="onVerifyUserSubmit">
         <base-field-set
           :disabled="actorState.matches('verifyUser.pending')"
-          class="amplify-flex"
-          style="flex-direction: column"
+          class="amplify-flex amplify-authenticator__column"
         >
           <slot name="header">
             <base-heading class="amplify-heading" :level="3">
@@ -81,8 +80,10 @@ const onSkipClicked = (): void => {
             </base-heading>
           </slot>
           <base-wrapper
-            class="amplify-flex amplify-field amplify-radiogroupfield"
-            style="flex-direction: column"
+            class="
+              amplify-flex amplify-field amplify-radiogroupfield
+              amplify-authenticator__column
+            "
           >
             <base-label
               class="amplify-visually-hidden amplify-label"
@@ -91,8 +92,10 @@ const onSkipClicked = (): void => {
               {{ verifyContactText }}
             </base-label>
             <base-wrapper
-              class="amplify-flex amplify-field amplify-radiogroupfield"
-              style="flex-direction: column"
+              class="
+                amplify-flex amplify-field amplify-radiogroupfield
+                amplify-authenticator__column
+              "
               aria-labelledby="amplify-field-493c"
             >
               <base-label
@@ -127,25 +130,23 @@ const onSkipClicked = (): void => {
               </base-label>
             </base-wrapper>
           </base-wrapper>
-          <base-footer class="amplify-flex" style="flex-direction: column">
+          <base-footer class="amplify-flex amplify-authenticator__column">
             <base-alert v-if="actorState?.context?.remoteError">
               {{ translate(actorState?.context.remoteError) }}
             </base-alert>
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-variation="primary"
               type="submit"
-              style="font-weight: normal"
               :disabled="actorState.matches('verifyUser.pending')"
               >{{ verifyText }}</amplify-button
             >
             <amplify-button
-              class="amplify-field-group__control"
+              class="amplify-field-group__control amplify-authenticator__font"
               data-fullwidth="false"
               data-size="small"
               data-variation="link"
-              style="font-weight: normal"
               type="button"
               @click.prevent="onSkipClicked"
             >

--- a/packages/vue/src/styles.css
+++ b/packages/vue/src/styles.css
@@ -1,2 +1,43 @@
 @import '@aws-amplify/ui/styles.css';
 @import './components/primitives/styles.css';
+
+.amplify-authenticator__font {
+  font-weight: normal;
+}
+
+.amplify-authenticator__icon-wrapper {
+  align-items: center;
+  justify-content: center;
+}
+
+.amplify-authenticator__signup-footer {
+  align-items: unset;
+}
+
+.amplify-authenticator__sign-in-button-wrapper {
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+.amplify-authenticator__sign-in-base {
+  padding: 0 0 1rem 0;
+}
+
+.amplify-authenticator__sign-in-button {
+  border-radius: 0x;
+}
+
+.amplify-authenticator__base {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.amplify-authenticator__tabs {
+  outline: none;
+}
+
+.amplify-authenticator__tabs-wrapper {
+  gap: 0px;
+  justify-content: center;
+}


### PR DESCRIPTION
#### Description of changes
This pull request removes all of the inline styles for the authenticator component in react, vue, and angular.  The ui package is being updated to include the classes shared between frameworks.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
