### PR TITLE
bug(fix): MenuItem minHeight mapped incorrectly

### DIFF
--- a/.changeset/wild-vans-pay.md
+++ b/.changeset/wild-vans-pay.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+bug(fix): MenuItem minHeight mapped incorrectly

--- a/packages/ui/src/theme/css/component/menu.scss
+++ b/packages/ui/src/theme/css/component/menu.scss
@@ -16,7 +16,7 @@
   border-style: var(--amplify-components-menu-border-style);
 }
 .amplify-menu-content__item {
-  min-height: var(--amplify-components-menu-item-min-width);
+  min-height: var(--amplify-components-menu-item-min-height);
   padding-inline-start: var(
     --amplify-components-menu-item-padding-inline-start
   );


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

While updating the Menu docs, I stumbled across this small bug mapping `minHeight` to the min-width CSS variable. I can confirm that this change fixes the problem. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the docs locally. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
