### PR TITLE
feat: Added Auth Status 

### DIFF
--- a/.changeset/spicy-queens-happen.md
+++ b/.changeset/spicy-queens-happen.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/ui-angular': minor
+'@aws-amplify/ui': minor
+'@aws-amplify/ui-vue': minor
+---
+
+New authCheck feature, to check if a user is authenticated or not

--- a/.changeset/spicy-queens-happen.md
+++ b/.changeset/spicy-queens-happen.md
@@ -4,4 +4,4 @@
 '@aws-amplify/ui-vue': minor
 ---
 
-New authCheck feature, to check if a user is authenticated or not
+New authStatus feature, to check if a user is authenticated or not

--- a/docs/src/pages/components/authenticator/advanced/current-route.angular.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.angular.mdx
@@ -31,15 +31,15 @@ You can use `AuthenticatorService` to access `route` string that represents the 
 
 If you just need to check if you're authenticated or not, you can use the more straightforward `AuthenticatorService` to access the `authStatus` string. The `authStatus` string can represent the following states:
 
-- `pending`
+- `configuring`
 - `authenticated`
 - `unauthenticated`
 
-> The `pending` state only occurs when the `Authenticator` is first loading.
+> The `configuring` state only occurs when the `Authenticator` is first loading.
 
 ```html
-<!-- Render loading if authStatus is still pending  -->
-<ng-container *ngIf="authenticator.authStatus === 'pending'">
+<!-- Render loading if authStatus is still configuring  -->
+<ng-container *ngIf="authenticator.authStatus === 'configuring'">
   Loading...
 </ng-container>
 

--- a/docs/src/pages/components/authenticator/advanced/current-route.angular.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.angular.mdx
@@ -29,13 +29,20 @@ You can use `AuthenticatorService` to access `route` string that represents the 
 
 #### Authentication Check
 
-If you just need to check if you're authenticated or not, you can use the more straight forward `AuthenticatorService` to access the `authStatus` string. The `authStatus` string can represent the following states:
+If you just need to check if you're authenticated or not, you can use the more straightforward `AuthenticatorService` to access the `authStatus` string. The `authStatus` string can represent the following states:
 
 - `pending`
 - `authenticated`
 - `unauthenticated`
 
+> The `pending` state only occurs when the `Authenticator` is first loading.
+
 ```html
+<!-- Render loading if authStatus is still pending  -->
+<ng-container *ngIf="authenticator.authStatus === 'pending'">
+  Loading...
+</ng-container>
+
 <!-- Only render this if there's an authenticated user -->
 <ng-container *ngIf="authenticator.authStatus === 'authenticated'">
   Welcome back!

--- a/docs/src/pages/components/authenticator/advanced/current-route.angular.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.angular.mdx
@@ -26,3 +26,23 @@ You can use `AuthenticatorService` to access `route` string that represents the 
   <amplify-authenticator></amplify-authenticator>
 </ng-container>
 ```
+
+#### Authentication Check
+
+If you just need to check if you're authenticated or not, you can use the more straight forward `AuthenticatorService` to access the `authCheck` string. The `authCheck` string can represent the following states:
+
+- `pending`
+- `authenticated`
+- `unAuthenticated`
+
+```html
+<!-- Only render this if there's an authenticated user -->
+<ng-container *ngIf="authenticator.authCheck === 'authenticated'">
+  Welcome back!
+</ng-container>
+
+<!-- Render sign-in screen otherwise with authenticator -->
+<ng-container *ngIf="authenticator.authCheck !== 'authenticated'">
+  <amplify-authenticator></amplify-authenticator>
+</ng-container>
+```

--- a/docs/src/pages/components/authenticator/advanced/current-route.angular.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.angular.mdx
@@ -29,20 +29,20 @@ You can use `AuthenticatorService` to access `route` string that represents the 
 
 #### Authentication Check
 
-If you just need to check if you're authenticated or not, you can use the more straight forward `AuthenticatorService` to access the `authCheck` string. The `authCheck` string can represent the following states:
+If you just need to check if you're authenticated or not, you can use the more straight forward `AuthenticatorService` to access the `authStatus` string. The `authStatus` string can represent the following states:
 
 - `pending`
 - `authenticated`
-- `unAuthenticated`
+- `unauthenticated`
 
 ```html
 <!-- Only render this if there's an authenticated user -->
