### PR TITLE
Remove is disabled

### DIFF
--- a/.changeset/rude-wasps-hammer.md
+++ b/.changeset/rude-wasps-hammer.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Removed isDisabled prop, since it doesn't exist as an HTML element

--- a/packages/react/src/primitives/View/View.tsx
+++ b/packages/react/src/primitives/View/View.tsx
@@ -27,7 +27,6 @@ const ViewPrimitive = <Element extends ElementType = 'div'>(
       'aria-label': ariaLabel,
       'data-testid': testId,
       disabled: isDisabled,
-      isDisabled: isDisabled,
       ref,
       style: propStyles,
       ...nonStyleProps,


### PR DESCRIPTION
#### Description of changes
Removing non-existant prop `isDisabled` on DOM element on View primitive.

Was causing this warning

<img width="1691" alt="image" src="https://user-images.githubusercontent.com/65630/167740532-d32e10c0-03c6-4a7a-85dc-935c19b718cd.png">



#### Description of how you validated changes
Ran manually

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
