### PR TITLE
fix(sitemap): dynamically generate urls

### DIFF
--- a/docs/scripts/generate-sitemap-robotstxt.ts
+++ b/docs/scripts/generate-sitemap-robotstxt.ts
@@ -67,7 +67,7 @@ async function generateSitemap() {
     <?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
           <url>
-            <loc>https://ui.docs.amplify.aws</loc>
+            <loc>${process.env.SITE_URL}</loc>
             <changefreq>weekly</changefreq>
             <priority>0.5</priority>
             <lastmod>2022-05-19T16:24:03.254Z</lastmod>
@@ -95,7 +95,9 @@ async function generateSitemap() {
 
             return `
               <url>
-                  <loc>${'https://ui.docs.amplify.aws'}${route}</loc>
+                  <loc>${
+                    process.env.SITE_URL ?? 'https://ui.docs.amplify.aws'
+                  }${route}</loc>
                   <changefreq>weekly</changefreq>
                   <priority>${priority}</priority>
                   <lastmod>${new Date().toISOString()}</lastmod>
@@ -140,7 +142,7 @@ Allow: /
 Host: ui.docs.amplify.aws
 
 # Sitemaps
-Sitemap: ${'https://ui.docs.amplify.aws'}
+Sitemap: ${process.env.SITE_URL ?? 'https://ui.docs.amplify.aws'}/sitemap.xml
 `;
   writeFileSync(path.resolve(__dirname, '../public/robots.txt'), txt);
   console.log('🤖✅ robots.txt generated.');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**Issue**: hard-coded prod url for sitemap
**fix**: dynamically use `SITE_URL` from the environment to generate sitemap

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

tested at local

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