-<ng-container *ngIf="authenticator.authCheck === 'authenticated'">
+<ng-container *ngIf="authenticator.authStatus === 'authenticated'">
   Welcome back!
 </ng-container>
 
 <!-- Render sign-in screen otherwise with authenticator -->
-<ng-container *ngIf="authenticator.authCheck !== 'authenticated'">
+<ng-container *ngIf="authenticator.authStatus !== 'authenticated'">
   <amplify-authenticator></amplify-authenticator>
 </ng-container>
 ```

--- a/docs/src/pages/components/authenticator/advanced/current-route.react.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.react.mdx
@@ -42,7 +42,7 @@ import { useAuthenticator } from '@aws-amplify/ui-react';
 const App = () => {
   const { authStatus } = useAuthenticator(context => [context.authStatus]);
 
-  // Use the value of route to decide which page to render
+  // Use the value of authStatus to decide which page to render
  return (
     <>
       {authStatus === 'configuring' && 'Loading...'}

--- a/docs/src/pages/components/authenticator/advanced/current-route.react.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.react.mdx
@@ -28,11 +28,13 @@ const App = () => {
 
 #### Authentication Check
 
-If you just need to check if you're authenticated or not, you can use the more straight forward `useAuthenticator` hook to access the `authStatus` string. The `authStatus` string can represent the following states:
+If you just need to check if you're authenticated or not, you can use the more straightforward `useAuthenticator` hook to access the `authStatus` string. The `authStatus` string can represent the following states:
 
 - `pending`
 - `authenticated`
 - `unauthenticated`
+
+> The `pending` state only occurs when the `Authenticator` is first loading.
 
 ```tsx{1,4-7}
 import { useAuthenticator } from '@aws-amplify/ui-react';
@@ -41,6 +43,11 @@ const App = () => {
   const { authStatus } = useAuthenticator(context => [context.authStatus]);
 
   // Use the value of route to decide which page to render
-  return authStatus === 'authenticated' ? <Home /> : <Authenticator />;
+ return (
+    <>
+      {authStatus === 'pending' && 'Loading...'}
+      {authStatus !== 'authenticated' ? <Authenticator /> : <Home />}
+    </>
+  );
 };
 ```

--- a/docs/src/pages/components/authenticator/advanced/current-route.react.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.react.mdx
@@ -30,11 +30,11 @@ const App = () => {
 
 If you just need to check if you're authenticated or not, you can use the more straightforward `useAuthenticator` hook to access the `authStatus` string. The `authStatus` string can represent the following states:
 
-- `pending`
+- `configuring`
 - `authenticated`
 - `unauthenticated`
 
-> The `pending` state only occurs when the `Authenticator` is first loading.
+> The `configuring` state only occurs when the `Authenticator` is first loading.
 
 ```tsx{1,4-7}
 import { useAuthenticator } from '@aws-amplify/ui-react';
