### PR TITLE
bug(fix): MenuItem disabled styling not applied

### DIFF
--- a/.changeset/tasty-pans-rhyme.md
+++ b/.changeset/tasty-pans-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+bug(fix): Apply styling to disabled MenuItems

--- a/packages/react/src/primitives/Menu/MenuButton.tsx
+++ b/packages/react/src/primitives/Menu/MenuButton.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import { Button } from '../Button';
 
 import { classNameModifier } from '../shared/utils';
 import { ButtonProps, PrimitiveProps } from '../types';
@@ -37,7 +38,7 @@ export const MenuButton = React.forwardRef<
     );
 
     return (
-      <button
+      <Button
         ref={ref}
         className={componentClasses}
         data-fullwidth={isFullWidth}
@@ -52,7 +53,7 @@ export const MenuButton = React.forwardRef<
         {...nonStyleProps}
       >
         {children}
-      </button>
+      </Button>
     );
   }
 );

--- a/packages/react/src/primitives/Menu/__tests_/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests_/menu.test.tsx
@@ -141,5 +141,22 @@ describe('Menu: ', () => {
         menuItem1ClassName
       );
     });
+
+    it('should add the Amplify UI Button disabled class to disabled MenuItems', async () => {
+      render(
+        <Menu isOpen>
+          {/* Force open to test menu items */}
+          <MenuItem>Option 1</MenuItem>
+          <MenuItem>Option 2</MenuItem>
+          <MenuItem isDisabled testId="disabled_option">
+            Option 3
+          </MenuItem>
+        </Menu>
+      );
+
+      const disabled = await screen.findByTestId('disabled_option');
+
+      expect(disabled).toHaveClass('amplify-button--disabled');
+    });
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

While updating the Menu docs, I noticed that there was no visual change for a disabled `MenuItem`, even though the `isDisabled` prop is getting passed through and works with screen readers. 

To fix this, I replaced the HTML `<button>` element used in `MenuButton` to our own `Button` component. This allows disabled styling to get applied to MenuItems via the `amplify-button--disabled` class (`MenuItem` renders a `MenuButton`). 

Before:
<img width="432" alt="BeforeMenuItem" src="https://user-images.githubusercontent.com/48109584/168327638-73ec2b65-b3db-49b3-ac0d-842009a7cb70.png">

After:
<img width="432" alt="AfterMenuItem" src="https://user-images.githubusercontent.com/48109584/168327681-daf28a3d-f9ab-4e91-ab51-2114b61bb5ec.png">

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the docs locally. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are updated
- [X] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
