### PR TITLE
ci: Add action that checks whether there are changesets in `.changeset`

### DIFF
--- a/.github/actions/has-changesets/action.yml
+++ b/.github/actions/has-changesets/action.yml
@@ -1,0 +1,18 @@
+name: 'Has Changesets'
+description: 'Checks if `.changeset` directory has valid changesets'
+outputs:
+  has-changesets:
+    description: "Whether `.changeset` directory has at least one changeset"
+    value: ${{ steps.check-changesets.outputs.has-changesets }}
+runs:
+  using: "composite"
+  steps:
+    - name: Check .changeseet folder for changesets
+      id: check-changesets
+      shell: bash
+      run: |
+        if (find .changeset -type f -name '*.md' ! -name 'README.md' | grep -q .) ; then
+            echo "::set-output name=has-changesets::true"
+        else
+            echo "::set-output name=has-changesets::false"
+        fi

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
+      - name: Check if repo has unconsumed changesets
+        id: has-changesets
+        uses: ./.github/actions/has-changesets
+      - name: Echo has-changesets
+        run: echo ${{ steps.has-changesets.outputs.has-changesets }}
       - name: Setup Node.js LTS
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR adds a reusable action to check whether there are changesets in `.changeset` directory. This will be used to later split `publish-latest` to `version-packages` and `publish-latest`. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

This composite action has been tested in a POC -- https://github.com/aws-amplify/amplify-ui/pull/1770:
- `has-changesets` is true when `.changeset` folder is empty: [workflow run](https://github.com/aws-amplify/amplify-ui/runs/6162647393?check_suite_focus=true), [commit](https://github.com/aws-amplify/amplify-ui/pull/1770/commits/fed90313491a26cfb4b386109395bce4ec16f96d)
- `has-changesets` is false when `.changeset` folder is not empty: [workflow run](https://github.com/aws-amplify/amplify-ui/runs/6162670185?check_suite_focus=true), [797c50c](https://github.com/aws-amplify/amplify-ui/pull/1770/commits/797c50c74bbee9eec2345b4c9d8ca86214de9862)


Please check "Echo has-changesets step" on the workflows to check the desired results.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
