### PR TITLE
chore(ui-react): update eslint config

### DIFF
--- a/.changeset/good-gifts-camp.md
+++ b/.changeset/good-gifts-camp.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+chore(ui-react): update eslint config

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -1,22 +1,43 @@
+// TODO remove these once the full set of rules can be turned on for the repo
+// extensions that should be ran against the entire repo
+const sharedExtensions = [
+  'plugin:react-hooks/recommended',
+
+  // always extend last to override previous extensions
+  'prettier',
+];
+
+// rules that should be ran against the entire repo
+const sharedRules = {
+  // react hook rules
+  'react-hooks/rules-of-hooks': 'error',
+  'react-hooks/exhaustive-deps': 'error',
+};
+
 module.exports = {
   env: { node: true },
   root: true,
   ignorePatterns: [
+    // top level directories
     '__tests__',
-    '.eslintrc.js',
-    'jest.config.js',
-    'tsup.config.ts',
-    'scripts',
     'dist',
     'node_modules',
+    'scripts',
 
-    // TODO Delete this file once the above directories are no longer ignored
+    // config files
+    '.eslintrc.js',
+    'jest.config.js',
+    'jest.setup.ts',
+    'rollup.config.js',
+    'tsup.config.ts',
+
+    // TODO remove once the full set of rules can be turned on for the repo
     'src/react-shim.js',
 
     // TODO remove once the icons have been deprecated for v3
     'src/primitives/Icon/icons',
   ],
-  extends: ['plugin:react-hooks/recommended'],
+  extends: sharedExtensions,
   plugins: ['react-hooks'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -40,7 +61,7 @@ module.exports = {
         'jest/unbound-method': 'error',
       },
     },
-    // TODO remove once the larger set of rules is applied to the whole repo.
+    // TODO remove once the full set of rules can be turned on for the repo
     // To keep the rules-of-hooks on for the entire ui-react package while
     // we add the larger set of rules incrementally, use an overrides object
     // to incrementally apply the new rules
@@ -54,30 +75,33 @@ module.exports = {
         // 'src/primitives/**/*',
       ],
       extends: [
-        'airbnb',
-        'airbnb-typescript',
+        'eslint:recommended',
         'plugin:jest/recommended',
         'plugin:react/recommended',
-        'plugin:react-hooks/recommended',
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
-        'plugin:prettier/recommended',
+
+        // extend last to override previous extensions
+        ...sharedExtensions,
       ],
-      plugins: [
-        'react',
-        '@typescript-eslint',
-        'react-hooks',
-        'jest',
-        'prettier',
-      ],
+      plugins: ['@typescript-eslint', 'jest', 'react', 'react-hooks'],
+      settings: {
+        react: {
+          version: 'detect',
+        },
+      },
       rules: {
+        ...sharedRules,
+
+        // typescript eslint rules either not in recommended rule set or overridden
         '@typescript-eslint/explicit-module-boundary-types': 2,
         '@typescript-eslint/member-ordering': 'error',
         '@typescript-eslint/no-extra-semi': 'error',
+        '@typescript-eslint/no-floating-promises': ['off'],
         '@typescript-eslint/no-unused-expressions': [
           'error',
           { allowTernary: true },
         ],
-        '@typescript-eslint/no-floating-promises': ['off'],
+        '@typescript-eslint/no-use-before-define': ['error'],
         '@typescript-eslint/no-unused-vars': [
           'error',
           { argsIgnorePattern: '_', varsIgnorePattern: '_' },
@@ -85,39 +109,41 @@ module.exports = {
         '@typescript-eslint/prefer-nullish-coalescing': 'error',
         '@typescript-eslint/restrict-template-expressions': ['off'],
         '@typescript-eslint/unbound-method': 'error',
+
+        // eslint rules either not in recommended rule set or overridden
         'comma-dangle': ['error', 'only-multiline'],
         'function-paren-newline': 'off',
         'generator-star-spacing': 'off',
         'global-require': 'off',
         'implicit-arrow-linebreak': 'off',
-        'import/no-cycle': 'off',
-        'import/no-extraneous-dependencies': ['off'],
-        'import/prefer-default-export': 'off',
-        'jest/expect-expect': ['error', { assertFunctionNames: ['expect*'] }],
-        'jest/no-mocks-import': 'off',
         'max-params': 2,
         'no-alert': 'error',
         'no-console': 'error',
+        'no-eval': 'error',
         'no-tabs': ['error', { allowIndentationTabs: true }],
+        'no-unused-vars': 'off', // prefer @typescript-eslint version
+        'prefer-const': 'error',
         'prefer-destructuring': ['error', { array: false, object: true }],
-        'prettier/prettier': ['error'],
+
+        // jest rules either not in recommended rule set or overridden
+        'jest/expect-expect': ['error', { assertFunctionNames: ['expect*'] }],
+        'jest/no-mocks-import': 'off',
+
+        // react rules either not in recommended rule set or overridden
+        'react/destructuring-assignment': ['error', 'always'],
+        'react/jsx-boolean-value': 'error',
+        'react/jsx-no-constructed-context-values': ['error'],
+        'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
         'react/jsx-props-no-spreading': 'off',
         'react/jsx-wrap-multilines': ['error', { declaration: 'ignore' }],
         'react/no-array-index-key': 'off',
+        'react/no-danger': ['error'],
+        'react/no-unused-prop-types': ['error'],
         'react/prop-types': 'off',
-        'react/require-default-props': [
-          2,
-          { ignoreFunctionalComponents: true },
-        ],
         'react/static-property-placement': ['error', 'static public field'],
-        'react-hooks/rules-of-hooks': 'error',
-        'react-hooks/exhaustive-deps': 'error',
       },
     },
   ],
 
-  rules: {
-    'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'error',
-  },
+  rules: sharedRules,
 };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -98,8 +98,6 @@
     "@typescript-eslint/parser": "^5.20.0",
     "degit": "^2.8.4",
     "eslint": "^8.13.0",
