### PR TITLE
fix(ui-react): remove optional flag from render prop child in RouterProps

### DIFF
--- a/.changeset/soft-panthers-hug.md
+++ b/.changeset/soft-panthers-hug.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(ui-react): remove optional flag from render child prop in RouterProps

--- a/packages/react/src/components/Authenticator/Router/types.ts
+++ b/packages/react/src/components/Authenticator/Router/types.ts
@@ -7,7 +7,7 @@ import { UseAuthenticator } from '../hooks/useAuthenticator';
 export type RouterProps = {
   children:
     | React.ReactNode
-    | ((props?: {
+    | ((props: {
         signOut?: UseAuthenticator['signOut'];
         user?: CognitoUserAmplify;
       }) => React.ReactNode);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Remove `?` flag from `props` of render prop children of `RouterProps`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://github.com/aws-amplify/amplify-ui/issues/1845

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested in sample app

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
