### PR TITLE
fix(style): adjust switch track color to comply with 3:1 contrast ratio

### DIFF
--- a/docs/src/pages/components/switchfield/examples/SwitchFieldThumbColorExample.tsx
+++ b/docs/src/pages/components/switchfield/examples/SwitchFieldThumbColorExample.tsx
@@ -5,7 +5,7 @@ export const SwitchFieldThumbColorExample = () => {
   return (
     <SwitchField
       label="This is a switch"
-      thumbColor={`${tokens.colors.red[60]}`}
+      thumbColor={`${tokens.colors.yellow[20]}`}
     />
   );
 };

--- a/docs/src/pages/components/switchfield/examples/SwitchFieldThumbColorExample.tsx
+++ b/docs/src/pages/components/switchfield/examples/SwitchFieldThumbColorExample.tsx
@@ -5,7 +5,7 @@ export const SwitchFieldThumbColorExample = () => {
   return (
     <SwitchField
       label="This is a switch"
-      thumbColor={`${tokens.colors.yellow[20]}`}
+      thumbColor={`${tokens.colors.orange[10]}`}
     />
   );
 };

--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -35,6 +35,13 @@ export const theme: Theme = {
     {
       colorMode: 'dark',
       tokens: {
+        components: {
+          switchfield: {
+            thumb: {
+              backgroundColor: { value: '#fff' },
+            },
+          },
+        },
         colors: {
           red: flipPalette(defaultTheme.tokens.colors.red),
           orange: flipPalette(defaultTheme.tokens.colors.orange),

--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -35,13 +35,6 @@ export const theme: Theme = {
     {
       colorMode: 'dark',
       tokens: {
-        components: {
-          switchfield: {
-            thumb: {
-              backgroundColor: { value: '#fff' },
-            },
-          },
-        },
         colors: {
           red: flipPalette(defaultTheme.tokens.colors.red),
           orange: flipPalette(defaultTheme.tokens.colors.orange),

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -497,7 +497,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-select-large-min-width: 7.5rem;
         --amplify-components-selectfield-flex-direction: column;
         --amplify-components-sliderfield-padding-block: var(--amplify-space-xs);
-        --amplify-components-sliderfield-track-background-color: var(--amplify-colors-background-tertiary);
+        --amplify-components-sliderfield-track-background-color: var(--amplify-colors-background-quaternary);
         --amplify-components-sliderfield-track-border-radius: 9999px;
         --amplify-components-sliderfield-track-height: 0.375rem;
         --amplify-components-sliderfield-track-min-width: 10rem;
@@ -537,9 +537,9 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-switchfield-thumb-checked-transform: var(--amplify-transforms-slide-x-medium);
         --amplify-components-switchfield-thumb-transition-duration: var(--amplify-time-medium);
         --amplify-components-switchfield-thumb-width: var(--amplify-space-relative-medium);
-        --amplify-components-switchfield-track-background-color: var(--amplify-colors-background-tertiary);
+        --amplify-components-switchfield-track-background-color: var(--amplify-colors-background-quaternary);
         --amplify-components-switchfield-track-border-radius: var(--amplify-radii-xxxl);
-        --amplify-components-switchfield-track-checked-background-color: var(--amplify-colors-brand-primary-60);
+        --amplify-components-switchfield-track-checked-background-color: var(--amplify-colors-brand-primary-80);
         --amplify-components-switchfield-track-height: var(--amplify-space-relative-medium);
         --amplify-components-switchfield-track-padding: var(--amplify-outline-widths-medium);
         --amplify-components-switchfield-track-transition-duration: var(--amplify-time-short);
@@ -726,7 +726,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-colors-neutral-10: hsl(210, 5%, 98%);
         --amplify-colors-neutral-20: hsl(210, 5%, 94%);
         --amplify-colors-neutral-40: hsl(210, 5%, 87%);
-        --amplify-colors-neutral-60: hsl(210, 6%, 70%);
+        --amplify-colors-neutral-60: hsl(210, 8%, 55%);
         --amplify-colors-neutral-80: hsl(210, 10%, 40%);
         --amplify-colors-neutral-90: hsl(210, 25%, 25%);
         --amplify-colors-neutral-100: hsl(210, 50%, 10%);
@@ -760,6 +760,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-colors-background-primary: var(--amplify-colors-white);
         --amplify-colors-background-secondary: var(--amplify-colors-neutral-10);
         --amplify-colors-background-tertiary: var(--amplify-colors-neutral-20);
+        --amplify-colors-background-quaternary: var(--amplify-colors-neutral-60);
         --amplify-colors-background-disabled: var(--amplify-colors-background-tertiary);
         --amplify-colors-background-info: var(--amplify-colors-blue-20);
         --amplify-colors-background-warning: var(--amplify-colors-orange-20);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -531,7 +531,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-select-large-min-width: 7.5rem;
         --amplify-components-selectfield-flex-direction: column;
         --amplify-components-sliderfield-padding-block: var(--amplify-space-xs);
-        --amplify-components-sliderfield-track-background-color: var(--amplify-colors-background-tertiary);
+        --amplify-components-sliderfield-track-background-color: var(--amplify-colors-background-quaternary);
         --amplify-components-sliderfield-track-border-radius: 9999px;
         --amplify-components-sliderfield-track-height: 0.375rem;
         --amplify-components-sliderfield-track-min-width: 10rem;
@@ -571,9 +571,9 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-switchfield-thumb-checked-transform: var(--amplify-transforms-slide-x-medium);
         --amplify-components-switchfield-thumb-transition-duration: var(--amplify-time-medium);
         --amplify-components-switchfield-thumb-width: var(--amplify-space-relative-medium);
-        --amplify-components-switchfield-track-background-color: var(--amplify-colors-background-tertiary);
+        --amplify-components-switchfield-track-background-color: var(--amplify-colors-background-quaternary);
         --amplify-components-switchfield-track-border-radius: var(--amplify-radii-xxxl);
-        --amplify-components-switchfield-track-checked-background-color: var(--amplify-colors-brand-primary-60);
+        --amplify-components-switchfield-track-checked-background-color: var(--amplify-colors-brand-primary-80);
         --amplify-components-switchfield-track-height: var(--amplify-space-relative-medium);
         --amplify-components-switchfield-track-padding: var(--amplify-outline-widths-medium);
         --amplify-components-switchfield-track-transition-duration: var(--amplify-time-short);
@@ -760,7 +760,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-colors-neutral-10: hsl(210, 5%, 98%);
         --amplify-colors-neutral-20: hsl(210, 5%, 94%);
         --amplify-colors-neutral-40: hsl(210, 5%, 87%);
-        --amplify-colors-neutral-60: hsl(210, 6%, 70%);
+        --amplify-colors-neutral-60: hsl(210, 8%, 55%);
         --amplify-colors-neutral-80: hsl(210, 10%, 40%);
         --amplify-colors-neutral-90: hsl(210, 25%, 25%);
         --amplify-colors-neutral-100: hsl(210, 50%, 10%);
@@ -794,6 +794,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-colors-background-primary: var(--amplify-colors-white);
         --amplify-colors-background-secondary: var(--amplify-colors-neutral-10);
         --amplify-colors-background-tertiary: var(--amplify-colors-neutral-20);
+        --amplify-colors-background-quaternary: var(--amplify-colors-neutral-60);
         --amplify-colors-background-disabled: var(--amplify-colors-background-tertiary);
         --amplify-colors-background-info: var(--amplify-colors-blue-20);
         --amplify-colors-background-warning: var(--amplify-colors-orange-20);

--- a/packages/ui/src/theme/tokens/colors.ts
+++ b/packages/ui/src/theme/tokens/colors.ts
@@ -181,7 +181,7 @@ export const colors: Colors = {
     10: { value: 'hsl(210, 5%, 98%)' },
     20: { value: 'hsl(210, 5%, 94%)' },
     40: { value: 'hsl(210, 5%, 87%)' },
-    60: { value: 'hsl(210, 6%, 70%)' },
+    60: { value: 'hsl(210, 8%, 55%)' },
     80: { value: 'hsl(210, 10%, 40%)' },
     90: { value: 'hsl(210, 25%, 25%)' },
     100: { value: 'hsl(210, 50%, 10%)' },
@@ -234,6 +234,7 @@ export const colors: Colors = {
     primary: { value: '{colors.white.value}' },
     secondary: { value: '{colors.neutral.10.value}' },
     tertiary: { value: '{colors.neutral.20.value}' },
+    quaternary: { value: '{colors.neutral.60.value}' },
     disabled: { value: '{colors.background.tertiary.value}' },
 
     info: { value: '{colors.blue.20.value}' },

--- a/packages/ui/src/theme/tokens/components/sliderField.ts
+++ b/packages/ui/src/theme/tokens/components/sliderField.ts
@@ -83,7 +83,7 @@ export const sliderfield: SliderFieldTokens = {
 
   // The track is the thin background of the slider
   track: {
-    backgroundColor: { value: '{colors.background.tertiary.value}' },
+    backgroundColor: { value: '{colors.background.quaternary.value}' },
     borderRadius: { value: '9999px' },
     height: { value: '0.375rem' },
     minWidth: { value: '10rem' },

--- a/packages/ui/src/theme/tokens/components/switchField.ts
+++ b/packages/ui/src/theme/tokens/components/switchField.ts
@@ -115,10 +115,10 @@ export const switchfield: SwitchFieldTokens = {
   },
 
   track: {
-    backgroundColor: { value: '{colors.background.tertiary.value}' },
+    backgroundColor: { value: '{colors.background.quaternary.value}' },
     borderRadius: { value: '{radii.xxxl.value}' },
     checked: {
-      backgroundColor: { value: '{colors.brand.primary.60.value}' },
+      backgroundColor: { value: '{colors.brand.primary.80.value}' },
     },
     height: { value: '{space.relative.medium.value}' },
     padding: { value: '{outlineWidths.medium.value}' },

--- a/packages/ui/src/theme/tokens/types/scales.ts
+++ b/packages/ui/src/theme/tokens/types/scales.ts
@@ -4,6 +4,7 @@ export interface OrdinalScale<DesignTokenType = DesignToken<ColorValue>> {
   primary: DesignTokenType;
   secondary: DesignTokenType;
   tertiary: DesignTokenType;
+  quaternary?: DesignTokenType;
 }
 
 export interface OrdinalVariation<DesignTokenType = DesignToken<ColorValue>> {


### PR DESCRIPTION
#### Description of changes

1. Bump up neutral-60 to 3:1 ratio compared with white

2. Update track background color of switch and slider to use neutral-60

#### Issue #, if available

Fixes #1820 

#### Description of how you validated changes

| Light   | Dark |
| ----------- | ----------- |
| ![Screen Shot 2022-05-11 at 2 49 55 PM](https://user-images.githubusercontent.com/40295569/167958556-d4b98988-2d2a-47d9-9bfc-243a37518cb5.png) | ![Screen Shot 2022-05-11 at 2 51 40 PM](https://user-images.githubusercontent.com/40295569/167958566-5fbbfdde-e1f7-4bf7-9907-23fab667e847.png)  |
| ![Screen Shot 2022-05-11 at 3 02 07 PM](https://user-images.githubusercontent.com/40295569/167958630-ae07c656-f008-4a63-a01e-a60e818efa8b.png) | ![Screen Shot 2022-05-11 at 3 28 09 PM](https://user-images.githubusercontent.com/40295569/167958644-ac1cdaeb-6f94-43a2-8958-93a4b470cf48.png) |


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
