### PR TITLE
docs/fix: update aria pattern links to point to new W3 APG site

### DIFF
--- a/docs/src/pages/[platform]/components/alert/index.page.mdx
+++ b/docs/src/pages/[platform]/components/alert/index.page.mdx
@@ -3,7 +3,7 @@ title: Alert
 metaTitle: Alert
 description: An Alert displays a brief, important message in a way that attracts the user's attention without interrupting the user's task. Alerts are typically intended to be read out dynamically by a screen reader.
 metaDescription: An Alert displays a brief, important message in a way that attracts the user's attention without interrupting the user's task. Alerts are typically intended to be read out dynamically by a screen reader.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices/#alert
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/alert
 themeSource: packages/ui/src/theme/tokens/components/alert.ts
 reactSource: packages/react/src/primitives/Alert/Alert.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/button/index.page.mdx
+++ b/docs/src/pages/[platform]/components/button/index.page.mdx
@@ -3,7 +3,7 @@ title: Button
 metaTitle: Button
 description: The Button primitive is used to trigger an action or event, such as submitting a form, opening a dialog, canceling an action, or performing a delete operation.
 metaDescription: The Button primitive is used to trigger an action or event, such as submitting a form, opening a dialog, canceling an action, or performing a delete operation.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices/#button
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/button
 themeSource: packages/ui/src/theme/tokens/components/button.ts
 reactSource: packages/react/src/primitives/Button/Button.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/checkboxfield/index.page.mdx
+++ b/docs/src/pages/[platform]/components/checkboxfield/index.page.mdx
@@ -3,7 +3,7 @@ title: CheckboxField
 metaTitle: CheckboxField
 description: CheckboxField is used to mark an individual item as selected, or to select multiple items from a list of individual items.
 metaDescription: CheckboxField is used to mark an individual item as selected, or to select multiple items from a list of individual items.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices/#checkbox
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox
 themeSource: packages/ui/src/theme/tokens/components/checkbox.ts
 reactSource: packages/react/src/primitives/CheckboxField/CheckboxField.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/expander/index.page.mdx
+++ b/docs/src/pages/[platform]/components/expander/index.page.mdx
@@ -3,7 +3,7 @@ title: Expander
 metaTitle: Expander
 description: The Expander primitive enables users to expand or collapse a set of sections.
 metaDescription: The Expander primitive enables users to expand or collapse a set of sections.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices/#accordion
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/accordion
 themeSource: packages/ui/src/theme/tokens/components/expander.ts
 reactSource: packages/react/src/primitives/Expander/Expander.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/grid/index.page.mdx
+++ b/docs/src/pages/[platform]/components/grid/index.page.mdx
@@ -3,7 +3,6 @@ title: Grid
 metaTitle: Grid
 description: Grid provides a CSS grid container.
 metaDescription: Grid provides a CSS grid container.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices-1.2/#grid
 reactSource: packages/react/src/primitives/Grid/Grid.tsx
 supportedFrameworks: react
 ---

--- a/docs/src/pages/[platform]/components/link/index.page.mdx
+++ b/docs/src/pages/[platform]/components/link/index.page.mdx
@@ -3,7 +3,7 @@ title: Link
 metaTitle: Link
 description: Links are customizable and themable elements used for Navigation. By default Links render an anchor tag but can be configured to be used with routing libraries.
 metaDescription: Links are customizable and themable elements used for Navigation. By default Links render an anchor tag but can be configured to be used with routing libraries.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices/#link
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/link
 themeSource: packages/ui/src/theme/tokens/components/link.ts
 reactSource: packages/react/src/primitives/Link/Link.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/menu/index.page.mdx
+++ b/docs/src/pages/[platform]/components/menu/index.page.mdx
@@ -3,7 +3,7 @@ title: Menu
 metaTitle: Menu
 description: Menu provides an accessible, interactive menu for selecting actions within an application. Dropdown menu is collision-aware and will automatically change location based on available space.
 metaDescription: Menu provides an accessible, interactive menu for selecting actions within an application. Dropdown menu is collision-aware and will automatically change location based on available space.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices-1.2/#menubutton
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/
 themeSource: packages/ui/src/theme/tokens/components/menu.ts
 reactSource: packages/react/src/primitives/Menu/Menu.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/radiogroupfield/index.page.mdx
+++ b/docs/src/pages/[platform]/components/radiogroupfield/index.page.mdx
@@ -3,7 +3,7 @@ title: RadioGroupField
 metaTitle: RadioGroupField
 description: A RadioGroupField allows users to select a single option from a list of mutually exclusive options.
 metaDescription: A RadioGroupField allows users to select a single option from a list of mutually exclusive options.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices-1.2/#radiobutton
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton
 themeSource: packages/ui/src/theme/tokens/components/radio.ts
 reactSource: packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/selectfield/index.page.mdx
