### PR TITLE
chore(geo): Replace mapbox-gl resolution with a local file

### DIFF
--- a/.changeset/early-guests-listen.md
+++ b/.changeset/early-guests-listen.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Update mapbox-gl resolution to a local file

--- a/packages/react/lib/mapbox-gl/index.js
+++ b/packages/react/lib/mapbox-gl/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * This empty file is used in our `package.json` to resolve the `mapbox-gl` module. It provides a resolution for
  * bundlers like Webpack which treats a dynamically imported module like `mapbox-gl` as a separate bundle even if it

--- a/packages/react/mapbox-resolution/index.js
+++ b/packages/react/mapbox-resolution/index.js
@@ -1,0 +1,6 @@
+/**
+ * This empty file is used in our `package.json` to resolve the `mapbox-gl` module. It provides a resolution for
+ * bundlers like Webpack which treats a dynamically imported module like `mapbox-gl` as a separate bundle even if it
+ * isn't used.
+ */
+module.exports = {};

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,6 +37,7 @@
     "dist",
     "legacy",
     "internal",
+    "lib",
     "LICENSE"
   ],
   "scripts": {
@@ -67,7 +68,7 @@
     "classnames": "2.3.1",
     "deepmerge": "4.2.2",
     "lodash": "4.17.21",
-    "mapbox-gl": "file:mapbox-resolution",
+    "mapbox-gl": "file:lib/mapbox-gl",
     "maplibre-gl": "1.15.3",
     "maplibre-gl-js-amplify": "1.5.0",
     "qrcode": "1.5.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -67,7 +67,7 @@
     "classnames": "2.3.1",
     "deepmerge": "4.2.2",
     "lodash": "4.17.21",
-    "mapbox-gl": "npm:empty-npm-package@1.0.0",
+    "mapbox-gl": "file:mapbox-resolution",
     "maplibre-gl": "1.15.3",
     "maplibre-gl-js-amplify": "1.5.0",
     "qrcode": "1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15181,10 +15181,8 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-"mapbox-gl@npm:empty-npm-package@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/empty-npm-package/-/empty-npm-package-1.0.0.tgz#fda29eb6de5efa391f73d578697853af55f6793a"
-  integrity sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA==
+"mapbox-gl@file:packages/react/mapbox-resolution":
+  version "0.0.0"
 
 maplibre-gl-js-amplify@1.5.0:
   version "1.5.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This PR changes the resolution for the `mapbox-gl` dependency to a local file that does nothing, rather than the `empty-npm-package` from the npm registry as [recommended by react-map-gl](https://visgl.github.io/react-map-gl/docs/get-started/get-started#using-with-a-mapbox-gl-fork). This change has a couple of advantages even though `mapbox-gl` isn't used:
1. We control the resolution file as opposed to relying on another dependency
2. There's more history of the `file:` [protocol](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#local-paths) which has been supported by npm since version 2.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
All e2e tests pass with the change. One may see the new resolution for `mapbox-gl` in `node_modules/mapbox-gl`.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated - N/A
- [x] Relevant documentation is changed or added (and PR referenced) - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
