### PR TITLE
fix(authenticator): Only pass hub event when authenticator is in correct state

### DIFF
--- a/.changeset/cyan-tips-pull.md
+++ b/.changeset/cyan-tips-pull.md
@@ -1,0 +1,8 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-vue": patch
+"@aws-amplify/ui-angular": patch
+---
+
+This PR adds additional safeguards to hub event listeners we use. Now, we will only pass hub events to the auth machine if it is in the correct state.

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import {
   AuthenticatorMachineOptions,
+  defaultAuthHubHandler,
   listenToAuthHub,
   SocialProvider,
   translate,
@@ -66,7 +67,10 @@ export class AuthenticatorComponent
       formFields,
     } = this;
 
-    this.unsubscribeHub = listenToAuthHub((event) => {
+    const { authService } = this.authenticator;
+
+    this.unsubscribeHub = listenToAuthHub(authService, (data, service) => {
+      defaultAuthHubHandler(data, service);
       /**
        * Hub events aren't properly caught by Angular, because they are
        * synchronous events. Angular tracks async network events and
@@ -74,7 +78,6 @@ export class AuthenticatorComponent
        *
        * On any notable hub events, we run change detection manually.
        */
-      const state = this.authenticator.authService.send(event);
       this.changeDetector.detectChanges();
 
       /**
@@ -86,7 +89,6 @@ export class AuthenticatorComponent
        * to true to until we reach initial state.
        */
       this.isHandlingHubEvent = true;
-      return state;
     });
 
     /**

--- a/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
@@ -41,26 +41,22 @@ export const Provider = ({ children }: { children: React.ReactNode }) => {
    *
    * Leaving this as is for now in the interest of suggested code guideline.
    */
-  const service = useInterpret(createAuthenticatorMachine);
+  const service = useInterpret(createAuthenticatorMachine, { devTools: true });
   const currentProviderVal = { service };
 
   const value = isEmpty(parentProviderVal)
     ? currentProviderVal
     : parentProviderVal;
 
-  const {
-    service: { send },
-  } = value;
+  const { service: activeService } = value;
 
   const isListening = React.useRef(false);
   React.useEffect(() => {
-    if (isListening.current) {
-      return;
-    }
+    if (isListening.current) return;
 
     isListening.current = true;
-    return listenToAuthHub(send);
-  }, [send]);
+    return listenToAuthHub(activeService);
+  }, [activeService]);
 
   return (
     <AuthenticatorContext.Provider value={value}>

--- a/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
@@ -41,7 +41,7 @@ export const Provider = ({ children }: { children: React.ReactNode }) => {
    *
    * Leaving this as is for now in the interest of suggested code guideline.
    */
-  const service = useInterpret(createAuthenticatorMachine, { devTools: true });
+  const service = useInterpret(createAuthenticatorMachine);
   const currentProviderVal = { service };
 
   const value = isEmpty(parentProviderVal)

--- a/packages/ui/src/helpers/authenticator/utils.ts
+++ b/packages/ui/src/helpers/authenticator/utils.ts
@@ -51,6 +51,8 @@ export const defaultAuthHubHandler: HubHandler = (data, service) => {
         send('SIGN_OUT');
       }
       break;
+    case default:
+      break;
   }
 };
 

--- a/packages/ui/src/helpers/authenticator/utils.ts
+++ b/packages/ui/src/helpers/authenticator/utils.ts
@@ -51,7 +51,7 @@ export const defaultAuthHubHandler: HubHandler = (data, service) => {
         send('SIGN_OUT');
       }
       break;
-    case default:
+    default:
       break;
   }
 };

--- a/packages/ui/src/helpers/authenticator/utils.ts
+++ b/packages/ui/src/helpers/authenticator/utils.ts
@@ -4,7 +4,8 @@
  */
 
 import { Hub } from 'aws-amplify';
-import { AuthMachineSend } from '../../types';
+import { HubCapsule } from '@aws-amplify/core';
+import { AuthInterpreter, HubHandler } from '../../types';
 
 // replaces all characters in a string with '*', except for the first and last char
 export const censorAllButFirstAndLast = (value: string): string => {
@@ -32,6 +33,27 @@ export const censorPhoneNumber = (val: string): string => {
   return split.join('');
 };
 
+export const defaultAuthHubHandler: HubHandler = (data, service) => {
+  const { send } = service;
+  const state = service.getSnapshot(); // this is just a getter and is not expensive
+
+  switch (data.payload.event) {
+    // TODO: We can add more cases here, according to
+    // https://docs.amplify.aws/lib/auth/auth-events/q/platform/js/
+    case 'tokenRefresh':
+      if (state.matches('authenticated.idle')) {
+        send('TOKEN_REFRESH');
+      }
+      break;
+    case 'signOut':
+    case 'tokenRefresh_failure':
+      if (state.matches('authenticated.idle')) {
+        send('SIGN_OUT');
+      }
+      break;
+  }
+};
+
 /**
  * Listens to external auth Hub events and sends corresponding event to
  * the `authService` of interest
@@ -40,18 +62,11 @@ export const censorPhoneNumber = (val: string): string => {
  *
  * @returns function that unsubscribes to the hub evenmt
  */
-export const listenToAuthHub = (send: AuthMachineSend) => {
+export const listenToAuthHub = (
+  service: AuthInterpreter,
+  handler: HubHandler = defaultAuthHubHandler
+) => {
   return Hub.listen('auth', (data) => {
-    switch (data.payload.event) {
-      // TODO: We can add more cases here, according to
-      // https://docs.amplify.aws/lib/auth/auth-events/q/platform/js/
-      case 'tokenRefresh':
-        send('TOKEN_REFRESH');
-        break;
-      case 'signOut':
-      case 'tokenRefresh_failure':
-        send('SIGN_OUT');
-        break;
-    }
+    handler(data, service);
   });
 };

--- a/packages/ui/src/types/authenticator/stateMachine/authMachine.ts
+++ b/packages/ui/src/types/authenticator/stateMachine/authMachine.ts
@@ -5,6 +5,7 @@
 import { Interpreter } from 'xstate';
 import { AuthContext } from './context';
 import { AuthEvent } from './event';
+import { HubCapsule } from '@aws-amplify/core';
 
 /**
  * Intefrace for `authMachine` machine interpreter
@@ -23,3 +24,5 @@ export type AuthInterpreter = Interpreter<
  * Function type for `send` in `authMachine`
  */
 export type AuthMachineSend = AuthInterpreter['send'];
+
+export type HubHandler = (data: HubCapsule, service: AuthInterpreter) => void;

--- a/packages/vue/src/components/authenticator.vue
+++ b/packages/vue/src/components/authenticator.vue
@@ -105,7 +105,7 @@ unsubscribeMachine = service.subscribe((newState) => {
 }).unsubscribe;
 
 onMounted(() => {
-  unsubscribeHub = listenToAuthHub(send);
+  unsubscribeHub = listenToAuthHub(service);
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Instead of blindly accepting hub events and passing them to state machine, this PR adds a state check to ensure that the authenticator is in the correct state. 

This will prevent sending hub events (e.g. `tokenRefresh`) over and over when Authenticator is already handling it.

#### Refactor

`listenToAuthHub` now needs access to current state, so I refactored the signature to accept `authService`, which is a static context that provides access to `state` and `send`. I also abstracted out the default hub handler, and enabled other libraries to pass custom hub handler. This helps Angular because it has been using extra handling for change detection (see #1809).

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

Related to #1683.

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
