### PR TITLE
docs/fix: radio groups missing unique names causes focus/styling issues

### DIFF
--- a/docs/src/pages/components/radiogroupfield/examples/BasicExample.tsx
+++ b/docs/src/pages/components/radiogroupfield/examples/BasicExample.tsx
@@ -3,7 +3,7 @@ import { Radio, RadioGroupField } from '@aws-amplify/ui-react';
 const options = ['html', 'css', 'javascript'];
 
 export const BasicExample = () => (
-  <RadioGroupField label="Language" name="language" defaultValue="html">
+  <RadioGroupField label="Language" name="language2" defaultValue="html">
     {options.map((option) => (
       <Radio key={option} value={option}>
         {option}

--- a/docs/src/pages/components/radiogroupfield/examples/LabelPositionExample.tsx
+++ b/docs/src/pages/components/radiogroupfield/examples/LabelPositionExample.tsx
@@ -2,7 +2,7 @@ import { Radio, RadioGroupField, Flex } from '@aws-amplify/ui-react';
 
 export const LabelPositionExample = () => (
   <Flex direction="row">
-    <RadioGroupField label="Language" name="language" defaultValue="html">
+    <RadioGroupField label="Language" name="language3" defaultValue="html">
       <Radio value="html">html</Radio>
       <Radio value="css">css</Radio>
       <Radio value="javascript">javascript</Radio>
@@ -10,7 +10,7 @@ export const LabelPositionExample = () => (
 
     <RadioGroupField
       label="Language"
-      name="language"
+      name="language4"
       defaultValue="html"
       labelPosition="start"
     >
@@ -21,7 +21,7 @@ export const LabelPositionExample = () => (
 
     <RadioGroupField
       label="Language"
-      name="language"
+      name="language5"
       defaultValue="html"
       labelPosition="start"
     >

--- a/docs/src/pages/components/radiogroupfield/examples/ThemeExample.tsx
+++ b/docs/src/pages/components/radiogroupfield/examples/ThemeExample.tsx
@@ -29,7 +29,7 @@ const options = ['html', 'css', 'javascript'];
 
 export const ThemeExample = () => (
   <AmplifyProvider theme={theme}>
-    <RadioGroupField label="Language" name="language" defaultValue="html">
+    <RadioGroupField label="Language" name="language6" defaultValue="html">
       {options.map((option) => (
         <Radio key={option} value={option}>
           {option}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This updates examples for RadioGroupField to use a unique `name` prop per example.

RadioGroupFields that have the same name can cause issues with tabbing; one group might be skipped completely from the tab order. You can see this happening now by attempting to tab to the Demo example on https://ui.docs.amplify.aws/components/radiogroupfield

**Before**
<img src="https://user-images.githubusercontent.com/376920/166067794-8a167f07-e52b-48b8-a841-9e9af8054f54.gif" width="300" />

**After**
<img src="https://user-images.githubusercontent.com/376920/166067949-26561f9b-5f88-46c6-8c8b-1272e9307d86.gif" width="300" />

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Tested in local docs instance in Chrome and Safari

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
