### PR TITLE
bug(fix): PhoneNumberField does not honor readonly prop

### DIFF
--- a/.changeset/serious-geckos-act.md
+++ b/.changeset/serious-geckos-act.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+bug(fix): PhoneNumberField does not honor readonly prop

--- a/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
@@ -12,6 +12,7 @@ const CountryCodeSelectPrimitive: Primitive<CountryCodeSelectProps, 'select'> =
     const countryCodeOptions = React.useMemo(
       () =>
         dialList.map((dialCode) => (
+          // Regarding the `disabled` attribute, see comment in SelectField below
           <option key={dialCode} value={dialCode} disabled={isReadOnly}>
             {dialCode}
           </option>
@@ -21,6 +22,10 @@ const CountryCodeSelectPrimitive: Primitive<CountryCodeSelectProps, 'select'> =
 
     return (
       <SelectField
+        /*
+          Since <select> elements do not support the `readonly` html attribute, it is suggested to use the `disabled` html attribute 
+          so that a screen reader will announce something to the user about the interactivity of the options list ( https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
+        */
         aria-disabled={isReadOnly}
         autoComplete="tel-country-code"
         className={classNames(ComponentClassNames.CountryCodeSelect, className)}

--- a/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/CountryCodeSelect.tsx
@@ -7,20 +7,21 @@ import { CountryCodeSelectProps, Primitive } from '../types';
 import { SelectField } from '../SelectField';
 
 const CountryCodeSelectPrimitive: Primitive<CountryCodeSelectProps, 'select'> =
-  ({ className, dialCodeList, ...props }, ref) => {
+  ({ className, dialCodeList, isReadOnly, ...props }, ref) => {
     const dialList = dialCodeList ?? countryDialCodes;
     const countryCodeOptions = React.useMemo(
       () =>
         dialList.map((dialCode) => (
-          <option key={dialCode} value={dialCode}>
+          <option key={dialCode} value={dialCode} disabled={isReadOnly}>
             {dialCode}
           </option>
         )),
-      [dialList]
+      [dialList, isReadOnly]
     );
 
     return (
       <SelectField
+        aria-disabled={isReadOnly}
         autoComplete="tel-country-code"
         className={classNames(ComponentClassNames.CountryCodeSelect, className)}
         labelHidden={true}

--- a/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
@@ -16,6 +16,7 @@ const PhoneNumberFieldPrimitive: Primitive<PhoneNumberFieldProps, 'input'> = (
     defaultCountryCode,
     hasError,
     isDisabled,
+    isReadOnly,
     onCountryCodeChange,
     onInput,
     size,
@@ -36,6 +37,7 @@ const PhoneNumberFieldPrimitive: Primitive<PhoneNumberFieldProps, 'input'> = (
           className={className}
           hasError={hasError}
           isDisabled={isDisabled}
+          isReadOnly={isReadOnly}
           label={countryCodeLabel}
           name={countryCodeName}
           onChange={onCountryCodeChange}
@@ -48,6 +50,7 @@ const PhoneNumberFieldPrimitive: Primitive<PhoneNumberFieldProps, 'input'> = (
       className={classNames(ComponentClassNames.PhoneNumberField, className)}
       hasError={hasError}
       isDisabled={isDisabled}
+      isReadOnly={isReadOnly}
       isMultiline={false}
       onInput={onInput}
       ref={ref}

--- a/packages/react/src/primitives/PhoneNumberField/__tests__/PhoneNumberField.test.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/__tests__/PhoneNumberField.test.tsx
@@ -7,6 +7,9 @@ import { Flex } from '../../Flex';
 import { Button } from '../../Button';
 import { ComponentClassNames } from '../../shared/constants';
 
+const originalLog = console.log;
+console.log = jest.fn();
+
 describe('PhoneNumberField primitive', () => {
   const setup = async ({
     defaultCountryCode = '+1',
@@ -30,9 +33,6 @@ describe('PhoneNumberField primitive', () => {
       }),
     };
   };
-
-  const originalLog = console.log;
-  console.log = jest.fn();
 
   const ReadOnlyFormTest = () => {
     const inputRef = React.useRef(null);
@@ -166,6 +166,10 @@ describe('PhoneNumberField primitive', () => {
     expect(onCountryCodeChange).toHaveBeenCalled();
   });
 
+  /*
+    Since <select> elements do not support the `readonly` html attribute, it is suggested to use the `disabled` html attribute 
+    so that a screen reader will announce something to the user about the interactivity of the options list ( https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
+  */
   it('should set aria-disabled="true" when the isReadOnly prop is passed, and disable all the select options', async () => {
     const { $countryCodeSelector } = await setup({ isReadOnly: true });
 

--- a/packages/react/src/primitives/types/phoneNumberField.ts
+++ b/packages/react/src/primitives/types/phoneNumberField.ts
@@ -19,4 +19,5 @@ export interface PhoneNumberFieldProps extends TextInputFieldProps {
 export interface CountryCodeSelectProps extends SelectFieldProps {
   defaultValue: string;
   dialCodeList?: Array<string>;
+  isReadOnly?: boolean;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR address [this issue](https://github.com/aws-amplify/amplify-ui/issues/1795): "PhoneNumberField dial code dropdown doesn't honor readonly prop"

As a result of these changes, if the `isReadOnly` prop is passed to the `PhoneNumberField`:
- The `CountryCodeSelect` primitive is marked with the `aria-disabled=“true”` attribute. The reason we’re not marking it with `aria-readonly=“true”` is because that does not cause screen readers to announce anything to customers. @hbuchel 
- All the options in the `CountryCodeSelect` are marked with the `disabled` attribute because the select field should still be readable and focusable, but disallow changing the readonly selection. 
- Form data is still submitted if the `isReadOnly` prop is passed. 

![readonlygif](https://user-images.githubusercontent.com/48109584/167948973-f44be21b-c17c-4f94-8bbd-5631c6980ed3.gif)



<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-ui/issues/1795

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the docs locally and wrote some unit tests. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are updated
- [X] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
