### PR TITLE
fix(authenticator): fix infinite loop on refresh after refresh token expires

### DIFF
--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -206,7 +206,6 @@ export function createAuthenticatorMachine() {
         SUBMIT: { actions: 'forwardToActor' },
         FEDERATED_SIGN_IN: { actions: 'forwardToActor' },
         RESEND: { actions: 'forwardToActor' },
-        SIGN_OUT: { actions: 'forwardToActor' },
         SIGN_IN: { actions: 'forwardToActor' },
         SKIP: { actions: 'forwardToActor' },
       },
@@ -216,7 +215,7 @@ export function createAuthenticatorMachine() {
         forwardToActor: choose([
           {
             cond: 'hasActor',
-            actions: forwardTo((context, event) => context.actorRef),
+            actions: forwardTo((context) => context.actorRef),
           },
         ]),
         setUser: assign({

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -1,4 +1,5 @@
 import { assign, createMachine, forwardTo, spawn } from 'xstate';
+import { choose } from 'xstate/lib/actions';
 
 import {
   AuthContext,
@@ -212,7 +213,12 @@ export function createAuthenticatorMachine() {
     },
     {
       actions: {
-        forwardToActor: forwardTo((context) => context.actorRef),
+        forwardToActor: choose([
+          {
+            cond: 'hasActor',
+            actions: forwardTo((context, event) => context.actorRef),
+          },
+        ]),
         setUser: assign({
           user: (_, event) => event.data as CognitoUserAmplify,
         }),
@@ -369,6 +375,8 @@ export function createAuthenticatorMachine() {
         shouldRedirectToResetPassword: (_, event) =>
           event.data?.intent === 'confirmPasswordReset',
         shouldSetup: (context) => context.hasSetup === false,
+        // other context guards
+        hasActor: (context) => !!context.actorRef,
       },
       services: {
         getCurrentUser: (context, _) => context.services.getCurrentUser(),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

While #1809 resolves happy cases, refresh token could still cause an infinite loop when it expires (default 30 days). 

This is because we have

https://github.com/aws-amplify/amplify-ui/blob/04c49c44999d62287a6e932f7d0188c84a90ede6/packages/ui/src/machines/authenticator/index.ts#L208

which forwards any `SIGN_OUT` event to the actor. 

But when refresh token is expired and the app is refreshed, it calls `SIGN_OUT` event before state machine has any actor. This confuses the `forwardTo` action. Specifically, `forwardTo` action uses `send` under the hood, and it sends the event to itself if [the target is undefined](https://xstate.js.org/docs/guides/actions.html#send-action). So when `SIGN_OUT` is called when actor doesn't exist yet, it sends that event over and over to itself.

This PR fixes it by having `hasActor` condition to `forwardTo`.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I verified the fix on a mock environment, but I'm working on verifying the fix on actual app. Will update once done.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
