### PR TITLE
update scrollability and width values for view docs on mobile

### DIFF
--- a/docs/src/components/Demo.tsx
+++ b/docs/src/components/Demo.tsx
@@ -43,7 +43,7 @@ export const Demo = ({
         alignItems="stretch"
       >
         <Flex direction="column" flex="1">
-          <View>{children}</View>
+          <View overflow="auto">{children}</View>
           {propControls && (
             <Tabs>
               <TabItem title="Props">
@@ -58,7 +58,7 @@ export const Demo = ({
         </Flex>
         <View
           flex="1"
-          maxWidth="50%"
+          overflow="auto"
           position="relative"
           backgroundColor={tokens.colors.background.secondary}
         >

--- a/docs/src/pages/components/view/ViewPropControls.tsx
+++ b/docs/src/pages/components/view/ViewPropControls.tsx
@@ -4,6 +4,7 @@ import { Flex, ViewProps, SelectField, TextField } from '@aws-amplify/ui-react';
 export interface ViewPropControlsProps extends ViewProps {
   setAriaLabel: (value: React.SetStateAction<ViewProps['ariaLabel']>) => void;
   setWidth: (value: React.SetStateAction<ViewProps['width']>) => void;
+  setMaxWidth: (value: React.SetStateAction<ViewProps['maxWidth']>) => void;
   setHeight: (value: React.SetStateAction<ViewProps['height']>) => void;
   setColor: (value: React.SetStateAction<ViewProps['color']>) => void;
   setBackgroundColor: (
@@ -31,6 +32,7 @@ export const ViewPropControls: ViewPropControlsInterface = ({
   boxShadow,
   color,
   height,
+  maxWidth,
   padding,
   setAriaLabel,
   setAsElementType,
@@ -40,6 +42,7 @@ export const ViewPropControls: ViewPropControlsInterface = ({
   setBoxShadow,
   setColor,
   setHeight,
+  setMaxWidth,
   setPadding,
   setWidth,
   width,
@@ -93,7 +96,11 @@ export const ViewPropControls: ViewPropControlsInterface = ({
         onChange={(event) => setHeight(event.target.value)}
         label="Height"
       />
-
+      <TextField
+        value={maxWidth as string}
+        onChange={(event) => setMaxWidth(event.target.value)}
+        label="Max Width"
+      />
       <TextField
         value={padding as string}
         onChange={(event) => setPadding(event.target.value)}

--- a/docs/src/pages/components/view/demo.tsx
+++ b/docs/src/pages/components/view/demo.tsx
@@ -18,6 +18,7 @@ const propsToCode = (props: ViewProps) => {
     getPropString(props.boxShadow, 'boxShadow') +
     getPropString(props.color, 'color') +
     getPropString(props.height, 'height') +
+    getPropString(props.maxWidth, 'maxWidth') +
     getPropString(props.padding, 'padding') +
     getPropString(props.width, 'width') +
     `\n  onClick={() => alert('🏔 What a beautiful <View>! 🔭')}
@@ -31,6 +32,7 @@ const defaultViewProps = {
   as: 'div',
   ariaLabel: 'View example',
   width: '20rem',
+  maxWidth: '100%',
   height: '4rem',
   color: 'var(--amplify-colors-blue-60)',
   backgroundColor: 'var(--amplify-colors-white)',
@@ -54,6 +56,7 @@ export const ViewDemo = () => {
     border,
     color,
     height,
+    maxWidth,
     padding,
     width,
   } = props;
@@ -72,6 +75,7 @@ export const ViewDemo = () => {
         boxShadow={boxShadow}
         color={color}
         height={height}
+        maxWidth={maxWidth}
         onClick={() => alert('🏔 What a beautiful <View>! 🔭')}
         padding={padding}
         width={width}

--- a/docs/src/pages/components/view/useViewProps.tsx
+++ b/docs/src/pages/components/view/useViewProps.tsx
@@ -15,6 +15,9 @@ export const useViewProps: UseViewProps = (initialValues) => {
   const [width, setWidth] = React.useState<ViewProps['width']>(
     initialValues.width
   );
+  const [maxWidth, setMaxWidth] = React.useState<ViewProps['maxWidth']>(
+    initialValues.maxWidth
+  );
   const [height, setHeight] = React.useState<ViewProps['height']>(
     initialValues.height
   );
@@ -45,6 +48,7 @@ export const useViewProps: UseViewProps = (initialValues) => {
     demoState.set(View.displayName, {
       ariaLabel,
       width,
+      maxWidth,
       height,
       color,
       backgroundColor,
@@ -57,6 +61,7 @@ export const useViewProps: UseViewProps = (initialValues) => {
   }, [
     ariaLabel,
     width,
+    maxWidth,
     height,
     color,
     backgroundColor,
@@ -73,6 +78,8 @@ export const useViewProps: UseViewProps = (initialValues) => {
       setAriaLabel,
       width,
       setWidth,
+      maxWidth,
+      setMaxWidth,
       height,
       setHeight,
       color,
@@ -95,6 +102,8 @@ export const useViewProps: UseViewProps = (initialValues) => {
       setAriaLabel,
       width,
       setWidth,
+      maxWidth,
+      setMaxWidth,
       height,
       setHeight,
       color,


### PR DESCRIPTION
#### Description of changes
Add maxWidth Value to View Demo, Update Demo to scroll if the demo is larger than avaialbe space on the screen, remove maxWidth from demo `propsToCode` for mobile view.

![Kapture 2022-05-12 at 10 00 31](https://user-images.githubusercontent.com/7351516/168129577-16c4fecf-5faf-4fb0-bd70-1a54a4e9bcd7.gif)


#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
