### PR TITLE
fix(style): adjust slider thumb border width, focus color and box shadow

### DIFF
--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -509,7 +509,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-sliderfield-thumb-background-color: var(--amplify-colors-background-primary);
         --amplify-components-sliderfield-thumb-box-shadow: var(--amplify-shadows-small);
         --amplify-components-sliderfield-thumb-border-radius: 50%;
-        --amplify-components-sliderfield-thumb-border-width: var(--amplify-border-widths-small);
+        --amplify-components-sliderfield-thumb-border-width: var(--amplify-border-widths-medium);
         --amplify-components-sliderfield-thumb-border-color: var(--amplify-colors-border-primary);
         --amplify-components-sliderfield-thumb-border-style: solid;
         --amplify-components-sliderfield-thumb-disabled-background-color: var(--amplify-colors-background-disabled);
@@ -517,7 +517,8 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-sliderfield-thumb-disabled-box-shadow: none;
         --amplify-components-sliderfield-thumb-hover-background-color: var(--amplify-colors-background-primary);
         --amplify-components-sliderfield-thumb-hover-border-color: var(--amplify-colors-border-focus);
-        --amplify-components-sliderfield-thumb-focus-box-shadow: 0 0 0 3px var(--amplify-colors-border-focus);
+        --amplify-components-sliderfield-thumb-focus-border-color: var(--amplify-colors-border-focus);
+        --amplify-components-sliderfield-thumb-focus-box-shadow: 0 0 0 2px var(--amplify-colors-border-focus);
         --amplify-components-sliderfield-small-track-height: 0.25rem;
         --amplify-components-sliderfield-small-thumb-width: 1rem;
         --amplify-components-sliderfield-small-thumb-height: 1rem;

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -543,7 +543,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-sliderfield-thumb-background-color: var(--amplify-colors-background-primary);
         --amplify-components-sliderfield-thumb-box-shadow: var(--amplify-shadows-small);
         --amplify-components-sliderfield-thumb-border-radius: 50%;
-        --amplify-components-sliderfield-thumb-border-width: var(--amplify-border-widths-small);
+        --amplify-components-sliderfield-thumb-border-width: var(--amplify-border-widths-medium);
         --amplify-components-sliderfield-thumb-border-color: var(--amplify-colors-border-primary);
         --amplify-components-sliderfield-thumb-border-style: solid;
         --amplify-components-sliderfield-thumb-disabled-background-color: var(--amplify-colors-background-disabled);
@@ -551,7 +551,8 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-sliderfield-thumb-disabled-box-shadow: none;
         --amplify-components-sliderfield-thumb-hover-background-color: var(--amplify-colors-background-primary);
         --amplify-components-sliderfield-thumb-hover-border-color: var(--amplify-colors-border-focus);
-        --amplify-components-sliderfield-thumb-focus-box-shadow: 0 0 0 3px var(--amplify-colors-border-focus);
+        --amplify-components-sliderfield-thumb-focus-border-color: var(--amplify-colors-border-focus);
+        --amplify-components-sliderfield-thumb-focus-box-shadow: 0 0 0 2px var(--amplify-colors-border-focus);
         --amplify-components-sliderfield-small-track-height: 0.25rem;
         --amplify-components-sliderfield-small-thumb-width: 1rem;
         --amplify-components-sliderfield-small-thumb-height: 1rem;

--- a/packages/ui/src/theme/css/component/sliderField.scss
+++ b/packages/ui/src/theme/css/component/sliderField.scss
@@ -146,6 +146,9 @@
     );
   }
   &:focus {
+    border-color: var(
+      --amplify-components-sliderfield-thumb-focus-border-color
+    );
     box-shadow: var(--amplify-components-sliderfield-thumb-focus-box-shadow);
   }
 

--- a/packages/ui/src/theme/tokens/components/sliderField.ts
+++ b/packages/ui/src/theme/tokens/components/sliderField.ts
@@ -105,7 +105,7 @@ export const sliderfield: SliderFieldTokens = {
     backgroundColor: { value: '{colors.background.primary.value}' },
     boxShadow: { value: '{shadows.small.value}' },
     borderRadius: { value: '50%' },
-    borderWidth: { value: '{borderWidths.small.value}' },
+    borderWidth: { value: '{borderWidths.medium.value}' },
     borderColor: { value: '{colors.border.primary.value}' },
     borderStyle: { value: 'solid' },
     _disabled: {

--- a/packages/ui/src/theme/tokens/components/sliderField.ts
+++ b/packages/ui/src/theme/tokens/components/sliderField.ts
@@ -52,6 +52,7 @@ interface SliderFieldThumbHoverTokens {
 }
 
 interface SliderFieldThumbFocusTokens {
+  borderColor: DesignToken<BorderColorValue>;
   boxShadow: DesignToken<BoxShadowValue>;
 }
 
@@ -118,12 +119,13 @@ export const sliderfield: SliderFieldTokens = {
       borderColor: { value: '{colors.border.focus.value}' },
     },
     _focus: {
+      borderColor: { value: '{colors.border.focus.value}' },
       boxShadow: {
         value: {
           offsetX: '0',
           offsetY: '0',
           blurRadius: '0',
-          spreadRadius: '3px',
+          spreadRadius: '2px',
           color: '{colors.border.focus.value}',
         },
       },


### PR DESCRIPTION
#### Description of changes

1. Bump up slider thumb border width
2. Add focus border color and adjust box shadow
3. Update test snapshots

#### Description of how you validated changes

##### Light mode
![Screen Shot 2022-05-17 at 4 01 35 PM](https://user-images.githubusercontent.com/40295569/168929568-abfdfe86-48ba-4306-b6ef-2f671e1a9789.png)

###### Boder color ratio
![Screen Shot 2022-05-17 at 3 43 05 PM](https://user-images.githubusercontent.com/40295569/168929627-7526d6bb-1486-4971-8601-043b323b90e7.png)

###### On focus
![Screen Shot 2022-05-17 at 4 26 11 PM](https://user-images.githubusercontent.com/40295569/168929487-f563d691-0c44-4890-9922-495294847c31.png)

##### Dark mode
![Screen Shot 2022-05-17 at 4 45 26 PM](https://user-images.githubusercontent.com/40295569/168929816-0181bbc5-d2bb-4104-980c-ac69a7802b54.png)

###### Boder color ratio
![Screen Shot 2022-05-17 at 4 28 47 PM](https://user-images.githubusercontent.com/40295569/168929827-83f84752-442d-41f3-8b53-ab949bb0de79.png)

###### On focus
![Screen Shot 2022-05-17 at 4 28 15 PM](https://user-images.githubusercontent.com/40295569/168929706-85113844-38ae-413d-b6e1-ffc5d1dead81.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
