### PR TITLE
chore: update `yarn.lock`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6466,7 +6466,7 @@
   dependencies:
     fast-safe-stringify "^2.0.7"
 
-"@xstate/react@^3.0.0":
+"@xstate/react@3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@xstate/react/-/react-3.0.0.tgz#888d9a6f128c70b632c18ad55f1f851f6ab092ba"
   integrity sha512-KHSCfwtb8gZ7QH2luihvmKYI+0lcdHQOmGNRUxUEs4zVgaJCyd8csCEmwPsudpliLdUmyxX2pzUBojFkINpotw==


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This is totally on me, I forgot to update `yarn.lock` after I pinned `@xstate/react` version in https://github.com/aws-amplify/amplify-ui/pull/1798/commits/9a5ea7e82db22872dd7a1fcab9ab78a57e9d334b of #1793. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