@@ -45,7 +45,7 @@ const App = () => {
   // Use the value of route to decide which page to render
  return (
     <>
-      {authStatus === 'pending' && 'Loading...'}
+      {authStatus === 'configuring' && 'Loading...'}
       {authStatus !== 'authenticated' ? <Authenticator /> : <Home />}
     </>
   );

--- a/docs/src/pages/components/authenticator/advanced/current-route.react.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.react.mdx
@@ -25,3 +25,22 @@ const App = () => {
   return route === 'authenticated' ? <Home /> : <Authenticator />;
 };
 ```
+
+#### Authentication Check
+
+If you just need to check if you're authenticated or not, you can use the more straight forward `useAuthenticator` hook to access the `authCheck` string. The `authCheck` string can represent the following states:
+
+- `pending`
+- `authenticated`
+- `unAuthenticated`
+
+```tsx{1,4-7}
+import { useAuthenticator } from '@aws-amplify/ui-react';
+
+const App = () => {
+  const { authCheck } = useAuthenticator(context => [context.authCheck]);
+
+  // Use the value of route to decide which page to render
+  return authCheck === 'authenticated' ? <Home /> : <Authenticator />;
+};
+```

--- a/docs/src/pages/components/authenticator/advanced/current-route.react.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.react.mdx
@@ -28,19 +28,19 @@ const App = () => {
 
 #### Authentication Check
 
-If you just need to check if you're authenticated or not, you can use the more straight forward `useAuthenticator` hook to access the `authCheck` string. The `authCheck` string can represent the following states:
+If you just need to check if you're authenticated or not, you can use the more straight forward `useAuthenticator` hook to access the `authStatus` string. The `authStatus` string can represent the following states:
 
 - `pending`
 - `authenticated`
-- `unAuthenticated`
+- `unauthenticated`
 
 ```tsx{1,4-7}
 import { useAuthenticator } from '@aws-amplify/ui-react';
 
 const App = () => {
-  const { authCheck } = useAuthenticator(context => [context.authCheck]);
+  const { authStatus } = useAuthenticator(context => [context.authStatus]);
 
   // Use the value of route to decide which page to render
-  return authCheck === 'authenticated' ? <Home /> : <Authenticator />;
+  return authStatus === 'authenticated' ? <Home /> : <Authenticator />;
 };
 ```

--- a/docs/src/pages/components/authenticator/advanced/current-route.vue.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.vue.mdx
@@ -31,11 +31,13 @@ You can use `useAuthenticator` composable to access `route` string that represen
 
 #### Authentication Check
 
-If you just need to check if you're authenticated or not, you can use the more straight forward `useAuthenticator` composable to access the `authStatus` string. The `authStatus` string can represent the following states:
+If you just need to check if you're authenticated or not, you can use the more straightforward `useAuthenticator` composable to access the `authStatus` string. The `authStatus` string can represent the following states:
 
 - `pending`
 - `authenticated`
 - `unauthenticated`
+
+> The `pending` state only occurs when the `Authenticator` is first loading.
 
 ```html{1,5-7}
 <script setup>
@@ -45,6 +47,9 @@ If you just need to check if you're authenticated or not, you can use the more s
 
 <template>
   <authenticator></authenticator>
+  <template v-if="auth.authStatus === 'pending'">
+    <button @click="auth.signOut">Loading...</button>
+  </template>
   <template v-if="auth.authStatus === 'authenticated'">
     <button @click="auth.signOut">Sign out</button>
   </template>

--- a/docs/src/pages/components/authenticator/advanced/current-route.vue.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.vue.mdx
@@ -33,11 +33,11 @@ You can use `useAuthenticator` composable to access `route` string that represen
 
 If you just need to check if you're authenticated or not, you can use the more straightforward `useAuthenticator` composable to access the `authStatus` string. The `authStatus` string can represent the following states:
 
-- `pending`
+- `configuring`
 - `authenticated`
 - `unauthenticated`
 
-> The `pending` state only occurs when the `Authenticator` is first loading.
+> The `configuring` state only occurs when the `Authenticator` is first loading.
 
 ```html{1,5-7}
 <script setup>
@@ -47,7 +47,7 @@ If you just need to check if you're authenticated or not, you can use the more s
 
 <template>
   <authenticator></authenticator>
-  <template v-if="auth.authStatus === 'pending'">
+  <template v-if="auth.authStatus === 'configuring'">
     <button @click="auth.signOut">Loading...</button>
   </template>
   <template v-if="auth.authStatus === 'authenticated'">

--- a/docs/src/pages/components/authenticator/advanced/current-route.vue.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.vue.mdx
@@ -31,11 +31,11 @@ You can use `useAuthenticator` composable to access `route` string that represen
 
 #### Authentication Check
 
-If you just need to check if you're authenticated or not, you can use the more straight forward `useAuthenticator` composable to access the `authCheck` string. The `authCheck` string can represent the following states:
+If you just need to check if you're authenticated or not, you can use the more straight forward `useAuthenticator` composable to access the `authStatus` string. The `authStatus` string can represent the following states:
 
 - `pending`
 - `authenticated`
-- `unAuthenticated`
+- `unauthenticated`
 
 ```html{1,5-7}
 <script setup>
@@ -45,7 +45,7 @@ If you just need to check if you're authenticated or not, you can use the more s
 
 <template>
   <authenticator></authenticator>
-  <template v-if="auth.authCheck === 'authenticated'">
+  <template v-if="auth.authStatus === 'authenticated'">
     <button @click="auth.signOut">Sign out</button>
   </template>
 </template>

--- a/docs/src/pages/components/authenticator/advanced/current-route.vue.mdx
+++ b/docs/src/pages/components/authenticator/advanced/current-route.vue.mdx
@@ -28,3 +28,25 @@ You can use `useAuthenticator` composable to access `route` string that represen
   </template>
 </template>
 ```
+
+#### Authentication Check
+
+If you just need to check if you're authenticated or not, you can use the more straight forward `useAuthenticator` composable to access the `authCheck` string. The `authCheck` string can represent the following states:
+
+- `pending`
+- `authenticated`
+- `unAuthenticated`
+
+```html{1,5-7}
+<script setup>
+  import { Authenticator, useAuthenticator } from '@aws-amplify/ui-vue';
+  const auth = useAuthenticator();
+</script>
+
+<template>
+  <authenticator></authenticator>
+  <template v-if="auth.authCheck === 'authenticated'">
+    <button @click="auth.signOut">Sign out</button>
+  </template>
+</template>
+```

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.html
@@ -1,4 +1,4 @@
-{{ authCheck }}
+{{ authStatus }}
 <amplify-authenticator
   [formFields]="formFields"
   [services]="services"

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.html
@@ -1,3 +1,4 @@
+{{ authCheck }}
 <amplify-authenticator
   [formFields]="formFields"
   [services]="services"

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.ts
@@ -33,8 +33,8 @@ export class SignUpWithEmailComponent implements OnInit {
     },
   };
 
-  get authCheck() {
-    return this.authenticator.authCheck;
+  get authStatus() {
+    return this.authenticator.authStatus;
   }
 
   services = {

--- a/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-up-with-email/sign-up-with-email.component.ts
@@ -1,14 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { Amplify, Auth, I18n } from 'aws-amplify';
 import awsExports from './aws-exports';
-import { translations } from '@aws-amplify/ui-angular';
+import { AuthenticatorService, translations } from '@aws-amplify/ui-angular';
 
 @Component({
   selector: 'sign-up-with-email',
   templateUrl: 'sign-up-with-email.component.html',
 })
 export class SignUpWithEmailComponent implements OnInit {
-  constructor() {
+  constructor(public authenticator: AuthenticatorService) {
     Amplify.configure(awsExports);
   }
 
@@ -32,6 +32,10 @@ export class SignUpWithEmailComponent implements OnInit {
       },
     },
   };
+
+  get authCheck() {
+    return this.authenticator.authCheck;
+  }
 
   services = {
     async handleSignUp(formData: Record<string, any>) {

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
@@ -1,6 +1,11 @@
 import { Amplify, Auth, I18n } from 'aws-amplify';
 
-import { Authenticator, translations } from '@aws-amplify/ui-react';
+import {
+  Authenticator,
+  translations,
+  useAuthenticator,
+  View,
+} from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
 import awsExports from './aws-exports';
@@ -25,6 +30,7 @@ I18n.putVocabulariesForLanguage('en', {
 });
 
 export default function AuthenticatorWithEmail() {
+  const { authCheck } = useAuthenticator((context) => [context.authCheck]);
   const services = {
     async handleSignUp(formData) {
       let { username, password, attributes } = formData;
@@ -40,12 +46,15 @@ export default function AuthenticatorWithEmail() {
   };
 
   return (
-    <Authenticator
-      formFields={formFields}
-      services={services}
-      initialState="signUp"
-    >
-      {({ signOut }) => <button onClick={signOut}>Sign out</button>}
-    </Authenticator>
+    <>
+      <View>{authCheck}</View>
+      <Authenticator
+        formFields={formFields}
+        services={services}
+        initialState="signUp"
+      >
+        {({ signOut }) => <button onClick={signOut}>Sign out</button>}
+      </Authenticator>
+    </>
   );
 }

--- a/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-up-with-email/index.page.tsx
@@ -30,7 +30,7 @@ I18n.putVocabulariesForLanguage('en', {
 });
 
 export default function AuthenticatorWithEmail() {
-  const { authCheck } = useAuthenticator((context) => [context.authCheck]);
+  const { authStatus } = useAuthenticator((context) => [context.authStatus]);
   const services = {
     async handleSignUp(formData) {
       let { username, password, attributes } = formData;
@@ -47,7 +47,7 @@ export default function AuthenticatorWithEmail() {
 
   return (
     <>
-      <View>{authCheck}</View>
+      <View>{authStatus}</View>
       <Authenticator
         formFields={formFields}
         services={services}

--- a/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
@@ -11,7 +11,7 @@ import aws_exports from './aws-exports';
 
 Amplify.configure(aws_exports);
 
-const { authCheck } = toRefs(useAuthenticator());
+const { authStatus } = toRefs(useAuthenticator());
 
 const formFields = {
   confirmSignUp: {
@@ -46,7 +46,7 @@ const services = {
 </script>
 
 <template>
-  {{ authCheck }}
+  {{ authStatus }}
   <authenticator
     :services="services"
     :form-fields="formFields"

--- a/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
 import Amplify, { Auth, I18n } from 'aws-amplify';
-import { Authenticator, translations } from '@aws-amplify/ui-vue';
+import {
+  Authenticator,
+  translations,
+  useAuthenticator,
+} from '@aws-amplify/ui-vue';
+import { toRefs } from 'vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from './aws-exports';
 
 Amplify.configure(aws_exports);
+
+const { authCheck } = toRefs(useAuthenticator());
 
 const formFields = {
   confirmSignUp: {
@@ -39,6 +46,7 @@ const services = {
 </script>
 
 <template>
+  {{ authCheck }}
   <authenticator
     :services="services"
     :form-fields="formFields"

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
@@ -70,8 +70,8 @@ export class AuthenticatorService implements OnDestroy {
     return this._facade?.route;
   }
 
-  public get authCheck() {
-    return this._facade?.authCheck;
+  public get authStatus() {
+    return this._facade?.authStatus;
   }
 
   public get user() {

--- a/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/authenticator.service.ts
@@ -70,6 +70,10 @@ export class AuthenticatorService implements OnDestroy {
     return this._facade?.route;
   }
 
+  public get authCheck() {
+    return this._facade?.authCheck;
+  }
+
   public get user() {
     return this._facade?.user;
   }

--- a/packages/e2e/cypress/integration/ui/components/geo/map-with-geocoder/map-with-geocoder.steps.ts
+++ b/packages/e2e/cypress/integration/ui/components/geo/map-with-geocoder/map-with-geocoder.steps.ts
@@ -13,7 +13,7 @@ When('I press the enter key', () => {
 });
 
 When('I click on a map marker', () => {
-  cy.get('.maplibregl-marker').first().click();
+  cy.get('.maplibregl-marker').first().click({ force: true });
 });
 
 Then('I see markers equal to my default search results', () => {

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
@@ -12,6 +12,17 @@ Feature: Sign Up with Email
     And I don't see "Phone Number" as an input field
 
   @angular @react @vue  
+  Scenario: Sign up with a new email & password and check auth message
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-email"
+    And I see "unAuthenticated"
+    When I type a new "email"
+    And I type my password
+    And I confirm my password
+    And I click the "Create Account" button
+    And I see "authenticated"
+    Then I see "Confirmation Code"
+
+@angular @react @vue  
   Scenario: Sign up with a new email & password and lowercase the email 
     Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-email"
     When I type a new "email" with value "TEST@example.com"

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
@@ -14,7 +14,7 @@ Feature: Sign Up with Email
   @angular @react @vue  
   Scenario: Sign up with a new email & password and check auth message
     Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-email"
-    And I see "unAuthenticated"
+    And I see "unauthenticated"
     When I type a new "email"
     And I type my password
     And I confirm my password

--- a/packages/ui/src/helpers/authenticator/facade.ts
+++ b/packages/ui/src/helpers/authenticator/facade.ts
@@ -62,6 +62,7 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
   const isPending =
     state.hasTag('pending') || getActorState(state)?.hasTag('pending');
 
+  // Any additional idle states, (idle, setup, etc) should be updated inside the authStatus below
   const route = (() => {
     switch (true) {
       case state.matches('idle'):
@@ -101,12 +102,14 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
     }
   })();
 
+  // Auth status represents the current state of the auth flow
+  // The `pending` state is used to indicate when the xState machine, or Authenticate is being setup
   const authStatus = ((route) => {
-    switch (true) {
-      case route === 'idle':
-      case route === 'setup':
+    switch (route) {
+      case 'idle':
+      case 'setup':
         return 'pending';
-      case route === 'authenticated':
+      case 'authenticated':
         return 'authenticated';
       default:
         return 'unauthenticated';

--- a/packages/ui/src/helpers/authenticator/facade.ts
+++ b/packages/ui/src/helpers/authenticator/facade.ts
@@ -103,12 +103,12 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
   })();
 
   // Auth status represents the current state of the auth flow
-  // The `pending` state is used to indicate when the xState machine, or Authenticate is being setup
+  // The `configuring` state is used to indicate when the xState machine, or Authenticate is being setup
   const authStatus = ((route) => {
     switch (route) {
       case 'idle':
       case 'setup':
-        return 'pending';
+        return 'configuring';
       case 'authenticated':
         return 'authenticated';
       default:

--- a/packages/ui/src/helpers/authenticator/facade.ts
+++ b/packages/ui/src/helpers/authenticator/facade.ts
@@ -61,6 +61,7 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
   const hasValidationErrors = Object.keys(validationErrors).length > 0;
   const isPending =
     state.hasTag('pending') || getActorState(state)?.hasTag('pending');
+
   const route = (() => {
     switch (true) {
       case state.matches('idle'):
@@ -100,11 +101,24 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
     }
   })();
 
+  const authCheck = ((route) => {
+    switch (true) {
+      case route === 'idle':
+      case route === 'setup':
+        return 'pending';
+      case route === 'authenticated':
+        return 'authenticated';
+      default:
+        return 'unAuthenticated';
+    }
+  })(route);
+
   return {
     error,
     hasValidationErrors,
     isPending,
     route,
+    authCheck,
     user,
     validationErrors,
     codeDeliveryDetails,

--- a/packages/ui/src/helpers/authenticator/facade.ts
+++ b/packages/ui/src/helpers/authenticator/facade.ts
@@ -62,7 +62,7 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
   const isPending =
     state.hasTag('pending') || getActorState(state)?.hasTag('pending');
 
-  // Any additional idle states, (idle, setup, etc) should be updated inside the authStatus below
+  // Any additional idle states added beyond (idle, setup) should be updated inside the authStatus below as well
   const route = (() => {
     switch (true) {
       case state.matches('idle'):
@@ -103,7 +103,7 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
   })();
 
   // Auth status represents the current state of the auth flow
-  // The `configuring` state is used to indicate when the xState machine, or Authenticate is being setup
+  // The `configuring` state is used to indicate when the xState machine is loading
   const authStatus = ((route) => {
     switch (route) {
       case 'idle':

--- a/packages/ui/src/helpers/authenticator/facade.ts
+++ b/packages/ui/src/helpers/authenticator/facade.ts
@@ -101,7 +101,7 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
     }
   })();
 
-  const authCheck = ((route) => {
+  const authStatus = ((route) => {
     switch (true) {
       case route === 'idle':
       case route === 'setup':
@@ -109,7 +109,7 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
       case route === 'authenticated':
         return 'authenticated';
       default:
-        return 'unAuthenticated';
+        return 'unauthenticated';
     }
   })(route);
 
@@ -118,7 +118,7 @@ export const getServiceContextFacade = (state: AuthMachineState) => {
     hasValidationErrors,
     isPending,
     route,
-    authCheck,
+    authStatus,
     user,
     validationErrors,
     codeDeliveryDetails,

--- a/packages/vue/src/composables/useUtils.ts
+++ b/packages/vue/src/composables/useUtils.ts
@@ -5,6 +5,7 @@ export const facade = {
   hasValidationErrors: false,
   isPending: false,
   route: '',
+  authCheck: '',
   user: '',
   validationErrors: {
     val: '',

--- a/packages/vue/src/composables/useUtils.ts
+++ b/packages/vue/src/composables/useUtils.ts
@@ -5,7 +5,7 @@ export const facade = {
   hasValidationErrors: false,
   isPending: false,
   route: '',
-  authCheck: '',
+  authStatus: '',
   user: '',
   validationErrors: {
     val: '',


### PR DESCRIPTION
#### Description of changes

To make it simple for people to access our `authenticated` state, we've added in another facade called `authStatus`. This will return if the user is `authenticated`, `unauthenticated` or `configuring`.

#### Issue #, if available
#1497 

#### Description of how you validated changes
Added test

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
