### PR TITLE
fix: Fix Guide title for Vue and Angular

### DIFF
--- a/docs/src/components/Layout/SecondaryNav.tsx
+++ b/docs/src/components/Layout/SecondaryNav.tsx
@@ -113,9 +113,11 @@ export const SecondaryNav = (props) => {
         <NavLink {...props} href="/guides">
           Guides
         </NavLink>
-        <NavLink {...props} href="/guides/auth-protected">
-          Protected Routes
-        </NavLink>
+        {platform === 'react' && (
+          <NavLink {...props} href="/guides/auth-protected">
+            Protected Routes
+          </NavLink>
+        )}
       </>
     );
   }

--- a/docs/src/pages/guides/auth-protected/index.page.mdx
+++ b/docs/src/pages/guides/auth-protected/index.page.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to create a React application with protected routes using the Authenticator component
+title: How to create an application with protected routes using the Authenticator component
 ---
 
 import { Fragment } from '@/components/Fragment';


### PR DESCRIPTION
#### Description of changes
The guides for Angular and Vue show under protected routes `How to create a React application with protected routes using the Authenticator component`

This should be hidden instead, and only show for React.

#### Issue #, if available

fixes #1874 

#### Description of how you validated changes
Manual

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
