### PR TITLE
feat(ci): Add continuous deployment to @studio tag

### DIFF
--- a/.github/workflows/test-deploy-studio.yml
+++ b/.github/workflows/test-deploy-studio.yml
@@ -8,7 +8,7 @@ concurrency:
 
 on:
   push:
-    branches: [ui-geo/main]
+    branches: [studio]
 
 jobs:
   setup:
@@ -315,13 +315,13 @@ jobs:
         run: yarn --frozen-lockfile && yarn build
       - name: Bump ui and ui-react packages
         run: cp .github/changeset-presets/bump-react.md .changeset
-      - name: Run changeset version to geo tag
-        run: yarn changeset version --snapshot geo-$(git rev-parse --short=7 HEAD) && yarn angular build
+      - name: Run changeset version to studio tag
+        run: yarn version:studio
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create .npmrc
         run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Publish to geo tag
-        run: yarn changeset publish --tag geo
+      - name: Publish to studio tag
+        run: yarn publish:studio

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "prepare": "husky install",
     "version:next": "yarn changeset version --snapshot next-$(git rev-parse --short=7 HEAD) && yarn angular build",
     "publish:next": "yarn changeset publish --tag next",
+    "version:studio": "yarn changeset version --snapshot studio-$(git rev-parse --short=7 HEAD) && yarn angular build",
+    "publish:studio": "yarn changeset publish --tag studio",
     "version:latest": "yarn changeset version && yarn angular build",
     "publish:latest": "yarn changeset publish"
   },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This adds continuous deployment to `studio` tag. To do so, we simply modifying the stale `test-deploy-geo.yml` to have it point to `@studio` instead of `@geo`. To my knowledge, `@geo` tag can now be replaced by our usual deployment to `@next`, so we should be safe to make this change.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