-    "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^26.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8924,11 +8924,6 @@ config-chain@^1.1.12:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
-confusing-browser-globals@^1.0.10:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
-  integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
-
 connect-history-api-fallback@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
@@ -10819,32 +10814,6 @@ escodegen@^2.0.0:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
-
-eslint-config-airbnb-base@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz#6b09add90ac79c2f8d723a2580e07f3925afd236"
-  integrity sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==
-  dependencies:
-    confusing-browser-globals "^1.0.10"
-    object.assign "^4.1.2"
-    object.entries "^1.1.5"
-    semver "^6.3.0"
-
-eslint-config-airbnb-typescript@^17.0.0:
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.0.0.tgz#360dbcf810b26bbcf2ff716198465775f1c49a07"
-  integrity sha512-elNiuzD0kPAPTXjFWg+lE24nMdHMtuxgYoD30OyMD6yrW1AhFZPAg27VX7d3tzOErw+dgJTNWfRSDqEcXb4V0g==
-  dependencies:
-    eslint-config-airbnb-base "^15.0.0"
-
-eslint-config-airbnb@^19.0.4:
-  version "19.0.4"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz#84d4c3490ad70a0ffa571138ebcdea6ab085fdc3"
-  integrity sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==
-  dependencies:
-    eslint-config-airbnb-base "^15.0.0"
-    object.assign "^4.1.2"
-    object.entries "^1.1.5"
 
 eslint-config-next@11.0.1:
   version "11.0.1"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Remove `eslint-config-airbnb` and `eslint--config-airbnb-typescript` plugins and other `eslint` updates:
- remove aforementioned configs as:
  - the configs are very opinionated and come with a ton of predefined rules, creating more maintenance overhead in both resolving linting errors and determining which preconfigured rules need to be overridden
  - allows for easier refinement of applied `eslint` rules to match better serve the `ui-react` codebase, and ensures they are easily visible in the local _.eslintrc.js_ config
- remove `import` overrides related to the aforementioned configs
- add back some rules from the aforementioned configs
- improve file structure/commenting
- add `eslint:recommended` rule set
- add additional `react` rules
- replace `plugin:prettier/recommended` with just `prettier` to prevent extraneous errors while typing
- add _rollup.config.js_ and _jest.setup.ts_ to `ignorePatterns`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually validated rule updates

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
