### PR TITLE
Docs bug fix (draft) - Switching themes wipes out state

### DIFF
--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -15,6 +15,8 @@ import '../styles/index.scss';
 // @ts-ignore Cannot assign to 'useLayoutEffect' because it is a read-only property.ts(2540)
 if (typeof window === 'undefined') React.useLayoutEffect = React.useEffect;
 
+export const DemoState = new Map();
+
 function MyApp({ Component, pageProps }) {
   const router = useRouter();
   const { platform = 'react' } = router.query;

--- a/docs/src/pages/components/alert/demo.tsx
+++ b/docs/src/pages/components/alert/demo.tsx
@@ -1,8 +1,9 @@
+import * as React from 'react';
 import { Alert } from '@aws-amplify/ui-react';
-
 import { Demo } from '@/components/Demo';
 import { AlertPropControls } from './AlertPropControls';
 import { useAlertProps } from './useAlertProps';
+import { DemoState } from 'src/pages/_app.page';
 
 const propsToCode = (props) => {
   return (
@@ -21,11 +22,17 @@ const propsToCode = (props) => {
 };
 
 export const AlertDemo = () => {
-  const alertProps = useAlertProps({
-    isDismissible: false,
-    hasIcon: true,
-    heading: 'Alert heading',
-    body: 'This is the alert message',
+  const alertProps = useAlertProps(
+    DemoState.get('alert') || {
+      isDismissible: false,
+      hasIcon: true,
+      heading: 'Alert heading',
+      body: 'This is the alert message',
+    }
+  );
+
+  React.useEffect(() => {
+    DemoState.set('alert', alertProps);
   });
 
   return (


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

#### Problem
- When a customer toggles light/dark mode on the Amplify UI Docs site, it wipes out state in the component demos: https://github.com/aws-amplify/amplify-ui/issues/678
- This docs bug has been outstanding for 5 months, so it’d be nice to get it solved. 

#### What we’ve tried
- @dbanksdesign told me that they’d narrowed it down to how the docs site does dynamic imports, which give us a lot of performance benefits. 
- After spending a few days diving into the weeds of NextJS, I wasn’t able to find a way to prevent NextJS from re-rendering the page and wiping out state when the user toggles light/dark mode. 
- I also tried memoizing various components in the render path, but that didn’t work either. 

#### Proposed solution
- Basically, we just want to lift state up from the demos so that it doesn’t get wiped out after each re-render. 
- To do this, I’ve declared a `Map` object above `MyApp` at the top of the component tree, which functions as a very simple datastore:

```js
export const DemoState = new Map();

function MyApp({ Component, pageProps }) {
   // code...
}
```

Then, in each demo, we can use the `Map` to get and set demo props:

```js
import { DemoState } from 'src/pages/_app.page';

export const AlertDemo = () => {
  const alertProps = useAlertProps(
    DemoState.get('alert') || {
      isDismissible: false,
      hasIcon: true,
      heading: 'Alert heading',
      body: 'This is the alert message',
    }
  );

  React.useEffect(() => {
    DemoState.set('alert', alertProps);
  });
// code...
```

In the example above, we make a call to get the props for the `'alert'` demo from the `Map` object. If they exist, then `alertProps` are set to what they were before the alert demo got re-rendered, thus persisting the demo’s state. If `get` returns `undefined`, then the default props get applied. 

Every time the `alertProps` change, this triggers the `useEffect` hook to set the demo's state on the `Map` object. 
- Ideally, we’d only have to set state when the customer toggles light/dark mode, but we have no way of knowing when they’ll toggle and re-render the page

#### Tradeoffs
- I’ll have to add a few lines of code to each component demo in order to get and set component state
- Worst case, the `Map` could store state for every component if a customer went through each demo without doing a browser refresh. But even so, that wouldn’t take up much memory at all. 

I am totally open to comments/suggestions. Please let me know if you can think of a better way to solve this bug!


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/678

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