+++ b/docs/src/pages/[platform]/components/selectfield/index.page.mdx
@@ -3,7 +3,7 @@ title: SelectField
 metaTitle: SelectField
 metaDescription: The SelectField primitive allows you to create a drop-down list.
 description: The SelectField primitive allows you to create a drop-down list.
-ariaSource: https://www.w3.org/TR/wai-aria-practices/#combobox
+ariaSource: https://www.w3.org/WAI/ARIA/apg/patterns/combobox
 themeSource: packages/ui/src/theme/tokens/components/select.ts
 reactSource: packages/react/src/primitives/SelectField/SelectField.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/sliderfield/index.page.mdx
+++ b/docs/src/pages/[platform]/components/sliderfield/index.page.mdx
@@ -3,7 +3,7 @@ title: SliderField
 metaTitle: SliderField
 description: Sliders allow users to quickly select a value within a range. They should be used when the upper and lower bounds to the range are invariable.
 metaDescription: Sliders allow users to quickly select a value within a range. They should be used when the upper and lower bounds to the range are invariable.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices-1.2/#slider
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/slider
 themeSource: packages/ui/src/theme/tokens/components/sliderField.ts
 reactSource: packages/react/src/primitives/SliderField/SliderField.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/stepperfield/index.page.mdx
+++ b/docs/src/pages/[platform]/components/stepperfield/index.page.mdx
@@ -3,7 +3,7 @@ title: StepperField
 metaTitle: StepperField
 description: A StepperField is a number input with buttons to increase or decrease the value.
 metaDescription: A StepperField is a number input with buttons to increase or decrease the value.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices-1.2/#spinbutton
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton
 themeSource: packages/ui/src/theme/tokens/components/stepperField.ts
 reactSource: packages/react/src/primitives/StepperField/StepperField.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/switchfield/index.page.mdx
+++ b/docs/src/pages/[platform]/components/switchfield/index.page.mdx
@@ -3,7 +3,7 @@ title: SwitchField
 metaTitle: SwitchField
 description: The SwitchField form primitive is a toggleable input type with a checked (on) and unchecked (off) state.
 metaDescription: The SwitchField form primitive is a toggleable input type with a checked (on) and unchecked (off) state.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices-1.2/#switch
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/switch
 themeSource: packages/ui/src/theme/tokens/components/switchField.ts
 reactSource: packages/react/src/primitives/SwitchField/SwitchField.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/table/index.page.mdx
+++ b/docs/src/pages/[platform]/components/table/index.page.mdx
@@ -3,7 +3,7 @@ title: Table
 metaTitle: Table
 description: The Table primitive provides users with a styled and customizable table element.
 metaDescription: The Table primitive provides users with a styled and customizable table element.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices-1.2/#table
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/table
 themeSource: packages/ui/src/theme/tokens/components/table.ts
 reactSource: packages/react/src/primitives/Table/Table.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/tabs/index.page.mdx
+++ b/docs/src/pages/[platform]/components/tabs/index.page.mdx
@@ -3,7 +3,7 @@ title: Tabs
 metaTitle: Tabs
 description: Tabs organize content into multiple sections and allow users to navigate between them. The content under the set of Tabs should be related and form a coherent unit.
 metaDescription: Tabs organize content into multiple sections and allow users to navigate between them. The content under the set of Tabs should be related and form a coherent unit.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices-1.2/#tabpanel
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel
 themeSource: packages/ui/src/theme/tokens/components/tabs.ts
 reactSource: packages/react/src/primitives/Tabs/Tabs.tsx
 supportedFrameworks: react

--- a/docs/src/pages/[platform]/components/tabs/react.mdx
+++ b/docs/src/pages/[platform]/components/tabs/react.mdx
@@ -327,7 +327,7 @@ Note: there is currently no way to style different states like hover using only 
 
 ## Accessibility
 
-Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel).
+Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/).
 
 We recommend passing an `ariaLabel` prop to help enable assistive technology.
 

--- a/docs/src/pages/[platform]/components/togglebutton/index.page.mdx
+++ b/docs/src/pages/[platform]/components/togglebutton/index.page.mdx
@@ -3,7 +3,7 @@ title: ToggleButton
 metaTitle: ToggleButton
 description: A toggle button represents an on/off state for some configuration, for example switching on/off bold text in a text editor.
 metaDescription: A toggle button represents an on/off state for some configuration, for example switching on/off bold text in a text editor.
-ariaPattern: https://www.w3.org/TR/wai-aria-practices-1.2/#button
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/button
 themeSource: packages/ui/src/theme/tokens/components/toggleButton.ts
 reactSource: packages/react/src/primitives/ToggleButton/ToggleButton.tsx
 supportedFrameworks: react


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

The [WAI Aria Practices](https://www.w3.org/TR/wai-aria-practices/#abstract) site we were using to link to our component's aria patterns has been deprecated in favor of the new [Aria Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/). This PR updates all of our links, example:

```
ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/button
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Tested in docs instance locally and verified each new link works.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
