### PR TITLE
Docs/a11y roundup

### DIFF
--- a/docs/src/components/ComponentStyleDisplay.tsx
+++ b/docs/src/components/ComponentStyleDisplay.tsx
@@ -26,13 +26,11 @@ export const ComponentStyleDisplay = ({ componentName }) => {
           <Tabs>
             <TabItem title="Target Classes">
               <View padding={`${tokens.space.medium} 0`}>
-                <Heading>Component Class Names</Heading>
                 <ComponentClassTable componentName={componentName} />
               </View>
             </TabItem>
             <TabItem title="CSS Variables">
               <View padding={`${tokens.space.medium} 0`}>
-                <Heading>Component CSS Variable Names</Heading>
                 <ComponentVariableTable
                   componentName={componentName.toLowerCase()}
                 />

--- a/docs/src/components/Layout/Header.tsx
+++ b/docs/src/components/Layout/Header.tsx
@@ -57,7 +57,14 @@ const NavLink = ({
 };
 
 const Nav = (props) => (
-  <Flex as="nav" className="docs-nav" alignItems="center" gap="0" grow="1">
+  <Flex
+    as="nav"
+    aria-label="Main navigation"
+    className="docs-nav"
+    alignItems="center"
+    gap="0"
+    grow="1"
+  >
     <NavLink {...props} href="/getting-started/installation">
       Getting started
     </NavLink>
@@ -156,7 +163,7 @@ export const Header = ({ platform, colorMode, setColorMode }) => {
           </Flex>
 
           <Nav onClick={() => setExpanded(false)} />
-          <nav className="docs-sidebar-nav">
+          <nav aria-label="Section navigation" className="docs-sidebar-nav">
             <SecondaryNav onClick={() => setExpanded(false)} />
           </nav>
         </View>

--- a/docs/src/components/Layout/SecondaryNav.tsx
+++ b/docs/src/components/Layout/SecondaryNav.tsx
@@ -185,12 +185,12 @@ export const SecondaryNav = (props) => {
 
 export const Sidebar = () => {
   return (
-    <aside className="docs-sidebar">
+    <nav aria-label="Section navigation" className="docs-sidebar">
       <div className="docs-sidebar-inner">
-        <nav className="docs-sidebar-nav">
+        <div className="docs-sidebar-nav">
           <SecondaryNav />
-        </nav>
+        </div>
       </div>
-    </aside>
+    </nav>
   );
 };

--- a/docs/src/components/Layout/index.tsx
+++ b/docs/src/components/Layout/index.tsx
@@ -123,6 +123,7 @@ export default function Page({
                 >
                   <Icon
                     ariaLabel=""
+                    aria-hidden="true"
                     as={SiReact}
                     marginInlineEnd={tokens.space.xs}
                   />

--- a/docs/src/components/Layout/index.tsx
+++ b/docs/src/components/Layout/index.tsx
@@ -95,7 +95,7 @@ export default function Page({
                   isExternal
                 >
                   <Icon
-                    ariaLabel=""
+                    ariaLabel="W3C"
                     as={SiW3C}
                     marginInlineEnd={tokens.space.xs}
                   />


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Small roundup of "low hanging fruit" accessibility fixes that are spread around the docs site (ignoring any that are component specific). Added some comments to Files changed to describe the changes.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**Before: Component page (Button) scan results.**

<img width="750" alt="Screen Shot 2022-05-10 at 1 35 26 PM" src="https://user-images.githubusercontent.com/376920/167688736-0e62a0a5-e855-4ea9-8800-512d45ea927e.png">

**After: Component page (Button) scan results**

<img width="752" alt="Screen Shot 2022-05-10 at 1 36 07 PM" src="https://user-images.githubusercontent.com/376920/167688905-aa2e5519-8bdb-4026-9b94-0b33edfdb89c.png">

**What about the other 10 issues?**
The other issues are specific to the Button docs examples (buttons with the same name, links with the same name, etc).

Additionally, axe picks up that the code examples are not keyboard navigable since they cannot be scrolled; adding tabindex="0" would likely fix that but might require some further investigation for implementing since we're generating those `<pre>` elements within an mdx file. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
