### PR TITLE
fix(ui): Remove default css margins for <body>

### DIFF
--- a/.changeset/healthy-eagles-do.md
+++ b/.changeset/healthy-eagles-do.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(ui): Remove default css margins for <body>

--- a/examples/next/pages/_document.page.tsx
+++ b/examples/next/pages/_document.page.tsx
@@ -20,7 +20,6 @@ class MyDocument extends Document {
         </Head>
         <body>
           <title>React Example App</title>
-          <h1>React Example App</h1>
 
           <Main />
           <NextScript />

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -20,6 +20,23 @@ html:focus-within {
   scroll-behavior: smooth;
 }
 
+// Remove default margin
+// https://piccalil.li/blog/a-modern-css-reset/
+body,
+h1,
+h2,
+h3,
+h4,
+p,
+li,
+figure,
+figcaption,
+blockquote,
+dl,
+dd {
+  margin: 0;
+}
+
 // https://piccalil.li/blog/a-modern-css-reset/
 body {
   min-height: 100vh;

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -20,25 +20,9 @@ html:focus-within {
   scroll-behavior: smooth;
 }
 
-// Remove default margin
-// https://piccalil.li/blog/a-modern-css-reset/
-body,
-h1,
-h2,
-h3,
-h4,
-p,
-li,
-figure,
-figcaption,
-blockquote,
-dl,
-dd {
-  margin: 0;
-}
-
 // https://piccalil.li/blog/a-modern-css-reset/
 body {
+  margin: 0;
   min-height: 100vh;
   text-rendering: optimizeSpeed;
   line-height: var(--amplify-line-heights-medium);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Browsers will set default margins for elements (known as User Agent Style sheets). Since `<body>` elements in Amplify UI applications are set to have a `min-height: 100vh;`, whenever a browser sets a default `margin` for `<body>` a scroll bar will always appear on the page even if there aren't enough elements on the page to warrant scrolling.

This PR resets the `margin` for `<body>` (and other elements) to ensure setting `min-height: 100vh;` will only take up the available screen real estate. You can review [https://piccalil.li/blog/a-modern-css-reset/](https://piccalil.li/blog/a-modern-css-reset/) which we use as a reference for our CSS reset.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Below is an example of how an Amplify UI application currently looks without a margin reset. Note that I've made the `<html>` element have a background of `lightpink` and the `<body>` element have a background of `lightblue` for visual clarity. Notice that a scroll bar appears even though this app only contains an `<h1>` element:
![with-margins](https://user-images.githubusercontent.com/26472139/169960915-836f389e-a58a-4b32-98ce-149837432502.gif)

With this PR, the `<body>` margin is reset and the height takes up the entire screen with no scroll bar:
![without-margins](https://user-images.githubusercontent.com/26472139/169961092-54b0d329-2fb5-4377-8c4d-3f3918272500.gif)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated - N/A
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated - N/A
- [x] Relevant documentation is changed or added (and PR referenced) - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
