### PR TITLE
Button disabled

### DIFF
--- a/.changeset/five-experts-hunt.md
+++ b/.changeset/five-experts-hunt.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Update Button to include disabled classes with disabled attribute

--- a/packages/react/src/primitives/Button/Button.tsx
+++ b/packages/react/src/primitives/Button/Button.tsx
@@ -31,7 +31,7 @@ const ButtonPrimitive: Primitive<ButtonProps, 'button'> = (
     classNameModifierByFlag(
       ComponentClassNames.Button,
       'disabled',
-      isDisabled || isLoading
+      isDisabled || isLoading || rest['disabled']
     ),
     classNameModifierByFlag(ComponentClassNames.Button, 'loading', isLoading),
     classNameModifierByFlag(

--- a/packages/react/src/primitives/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/primitives/Button/__tests__/Button.test.tsx
@@ -27,16 +27,14 @@ describe('Button test suite', () => {
 
   it('should add the disabled class with the disabled attribute', async () => {
     render(
-      <div>
-        <Button disabled testId="disabled">
-          Disabled
-        </Button>
-      </div>
+      <Button disabled testId="disabled">
+        Disabled
+      </Button>
     );
 
     const disabled = await screen.findByTestId('disabled');
 
-    expect(disabled.classList).toContain('amplify-button--disabled');
+    expect(disabled).toHaveClass('amplify-button--disabled');
   });
 
   it('should render button variations', async () => {

--- a/packages/react/src/primitives/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/primitives/Button/__tests__/Button.test.tsx
@@ -25,6 +25,20 @@ describe('Button test suite', () => {
     expect(link.classList).toContain('amplify-button--link');
   });
 
+  it('should add the disabled class with the disabled attribute', async () => {
+    render(
+      <div>
+        <Button disabled testId="disabled">
+          Disabled
+        </Button>
+      </div>
+    );
+
+    const disabled = await screen.findByTestId('disabled');
+
+    expect(disabled.classList).toContain('amplify-button--disabled');
+  });
+
   it('should render button variations', async () => {
     render(
       <div>

--- a/packages/react/src/primitives/FieldGroupIcon/__tests__/FieldGroupIconButton.test.tsx
+++ b/packages/react/src/primitives/FieldGroupIcon/__tests__/FieldGroupIconButton.test.tsx
@@ -23,4 +23,12 @@ describe('FieldGroupIconButton: ', () => {
     await screen.findAllByTestId(testId);
     expect(ref.current.nodeName).toBe('BUTTON');
   });
+
+  it('should add the disabled button class to the underlying button element', async () => {
+    render(<FieldGroupIconButton isDisabled={true} testId="disabled" />);
+
+    const disabled = await screen.findByTestId('disabled');
+
+    expect(disabled).toHaveClass(`${ComponentClassNames.Button}--disabled`);
+  });
 });


### PR DESCRIPTION
#### Description of changes

This PR is to add the disabled class to Button primitives when the disabled attribute is present

#### Description of how you validated changes
Validated on docs site with the pagination primitive which uses an `as={Button}` that strips out the `isDisabled` property

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
