### PR TITLE
Doc home scope

### DIFF
--- a/docs/src/pages/[platform]/index.page.tsx
+++ b/docs/src/pages/[platform]/index.page.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {
+  AmplifyProvider,
   Authenticator,
   Button,
   Card,
@@ -24,6 +25,7 @@ import { HomeLogo } from '../HomeLogo';
 import { HomePrimitivePreview } from '../HomePrimitivePreview';
 import { Sandpack } from '@codesandbox/sandpack-react';
 import type { SandpackThemeProp } from '@codesandbox/sandpack-react';
+import { theme } from '../../theme';
 import { ThemeButton } from '../ThemeButton';
 import { useCustomRouter } from '@/components/useCustomRouter';
 
@@ -95,11 +97,12 @@ const AmpCard = ({ title, description, href }) => (
   </Link>
 );
 
-const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
+const HomePage = ({ colorMode }) => {
   const {
     query: { platform = 'react' },
   } = useCustomRouter();
   const { tokens } = useTheme();
+  const [themeOverride, setThemeOverride] = React.useState('');
   const sandPackTheme: SandpackThemeProp = {
     palette: {
       activeText: `${tokens.colors.font.interactive}`,
@@ -143,313 +146,315 @@ const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
   };
   const frameworkInstallScript = installScripts[platform.toString()];
   return (
-    <>
-      <View as="section" className="container">
-        <h1 className="docs-home-logo">
-          <HomeLogo />
-        </h1>
+    <View data-amplify-theme-override={themeOverride}>
+      <AmplifyProvider theme={theme} colorMode={colorMode}>
+        <View as="section" className="container">
+          <h1 className="docs-home-logo">
+            <HomeLogo />
+          </h1>
 
-        <Flex
-          direction={{ base: 'column', medium: 'row' }}
+          <Flex
+            direction={{ base: 'column', medium: 'row' }}
+            padding={tokens.space.large}
+          >
+            <Card variation="outlined" flex="1">
+              <Text
+                fontSize={{
+                  base: tokens.fontSizes.large,
+                  small: tokens.fontSizes.xl,
+                }}
+              >
+                Amplify UI is an open-source design system with cloud-connected
+                components and primitives that simplify building accessible,
+                performant, and beautiful applications in React, Angular, Vue,
+                and Flutter (more coming soon).
+              </Text>
+
+              <Flex
+                direction={{ base: 'column-reverse', medium: 'row' }}
+                padding={`${tokens.space.medium} 0 0 0`}
+              >
+                <Button
+                  size="large"
+                  variation="primary"
+                  as="a"
+                  href={`/${platform}/getting-started/installation`}
+                >
+                  Get started
+                  <IconChevronRight />
+                </Button>
+                <code className="install-code__container">
+                  <p className="install-code__content">
+                    {frameworkInstallScript}
+                  </p>
+                  <Copy
+                    className="install-code__button"
+                    size=""
+                    variation="link"
+                    text={frameworkInstallScript}
+                  />
+                </code>
+              </Flex>
+            </Card>
+            <Flex
+              alignSelf="center"
+              textAlign="center"
+              flex="1"
+              display={{ base: 'none', large: 'initial' }}
+            >
+              <Image
+                alt="React logo"
+                className="docs-home-react"
+                src="/svg/integrations/react.svg"
+              />
+              <Image
+                alt="Angular logo"
+                className="docs-home-angular"
+                src="/svg/integrations/angular.svg"
+              />
+              <Image
+                alt="Vue logo"
+                className="docs-home-vue"
+                src="/svg/integrations/vue.svg"
+              />
+              <Image
+                alt="Flutter logo"
+                className="docs-home-flutter"
+                src="/svg/integrations/flutter.svg"
+              />
+            </Flex>
+          </Flex>
+        </View>
+        <View
+          backgroundColor={tokens.colors.background.secondary}
           padding={tokens.space.large}
         >
-          <Card variation="outlined" flex="1">
-            <Text
-              fontSize={{
-                base: tokens.fontSizes.large,
-                small: tokens.fontSizes.xl,
-              }}
-            >
-              Amplify UI is an open-source design system with cloud-connected
-              components and primitives that simplify building accessible,
-              performant, and beautiful applications in React, Angular, Vue, and
-              Flutter (more coming soon).
-            </Text>
-
-            <Flex
-              direction={{ base: 'column-reverse', medium: 'row' }}
-              padding={`${tokens.space.medium} 0 0 0`}
-            >
-              <Button
-                size="large"
-                variation="primary"
-                as="a"
-                href={`/${platform}/getting-started/installation`}
-              >
-                Get started
-                <IconChevronRight />
-              </Button>
-              <code className="install-code__container">
-                <p className="install-code__content">
-                  {frameworkInstallScript}
-                </p>
-                <Copy
-                  className="install-code__button"
-                  size=""
-                  variation="link"
-                  text={frameworkInstallScript}
-                />
-              </code>
-            </Flex>
-          </Card>
-          <Flex
-            alignSelf="center"
-            textAlign="center"
-            flex="1"
-            display={{ base: 'none', large: 'initial' }}
-          >
-            <Image
-              alt="React logo"
-              className="docs-home-react"
-              src="/svg/integrations/react.svg"
-            />
-            <Image
-              alt="Angular logo"
-              className="docs-home-angular"
-              src="/svg/integrations/angular.svg"
-            />
-            <Image
-              alt="Vue logo"
-              className="docs-home-vue"
-              src="/svg/integrations/vue.svg"
-            />
-            <Image
-              alt="Flutter logo"
-              className="docs-home-flutter"
-              src="/svg/integrations/flutter.svg"
-            />
-          </Flex>
-        </Flex>
-      </View>
-      <View
-        backgroundColor={tokens.colors.background.secondary}
-        padding={tokens.space.large}
-      >
-        <Heading level={2} textAlign="center" margin={tokens.space.large}>
-          Take it for a test drive
-        </Heading>
-        <View className="container">
-          <Card style={{ width: '100%', padding: 0 }} variation="outlined">
-            <Sandpack
-              template="react"
-              files={{
-                '/App.js': { code: code, active: true },
-                '/theme.js': { code: themeCode },
-              }}
-              theme={sandPackTheme}
-              options={{
-                autorun: false,
-                editorHeight: 500,
-                showNavigator: true, // this will show a top navigator bar instead of the refresh button
-                showTabs: true, // you can toggle the tabs on/off manually
-                showLineNumbers: true, // this is off by default, but you can show line numbers for the editor
-                wrapContent: true, // also off by default, this wraps the code instead of creating horizontal overflow
-              }}
-              customSetup={{
-                dependencies: {
-                  '@aws-amplify/ui-react': 'latest',
-                  'aws-amplify': 'latest',
-                },
-                entry: '/index.js',
-              }}
-            />
-          </Card>
-        </View>
-      </View>
-
-      <View as="section" className="docs-home-section container">
-        <Flex
-          direction={{
-            base: 'column-reverse',
-            large: 'row',
-          }}
-        >
-          <View flex="1" className="example">
-            <Authenticator
-              socialProviders={['amazon', 'apple', 'facebook', 'google']}
-            />
+          <Heading level={2} textAlign="center" margin={tokens.space.large}>
+            Take it for a test drive
+          </Heading>
+          <View className="container">
+            <Card style={{ width: '100%', padding: 0 }} variation="outlined">
+              <Sandpack
+                template="react"
+                files={{
+                  '/App.js': { code: code, active: true },
+                  '/theme.js': { code: themeCode },
+                }}
+                theme={sandPackTheme}
+                options={{
+                  autorun: false,
+                  editorHeight: 500,
+                  showNavigator: true, // this will show a top navigator bar instead of the refresh button
+                  showTabs: true, // you can toggle the tabs on/off manually
+                  showLineNumbers: true, // this is off by default, but you can show line numbers for the editor
+                  wrapContent: true, // also off by default, this wraps the code instead of creating horizontal overflow
+                }}
+                customSetup={{
+                  dependencies: {
+                    '@aws-amplify/ui-react': 'latest',
+                    'aws-amplify': 'latest',
+                  },
+                  entry: '/index.js',
+                }}
+              />
+            </Card>
           </View>
-          <Flex flex="1" direction="column" alignItems="flex-start">
-            <Heading level={2}>Cloud-Connected Components</Heading>
-            <Text className="docs-home-description">
-              Simplify complex cloud-connected workflows like authentication
-              with minimal boilerplate code.
-            </Text>
-            <Button
-              as="a"
-              size="large"
-              href={`/${platform}/components/authenticator`}
-              isFullWidth
-            >
-              Authenticator
-              <IconChevronRight />
-            </Button>
-          </Flex>
-        </Flex>
-      </View>
+        </View>
 
-      <View
-        as="section"
-        className="docs-home-section"
-        backgroundColor={tokens.colors.background.secondary}
-      >
-        <Flex
-          className="container"
-          direction={{
-            base: 'column',
-            large: 'row',
-          }}
-        >
-          <Flex flex="1" direction="column" alignItems="flex-start">
-            <Heading level={2}>Theming</Heading>
-            <Text className="docs-home-description">
-              Theming capabilities that allow you to customize the appearance of
-              Amplify UI to match your brand.
-            </Text>
-            <Button as="a" size="large" href={`/${platform}/theming/`}>
-              Get started with theming
-              <IconChevronRight />
-            </Button>
-          </Flex>
+        <View as="section" className="docs-home-section container">
           <Flex
-            flex="1"
-            alignContent="center"
-            padding={{
-              base: '0',
-              large: tokens.space.large,
+            direction={{
+              base: 'column-reverse',
+              large: 'row',
             }}
           >
-            <ToggleButtonGroup
-              width="100%"
-              value={themeOverride}
-              isExclusive
-              onChange={(value: string) => setThemeOverride(value)}
-            >
-              <ToggleButton value="" flex="1">
-                <ThemeButton
-                  label="Default"
-                  colors={[
-                    'var(--amplify-colors-teal-60)',
-                    'var(--amplify-colors-purple-60)',
-                  ]}
-                />
-              </ToggleButton>
-              <ToggleButton value="terminal" flex="1">
-                <ThemeButton label="Terminal" colors={['#44AF5B', '#000']} />
-              </ToggleButton>
-              <ToggleButton value="classic" flex="1">
-                <ThemeButton
-                  label="Classic"
-                  colors={[
-                    'var(--amplify-colors-blue-60)',
-                    'var(--amplify-colors-neutral-60)',
-                  ]}
-                />
-              </ToggleButton>
-            </ToggleButtonGroup>
-          </Flex>
-        </Flex>
-      </View>
-
-      <View as="section" className="docs-home-section">
-        <Flex
-          className="container"
-          direction={{
-            base: 'column',
-            large: 'row',
-          }}
-          gap={tokens.space.xxl}
-        >
-          <View maxWidth="100%" overflow="hidden">
-            <HomePrimitivePreview />
-          </View>
-          <Flex flex="1" direction="column" alignItems="flex-start">
-            <Heading level={2}>Primitive Components</Heading>
-            <Text className="docs-home-description">
-              Primitive components that create consistency across Amplify UI and
-              allow you to build complete applications that fit your brand, like
-              Buttons and Badges.
-            </Text>
-            <Button
-              as="a"
-              size="large"
-              href={`/${platform}/components/authenticator`}
-            >
-              Get started with components
-              <IconChevronRight />
-            </Button>
-          </Flex>
-        </Flex>
-      </View>
-
-      <View
-        as="section"
-        className="docs-home-section"
-        backgroundColor={tokens.colors.background.secondary}
-      >
-        <Flex
-          className="container"
-          direction={{
-            base: 'column',
-            large: 'row',
-          }}
-        >
-          <View flex="1">
-            <Heading level={2}>Accessibility</Heading>
-            <Text className="docs-home-description">
-              Amplify UI components follow{' '}
-              <Link
-                isExternal
-                href="https://www.w3.org/WAI/standards-guidelines/wcag/"
+            <View flex="1" className="example">
+              <Authenticator
+                socialProviders={['amazon', 'apple', 'facebook', 'google']}
+              />
+            </View>
+            <Flex flex="1" direction="column" alignItems="flex-start">
+              <Heading level={2}>Cloud-Connected Components</Heading>
+              <Text className="docs-home-description">
+                Simplify complex cloud-connected workflows like authentication
+                with minimal boilerplate code.
+              </Text>
+              <Button
+                as="a"
+                size="large"
+                href={`/${platform}/components/authenticator`}
+                isFullWidth
               >
-                WCAG
-              </Link>{' '}
-              and{' '}
-              <Link isExternal href="https://www.w3.org/TR/wai-aria-1.2/">
-                WAI-ARIA
-              </Link>{' '}
-              best practices and guidelines such as color contrast, keyboard
-              navigation, accessible labels, and focus management.
-            </Text>
-          </View>
-          <View flex="1"></View>
-        </Flex>
-      </View>
+                Authenticator
+                <IconChevronRight />
+              </Button>
+            </Flex>
+          </Flex>
+        </View>
 
-      <View as="section" className="docs-home-section">
-        <Heading level={2} textAlign="center" margin={tokens.space.large}>
-          Looking for other Amplify Products?
-        </Heading>
-        <Grid
-          className="container"
-          templateColumns={{ base: '1fr', medium: '1fr 1fr' }}
-          gap={tokens.space.medium}
-          flex="1"
+        <View
+          as="section"
+          className="docs-home-section"
+          backgroundColor={tokens.colors.background.secondary}
         >
-          <AmpCard
-            href="https://docs.amplify.aws/lib/q/platform/js/"
-            title="Amplify Libraries"
-            description="Connect app to new or existing AWS services (Cognito, S3, and more)."
-          />
-          <AmpCard
-            href="https://docs.amplify.aws/cli/"
-            title="Amplify CLI"
-            description="Configure an app backend with a guided CLI workflow."
-          />
-          <AmpCard
-            href="https://docs.amplify.aws/console/"
-            title="Amplify Hosting"
-            description="Fully managed web hosting with full-stack CI/CD."
-          />
-          <AmpCard
-            href="https://docs.amplify.aws/console/"
-            title="Amplify Studio"
-            description="Visual development environment to accelerate full-stack development."
-          />
-        </Grid>
-      </View>
-      <Footer />
-    </>
+          <Flex
+            className="container"
+            direction={{
+              base: 'column',
+              large: 'row',
+            }}
+          >
+            <Flex flex="1" direction="column" alignItems="flex-start">
+              <Heading level={2}>Theming</Heading>
+              <Text className="docs-home-description">
+                Theming capabilities that allow you to customize the appearance
+                of Amplify UI to match your brand.
+              </Text>
+              <Button as="a" size="large" href={`/${platform}/theming/`}>
+                Get started with theming
+                <IconChevronRight />
+              </Button>
+            </Flex>
+            <Flex
+              flex="1"
+              alignContent="center"
+              padding={{
+                base: '0',
+                large: tokens.space.large,
+              }}
+            >
+              <ToggleButtonGroup
+                width="100%"
+                value={themeOverride}
+                isExclusive
+                onChange={(value: string) => setThemeOverride(value)}
+              >
+                <ToggleButton value="" flex="1">
+                  <ThemeButton
+                    label="Default"
+                    colors={[
+                      'var(--amplify-colors-teal-60)',
+                      'var(--amplify-colors-purple-60)',
+                    ]}
+                  />
+                </ToggleButton>
+                <ToggleButton value="terminal" flex="1">
+                  <ThemeButton label="Terminal" colors={['#44AF5B', '#000']} />
+                </ToggleButton>
+                <ToggleButton value="classic" flex="1">
+                  <ThemeButton
+                    label="Classic"
+                    colors={[
+                      'var(--amplify-colors-blue-60)',
+                      'var(--amplify-colors-neutral-60)',
+                    ]}
+                  />
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </Flex>
+          </Flex>
+        </View>
+
+        <View as="section" className="docs-home-section">
+          <Flex
+            className="container"
+            direction={{
+              base: 'column',
+              large: 'row',
+            }}
+            gap={tokens.space.xxl}
+          >
+            <View maxWidth="100%" overflow="hidden">
+              <HomePrimitivePreview />
+            </View>
+            <Flex flex="1" direction="column" alignItems="flex-start">
+              <Heading level={2}>Primitive Components</Heading>
+              <Text className="docs-home-description">
+                Primitive components that create consistency across Amplify UI
+                and allow you to build complete applications that fit your
+                brand, like Buttons and Badges.
+              </Text>
+              <Button
+                as="a"
+                size="large"
+                href={`/${platform}/components/authenticator`}
+              >
+                Get started with components
+                <IconChevronRight />
+              </Button>
+            </Flex>
+          </Flex>
+        </View>
+
+        <View
+          as="section"
+          className="docs-home-section"
+          backgroundColor={tokens.colors.background.secondary}
+        >
+          <Flex
+            className="container"
+            direction={{
+              base: 'column',
+              large: 'row',
+            }}
+          >
+            <View flex="1">
+              <Heading level={2}>Accessibility</Heading>
+              <Text className="docs-home-description">
+                Amplify UI components follow{' '}
+                <Link
+                  isExternal
+                  href="https://www.w3.org/WAI/standards-guidelines/wcag/"
+                >
+                  WCAG
+                </Link>{' '}
+                and{' '}
+                <Link isExternal href="https://www.w3.org/TR/wai-aria-1.2/">
+                  WAI-ARIA
+                </Link>{' '}
+                best practices and guidelines such as color contrast, keyboard
+                navigation, accessible labels, and focus management.
+              </Text>
+            </View>
+            <View flex="1"></View>
+          </Flex>
+        </View>
+
+        <View as="section" className="docs-home-section">
+          <Heading level={2} textAlign="center" margin={tokens.space.large}>
+            Looking for other Amplify Products?
+          </Heading>
+          <Grid
+            className="container"
+            templateColumns={{ base: '1fr', medium: '1fr 1fr' }}
+            gap={tokens.space.medium}
+            flex="1"
+          >
+            <AmpCard
+              href="https://docs.amplify.aws/lib/q/platform/js/"
+              title="Amplify Libraries"
+              description="Connect app to new or existing AWS services (Cognito, S3, and more)."
+            />
+            <AmpCard
+              href="https://docs.amplify.aws/cli/"
+              title="Amplify CLI"
+              description="Configure an app backend with a guided CLI workflow."
+            />
+            <AmpCard
+              href="https://docs.amplify.aws/console/"
+              title="Amplify Hosting"
+              description="Fully managed web hosting with full-stack CI/CD."
+            />
+            <AmpCard
+              href="https://docs.amplify.aws/console/"
+              title="Amplify Studio"
+              description="Visual development environment to accelerate full-stack development."
+            />
+          </Grid>
+        </View>
+        <Footer />
+      </AmplifyProvider>
+    </View>
   );
 };
 

--- a/docs/src/pages/[platform]/index.page.tsx
+++ b/docs/src/pages/[platform]/index.page.tsx
@@ -26,6 +26,7 @@ import { Sandpack } from '@codesandbox/sandpack-react';
 import type { SandpackThemeProp } from '@codesandbox/sandpack-react';
 import { ThemeButton } from '../ThemeButton';
 import { useCustomRouter } from '@/components/useCustomRouter';
+import classNames from 'classnames';
 
 const code = `import { AmplifyProvider, Button, Card, Text, Heading, Flex, Badge, Image, StepperField, useTheme } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
@@ -98,10 +99,11 @@ const AmpCard = ({ title, description, href }) => (
   </Link>
 );
 
-const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
+const HomePage = ({ colorMode }) => {
   const {
     query: { platform = 'react' },
   } = useCustomRouter();
+  const [themeOverride, setThemeOverride] = React.useState('');
   const { tokens } = useTheme();
   const sandPackTheme: SandpackThemeProp = {
     palette: {
@@ -147,7 +149,11 @@ const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
   const frameworkInstallScript = installScripts[platform.toString()];
   return (
     <>
-      <View as="section" className="container">
+      <View
+        as="section"
+        className={classNames('container', 'home')}
+        data-amplify-theme-override={themeOverride}
+      >
         <h1 className="docs-home-logo">
           <HomeLogo />
         </h1>

--- a/docs/src/pages/[platform]/index.page.tsx
+++ b/docs/src/pages/[platform]/index.page.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {
+  AmplifyProvider,
   Authenticator,
   Button,
   Card,
@@ -26,7 +27,7 @@ import { Sandpack } from '@codesandbox/sandpack-react';
 import type { SandpackThemeProp } from '@codesandbox/sandpack-react';
 import { ThemeButton } from '../ThemeButton';
 import { useCustomRouter } from '@/components/useCustomRouter';
-import classNames from 'classnames';
+import { theme } from '../../theme';
 
 const code = `import { AmplifyProvider, Button, Card, Text, Heading, Flex, Badge, Image, StepperField, useTheme } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
@@ -148,317 +149,315 @@ const HomePage = ({ colorMode }) => {
   };
   const frameworkInstallScript = installScripts[platform.toString()];
   return (
-    <>
-      <View
-        as="section"
-        className={classNames('container', 'home')}
-        data-amplify-theme-override={themeOverride}
-      >
-        <h1 className="docs-home-logo">
-          <HomeLogo />
-        </h1>
+    <View data-amplify-theme-override={themeOverride}>
+      <AmplifyProvider theme={theme} colorMode={colorMode}>
+        <View as="section" className="container">
+          <h1 className="docs-home-logo">
+            <HomeLogo />
+          </h1>
 
-        <Flex
-          direction={{ base: 'column', medium: 'row' }}
+          <Flex
+            direction={{ base: 'column', medium: 'row' }}
+            padding={tokens.space.large}
+          >
+            <Card variation="outlined" flex="1">
+              <Text
+                fontSize={{
+                  base: tokens.fontSizes.large,
+                  small: tokens.fontSizes.xl,
+                }}
+              >
+                Amplify UI is an open-source design system with cloud-connected
+                components and primitives that simplify building accessible,
+                performant, and beautiful applications in React, Angular, Vue,
+                and Flutter (more coming soon).
+              </Text>
+
+              <Flex
+                direction={{ base: 'column-reverse', medium: 'row' }}
+                padding={`${tokens.space.medium} 0 0 0`}
+              >
+                <Button
+                  size="large"
+                  variation="primary"
+                  as="a"
+                  href={`/${platform}/getting-started/installation`}
+                >
+                  Get started
+                  <IconChevronRight />
+                </Button>
+                <code className="install-code__container">
+                  <p className="install-code__content">
+                    {frameworkInstallScript}
+                  </p>
+                  <Copy
+                    className="install-code__button"
+                    size=""
+                    variation="link"
+                    text={frameworkInstallScript}
+                  />
+                </code>
+              </Flex>
+            </Card>
+            <Flex
+              alignSelf="center"
+              textAlign="center"
+              flex="1"
+              display={{ base: 'none', large: 'initial' }}
+            >
+              <Image
+                alt="React logo"
+                className="docs-home-react"
+                src="/svg/integrations/react.svg"
+              />
+              <Image
+                alt="Angular logo"
+                className="docs-home-angular"
+                src="/svg/integrations/angular.svg"
+              />
+              <Image
+                alt="Vue logo"
+                className="docs-home-vue"
+                src="/svg/integrations/vue.svg"
+              />
+              <Image
+                alt="Flutter logo"
+                className="docs-home-flutter"
+                src="/svg/integrations/flutter.svg"
+              />
+            </Flex>
+          </Flex>
+        </View>
+        <View
+          backgroundColor={tokens.colors.background.secondary}
           padding={tokens.space.large}
         >
-          <Card variation="outlined" flex="1">
-            <Text
-              fontSize={{
-                base: tokens.fontSizes.large,
-                small: tokens.fontSizes.xl,
-              }}
-            >
-              Amplify UI is an open-source design system with cloud-connected
-              components and primitives that simplify building accessible,
-              performant, and beautiful applications in React, Angular, Vue, and
-              Flutter (more coming soon).
-            </Text>
-
-            <Flex
-              direction={{ base: 'column-reverse', medium: 'row' }}
-              padding={`${tokens.space.medium} 0 0 0`}
-            >
-              <Button
-                size="large"
-                variation="primary"
-                as="a"
-                href={`/${platform}/getting-started/installation`}
-              >
-                Get started
-                <IconChevronRight />
-              </Button>
-              <code className="install-code__container">
-                <p className="install-code__content">
-                  {frameworkInstallScript}
-                </p>
-                <Copy
-                  className="install-code__button"
-                  size=""
-                  variation="link"
-                  text={frameworkInstallScript}
-                />
-              </code>
-            </Flex>
-          </Card>
-          <Flex
-            alignSelf="center"
-            textAlign="center"
-            flex="1"
-            display={{ base: 'none', large: 'initial' }}
-          >
-            <Image
-              alt="React logo"
-              className="docs-home-react"
-              src="/svg/integrations/react.svg"
-            />
-            <Image
-              alt="Angular logo"
-              className="docs-home-angular"
-              src="/svg/integrations/angular.svg"
-            />
-            <Image
-              alt="Vue logo"
-              className="docs-home-vue"
-              src="/svg/integrations/vue.svg"
-            />
-            <Image
-              alt="Flutter logo"
-              className="docs-home-flutter"
-              src="/svg/integrations/flutter.svg"
-            />
-          </Flex>
-        </Flex>
-      </View>
-      <View
-        backgroundColor={tokens.colors.background.secondary}
-        padding={tokens.space.large}
-      >
-        <Heading level={2} textAlign="center" margin={tokens.space.large}>
-          Take it for a test drive
-        </Heading>
-        <View className="container">
-          <Card style={{ width: '100%', padding: 0 }} variation="outlined">
-            <Sandpack
-              template="react"
-              files={{
-                '/App.js': { code: code, active: true },
-                '/theme.js': { code: themeCode },
-              }}
-              theme={sandPackTheme}
-              options={{
-                autorun: false,
-                editorHeight: 500,
-                showNavigator: true, // this will show a top navigator bar instead of the refresh button
-                showTabs: true, // you can toggle the tabs on/off manually
-                showLineNumbers: true, // this is off by default, but you can show line numbers for the editor
-                wrapContent: true, // also off by default, this wraps the code instead of creating horizontal overflow
-              }}
-              customSetup={{
-                dependencies: {
-                  '@aws-amplify/ui-react': 'latest',
-                  'aws-amplify': 'latest',
-                },
-                entry: '/index.js',
-              }}
-            />
-          </Card>
-        </View>
-      </View>
-
-      <View as="section" className="docs-home-section container">
-        <Flex
-          direction={{
-            base: 'column-reverse',
-            large: 'row',
-          }}
-        >
-          <View flex="1" className="example">
-            <Authenticator
-              socialProviders={['amazon', 'apple', 'facebook', 'google']}
-            />
+          <Heading level={2} textAlign="center" margin={tokens.space.large}>
+            Take it for a test drive
+          </Heading>
+          <View className="container">
+            <Card style={{ width: '100%', padding: 0 }} variation="outlined">
+              <Sandpack
+                template="react"
+                files={{
+                  '/App.js': { code: code, active: true },
+                  '/theme.js': { code: themeCode },
+                }}
+                theme={sandPackTheme}
+                options={{
+                  autorun: false,
+                  editorHeight: 500,
+                  showNavigator: true, // this will show a top navigator bar instead of the refresh button
+                  showTabs: true, // you can toggle the tabs on/off manually
+                  showLineNumbers: true, // this is off by default, but you can show line numbers for the editor
+                  wrapContent: true, // also off by default, this wraps the code instead of creating horizontal overflow
+                }}
+                customSetup={{
+                  dependencies: {
+                    '@aws-amplify/ui-react': 'latest',
+                    'aws-amplify': 'latest',
+                  },
+                  entry: '/index.js',
+                }}
+              />
+            </Card>
           </View>
-          <Flex flex="1" direction="column" alignItems="flex-start">
-            <Heading level={2}>Cloud-Connected Components</Heading>
-            <Text className="docs-home-description">
-              Simplify complex cloud-connected workflows like authentication
-              with minimal boilerplate code.
-            </Text>
-            <Button
-              as="a"
-              size="large"
-              href={`/${platform}/components/authenticator`}
-              isFullWidth
-            >
-              Authenticator
-              <IconChevronRight />
-            </Button>
-          </Flex>
-        </Flex>
-      </View>
+        </View>
 
-      <View
-        as="section"
-        className="docs-home-section"
-        backgroundColor={tokens.colors.background.secondary}
-      >
-        <Flex
-          className="container"
-          direction={{
-            base: 'column',
-            large: 'row',
-          }}
-        >
-          <Flex flex="1" direction="column" alignItems="flex-start">
-            <Heading level={2}>Theming</Heading>
-            <Text className="docs-home-description">
-              Theming capabilities that allow you to customize the appearance of
-              Amplify UI to match your brand.
-            </Text>
-            <Button as="a" size="large" href={`/${platform}/theming/`}>
-              Get started with theming
-              <IconChevronRight />
-            </Button>
-          </Flex>
+        <View as="section" className="docs-home-section container">
           <Flex
-            flex="1"
-            alignContent="center"
-            padding={{
-              base: '0',
-              large: tokens.space.large,
+            direction={{
+              base: 'column-reverse',
+              large: 'row',
             }}
           >
-            <ToggleButtonGroup
-              width="100%"
-              value={themeOverride}
-              isExclusive
-              onChange={(value: string) => setThemeOverride(value)}
-            >
-              <ToggleButton value="" flex="1">
-                <ThemeButton
-                  label="Default"
-                  colors={[
-                    'var(--amplify-colors-teal-60)',
-                    'var(--amplify-colors-purple-60)',
-                  ]}
-                />
-              </ToggleButton>
-              <ToggleButton value="terminal" flex="1">
-                <ThemeButton label="Terminal" colors={['#44AF5B', '#000']} />
-              </ToggleButton>
-              <ToggleButton value="classic" flex="1">
-                <ThemeButton
-                  label="Classic"
-                  colors={[
-                    'var(--amplify-colors-blue-60)',
-                    'var(--amplify-colors-neutral-60)',
-                  ]}
-                />
-              </ToggleButton>
-            </ToggleButtonGroup>
-          </Flex>
-        </Flex>
-      </View>
-
-      <View as="section" className="docs-home-section">
-        <Flex
-          className="container"
-          direction={{
-            base: 'column',
-            large: 'row',
-          }}
-          gap={tokens.space.xxl}
-        >
-          <View maxWidth="100%" overflow="hidden">
-            <HomePrimitivePreview />
-          </View>
-          <Flex flex="1" direction="column" alignItems="flex-start">
-            <Heading level={2}>Primitive Components</Heading>
-            <Text className="docs-home-description">
-              Primitive components that create consistency across Amplify UI and
-              allow you to build complete applications that fit your brand, like
-              Buttons and Badges.
-            </Text>
-            <Button
-              as="a"
-              size="large"
-              href={`/${platform}/components/authenticator`}
-            >
-              Get started with components
-              <IconChevronRight />
-            </Button>
-          </Flex>
-        </Flex>
-      </View>
-
-      <View
-        as="section"
-        className="docs-home-section"
-        backgroundColor={tokens.colors.background.secondary}
-      >
-        <Flex
-          className="container"
-          direction={{
-            base: 'column',
-            large: 'row',
-          }}
-        >
-          <View flex="1">
-            <Heading level={2}>Accessibility</Heading>
-            <Text className="docs-home-description">
-              Amplify UI components follow{' '}
-              <Link
-                isExternal
-                href="https://www.w3.org/WAI/standards-guidelines/wcag/"
+            <View flex="1" className="example">
+              <Authenticator
+                socialProviders={['amazon', 'apple', 'facebook', 'google']}
+              />
+            </View>
+            <Flex flex="1" direction="column" alignItems="flex-start">
+              <Heading level={2}>Cloud-Connected Components</Heading>
+              <Text className="docs-home-description">
+                Simplify complex cloud-connected workflows like authentication
+                with minimal boilerplate code.
+              </Text>
+              <Button
+                as="a"
+                size="large"
+                href={`/${platform}/components/authenticator`}
+                isFullWidth
               >
-                WCAG
-              </Link>{' '}
-              and{' '}
-              <Link isExternal href="https://www.w3.org/TR/wai-aria-1.2/">
-                WAI-ARIA
-              </Link>{' '}
-              best practices and guidelines such as color contrast, keyboard
-              navigation, accessible labels, and focus management.
-            </Text>
-          </View>
-          <View flex="1"></View>
-        </Flex>
-      </View>
+                Authenticator
+                <IconChevronRight />
+              </Button>
+            </Flex>
+          </Flex>
+        </View>
 
-      <View as="section" className="docs-home-section">
-        <Heading level={2} textAlign="center" margin={tokens.space.large}>
-          Looking for other Amplify Products?
-        </Heading>
-        <Grid
-          className="container"
-          templateColumns={{ base: '1fr', medium: '1fr 1fr' }}
-          gap={tokens.space.medium}
-          flex="1"
+        <View
+          as="section"
+          className="docs-home-section"
+          backgroundColor={tokens.colors.background.secondary}
         >
-          <AmpCard
-            href="https://docs.amplify.aws/lib/q/platform/js/"
-            title="Amplify Libraries"
-            description="Connect app to new or existing AWS services (Cognito, S3, and more)."
-          />
-          <AmpCard
-            href="https://docs.amplify.aws/cli/"
-            title="Amplify CLI"
-            description="Configure an app backend with a guided CLI workflow."
-          />
-          <AmpCard
-            href="https://docs.amplify.aws/console/"
-            title="Amplify Hosting"
-            description="Fully managed web hosting with full-stack CI/CD."
-          />
-          <AmpCard
-            href="https://docs.amplify.aws/console/"
-            title="Amplify Studio"
-            description="Visual development environment to accelerate full-stack development."
-          />
-        </Grid>
-      </View>
-      <Footer />
-    </>
+          <Flex
+            className="container"
+            direction={{
+              base: 'column',
+              large: 'row',
+            }}
+          >
+            <Flex flex="1" direction="column" alignItems="flex-start">
+              <Heading level={2}>Theming</Heading>
+              <Text className="docs-home-description">
+                Theming capabilities that allow you to customize the appearance
+                of Amplify UI to match your brand.
+              </Text>
+              <Button as="a" size="large" href={`/${platform}/theming/`}>
+                Get started with theming
+                <IconChevronRight />
+              </Button>
+            </Flex>
+            <Flex
+              flex="1"
+              alignContent="center"
+              padding={{
+                base: '0',
+                large: tokens.space.large,
+              }}
+            >
+              <ToggleButtonGroup
+                width="100%"
+                value={themeOverride}
+                isExclusive
+                onChange={(value: string) => setThemeOverride(value)}
+              >
+                <ToggleButton value="" flex="1">
+                  <ThemeButton
+                    label="Default"
+                    colors={[
+                      'var(--amplify-colors-teal-60)',
+                      'var(--amplify-colors-purple-60)',
+                    ]}
+                  />
+                </ToggleButton>
+                <ToggleButton value="terminal" flex="1">
+                  <ThemeButton label="Terminal" colors={['#44AF5B', '#000']} />
+                </ToggleButton>
+                <ToggleButton value="classic" flex="1">
+                  <ThemeButton
+                    label="Classic"
+                    colors={[
+                      'var(--amplify-colors-blue-60)',
+                      'var(--amplify-colors-neutral-60)',
+                    ]}
+                  />
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </Flex>
+          </Flex>
+        </View>
+
+        <View as="section" className="docs-home-section">
+          <Flex
+            className="container"
+            direction={{
+              base: 'column',
+              large: 'row',
+            }}
+            gap={tokens.space.xxl}
+          >
+            <View maxWidth="100%" overflow="hidden">
+              <HomePrimitivePreview />
+            </View>
+            <Flex flex="1" direction="column" alignItems="flex-start">
+              <Heading level={2}>Primitive Components</Heading>
+              <Text className="docs-home-description">
+                Primitive components that create consistency across Amplify UI
+                and allow you to build complete applications that fit your
+                brand, like Buttons and Badges.
+              </Text>
+              <Button
+                as="a"
+                size="large"
+                href={`/${platform}/components/authenticator`}
+              >
+                Get started with components
+                <IconChevronRight />
+              </Button>
+            </Flex>
+          </Flex>
+        </View>
+
+        <View
+          as="section"
+          className="docs-home-section"
+          backgroundColor={tokens.colors.background.secondary}
+        >
+          <Flex
+            className="container"
+            direction={{
+              base: 'column',
+              large: 'row',
+            }}
+          >
+            <View flex="1">
+              <Heading level={2}>Accessibility</Heading>
+              <Text className="docs-home-description">
+                Amplify UI components follow{' '}
+                <Link
+                  isExternal
+                  href="https://www.w3.org/WAI/standards-guidelines/wcag/"
+                >
+                  WCAG
+                </Link>{' '}
+                and{' '}
+                <Link isExternal href="https://www.w3.org/TR/wai-aria-1.2/">
+                  WAI-ARIA
+                </Link>{' '}
+                best practices and guidelines such as color contrast, keyboard
+                navigation, accessible labels, and focus management.
+              </Text>
+            </View>
+            <View flex="1"></View>
+          </Flex>
+        </View>
+
+        <View as="section" className="docs-home-section">
+          <Heading level={2} textAlign="center" margin={tokens.space.large}>
+            Looking for other Amplify Products?
+          </Heading>
+          <Grid
+            className="container"
+            templateColumns={{ base: '1fr', medium: '1fr 1fr' }}
+            gap={tokens.space.medium}
+            flex="1"
+          >
+            <AmpCard
+              href="https://docs.amplify.aws/lib/q/platform/js/"
+              title="Amplify Libraries"
+              description="Connect app to new or existing AWS services (Cognito, S3, and more)."
+            />
+            <AmpCard
+              href="https://docs.amplify.aws/cli/"
+              title="Amplify CLI"
+              description="Configure an app backend with a guided CLI workflow."
+            />
+            <AmpCard
+              href="https://docs.amplify.aws/console/"
+              title="Amplify Hosting"
+              description="Fully managed web hosting with full-stack CI/CD."
+            />
+            <AmpCard
+              href="https://docs.amplify.aws/console/"
+              title="Amplify Studio"
+              description="Visual development environment to accelerate full-stack development."
+            />
+          </Grid>
+        </View>
+        <Footer />
+      </AmplifyProvider>
+    </View>
   );
 };
 

--- a/docs/src/pages/[platform]/index.page.tsx
+++ b/docs/src/pages/[platform]/index.page.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import {
-  AmplifyProvider,
   Authenticator,
   Button,
   Card,
@@ -27,13 +26,10 @@ import { Sandpack } from '@codesandbox/sandpack-react';
 import type { SandpackThemeProp } from '@codesandbox/sandpack-react';
 import { ThemeButton } from '../ThemeButton';
 import { useCustomRouter } from '@/components/useCustomRouter';
-import { theme } from '../../theme';
 
 const code = `import { AmplifyProvider, Button, Card, Text, Heading, Flex, Badge, Image, StepperField, useTheme } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
-
 import { theme } from './theme';
-
 const Example = () => {
   const { tokens } = useTheme();
   return (
@@ -70,7 +66,6 @@ const Example = () => {
     </Card>
   )
 }
-
 export default function App() {
   return (
     <AmplifyProvider theme={theme}>
@@ -100,11 +95,10 @@ const AmpCard = ({ title, description, href }) => (
   </Link>
 );
 
-const HomePage = ({ colorMode }) => {
+const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
   const {
     query: { platform = 'react' },
   } = useCustomRouter();
-  const [themeOverride, setThemeOverride] = React.useState('');
   const { tokens } = useTheme();
   const sandPackTheme: SandpackThemeProp = {
     palette: {
@@ -149,315 +143,313 @@ const HomePage = ({ colorMode }) => {
   };
   const frameworkInstallScript = installScripts[platform.toString()];
   return (
-    <View data-amplify-theme-override={themeOverride}>
-      <AmplifyProvider theme={theme} colorMode={colorMode}>
-        <View as="section" className="container">
-          <h1 className="docs-home-logo">
-            <HomeLogo />
-          </h1>
+    <>
+      <View as="section" className="container">
+        <h1 className="docs-home-logo">
+          <HomeLogo />
+        </h1>
 
-          <Flex
-            direction={{ base: 'column', medium: 'row' }}
-            padding={tokens.space.large}
-          >
-            <Card variation="outlined" flex="1">
-              <Text
-                fontSize={{
-                  base: tokens.fontSizes.large,
-                  small: tokens.fontSizes.xl,
-                }}
-              >
-                Amplify UI is an open-source design system with cloud-connected
-                components and primitives that simplify building accessible,
-                performant, and beautiful applications in React, Angular, Vue,
-                and Flutter (more coming soon).
-              </Text>
-
-              <Flex
-                direction={{ base: 'column-reverse', medium: 'row' }}
-                padding={`${tokens.space.medium} 0 0 0`}
-              >
-                <Button
-                  size="large"
-                  variation="primary"
-                  as="a"
-                  href={`/${platform}/getting-started/installation`}
-                >
-                  Get started
-                  <IconChevronRight />
-                </Button>
-                <code className="install-code__container">
-                  <p className="install-code__content">
-                    {frameworkInstallScript}
-                  </p>
-                  <Copy
-                    className="install-code__button"
-                    size=""
-                    variation="link"
-                    text={frameworkInstallScript}
-                  />
-                </code>
-              </Flex>
-            </Card>
-            <Flex
-              alignSelf="center"
-              textAlign="center"
-              flex="1"
-              display={{ base: 'none', large: 'initial' }}
-            >
-              <Image
-                alt="React logo"
-                className="docs-home-react"
-                src="/svg/integrations/react.svg"
-              />
-              <Image
-                alt="Angular logo"
-                className="docs-home-angular"
-                src="/svg/integrations/angular.svg"
-              />
-              <Image
-                alt="Vue logo"
-                className="docs-home-vue"
-                src="/svg/integrations/vue.svg"
-              />
-              <Image
-                alt="Flutter logo"
-                className="docs-home-flutter"
-                src="/svg/integrations/flutter.svg"
-              />
-            </Flex>
-          </Flex>
-        </View>
-        <View
-          backgroundColor={tokens.colors.background.secondary}
+        <Flex
+          direction={{ base: 'column', medium: 'row' }}
           padding={tokens.space.large}
         >
-          <Heading level={2} textAlign="center" margin={tokens.space.large}>
-            Take it for a test drive
-          </Heading>
-          <View className="container">
-            <Card style={{ width: '100%', padding: 0 }} variation="outlined">
-              <Sandpack
-                template="react"
-                files={{
-                  '/App.js': { code: code, active: true },
-                  '/theme.js': { code: themeCode },
-                }}
-                theme={sandPackTheme}
-                options={{
-                  autorun: false,
-                  editorHeight: 500,
-                  showNavigator: true, // this will show a top navigator bar instead of the refresh button
-                  showTabs: true, // you can toggle the tabs on/off manually
-                  showLineNumbers: true, // this is off by default, but you can show line numbers for the editor
-                  wrapContent: true, // also off by default, this wraps the code instead of creating horizontal overflow
-                }}
-                customSetup={{
-                  dependencies: {
-                    '@aws-amplify/ui-react': 'latest',
-                    'aws-amplify': 'latest',
-                  },
-                  entry: '/index.js',
-                }}
-              />
-            </Card>
-          </View>
-        </View>
-
-        <View as="section" className="docs-home-section container">
-          <Flex
-            direction={{
-              base: 'column-reverse',
-              large: 'row',
-            }}
-          >
-            <View flex="1" className="example">
-              <Authenticator
-                socialProviders={['amazon', 'apple', 'facebook', 'google']}
-              />
-            </View>
-            <Flex flex="1" direction="column" alignItems="flex-start">
-              <Heading level={2}>Cloud-Connected Components</Heading>
-              <Text className="docs-home-description">
-                Simplify complex cloud-connected workflows like authentication
-                with minimal boilerplate code.
-              </Text>
-              <Button
-                as="a"
-                size="large"
-                href={`/${platform}/components/authenticator`}
-                isFullWidth
-              >
-                Authenticator
-                <IconChevronRight />
-              </Button>
-            </Flex>
-          </Flex>
-        </View>
-
-        <View
-          as="section"
-          className="docs-home-section"
-          backgroundColor={tokens.colors.background.secondary}
-        >
-          <Flex
-            className="container"
-            direction={{
-              base: 'column',
-              large: 'row',
-            }}
-          >
-            <Flex flex="1" direction="column" alignItems="flex-start">
-              <Heading level={2}>Theming</Heading>
-              <Text className="docs-home-description">
-                Theming capabilities that allow you to customize the appearance
-                of Amplify UI to match your brand.
-              </Text>
-              <Button as="a" size="large" href={`/${platform}/theming/`}>
-                Get started with theming
-                <IconChevronRight />
-              </Button>
-            </Flex>
-            <Flex
-              flex="1"
-              alignContent="center"
-              padding={{
-                base: '0',
-                large: tokens.space.large,
+          <Card variation="outlined" flex="1">
+            <Text
+              fontSize={{
+                base: tokens.fontSizes.large,
+                small: tokens.fontSizes.xl,
               }}
             >
-              <ToggleButtonGroup
-                width="100%"
-                value={themeOverride}
-                isExclusive
-                onChange={(value: string) => setThemeOverride(value)}
-              >
-                <ToggleButton value="" flex="1">
-                  <ThemeButton
-                    label="Default"
-                    colors={[
-                      'var(--amplify-colors-teal-60)',
-                      'var(--amplify-colors-purple-60)',
-                    ]}
-                  />
-                </ToggleButton>
-                <ToggleButton value="terminal" flex="1">
-                  <ThemeButton label="Terminal" colors={['#44AF5B', '#000']} />
-                </ToggleButton>
-                <ToggleButton value="classic" flex="1">
-                  <ThemeButton
-                    label="Classic"
-                    colors={[
-                      'var(--amplify-colors-blue-60)',
-                      'var(--amplify-colors-neutral-60)',
-                    ]}
-                  />
-                </ToggleButton>
-              </ToggleButtonGroup>
-            </Flex>
-          </Flex>
-        </View>
+              Amplify UI is an open-source design system with cloud-connected
+              components and primitives that simplify building accessible,
+              performant, and beautiful applications in React, Angular, Vue, and
+              Flutter (more coming soon).
+            </Text>
 
-        <View as="section" className="docs-home-section">
-          <Flex
-            className="container"
-            direction={{
-              base: 'column',
-              large: 'row',
-            }}
-            gap={tokens.space.xxl}
-          >
-            <View maxWidth="100%" overflow="hidden">
-              <HomePrimitivePreview />
-            </View>
-            <Flex flex="1" direction="column" alignItems="flex-start">
-              <Heading level={2}>Primitive Components</Heading>
-              <Text className="docs-home-description">
-                Primitive components that create consistency across Amplify UI
-                and allow you to build complete applications that fit your
-                brand, like Buttons and Badges.
-              </Text>
+            <Flex
+              direction={{ base: 'column-reverse', medium: 'row' }}
+              padding={`${tokens.space.medium} 0 0 0`}
+            >
               <Button
-                as="a"
                 size="large"
-                href={`/${platform}/components/authenticator`}
+                variation="primary"
+                as="a"
+                href={`/${platform}/getting-started/installation`}
               >
-                Get started with components
+                Get started
                 <IconChevronRight />
               </Button>
+              <code className="install-code__container">
+                <p className="install-code__content">
+                  {frameworkInstallScript}
+                </p>
+                <Copy
+                  className="install-code__button"
+                  size=""
+                  variation="link"
+                  text={frameworkInstallScript}
+                />
+              </code>
             </Flex>
-          </Flex>
-        </View>
-
-        <View
-          as="section"
-          className="docs-home-section"
-          backgroundColor={tokens.colors.background.secondary}
-        >
+          </Card>
           <Flex
-            className="container"
-            direction={{
-              base: 'column',
-              large: 'row',
+            alignSelf="center"
+            textAlign="center"
+            flex="1"
+            display={{ base: 'none', large: 'initial' }}
+          >
+            <Image
+              alt="React logo"
+              className="docs-home-react"
+              src="/svg/integrations/react.svg"
+            />
+            <Image
+              alt="Angular logo"
+              className="docs-home-angular"
+              src="/svg/integrations/angular.svg"
+            />
+            <Image
+              alt="Vue logo"
+              className="docs-home-vue"
+              src="/svg/integrations/vue.svg"
+            />
+            <Image
+              alt="Flutter logo"
+              className="docs-home-flutter"
+              src="/svg/integrations/flutter.svg"
+            />
+          </Flex>
+        </Flex>
+      </View>
+      <View
+        backgroundColor={tokens.colors.background.secondary}
+        padding={tokens.space.large}
+      >
+        <Heading level={2} textAlign="center" margin={tokens.space.large}>
+          Take it for a test drive
+        </Heading>
+        <View className="container">
+          <Card style={{ width: '100%', padding: 0 }} variation="outlined">
+            <Sandpack
+              template="react"
+              files={{
+                '/App.js': { code: code, active: true },
+                '/theme.js': { code: themeCode },
+              }}
+              theme={sandPackTheme}
+              options={{
+                autorun: false,
+                editorHeight: 500,
+                showNavigator: true, // this will show a top navigator bar instead of the refresh button
+                showTabs: true, // you can toggle the tabs on/off manually
+                showLineNumbers: true, // this is off by default, but you can show line numbers for the editor
+                wrapContent: true, // also off by default, this wraps the code instead of creating horizontal overflow
+              }}
+              customSetup={{
+                dependencies: {
+                  '@aws-amplify/ui-react': 'latest',
+                  'aws-amplify': 'latest',
+                },
+                entry: '/index.js',
+              }}
+            />
+          </Card>
+        </View>
+      </View>
+
+      <View as="section" className="docs-home-section container">
+        <Flex
+          direction={{
+            base: 'column-reverse',
+            large: 'row',
+          }}
+        >
+          <View flex="1" className="example">
+            <Authenticator
+              socialProviders={['amazon', 'apple', 'facebook', 'google']}
+            />
+          </View>
+          <Flex flex="1" direction="column" alignItems="flex-start">
+            <Heading level={2}>Cloud-Connected Components</Heading>
+            <Text className="docs-home-description">
+              Simplify complex cloud-connected workflows like authentication
+              with minimal boilerplate code.
+            </Text>
+            <Button
+              as="a"
+              size="large"
+              href={`/${platform}/components/authenticator`}
+              isFullWidth
+            >
+              Authenticator
+              <IconChevronRight />
+            </Button>
+          </Flex>
+        </Flex>
+      </View>
+
+      <View
+        as="section"
+        className="docs-home-section"
+        backgroundColor={tokens.colors.background.secondary}
+      >
+        <Flex
+          className="container"
+          direction={{
+            base: 'column',
+            large: 'row',
+          }}
+        >
+          <Flex flex="1" direction="column" alignItems="flex-start">
+            <Heading level={2}>Theming</Heading>
+            <Text className="docs-home-description">
+              Theming capabilities that allow you to customize the appearance of
+              Amplify UI to match your brand.
+            </Text>
+            <Button as="a" size="large" href={`/${platform}/theming/`}>
+              Get started with theming
+              <IconChevronRight />
+            </Button>
+          </Flex>
+          <Flex
+            flex="1"
+            alignContent="center"
+            padding={{
+              base: '0',
+              large: tokens.space.large,
             }}
           >
-            <View flex="1">
-              <Heading level={2}>Accessibility</Heading>
-              <Text className="docs-home-description">
-                Amplify UI components follow{' '}
-                <Link
-                  isExternal
-                  href="https://www.w3.org/WAI/standards-guidelines/wcag/"
-                >
-                  WCAG
-                </Link>{' '}
-                and{' '}
-                <Link isExternal href="https://www.w3.org/TR/wai-aria-1.2/">
-                  WAI-ARIA
-                </Link>{' '}
-                best practices and guidelines such as color contrast, keyboard
-                navigation, accessible labels, and focus management.
-              </Text>
-            </View>
-            <View flex="1"></View>
+            <ToggleButtonGroup
+              width="100%"
+              value={themeOverride}
+              isExclusive
+              onChange={(value: string) => setThemeOverride(value)}
+            >
+              <ToggleButton value="" flex="1">
+                <ThemeButton
+                  label="Default"
+                  colors={[
+                    'var(--amplify-colors-teal-60)',
+                    'var(--amplify-colors-purple-60)',
+                  ]}
+                />
+              </ToggleButton>
+              <ToggleButton value="terminal" flex="1">
+                <ThemeButton label="Terminal" colors={['#44AF5B', '#000']} />
+              </ToggleButton>
+              <ToggleButton value="classic" flex="1">
+                <ThemeButton
+                  label="Classic"
+                  colors={[
+                    'var(--amplify-colors-blue-60)',
+                    'var(--amplify-colors-neutral-60)',
+                  ]}
+                />
+              </ToggleButton>
+            </ToggleButtonGroup>
           </Flex>
-        </View>
+        </Flex>
+      </View>
 
-        <View as="section" className="docs-home-section">
-          <Heading level={2} textAlign="center" margin={tokens.space.large}>
-            Looking for other Amplify Products?
-          </Heading>
-          <Grid
-            className="container"
-            templateColumns={{ base: '1fr', medium: '1fr 1fr' }}
-            gap={tokens.space.medium}
-            flex="1"
-          >
-            <AmpCard
-              href="https://docs.amplify.aws/lib/q/platform/js/"
-              title="Amplify Libraries"
-              description="Connect app to new or existing AWS services (Cognito, S3, and more)."
-            />
-            <AmpCard
-              href="https://docs.amplify.aws/cli/"
-              title="Amplify CLI"
-              description="Configure an app backend with a guided CLI workflow."
-            />
-            <AmpCard
-              href="https://docs.amplify.aws/console/"
-              title="Amplify Hosting"
-              description="Fully managed web hosting with full-stack CI/CD."
-            />
-            <AmpCard
-              href="https://docs.amplify.aws/console/"
-              title="Amplify Studio"
-              description="Visual development environment to accelerate full-stack development."
-            />
-          </Grid>
-        </View>
-        <Footer />
-      </AmplifyProvider>
-    </View>
+      <View as="section" className="docs-home-section">
+        <Flex
+          className="container"
+          direction={{
+            base: 'column',
+            large: 'row',
+          }}
+          gap={tokens.space.xxl}
+        >
+          <View maxWidth="100%" overflow="hidden">
+            <HomePrimitivePreview />
+          </View>
+          <Flex flex="1" direction="column" alignItems="flex-start">
+            <Heading level={2}>Primitive Components</Heading>
+            <Text className="docs-home-description">
+              Primitive components that create consistency across Amplify UI and
+              allow you to build complete applications that fit your brand, like
+              Buttons and Badges.
+            </Text>
+            <Button
+              as="a"
+              size="large"
+              href={`/${platform}/components/authenticator`}
+            >
+              Get started with components
+              <IconChevronRight />
+            </Button>
+          </Flex>
+        </Flex>
+      </View>
+
+      <View
+        as="section"
+        className="docs-home-section"
+        backgroundColor={tokens.colors.background.secondary}
+      >
+        <Flex
+          className="container"
+          direction={{
+            base: 'column',
+            large: 'row',
+          }}
+        >
+          <View flex="1">
+            <Heading level={2}>Accessibility</Heading>
+            <Text className="docs-home-description">
+              Amplify UI components follow{' '}
+              <Link
+                isExternal
+                href="https://www.w3.org/WAI/standards-guidelines/wcag/"
+              >
+                WCAG
+              </Link>{' '}
+              and{' '}
+              <Link isExternal href="https://www.w3.org/TR/wai-aria-1.2/">
+                WAI-ARIA
+              </Link>{' '}
+              best practices and guidelines such as color contrast, keyboard
+              navigation, accessible labels, and focus management.
+            </Text>
+          </View>
+          <View flex="1"></View>
+        </Flex>
+      </View>
+
+      <View as="section" className="docs-home-section">
+        <Heading level={2} textAlign="center" margin={tokens.space.large}>
+          Looking for other Amplify Products?
+        </Heading>
+        <Grid
+          className="container"
+          templateColumns={{ base: '1fr', medium: '1fr 1fr' }}
+          gap={tokens.space.medium}
+          flex="1"
+        >
+          <AmpCard
+            href="https://docs.amplify.aws/lib/q/platform/js/"
+            title="Amplify Libraries"
+            description="Connect app to new or existing AWS services (Cognito, S3, and more)."
+          />
+          <AmpCard
+            href="https://docs.amplify.aws/cli/"
+            title="Amplify CLI"
+            description="Configure an app backend with a guided CLI workflow."
+          />
+          <AmpCard
+            href="https://docs.amplify.aws/console/"
+            title="Amplify Hosting"
+            description="Fully managed web hosting with full-stack CI/CD."
+          />
+          <AmpCard
+            href="https://docs.amplify.aws/console/"
+            title="Amplify Studio"
+            description="Visual development environment to accelerate full-stack development."
+          />
+        </Grid>
+      </View>
+      <Footer />
+    </>
   );
 };
 

--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -30,14 +30,6 @@ function MyApp({ Component, pageProps }) {
     .filter((n) => n && n !== '[platform]')
     .join('/')}`;
   const [colorMode, setColorMode] = React.useState<ColorMode>('system');
-  const [themeOverride, setThemeOverride] = React.useState('');
-
-  React.useEffect(() => {
-    document.documentElement.setAttribute(
-      'data-amplify-theme-override',
-      themeOverride
-    );
-  }, [themeOverride]);
 
   configure();
   trackPageVisit();
@@ -67,12 +59,7 @@ function MyApp({ Component, pageProps }) {
           colorMode={colorMode}
           setColorMode={setColorMode}
         />
-        <Component
-          {...pageProps}
-          colorMode={colorMode}
-          setThemeOverride={setThemeOverride}
-          themeOverride={themeOverride}
-        />
+        <Component {...pageProps} colorMode={colorMode} />
       </AmplifyProvider>
       <Script src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js" />
       <Script src="/scripts/shortbreadv2.js" />

--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -2,7 +2,11 @@ import '../styles/index.scss';
 
 import * as React from 'react';
 
-import { AmplifyProvider, ColorMode } from '@aws-amplify/ui-react';
+import {
+  AmplifyProvider,
+  ColorMode,
+  defaultDarkModeOverride,
+} from '@aws-amplify/ui-react';
 import { configure, trackPageVisit } from '../utils/track';
 
 import Head from 'next/head';
@@ -10,7 +14,6 @@ import { Header } from '@/components/Layout/Header';
 import { META_INFO } from '@/data/meta'; // TODO: use data generated from pages.preval.ts instead
 import Script from 'next/script';
 import { capitalizeString } from '../utils/capitalizeString';
-import { theme } from '../theme';
 import { useCustomRouter } from '@/components/useCustomRouter';
 
 // suppress useLayoutEffect warnings when running outside a browser
@@ -37,6 +40,11 @@ function MyApp({ Component, pageProps }) {
   if (!META_INFO[filepath]?.description || !META_INFO[filepath]?.title) {
     throw new Error(`Meta Info missing on ${filepath}`);
   }
+
+  const theme = {
+    name: 'amplify-docs',
+    overrides: [defaultDarkModeOverride],
+  };
 
   return (
     <>

--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -13,6 +13,7 @@ import Head from 'next/head';
 import { Header } from '@/components/Layout/Header';
 import { META_INFO } from '@/data/meta'; // TODO: use data generated from pages.preval.ts instead
 import Script from 'next/script';
+import { baseTheme } from '../theme';
 import { capitalizeString } from '../utils/capitalizeString';
 import { useCustomRouter } from '@/components/useCustomRouter';
 
@@ -41,11 +42,6 @@ function MyApp({ Component, pageProps }) {
     throw new Error(`Meta Info missing on ${filepath}`);
   }
 
-  const theme = {
-    name: 'amplify-docs',
-    overrides: [defaultDarkModeOverride],
-  };
-
   return (
     <>
       <Head>
@@ -61,7 +57,7 @@ function MyApp({ Component, pageProps }) {
           <meta name="description" content={META_INFO[filepath].description} />
         )}
       </Head>
-      <AmplifyProvider theme={theme} colorMode={colorMode}>
+      <AmplifyProvider theme={baseTheme} colorMode={colorMode}>
         <Header
           platform={platform}
           colorMode={colorMode}

--- a/docs/src/pages/index.page.tsx
+++ b/docs/src/pages/index.page.tsx
@@ -1,13 +1,7 @@
 import PlatformHomepage from './[platform]/index.page';
 
-const HomePage = ({ colorMode, setThemeOverride, themeOverride }) => {
-  return (
-    <PlatformHomepage
-      colorMode={colorMode}
-      setThemeOverride={setThemeOverride}
-      themeOverride={themeOverride}
-    />
-  );
+const HomePage = ({ colorMode }) => {
+  return <PlatformHomepage colorMode={colorMode} />;
 };
 
 export default HomePage;

--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -19,6 +19,11 @@ const usePalette = (str) => {
   }, {});
 };
 
+export const baseTheme: Theme = {
+  name: 'amplify-docs',
+  overrides: [defaultDarkModeOverride],
+};
+
 export const theme: Theme = {
   name: 'amplify-docs',
   overrides: [

--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -24,7 +24,8 @@ export const theme: Theme = {
   overrides: [
     defaultDarkModeOverride,
     {
-      selector: '[data-amplify-theme-override="classic"].home',
+      selector:
+        '[data-amplify-theme-override="classic"] [data-amplify-theme="amplify-docs"]',
       tokens: {
         colors: {
           brand: {
@@ -46,7 +47,8 @@ export const theme: Theme = {
       },
     },
     {
-      selector: '[data-amplify-theme-override="terminal"].home',
+      selector:
+        '[data-amplify-theme-override="terminal"] [data-amplify-theme="amplify-docs"]',
       tokens: {
         colors: {
           green: {

--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -24,8 +24,7 @@ export const theme: Theme = {
   overrides: [
     defaultDarkModeOverride,
     {
-      selector:
-        '[data-amplify-theme-override="classic"] [data-amplify-theme="amplify-docs"]',
+      selector: '[data-amplify-theme-override="classic"].home',
       tokens: {
         colors: {
           brand: {
@@ -47,8 +46,7 @@ export const theme: Theme = {
       },
     },
     {
-      selector:
-        '[data-amplify-theme-override="terminal"] [data-amplify-theme="amplify-docs"]',
+      selector: '[data-amplify-theme-override="terminal"].home',
       tokens: {
         colors: {
           green: {


### PR DESCRIPTION
#### Description of changes
Add override amplify provide to home page of docs to scope the theme override examples from the home page to just the home page.

#### Description of how you validated changes
Manual inspection of the docs site.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
