### PR TITLE
remove inline styling from react authenticator

### DIFF
--- a/.changeset/silver-foxes-clap.md
+++ b/.changeset/silver-foxes-clap.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+remove inline styling from react authenticator

--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -5,6 +5,7 @@ import {
   SignInState,
   translate,
 } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -37,8 +38,7 @@ export const ConfirmSignIn = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -36,12 +36,7 @@ export const ConfirmSignIn = (): JSX.Element => {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <Flex
-        as="fieldset"
-        direction="column"
-        className="amplify-flex"
-        isDisabled={isPending}
-      >
+      <Flex as="fieldset" direction="column" isDisabled={isPending}>
         <Header />
 
         <Flex direction="column">

--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -5,7 +5,6 @@ import {
   SignInState,
   translate,
 } from '@aws-amplify/ui';
-import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -37,9 +36,11 @@ export const ConfirmSignIn = (): JSX.Element => {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <fieldset
-        className={classNames('amplify-flex', 'amplify-authenticator__column')}
-        disabled={isPending}
+      <Flex
+        as="fieldset"
+        direction="column"
+        className="amplify-flex"
+        isDisabled={isPending}
       >
         <Header />
 
@@ -50,7 +51,7 @@ export const ConfirmSignIn = (): JSX.Element => {
 
         <ConfirmSignInFooter />
         <Footer />
-      </fieldset>
+      </Flex>
     </form>
   );
 };

--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
@@ -60,14 +61,15 @@ export function ConfirmSignUp() {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />
 
         <Flex direction="column">
-          <Text style={{ marginBottom: '1rem' }}>{subtitleText}</Text>
+          <Text className="amplify-authenticator__subtitle">
+            {subtitleText}
+          </Text>
 
           <FormFields route="confirmSignUp" />
 
@@ -107,7 +109,7 @@ const DefaultHeader = () => {
       : translate('We Sent A Code');
 
   return (
-    <Heading level={3} style={{ fontSize: '1.5rem' }}>
+    <Heading level={3} className="amplify-authenticator__heading">
       {confirmSignUpHeading}
     </Heading>
   );

--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -59,12 +59,7 @@ export function ConfirmSignUp() {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <Flex
-        as="fieldset"
-        className="amplify-flex"
-        direction="column"
-        isDisabled={isPending}
-      >
+      <Flex as="fieldset" direction="column" isDisabled={isPending}>
         <Header />
 
         <Flex direction="column">

--- a/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignUp/ConfirmSignUp.tsx
@@ -1,5 +1,4 @@
 import { translate } from '@aws-amplify/ui';
-import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
@@ -60,9 +59,11 @@ export function ConfirmSignUp() {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <fieldset
-        className={classNames('amplify-flex', 'amplify-authenticator__column')}
-        disabled={isPending}
+      <Flex
+        as="fieldset"
+        className="amplify-flex"
+        direction="column"
+        isDisabled={isPending}
       >
         <Header />
 
@@ -91,7 +92,7 @@ export function ConfirmSignUp() {
           </Button>
         </Flex>
         <Footer />
-      </fieldset>
+      </Flex>
     </form>
   );
 }
@@ -108,11 +109,7 @@ const DefaultHeader = () => {
       ? translate('We Texted You')
       : translate('We Sent A Code');
 
-  return (
-    <Heading level={3} className="amplify-authenticator__heading">
-      {confirmSignUpHeading}
-    </Heading>
-  );
+  return <Heading level={4}>{confirmSignUpHeading}</Heading>;
 };
 
 ConfirmSignUp.Header = DefaultHeader;

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -1,7 +1,7 @@
 import { translate } from '@aws-amplify/ui';
-import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
+import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
 import { Text } from '../../../primitives/Text';
 import { useAuthenticator } from '../hooks/useAuthenticator';
@@ -32,9 +32,11 @@ export const ForceNewPassword = (): JSX.Element => {
       onSubmit={handleSubmit}
       onBlur={handleBlur}
     >
-      <fieldset
-        className={classNames('amplify-flex', 'amplify-authenticator__column')}
-        disabled={isPending}
+      <Flex
+        as="fieldset"
+        className="amplify-flex"
+        direction="column"
+        isDisabled={isPending}
       >
         <Heading level={3}>{translate('Change Password')}</Heading>
 
@@ -63,7 +65,7 @@ export const ForceNewPassword = (): JSX.Element => {
         >
           {translate('Back to Sign In')}
         </Button>
-      </fieldset>
+      </Flex>
     </form>
   );
 };

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -32,12 +32,7 @@ export const ForceNewPassword = (): JSX.Element => {
       onSubmit={handleSubmit}
       onBlur={handleBlur}
     >
-      <Flex
-        as="fieldset"
-        className="amplify-flex"
-        direction="column"
-        isDisabled={isPending}
-      >
+      <Flex as="fieldset" direction="column" isDisabled={isPending}>
         <Heading level={3}>{translate('Change Password')}</Heading>
 
         <FormFields />

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
 import { Heading } from '../../../primitives/Heading';
@@ -32,8 +33,7 @@ export const ForceNewPassword = (): JSX.Element => {
       onBlur={handleBlur}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Heading level={3}>{translate('Change Password')}</Heading>

--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -1,5 +1,4 @@
 import { translate } from '@aws-amplify/ui';
-import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -32,9 +31,11 @@ export const ConfirmResetPassword = (): JSX.Element => {
       onChange={handleChange}
       onBlur={handleBlur}
     >
-      <fieldset
-        className={classNames('amplify-flex', 'amplify-authenticator__column')}
-        disabled={isPending}
+      <Flex
+        as="fieldset"
+        className="amplify-flex"
+        direction="column"
+        isDisabled={isPending}
       >
         <Header />
 
@@ -48,7 +49,7 @@ export const ConfirmResetPassword = (): JSX.Element => {
           cancelButtonText={translate('Resend Code')}
         />
         <Footer />
-      </fieldset>
+      </Flex>
     </form>
   );
 };

--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -31,12 +31,7 @@ export const ConfirmResetPassword = (): JSX.Element => {
       onChange={handleChange}
       onBlur={handleBlur}
     >
-      <Flex
-        as="fieldset"
-        className="amplify-flex"
-        direction="column"
-        isDisabled={isPending}
-      >
+      <Flex as="fieldset" direction="column" isDisabled={isPending}>
         <Header />
 
         <Flex direction="column">

--- a/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ConfirmResetPassword.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -32,8 +33,7 @@ export const ConfirmResetPassword = (): JSX.Element => {
       onBlur={handleBlur}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -30,12 +30,7 @@ export const ResetPassword = (): JSX.Element => {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <Flex
-        as="fieldset"
-        className="amplify-flex"
-        direction="column"
-        isDisabled={isPending}
-      >
+      <Flex as="fieldset" direction="column" isDisabled={isPending}>
         <Header />
 
         <Flex direction="column">

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -31,8 +32,7 @@ export const ResetPassword = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
+++ b/packages/react/src/components/Authenticator/ResetPassword/ResetPassword.tsx
@@ -1,5 +1,4 @@
 import { translate } from '@aws-amplify/ui';
-import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -31,9 +30,11 @@ export const ResetPassword = (): JSX.Element => {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <fieldset
-        className={classNames('amplify-flex', 'amplify-authenticator__column')}
-        disabled={isPending}
+      <Flex
+        as="fieldset"
+        className="amplify-flex"
+        direction="column"
+        isDisabled={isPending}
       >
         <Header />
 
@@ -54,7 +55,7 @@ export const ResetPassword = (): JSX.Element => {
           }
         />
         <Footer />
-      </fieldset>
+      </Flex>
     </form>
   );
 };

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -1,5 +1,6 @@
 import QRCode from 'qrcode';
 import * as React from 'react';
+import classNames from 'classnames';
 
 import { Auth, Logger } from 'aws-amplify';
 import {
@@ -83,8 +84,7 @@ export const SetupTOTP = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -1,6 +1,5 @@
 import QRCode from 'qrcode';
 import * as React from 'react';
-import classNames from 'classnames';
 
 import { Auth, Logger } from 'aws-amplify';
 import {
@@ -83,9 +82,11 @@ export const SetupTOTP = (): JSX.Element => {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <fieldset
-        className={classNames('amplify-flex', 'amplify-authenticator__column')}
-        disabled={isPending}
+      <Flex
+        as="fieldset"
+        className="amplify-flex"
+        direction="column"
+        isDisabled={isPending}
       >
         <Header />
 
@@ -122,7 +123,7 @@ export const SetupTOTP = (): JSX.Element => {
 
         <ConfirmSignInFooter />
         <Footer />
-      </fieldset>
+      </Flex>
     </form>
   );
 };

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -82,12 +82,7 @@ export const SetupTOTP = (): JSX.Element => {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <Flex
-        as="fieldset"
-        className="amplify-flex"
-        direction="column"
-        isDisabled={isPending}
-      >
+      <Flex as="fieldset" direction="column" isDisabled={isPending}>
         <Header />
 
         <Flex direction="column">

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -1,4 +1,5 @@
 import { translate, hasTranslation } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
@@ -35,8 +36,10 @@ export function SignIn() {
         <FederatedSignIn />
         <Flex direction="column">
           <fieldset
-            style={{ display: 'flex', flexDirection: 'column' }}
-            className="amplify-flex"
+            className={classNames(
+              'amplify-flex',
+              'amplify-authenticator__column'
+            )}
             disabled={isPending}
           >
             <VisuallyHidden>

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -34,12 +34,7 @@ export function SignIn() {
       >
         <FederatedSignIn />
         <Flex direction="column">
-          <Flex
-            as="fieldset"
-            className="amplify-flex"
-            direction="column"
-            isDisabled={isPending}
-          >
+          <Flex as="fieldset" direction="column" isDisabled={isPending}>
             <VisuallyHidden>
               <legend>{translate('Sign in')}</legend>
             </VisuallyHidden>

--- a/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
+++ b/packages/react/src/components/Authenticator/SignIn/SignIn.tsx
@@ -1,5 +1,4 @@
 import { translate, hasTranslation } from '@aws-amplify/ui';
-import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
@@ -35,18 +34,17 @@ export function SignIn() {
       >
         <FederatedSignIn />
         <Flex direction="column">
-          <fieldset
-            className={classNames(
-              'amplify-flex',
-              'amplify-authenticator__column'
-            )}
-            disabled={isPending}
+          <Flex
+            as="fieldset"
+            className="amplify-flex"
+            direction="column"
+            isDisabled={isPending}
           >
             <VisuallyHidden>
               <legend>{translate('Sign in')}</legend>
             </VisuallyHidden>
             <FormFields route="signIn" />
-          </fieldset>
+          </Flex>
 
           <RemoteErrorMessage />
 

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
@@ -42,8 +43,10 @@ export function SignUp() {
         <FederatedSignIn />
 
         <fieldset
-          style={{ display: 'flex', flexDirection: 'column' }}
-          className="amplify-flex"
+          className={classNames(
+            'amplify-flex',
+            'amplify-authenticator__column'
+          )}
           disabled={isPending}
         >
           <Flex direction="column">

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -1,5 +1,4 @@
 import { translate } from '@aws-amplify/ui';
-import classNames from 'classnames';
 
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
@@ -42,12 +41,11 @@ export function SignUp() {
       >
         <FederatedSignIn />
 
-        <fieldset
-          className={classNames(
-            'amplify-flex',
-            'amplify-authenticator__column'
-          )}
-          disabled={isPending}
+        <Flex
+          as="fieldset"
+          className="amplify-flex"
+          direction="column"
+          isDisabled={isPending}
         >
           <Flex direction="column">
             <FormFields />
@@ -64,7 +62,7 @@ export function SignUp() {
           >
             {translate('Create Account')}
           </Button>
-        </fieldset>
+        </Flex>
       </form>
 
       <Footer />

--- a/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
+++ b/packages/react/src/components/Authenticator/SignUp/SignUp.tsx
@@ -41,12 +41,7 @@ export function SignUp() {
       >
         <FederatedSignIn />
 
-        <Flex
-          as="fieldset"
-          className="amplify-flex"
-          direction="column"
-          isDisabled={isPending}
-        >
+        <Flex as="fieldset" direction="column" isDisabled={isPending}>
           <Flex direction="column">
             <FormFields />
             <RemoteErrorMessage />

--- a/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
@@ -30,12 +30,7 @@ export const ConfirmVerifyUser = (): JSX.Element => {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <Flex
-        as="fieldset"
-        className="amplify-flex"
-        direction="column"
-        isDisabled={isPending}
-      >
+      <Flex as="fieldset" direction="column" isDisabled={isPending}>
         <Header />
 
         <Flex direction="column">

--- a/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -31,8 +32,7 @@ export const ConfirmVerifyUser = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/ConfirmVerifyUser.tsx
@@ -1,5 +1,4 @@
 import { translate } from '@aws-amplify/ui';
-import classNames from 'classnames';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -31,9 +30,11 @@ export const ConfirmVerifyUser = (): JSX.Element => {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <fieldset
-        className={classNames('amplify-flex', 'amplify-authenticator__column')}
-        disabled={isPending}
+      <Flex
+        as="fieldset"
+        className="amplify-flex"
+        direction="column"
+        isDisabled={isPending}
       >
         <Header />
 
@@ -48,7 +49,7 @@ export const ConfirmVerifyUser = (): JSX.Element => {
           cancelButtonSendType="SKIP"
         />
         <Footer />
-      </fieldset>
+      </Flex>
     </form>
   );
 };

--- a/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
@@ -94,12 +94,7 @@ export const VerifyUser = (): JSX.Element => {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <Flex
-        as="fieldset"
-        className="amplify-flex"
-        direction="column"
-        isDisabled={isPending}
-      >
+      <Flex as="fieldset" direction="column" isDisabled={isPending}>
         <Header />
 
         {verificationRadioGroup}

--- a/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
@@ -7,8 +7,8 @@ import {
   SignInContext,
   translate,
 } from '@aws-amplify/ui';
-import classNames from 'classnames';
 
+import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
 import { Radio } from '../../../primitives/Radio';
 import { RadioGroupField } from '../../../primitives/RadioGroupField';
@@ -94,9 +94,11 @@ export const VerifyUser = (): JSX.Element => {
       onChange={handleChange}
       onSubmit={handleSubmit}
     >
-      <fieldset
-        className={classNames('amplify-flex', 'amplify-authenticator__column')}
-        disabled={isPending}
+      <Flex
+        as="fieldset"
+        className="amplify-flex"
+        direction="column"
+        isDisabled={isPending}
       >
         <Header />
 
@@ -110,7 +112,7 @@ export const VerifyUser = (): JSX.Element => {
           submitButtonText={footerSubmitText}
         />
         <Footer />
-      </fieldset>
+      </Flex>
     </form>
   );
 };

--- a/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
+++ b/packages/react/src/components/Authenticator/VerifyUser/VerifyUser.tsx
@@ -7,6 +7,7 @@ import {
   SignInContext,
   translate,
 } from '@aws-amplify/ui';
+import classNames from 'classnames';
 
 import { Heading } from '../../../primitives/Heading';
 import { Radio } from '../../../primitives/Radio';
@@ -94,8 +95,7 @@ export const VerifyUser = (): JSX.Element => {
       onSubmit={handleSubmit}
     >
       <fieldset
-        style={{ display: 'flex', flexDirection: 'column' }}
-        className="amplify-flex"
+        className={classNames('amplify-flex', 'amplify-authenticator__column')}
         disabled={isPending}
       >
         <Header />

--- a/packages/ui/src/theme/css/component/authenticator.scss
+++ b/packages/ui/src/theme/css/component/authenticator.scss
@@ -58,6 +58,7 @@
   }
 }
 
+// To be removed once primitives have been implemented in angular and vue
 .amplify-authenticator__column {
   display: flex;
   flex-direction: column;

--- a/packages/ui/src/theme/css/component/authenticator.scss
+++ b/packages/ui/src/theme/css/component/authenticator.scss
@@ -57,3 +57,20 @@
     }
   }
 }
+
+.amplify-authenticator__column {
+  display: flex;
+  flex-direction: column;
+}
+
+.amplify-authenticator__subtitle {
+  margin-bottom: var(--amplify-space-medium);
+}
+
+.amplify-authenticator__heading {
+  font-size: var(--amplify-font-sizes-xl);
+}
+
+.amplify-authenticator__federated-text {
+  align-self: center;
+}


### PR DESCRIPTION
#### Description of changes
This pull request is to remove all inline styling from the react authenticator so that it can comply with strict csp rules

#### Description of how you validated changes

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
