### PR TITLE
docs: move troubleshooting to new page

### DIFF
--- a/docs/src/components/Layout/SecondaryNav.tsx
+++ b/docs/src/components/Layout/SecondaryNav.tsx
@@ -141,6 +141,11 @@ export const SecondaryNav = (props) => {
               Migration
             </NavLink>
           )}
+          {platform !== 'flutter' && (
+            <NavLink {...props} href="/getting-started/troubleshooting">
+              Troubleshooting
+            </NavLink>
+          )}
         </>
       );
     case 'components':

--- a/docs/src/pages/[platform]/getting-started/installation/dependencies.vue.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/dependencies.vue.mdx
@@ -25,3 +25,21 @@ yarn add aws-amplify @aws-amplify/ui-vue
   documentation](https://github.com/aws-amplify/amplify-ui/tree/legacy/legacy/amplify-ui-vue)
   please click here.
 </Alert>
+
+### Install as a global plugin (Optional)
+
+Optionally, you can register all the `@aws-amplify/ui-vue` components at once.
+
+```js
+// main.js
+import { createApp } from 'vue';
+import App from './App.vue';
+import AmplifyVue from '@aws-amplify/ui-vue';
+
+const app = createApp(App);
+app.use(AmplifyVue);
+app.mount('#app');
+```
+
+Otherwise, you can import individual components from the `@aws-amplify/ui-vue` package in each one of your components.
+

--- a/docs/src/pages/[platform]/getting-started/installation/dependencies.vue.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/dependencies.vue.mdx
@@ -26,7 +26,7 @@ yarn add aws-amplify @aws-amplify/ui-vue
   please click here.
 </Alert>
 
-### Install as a global plugin (Optional)
+### Register as a global plugin (Optional)
 
 Optionally, you can register all the `@aws-amplify/ui-vue` components at once.
 

--- a/docs/src/pages/[platform]/getting-started/installation/index.page.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/index.page.mdx
@@ -23,7 +23,3 @@ import { Fragment } from '@/components/Fragment';
 <Fragment platforms={['web']} useCommonWebContent>
   {({ platform }) => import(`./fonts.${platform}.mdx`)}
 </Fragment>
-
-<Fragment platforms={['react', 'vue', 'angular']}>
-  {({ platform }) => import(`./troubleshooting.${platform}.mdx`)}
-</Fragment>

--- a/docs/src/pages/[platform]/getting-started/troubleshooting/index.page.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 metaTitle: Troubleshooting
-metaDescription: Troubleshooting Guide - Common issues encountered, with workarounds, when installing Amplify UI.
+description: Workarounds for common issues using Amplify UI.
 supportedFrameworks: react|angular|vue
 ---
 

--- a/docs/src/pages/[platform]/getting-started/troubleshooting/index.page.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/index.page.mdx
@@ -1,0 +1,11 @@
+---
+title: Troubleshooting
+metaTitle: Troubleshooting
+metaDescription: Troubleshooting Guide - Common issues encountered, with workarounds, when installing Amplify UI.
+supportedFrameworks: react|angular|vue
+---
+
+import Link from 'next/link';
+import { Fragment } from '@/components/Fragment';
+
+<Fragment>{({ platform }) => import(`./troubleshooting.${platform}.mdx`)}</Fragment>

--- a/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.angular.mdx
@@ -1,5 +1,3 @@
-## Troubleshooting
-
 ### Global and Process Shim
 
 Angular 6+ no longer include shims for 'global' or 'process'. Add the following to your `src/polyfills.ts`:

--- a/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.react.mdx
@@ -1,8 +1,6 @@
 import { Alert, Tabs, TabItem } from '@aws-amplify/ui-react';
 
-## Troubleshooting
-
-### Webpack 5+
+## Webpack 5+
 
 Follow the instructions below to if you are using Webpack 5:
 
@@ -47,7 +45,7 @@ yarn add node-polyfill-webpack-plugin -D
   ],
 ```
 
-### Vite
+## Vite
 
 When working with a [Vite](https://vitejs.dev) project you must make a few modifications. Please follow the steps below.
 
@@ -91,7 +89,7 @@ export default defineConfig({
 ...
 ```
 
-### Jest
+## Jest
 
 As of v2.15.0 of `@aws-amplify/ui-react` which included the release of Geo components, users of the Jest testing framework may run into the following error when attempting to run tests:
 

--- a/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.vue.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.vue.mdx
@@ -1,23 +1,4 @@
-## Install as a global plugin (Optional)
-
-Optionally, you can register all the `@aws-amplify/ui-vue` components at once.
-
-```js
-// main.js
-import { createApp } from 'vue';
-import App from './App.vue';
-import AmplifyVue from '@aws-amplify/ui-vue';
-
-const app = createApp(App);
-app.use(AmplifyVue);
-app.mount('#app');
-```
-
-Otherwise, you can import individual components from the `@aws-amplify/ui-vue` package in each one of your components.
-
-## Troubleshooting
-
-### Vite
+## Vite
 
 When working with a [Vite](https://vitejs.dev) project you must make a few modifications. Please follow the steps below.
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR moves the Troubleshooting section off from `/{platform}/getting-started/installation` to its own page at `/{platform}/getting-started/troubleshooting` to align with our new IA.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Part of our "Docs: Getting Started - Installation refactor" task.

#### Description of how you validated changes

Tested changes in local docs install.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
