### PR TITLE
fix: add missing titles to framework switcher

### DIFF
--- a/docs/src/components/Layout/FrameworkChooser.tsx
+++ b/docs/src/components/Layout/FrameworkChooser.tsx
@@ -46,6 +46,7 @@ export const FrameworkChooser = ({ platform }) => {
       <ToggleButton
         value="react"
         size="small"
+        title="React"
         padding={{ base: '4px', medium: undefined }}
       >
         <VisuallyHidden>React</VisuallyHidden>
@@ -59,6 +60,7 @@ export const FrameworkChooser = ({ platform }) => {
       <ToggleButton
         value="angular"
         size="small"
+        title="Angular"
         padding={{ base: '4px', medium: undefined }}
       >
         <VisuallyHidden>Angular</VisuallyHidden>
@@ -72,6 +74,7 @@ export const FrameworkChooser = ({ platform }) => {
       <ToggleButton
         value="vue"
         size="small"
+        title="Vue"
         padding={{ base: '4px', medium: undefined }}
       >
         <VisuallyHidden>Vue</VisuallyHidden>
@@ -85,6 +88,7 @@ export const FrameworkChooser = ({ platform }) => {
       <ToggleButton
         value="flutter"
         size="small"
+        title="Flutter"
         padding={{ base: '4px', medium: undefined }}
       >
         <VisuallyHidden>Flutter</VisuallyHidden>

--- a/docs/src/components/Layout/Header.tsx
+++ b/docs/src/components/Layout/Header.tsx
@@ -94,15 +94,15 @@ const ColorModeSwitcher = ({ colorMode, setColorMode }) => {
       isSelectionRequired
       className="color-switcher"
     >
-      <ToggleButton value="light">
+      <ToggleButton value="light" title="Light mode">
         <VisuallyHidden>Light mode</VisuallyHidden>
         <MdWbSunny />
       </ToggleButton>
-      <ToggleButton value="dark">
+      <ToggleButton value="dark" title="Dark mode">
         <VisuallyHidden>Dark mode</VisuallyHidden>
         <MdBedtime />
       </ToggleButton>
-      <ToggleButton value="system">
+      <ToggleButton value="system" title="System preferences">
         <VisuallyHidden>System preference</VisuallyHidden>
         <MdTonality />
       </ToggleButton>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This PR adds titles to the Framework and Light/Dark mode switchers.

![2022-05-02 16 55 41](https://user-images.githubusercontent.com/6165315/166344344-c3f2a8b4-f37e-4ff8-9ed4-2bc3b7357435.gif)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
Ran `yarn docs dev`


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
