### PR TITLE
fix: Submit Code Text Translation Fix

### DIFF
--- a/.changeset/gentle-ears-hunt.md
+++ b/.changeset/gentle-ears-hunt.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-angular': patch
+---
+
+Updated translations for Send Code, while also preserving legacy customers who have already translated that text.

--- a/examples/angular/src/pages/ui/components/authenticator/reset-password/reset-password.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/reset-password/reset-password.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
-import { Amplify } from 'aws-amplify';
+import { Component, OnInit } from '@angular/core';
+import { Amplify, I18n } from 'aws-amplify';
+import { translations } from '@aws-amplify/ui-angular';
 
 import awsExports from './aws-exports';
 
@@ -7,8 +8,16 @@ import awsExports from './aws-exports';
   selector: 'reset-password',
   templateUrl: 'reset-password.component.html',
 })
-export class ResetPasswordComponent {
+export class ResetPasswordComponent implements OnInit {
   constructor() {
     Amplify.configure(awsExports);
+  }
+
+  ngOnInit() {
+    I18n.putVocabularies(translations);
+    I18n.setLanguage('en');
+    I18n.putVocabulariesForLanguage('en', {
+      'Send Code': 'Update Information',
+    });
   }
 }

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
@@ -24,7 +24,7 @@ export class ConfirmResetPasswordComponent {
    * See https://github.com/aws-amplify/amplify-ui/issues/1784
    * TODO: Remove support for 'Send Code' translation in next Major release
    */
-  public submitText = hasTranslation('Submit')
+  public submitText = !hasTranslation('Send Code')
     ? translate('Submit')
     : translate('Send Code');
 

--- a/packages/e2e/features/ui/components/authenticator/reset-password-angular.feature
+++ b/packages/e2e/features/ui/components/authenticator/reset-password-angular.feature
@@ -1,32 +1,27 @@
 Feature: Reset Password
 
-  End users can reset their password through "Forgot your password?" link.
+  This will be used specifically for Angular users who have changed the translations for 'Send Code' for GH #1784.
 
   Background:
     Given I'm running the example "ui/components/authenticator/reset-password"
 
-  @react @vue 
-  Scenario: Reset Password with valid username
+  @angular
+  Scenario: Verify translated 'Send Code' button text is correct on Confirm Reset Password page
     When I type my "username" with status "CONFIRMED"
     And I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.ForgotPassword" } }' with fixture "reset-password"
-    And I click the "Send code" button
+    And I click the "Update Information" button
     Then I will be redirected to the confirm forgot password page
     And I see "Code"
     Then I type a valid code
     And I type my new password
     And I confirm my password
     And I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmForgotPassword" } }' with fixture "confirm-reset-password"
-    And I click the submit button
-    Then I see "Sign In"
-    
-  @react @vue 
+    And I see "Update Information"
+
+
+  @angular
   Scenario: Reset Password with invalid username
     When I type my "username" with status "UNKNOWN"
-    And I click the "Send code" button
+    And I click the "Update Information" button
     Then I see "Username/client id combination not found."
 
-  @angular @react @vue
-  Scenario: Reset Password with valid placeholder 
-    Then I see "Enter your username"
-    And I don't see "Enter your phone number"
-    And I don't see "Enter your email"

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-username.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-username.feature
@@ -18,6 +18,20 @@ Feature: Sign In with Username
     Then I see "User does not exist"
 
   @angular @react @vue
+  Scenario: Verify Submit text is correct on confirm Reset Password Page without translation
+    And I click the "Forgot your Password?" button
+    When I type my "username" with status "CONFIRMED"
+    And I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.ForgotPassword" } }' with fixture "reset-password"
+    And I click the "Send code" button
+    Then I will be redirected to the confirm forgot password page
+    And I see "Code"
+    Then I type a valid code
+    And I type my new password
+    And I confirm my password
+    And I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmForgotPassword" } }' with fixture "confirm-reset-password"
+    And I see "Submit"
+
+  @angular @react @vue
   Scenario: Sign in with unconfirmed credentials
     When I type my "username" with status "UNCONFIRMED"
     And I type my password


### PR DESCRIPTION
#### Description of changes
This fix changes the `Send Code` text in the Confirm Reset Password page to show `Submit` instead (for Angular, already fixed in Vue and React). Unless, the customer already has a translation for `Send Code`, in that case it will show the translated message. This is for added backwards compatibility.

#### Issue #, if available
#1784 

#### Description of how you validated changes
Added a couple test, only for Angular

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
