### PR TITLE
fix(geo): Support Pascal case for Amazon Location Service config block

### DIFF
--- a/.changeset/angry-bags-behave.md
+++ b/.changeset/angry-bags-behave.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Support Pascal case for Amazon Location Service configuration block

--- a/packages/react/src/components/Geo/MapView/index.tsx
+++ b/packages/react/src/components/Geo/MapView/index.tsx
@@ -28,11 +28,13 @@ export const MapView = ({
   ...props
 }: MapViewProps) => {
   const amplifyConfig = Amplify.configure() as any;
-  const geoConfig =
-    amplifyConfig.geo?.amazon_location_service ??
-    amplifyConfig.geo?.AmazonLocationService ??
-    {};
-
+  const geoConfig = useMemo(
+    () =>
+      amplifyConfig.geo?.amazon_location_service ??
+      amplifyConfig.geo?.AmazonLocationService ??
+      {},
+    [amplifyConfig]
+  );
   const [transformRequest, setTransformRequest] = useState<
     TransformRequestFunction | undefined
   >();

--- a/packages/react/src/components/Geo/MapView/index.tsx
+++ b/packages/react/src/components/Geo/MapView/index.tsx
@@ -28,6 +28,10 @@ export const MapView = ({
   ...props
 }: MapViewProps) => {
   const amplifyConfig = Amplify.configure() as any;
+  const geoConfig =
+    amplifyConfig.geo?.amazon_location_service ??
+    amplifyConfig.geo?.AmazonLocationService ??
+    {};
 
   const [transformRequest, setTransformRequest] = useState<
     TransformRequestFunction | undefined
@@ -53,13 +57,13 @@ export const MapView = ({
       const credentials = await Auth.currentUserCredentials();
 
       if (credentials) {
-        const region = amplifyConfig.geo?.amazon_location_service.region;
+        const { region } = geoConfig;
         const { transformRequest: amplifyTransformRequest } =
           new AmplifyMapLibreRequest(credentials, region);
         setTransformRequest(() => amplifyTransformRequest);
       }
     })();
-  }, [amplifyConfig.geo?.amazon_location_service.region]);
+  }, [geoConfig]);
 
   /**
    * The mapLib property is used by react-map-gl@v7 to override the underlying map library. The default library is
@@ -72,9 +76,7 @@ export const MapView = ({
     <ReactMapGL
       {...props}
       mapLib={mapLib ?? maplibregl}
-      mapStyle={
-        mapStyle ?? amplifyConfig.geo?.amazon_location_service.maps.default
-      }
+      mapStyle={mapStyle ?? geoConfig.maps?.default}
       style={styleProps}
       transformRequest={transformRequest}
     />


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This PR allows `MapView` to work with an Amplify configuration where the Amazon Location Service block is snake case (`amazon_location_service` as generated by Amplify CLI) or Pascal case (`AmazonLocationService` as [advised in documentation for manual configuration](https://docs.amplify.aws/lib/geo/existing-resources/q/platform/js/#in-your-application)).

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#1764 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
e2e tests will pass as normal and if you change the Amazon Location Service block in `environments/basic-map/src/aws-exports.js` to Pascal case.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated - N/A
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
