### PR TITLE
fix(style): fix PasswordField and SearchField quiet styling

### DIFF
--- a/.changeset/orange-sheep-learn.md
+++ b/.changeset/orange-sheep-learn.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+fix(style): fix PasswordField and SearchField quiet styling

--- a/packages/react/src/primitives/FieldGroup/FieldGroup.tsx
+++ b/packages/react/src/primitives/FieldGroup/FieldGroup.tsx
@@ -16,6 +16,7 @@ const FieldGroupPrimitive: Primitive<FieldGroupOptions, typeof Flex> = (
     orientation = 'horizontal',
     outerEndComponent,
     outerStartComponent,
+    variation,
     ...rest
   },
   ref
@@ -45,7 +46,15 @@ const FieldGroupPrimitive: Primitive<FieldGroupOptions, typeof Flex> = (
       {...rest}
     >
       {outerStartComponent && (
-        <View className={ComponentClassNames.FieldGroupOuterStart}>
+        <View
+          className={classNames(
+            ComponentClassNames.FieldGroupOuterStart,
+            classNameModifier(
+              ComponentClassNames.FieldGroupOuterStart,
+              variation
+            )
+          )}
+        >
           {outerStartComponent}
         </View>
       )}
@@ -73,7 +82,12 @@ const FieldGroupPrimitive: Primitive<FieldGroupOptions, typeof Flex> = (
       </View>
 
       {outerEndComponent && (
-        <View className={ComponentClassNames.FieldGroupOuterEnd}>
+        <View
+          className={classNames(
+            ComponentClassNames.FieldGroupOuterEnd,
+            classNameModifier(ComponentClassNames.FieldGroupOuterEnd, variation)
+          )}
+        >
           {outerEndComponent}
         </View>
       )}

--- a/packages/react/src/primitives/FieldGroup/__tests__/FieldGroup.test.tsx
+++ b/packages/react/src/primitives/FieldGroup/__tests__/FieldGroup.test.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Button } from '../../Button';
-import { ComponentClassNames } from '../../shared';
 import { FieldGroup } from '../FieldGroup';
 import { Text } from '../../Text';
+import { ComponentClassNames } from '../../shared/constants';
+import { classNameModifier } from '../../shared/utils';
 
 describe('FieldGroup component', () => {
   const testId = 'fieldGroupTestId';
@@ -150,6 +151,35 @@ describe('FieldGroup component', () => {
     );
     expect(outerEndComponent).toHaveClass(
       ComponentClassNames.FieldGroupOuterEnd
+    );
+  });
+
+  it('should render quiet class on outer components when variation is set to quiet', async () => {
+    const outerStart = 'outerStart';
+    const outerEnd = 'outerEnd';
+    const variation = 'quiet';
+
+    render(
+      <FieldGroup
+        testId={testId}
+        outerStartComponent={outerStart}
+        outerEndComponent={outerEnd}
+        variation={variation}
+      >
+        <Text>Hello</Text>
+      </FieldGroup>
+    );
+
+    const outerStartComponent = await screen.queryByText(outerStart);
+    const outerEndComponent = await screen.queryByText(outerEnd);
+
+    expect(outerStartComponent).not.toBeNull();
+    expect(outerEndComponent).not.toBeNull();
+    expect(outerStartComponent).toHaveClass(
+      classNameModifier(ComponentClassNames.FieldGroupOuterStart, variation)
+    );
+    expect(outerEndComponent).toHaveClass(
+      classNameModifier(ComponentClassNames.FieldGroupOuterEnd, variation)
     );
   });
 

--- a/packages/react/src/primitives/TextField/TextField.tsx
+++ b/packages/react/src/primitives/TextField/TextField.tsx
@@ -42,6 +42,7 @@ const TextFieldPrimitive = <Multiline extends boolean>(
     type, // remove from rest to prevent passing as DOM attribute to textarea
     size,
     testId,
+    variation,
 
     bottom, // @TODO: remove custom destructuring for 3.0 release
     height, // @TODO: remove custom destructuring for 3.0 release
@@ -79,6 +80,7 @@ const TextFieldPrimitive = <Multiline extends boolean>(
         ref={isTextAreaRef(props, ref) ? ref : undefined}
         rows={rows ?? DEFAULT_ROW_COUNT}
         size={size}
+        variation={variation}
         {...baseStyleProps}
         {...rest}
       />
@@ -93,6 +95,7 @@ const TextFieldPrimitive = <Multiline extends boolean>(
         ref={isInputRef(props, ref) ? ref : undefined}
         size={size}
         type={type}
+        variation={variation}
         {...baseStyleProps}
         {...rest}
       />
@@ -132,6 +135,7 @@ const TextFieldPrimitive = <Multiline extends boolean>(
         outerEndComponent={outerEndComponent}
         innerStartComponent={innerStartComponent}
         innerEndComponent={innerEndComponent}
+        variation={variation}
       >
         {control}
       </FieldGroup>

--- a/packages/react/src/primitives/types/fieldGroup.ts
+++ b/packages/react/src/primitives/types/fieldGroup.ts
@@ -1,4 +1,5 @@
 import { FlexProps } from './flex';
+import { FieldVariations } from './field';
 export type FieldGroupOrientation = 'horizontal' | 'vertical';
 
 export interface FieldGroupOptions extends FlexProps {
@@ -8,4 +9,5 @@ export interface FieldGroupOptions extends FlexProps {
   outerEndComponent?: React.ReactNode;
   innerStartComponent?: React.ReactNode;
   innerEndComponent?: React.ReactNode;
+  variation?: FieldVariations;
 }

--- a/packages/ui/src/theme/css/component/fieldGroup.scss
+++ b/packages/ui/src/theme/css/component/fieldGroup.scss
@@ -58,7 +58,7 @@
     @extend %remove-end-radii;
 
     &:not(:focus) {
-      border-inline-end: none;
+      border-inline-end-color: transparent;
     }
     &:focus {
       z-index: 1;
@@ -70,6 +70,17 @@
       @extend %remove-start-radii;
     }
   }
+
+  &--quiet {
+    .amplify-field-group__control {
+      @extend %remove-start-radii;
+      &:not(:focus) {
+        border-block-start-color: transparent;
+        border-inline-start-color: transparent;
+      }
+    }
+  }
+
   // Select requires special rules due to icon
   .amplify-select__wrapper {
     .amplify-select {
@@ -87,7 +98,7 @@
     @extend %remove-start-radii;
 
     &:not(:focus) {
-      border-inline-start: none;
+      border-inline-start-color: transparent;
     }
     &:focus {
       z-index: 1;
@@ -99,6 +110,17 @@
       @extend %remove-end-radii;
     }
   }
+
+  &--quiet {
+    .amplify-field-group__control {
+      @extend %remove-end-radii;
+      &:not(:focus) {
+        border-block-start-color: transparent;
+        border-inline-end-color: transparent;
+      }
+    }
+  }
+
   // Select requires special rules due to icon
   .amplify-select__wrapper {
     .amplify-select {


### PR DESCRIPTION
#### Description of changes

1. Update corresponding border colors to fix `PasswordField` and `SearchField` quiet variation styling. Make the colors `transparent` to avoid border pixel shift when switching between focus and non-focus state

2. Update unit tests to cover new cases.

#### Issue #, if available

Fixes #1794, fixes #1634

#### Description of how you validated changes

![Screen Shot 2022-05-10 at 10 50 16 AM](https://user-images.githubusercontent.com/40295569/167706691-ba3c2912-b475-4218-9a41-f2ad3c18c744.png)

![Screen Shot 2022-05-10 at 10 50 25 AM](https://user-images.githubusercontent.com/40295569/167706678-0ac4bf4e-d008-4231-86d0-0fbe4d230d36.png)

![Screen Shot 2022-05-10 at 10 55 30 AM](https://user-images.githubusercontent.com/40295569/167706818-bd4d04ea-efb1-48fe-a5b2-b08e1ae77c66.png)

![Screen Shot 2022-05-10 at 10 55 41 AM](https://user-images.githubusercontent.com/40295569/167706837-862d8264-714a-468a-9b97-3323de157bde.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
