### PR TITLE
fix(authenticator): Update ConfirmResetPassword submit text for Angular

### DIFF
--- a/.changeset/shiny-bags-doubt.md
+++ b/.changeset/shiny-bags-doubt.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-angular': patch
+---
+
+Update submit text for Angular ConfirmResetPassword screen

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.html
@@ -14,7 +14,7 @@
     ></amplify-base-form-fields>
 
     <button amplify-button variation="primary" fullWidth="true" type="submit">
-      {{ sendCodeText }}
+      {{ submitText }}
     </button>
 
     <button

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
@@ -3,6 +3,7 @@ import { AuthenticatorService } from '../../../../services/authenticator.service
 import {
   FormFieldsArray,
   getFormDataFromEvent,
+  hasTranslation,
   translate,
 } from '@aws-amplify/ui';
 
@@ -15,10 +16,17 @@ export class ConfirmResetPasswordComponent {
   @Input() public headerText = translate('Reset your password');
 
   // translated strings
-  public submitText = translate('Submit');
   public backToSignInText = translate('Back to Sign In');
   public resendCodeText = translate('Resend Code');
   public sortedFormFields: FormFieldsArray;
+  /**
+   * Support backwards compatibility for erroneous 'Send Code' text
+   * See https://github.com/aws-amplify/amplify-ui/issues/1784
+   * TODO: Remove support for 'Send Code' translation in next Major release
+   */
+  public submitText = hasTranslation('Submit')
+    ? translate('Submit')
+    : translate('Send Code');
 
   constructor(public authenticator: AuthenticatorService) {}
 

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
@@ -15,7 +15,7 @@ export class ConfirmResetPasswordComponent {
   @Input() public headerText = translate('Reset your password');
 
   // translated strings
-  public sendCodeText = translate('Send Code');
+  public submitText = translate('Submit');
   public backToSignInText = translate('Back to Sign In');
   public resendCodeText = translate('Resend Code');
   public sortedFormFields: FormFieldsArray;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
The text for the submit button on the `ConfirmResetPassword` screen incorrectly showed `Send Code` even when the code was already sent during the `ResetPassword` state. This PR updates the text to `Submit` to match the experience in the React and Vue implementations.

Before:
![Screen Shot 2022-04-28 at 14 00 58](https://user-images.githubusercontent.com/26472139/165844968-ca9e34d4-a580-4065-916c-3511b963e126.png)

After:
![Screen Shot 2022-04-28 at 13 57 44](https://user-images.githubusercontent.com/26472139/165844986-881b445e-d775-4d6c-95d2-c7c01339851d.png)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#1784 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual visual validation.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated - N/A
- [x] Relevant documentation is changed or added (and PR referenced) - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
