### PR TITLE
fix(geo): Point to react-map-gl es5 bundle

### DIFF
--- a/.changeset/fast-chefs-rest.md
+++ b/.changeset/fast-chefs-rest.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(geo): Point to react-map-gl es5 bundle to mitigate es2020 build errors

--- a/packages/react/src/components/Geo/Geocoder/index.tsx
+++ b/packages/react/src/components/Geo/Geocoder/index.tsx
@@ -1,7 +1,7 @@
 import maplibregl from 'maplibre-gl';
 import { createAmplifyGeocoder } from 'maplibre-gl-js-amplify';
 import { useEffect, useRef } from 'react';
-import { useControl, useMap } from 'react-map-gl';
+import { useControl, useMap } from 'react-map-gl/dist/es5';
 import type { IControl } from 'react-map-gl';
 
 const GEOCODER_OPTIONS = {

--- a/packages/react/src/components/Geo/MapView/index.tsx
+++ b/packages/react/src/components/Geo/MapView/index.tsx
@@ -2,7 +2,7 @@ import { Amplify, Auth } from 'aws-amplify';
 import maplibregl from 'maplibre-gl';
 import { AmplifyMapLibreRequest } from 'maplibre-gl-js-amplify';
 import React, { forwardRef, useEffect, useMemo, useState } from 'react';
-import ReactMapGL from 'react-map-gl';
+import ReactMapGL from 'react-map-gl/dist/es5';
 import type { MapProps, MapRef, TransformRequestFunction } from 'react-map-gl';
 
 export type MapViewProps = Omit<MapProps, 'transformRequest'>;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Some users have reported issues with ES 2020 features that are used by our `react-map-gl` dependency and certain build tools that they're using (e.g. Create React App v4). This PR updates our use of `react-map-gl` to point to the ES5-compatible bundle provided by the library which will mitigate issues related to ES 2020 features.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#1656 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually validated this change by sym-linking it to a CRA4 sample application using the `<MapView>` component and verified that there were no build issues and the [workaround suggested in #1656](https://github.com/aws-amplify/amplify-ui/issues/1656#issuecomment-1095389881) is not needed.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated - N/A
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated - N/A
- [x] Relevant documentation is changed or added (and PR referenced) - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
