### PR TITLE
Revert "fix(geo): Point to react-map-gl es5 bundle"

### DIFF
--- a/.changeset/tough-sheep-cry.md
+++ b/.changeset/tough-sheep-cry.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+Revert "fix(geo): Point to react-map-gl es5 bundle"

--- a/packages/react/src/components/Geo/Geocoder/index.tsx
+++ b/packages/react/src/components/Geo/Geocoder/index.tsx
@@ -1,7 +1,7 @@
 import maplibregl from 'maplibre-gl';
 import { createAmplifyGeocoder } from 'maplibre-gl-js-amplify';
 import { useEffect, useRef } from 'react';
-import { useControl, useMap } from 'react-map-gl/dist/es5';
+import { useControl, useMap } from 'react-map-gl';
 import type { IControl } from 'react-map-gl';
 
 const GEOCODER_OPTIONS = {

--- a/packages/react/src/components/Geo/MapView/index.tsx
+++ b/packages/react/src/components/Geo/MapView/index.tsx
@@ -2,7 +2,7 @@ import { Amplify, Auth } from 'aws-amplify';
 import maplibregl from 'maplibre-gl';
 import { AmplifyMapLibreRequest } from 'maplibre-gl-js-amplify';
 import React, { forwardRef, useEffect, useMemo, useState } from 'react';
-import ReactMapGL from 'react-map-gl/dist/es5';
+import ReactMapGL from 'react-map-gl';
 import type { MapProps, MapRef, TransformRequestFunction } from 'react-map-gl';
 
 export type MapViewProps = Omit<MapProps, 'transformRequest'>;


### PR DESCRIPTION
Reverts aws-amplify/amplify-ui#1887

Pointing `react-map-gl` to the es5 bundle causes an error when an application uses the package with >=es6 module resolution. This represents a breaking change to customer applications.