### PR TITLE
fix: Add missing translation for force new password page

### DIFF
--- a/.changeset/tasty-tables-walk.md
+++ b/.changeset/tasty-tables-walk.md
@@ -2,4 +2,4 @@
 '@aws-amplify/ui-react': patch
 ---
 
-Added a translatable text for React on the Force new password change
+Added a translatable text for errors on the Force new password page

--- a/.changeset/tasty-tables-walk.md
+++ b/.changeset/tasty-tables-walk.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Added a translatable text for React on the Force new password change

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-phone/sign-in-with-phone.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-phone/sign-in-with-phone.component.ts
@@ -1,15 +1,25 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import { Amplify } from 'aws-amplify';
+import { Amplify, I18n } from 'aws-amplify';
+import { translations } from '@aws-amplify/ui-angular';
 import awsExports from './aws-exports';
 
 @Component({
   selector: 'sign-in-with-phone',
   templateUrl: 'sign-in-with-phone.component.html',
 })
-export class SignInWithPhoneComponent {
+export class SignInWithPhoneComponent implements OnInit {
   constructor() {
     Amplify.configure(awsExports);
+  }
+
+  ngOnInit(): void {
+    I18n.putVocabularies(translations);
+    I18n.setLanguage('en');
+    I18n.putVocabulariesForLanguage('en', {
+      'Password does not conform to policy: Password not long enough':
+        'Your password is too short! Try a longer password!',
+    });
   }
 
   public formFields = {

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-phone/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-phone/index.page.tsx
@@ -1,10 +1,17 @@
-import { Amplify } from 'aws-amplify';
+import { Amplify, I18n } from 'aws-amplify';
 
-import { withAuthenticator } from '@aws-amplify/ui-react';
+import { withAuthenticator, translations } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
 import awsExports from './aws-exports';
 Amplify.configure(awsExports);
+
+I18n.putVocabularies(translations);
+I18n.setLanguage('en');
+I18n.putVocabulariesForLanguage('en', {
+  'Password does not conform to policy: Password not long enough':
+    'Your password is too short! Try a longer password!',
+});
 
 const formFields = {
   signIn: {

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-with-phone/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-with-phone/index.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
-import Amplify from 'aws-amplify';
-import { Authenticator } from '@aws-amplify/ui-vue';
+import { Amplify, I18n } from 'aws-amplify';
+import { Authenticator, translations } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from './aws-exports';
 
 Amplify.configure(aws_exports);
+
+I18n.putVocabularies(translations);
+I18n.setLanguage('en');
+I18n.putVocabulariesForLanguage('en', {
+  'Password does not conform to policy: Password not long enough':
+    'Your password is too short! Try a longer password!',
+});
 
 const formFields = {
   signIn: {

--- a/packages/e2e/cypress/fixtures/force-change-password-phone-failure.json
+++ b/packages/e2e/cypress/fixtures/force-change-password-phone-failure.json
@@ -1,0 +1,4 @@
+{
+  "__type": "InvalidPasswordException",
+  "message": "Password does not conform to policy: Password not long enough"
+}

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -114,6 +114,10 @@ When('I type an invalid password', () => {
   cy.findInputField('Password').type('invalidpass');
 });
 
+When('I type a short password', () => {
+  cy.findInputField('Password').type('inv');
+});
+
 When('I type an invalid wrong complexity password', () => {
   cy.findInputField('Password').type('inv');
 });

--- a/packages/e2e/cypress/integration/common/sign-up.ts
+++ b/packages/e2e/cypress/integration/common/sign-up.ts
@@ -13,6 +13,10 @@ When('I confirm my password', () => {
     .wait(100);
 });
 
+When('I confirm my short password', () => {
+  cy.findInputField('Confirm Password').type('inv').blur().wait(100);
+});
+
 Then('I see {string} as an input field', (name: string) => {
   cy.findByRole('textbox', { name }).should('exist');
 });

--- a/packages/e2e/features/ui/components/authenticator/sign-in-force-new-password.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-force-new-password.feature
@@ -21,7 +21,6 @@ Feature: Sign In with Force New Password flow
     Then I click the "Change Password" button
     Then I see "Your password is too short! Try a longer password!"
 
-
   @angular @react @vue 
   Scenario: Back to Sign In works in the FORCE_CHANGE_PASSWORD state
     When I select my country code with status "FORCE_CHANGE_PASSWORD"
@@ -45,7 +44,6 @@ Feature: Sign In with Force New Password flow
     And I mock 'Amplify.Auth.currentAuthenticatedUser' with fixture "Auth.currentAuthenticatedUser-sms-mfa"
     Then I click the "Change Password" button
     Then I see "+17755551212"
-
 
   @angular @react @vue 
   Scenario: User is in a FORCE_CHANGE_PASSWORD state and then enters an invalid new password

--- a/packages/e2e/features/ui/components/authenticator/sign-in-force-new-password.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-force-new-password.feature
@@ -7,6 +7,21 @@ Feature: Sign In with Force New Password flow
     Given I'm running the example "ui/components/authenticator/sign-in-with-phone"
     Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge" } }' with fixture "force-change-password"
 
+
+  @angular @react @vue 
+  Scenario: User is in a FORCE_CHANGE_PASSWORD state and gets an error that's translated
+    When I select my country code with status "FORCE_CHANGE_PASSWORD"
+    And I type my "phone number" with status "FORCE_CHANGE_PASSWORD"
+    And I type my password
+    And I click the "Sign in" button
+    Then I should see the Force Change Password screen
+    And I type a short password
+    And I confirm my short password
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge" } }' with error fixture "force-change-password-phone-failure"
+    Then I click the "Change Password" button
+    Then I see "Your password is too short! Try a longer password!"
+
+
   @angular @react @vue 
   Scenario: Back to Sign In works in the FORCE_CHANGE_PASSWORD state
     When I select my country code with status "FORCE_CHANGE_PASSWORD"
@@ -30,6 +45,7 @@ Feature: Sign In with Force New Password flow
     And I mock 'Amplify.Auth.currentAuthenticatedUser' with fixture "Auth.currentAuthenticatedUser-sms-mfa"
     Then I click the "Change Password" button
     Then I see "+17755551212"
+
 
   @angular @react @vue 
   Scenario: User is in a FORCE_CHANGE_PASSWORD state and then enters an invalid new password

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -14,8 +14,7 @@ export const ForceNewPassword = ({
   className,
   variation,
 }: RouteProps): JSX.Element => {
-  const { error, isPending, toSignIn } = useAuthenticator((context) => [
-    context.error,
+  const { isPending, toSignIn } = useAuthenticator((context) => [
     context.isPending,
     context.toSignIn,
   ]);

--- a/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react/src/components/Authenticator/ForceNewPassword/ForceNewPassword.tsx
@@ -3,7 +3,7 @@ import { translate } from '@aws-amplify/ui';
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
-import { Text } from '../../../primitives/Text';
+import { RemoteErrorMessage } from '../shared/RemoteErrorMessage';
 import { useAuthenticator } from '../hooks/useAuthenticator';
 import { useCustomComponents } from '../hooks/useCustomComponents';
 import { useFormHandlers } from '../hooks/useFormHandlers';
@@ -41,11 +41,8 @@ export const ForceNewPassword = ({
           <Heading level={3}>{translate('Change Password')}</Heading>
 
           <FormFields />
-          {error && (
-            <Text className="forceNewPasswordErrorText" variation="error">
-              {error}
-            </Text>
-          )}
+
+          <RemoteErrorMessage />
           <Button
             isDisabled={isPending}
             type="submit"


### PR DESCRIPTION
#### Description of changes

Added missing translation for force new password page for React

#### Issue #, if available
#1789 

#### Description of how you validated changes
Added cypress test

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
