### PR TITLE
feat(ci): Run build test before publishing to latest

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -1,7 +1,7 @@
 name: Publish to latest
 
 on:
-  pull_request:
+  push:
     branches: [main]
 
 permissions:
@@ -25,7 +25,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     needs: setup
-    # if: ${{ needs.setup.outputs.has-changesets != 'true' }}
+    if: ${{ needs.setup.outputs.has-changesets != 'true' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -59,9 +59,9 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    # environment: ci
+    environment: ci
     needs: build-test
-    # if: ${{ needs.setup.outputs.has-changesets != 'true' }}
+    if: ${{ needs.setup.outputs.has-changesets != 'true' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -76,10 +76,9 @@ jobs:
       - name: Install and build packages
         run: yarn --frozen-lockfile && yarn build
       - name: Publish to @latest
-        run: echo "mock publish"
-      #   uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
-      #   with:
-      #     publish: yarn publish:latest
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
+        with:
+          publish: yarn publish:latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -22,10 +22,45 @@ jobs:
         id: has-changesets
         uses: ./.github/actions/has-changesets
 
+  build-test:
+    runs-on: ubuntu-latest
+    needs: setup
+    if: ${{ needs.setup.outputs.has-changesets != 'true' }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Add Amplify CLI
+        run: yarn global add @aws-amplify/cli
+      - name: Get CLI versions
+        id: cli-version
+        run: echo "::set-output name=version::$(amplify --version)"
+      - name: Create or restore environments cache
+        id: environments-cache
+        uses: actions/cache@v2
+        with:
+          path: canary/environments/**/aws-exports.js
+          key: ${{ runner.os }}-canary-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('canary/environments/**/amplify/**') }}
+      - name: Pull down AWS environments
+        if: steps.environments-cache.outputs.cache-hit != 'true'
+        run: yarn pull
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        working-directory: ./canary
+      - name: Setup canary apps against @next
+        run: yarn setup:next
+        working-directory: ./canary
+      - name: Run yarn install on each sample app
+        run: yarn install
+        working-directory: ./canary
+      - name: Run yarn build on each sample app
+        run: yarn build
+        working-directory: ./canary
+
   publish:
     runs-on: ubuntu-latest
     environment: ci
-    needs: setup
+    needs: build-test
     if: ${{ needs.setup.outputs.has-changesets != 'true' }}
     steps:
       - name: Checkout repo

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -25,6 +25,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     needs: setup
+    environment: ci
     if: ${{ needs.setup.outputs.has-changesets != 'true' }}
     steps:
       - name: Checkout repo

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -1,7 +1,7 @@
 name: Publish to latest
 
 on:
-  push:
+  pull_request:
     branches: [main]
 
 permissions:
@@ -25,7 +25,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     needs: setup
-    if: ${{ needs.setup.outputs.has-changesets != 'true' }}
+    # if: ${{ needs.setup.outputs.has-changesets != 'true' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -59,9 +59,9 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    environment: ci
+    # environment: ci
     needs: build-test
-    if: ${{ needs.setup.outputs.has-changesets != 'true' }}
+    # if: ${{ needs.setup.outputs.has-changesets != 'true' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -76,9 +76,10 @@ jobs:
       - name: Install and build packages
         run: yarn --frozen-lockfile && yarn build
       - name: Publish to @latest
-        uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
-        with:
-          publish: yarn publish:latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: echo "mock publish"
+      #   uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
+      #   with:
+      #     publish: yarn publish:latest
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This adds "canary" build tests before `publish-latest` workflow publishes to `@latest`. One less manual step we need to worry about!

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Test run here: https://github.com/aws-amplify/amplify-ui/actions/runs/2310172534

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
