### PR TITLE
fix(robotstxt):make isProd  more tolerant

### DIFF
--- a/docs/scripts/generate-sitemap-robotstxt.mjs
+++ b/docs/scripts/generate-sitemap-robotstxt.mjs
@@ -70,7 +70,9 @@ async function generateSitemap() {
 }
 
 function generateRobotsTxt() {
-  const isProd = process.env.SITE_URL === 'https://ui.docs.amplify.aws';
+  const isProd =
+    process.env.SITE_URL &&
+    process.env.SITE_URL.startsWith('https://ui.docs.amplify.aws');
   console.log(
     `🤖▶️ robots.txt generating for ${
       isProd
@@ -83,9 +85,7 @@ User-agent: Googlebot
 Disallow: /
 `;
 
-  const txt = `${
-    process.env.SITE_URL === 'https://ui.docs.amplify.aws' ? '' : disallowTxt
-  }
+  const txt = `${isProd ? '' : disallowTxt}
 User-agent: *
 Allow: /
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**issue**: Current `robots.txt` disallow googlebot
**reason**: There's a `/` in the environment. see the screenshots.

<img width="529" alt="image (1)" src="https://user-images.githubusercontent.com/11983489/169107518-7a73e592-876c-4b10-94c5-1e852934efc6.png">

<img width="673" alt="image (2)" src="https://user-images.githubusercontent.com/11983489/169107550-4288ca03-ecb6-447c-9073-8ff8f2708a29.png">

**fix**: make the script smarter to tell `isProd`


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

manual test on local running `yarn docs postbuilt`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
