### PR TITLE
fix(ui-react): add graceful handling of falsy form field values in SetupTOTP component

### DIFF
--- a/.changeset/silver-months-talk.md
+++ b/.changeset/silver-months-talk.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(ui-react): add graceful handling of falsy form field values in SetupTOTP component

--- a/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/SetupTOTP.tsx
@@ -20,6 +20,9 @@ import { FormFields } from '../shared/FormFields';
 
 const logger = new Logger('SetupTOTP-logger');
 
+export const getTotpCode = (issuer: string, username: string, secret: string) =>
+  `otpauth://totp/${issuer}:${username}?secret=${secret}&issuer=${issuer}`;
+
 export const SetupTOTP = (): JSX.Element => {
   // TODO: handle `formOverrides` outside `useAuthenticator`
   const { _state, isPending } = useAuthenticator((context) => [
@@ -43,14 +46,14 @@ export const SetupTOTP = (): JSX.Element => {
 
   const { formFields, user } = actorState.context;
   const { totpIssuer = 'AWSCognito', totpUsername = user.username } =
-    formFields?.setupTOTP?.QR;
+    formFields?.setupTOTP?.QR ?? {};
 
   const generateQRCode = React.useCallback(
     async (currentUser: CognitoUserAmplify): Promise<void> => {
       try {
         const newSecretKey = await Auth.setupTOTP(currentUser);
         setSecretKey(newSecretKey);
-        const totpCode = `otpauth://totp/${totpIssuer}:${totpUsername}?secret=${newSecretKey}&issuer=${totpIssuer}`;
+        const totpCode = getTotpCode(totpIssuer, totpUsername, newSecretKey);
         const qrCodeImageSource = await QRCode.toDataURL(totpCode);
 
         setQrCode(qrCodeImageSource);

--- a/packages/react/src/components/Authenticator/SetupTOTP/__tests__/SetupTOTP.test.tsx
+++ b/packages/react/src/components/Authenticator/SetupTOTP/__tests__/SetupTOTP.test.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { act, render } from '@testing-library/react';
+import QRCode from 'qrcode';
+import { Auth } from 'aws-amplify';
+
+import { getTotpCode, SetupTOTP } from '../SetupTOTP';
+
+jest.mock('../../hooks/useFormHandlers', () => ({
+  useFormHandlers: () => ({ handleChange: jest.fn(), handleSubmit: jest.fn() }),
+}));
+
+jest.mock('../../hooks/useAuthenticator', () => ({
+  useAuthenticator: () => ({ _state: {}, isPending: false }),
+}));
+
+jest.mock('../../hooks/useCustomComponents', () => ({
+  useCustomComponents: () => ({
+    components: { SetupTOTP: { Header: () => null, Footer: () => null } },
+  }),
+}));
+
+jest.mock('../../shared/FormFields', () => ({ FormFields: () => null }));
+
+const mockUser = { username: 'username' };
+const mockContext = { formFields: { setupTOTP: { QR: null } }, user: mockUser };
+jest.mock('@aws-amplify/ui', () => ({
+  ...(jest.requireActual('@aws-amplify/ui') as {}),
+  getActorState: () => ({ context: mockContext }),
+}));
+
+const DEFAULT_TOTP_ISSUER = 'AWSCognito';
+const SECRET_KEY = 'secretKey';
+
+const setupTOTPSpy = jest.spyOn(Auth, 'setupTOTP');
+const toDataURLSpy = jest.spyOn(QRCode, 'toDataURL');
+
+describe('SetupTOTP', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    setupTOTPSpy.mockResolvedValue(SECRET_KEY);
+  });
+
+  it('handles an undefined value when looking up its form field values', async () => {
+    const defaultTotpCode = getTotpCode(
+      DEFAULT_TOTP_ISSUER,
+      mockUser.username,
+      SECRET_KEY
+    );
+
+    await act(async () => {
+      render(<SetupTOTP />);
+    });
+
+    expect(setupTOTPSpy).toHaveBeenCalledTimes(1);
+    expect(setupTOTPSpy).toHaveBeenCalledWith(mockUser);
+
+    expect(toDataURLSpy).toHaveBeenCalledTimes(1);
+    expect(toDataURLSpy).toHaveBeenCalledWith(defaultTotpCode);
+  });
+
+  it('handles custom values passed as form field values', async () => {
+    const customTotpIssuer = 'customTOTPIssuer';
+    const customTotpUsername = 'customTotpUsername';
+
+    mockContext.formFields.setupTOTP.QR = {
+      totpIssuer: customTotpIssuer,
+      totpUsername: customTotpUsername,
+    };
+
+    const customTotpCode = getTotpCode(
+      customTotpIssuer,
+      customTotpUsername,
+      SECRET_KEY
+    );
+
+    await act(async () => {
+      render(<SetupTOTP />);
+    });
+
+    expect(setupTOTPSpy).toHaveBeenCalledTimes(1);
+    expect(setupTOTPSpy).toHaveBeenCalledWith(mockUser);
+
+    expect(toDataURLSpy).toHaveBeenCalledTimes(1);
+    expect(toDataURLSpy).toHaveBeenCalledWith(customTotpCode);
+  });
+});


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->



#### Description of changes

Prevent destructuring of `undefined` values from `formFields` lookup in `SetupTOTP` component:
- default to an empty object when `formFields` lookup resolves to falsy
- add unit tests
- add `getTotpCode` util

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/1785

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- recreated issue in example app by passing an empty object as `formFields` argument
- manually tested failing use case with changes in this PR
- added some unit testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
