### PR TITLE
fix: regression in scrollview that shows scrollbars when unneeded

### DIFF
--- a/.changeset/chilled-houses-impress.md
+++ b/.changeset/chilled-houses-impress.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix: regression in scrollview that shows scrollbars when unneeded

--- a/packages/ui/src/theme/css/component/scrollView.scss
+++ b/packages/ui/src/theme/css/component/scrollView.scss
@@ -1,6 +1,6 @@
 .amplify-scrollview {
   display: block;
-  overflow: scroll;
+  overflow: auto;
   // @TODO: Deprecated - Remove in 3.0
   &--horizontal {
     overflow-x: scroll;
@@ -8,7 +8,6 @@
   }
   // @TODO: Deprecated - Remove in 3.0
   &--vertical {
-    // @TODO: Deprecated - Remove in 3.0
     overflow-x: initial;
     overflow-y: scroll;
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fixes a regression which always shows scrollbars on the ScrollView component even when they are unneeded. This was introduced when #1236 was merged after https://github.com/aws-amplify/amplify-ui/pull/1835.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
`yarn docs dev`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
