### PR TITLE
fix(style): fix a regression on SliderField style

### DIFF
--- a/packages/react/src/primitives/SliderField/SliderField.tsx
+++ b/packages/react/src/primitives/SliderField/SliderField.tsx
@@ -85,8 +85,8 @@ const SliderFieldPrimitive: Primitive<SliderFieldProps, typeof Root> = (
   );
   const rootComponentClasses = classNames(
     ComponentClassNames.SliderFieldRoot,
-    classNameModifier(ComponentClassNames.SliderFieldTrack, orientation),
-    classNameModifier(ComponentClassNames.SliderFieldTrack, size),
+    classNameModifier(ComponentClassNames.SliderFieldRoot, orientation),
+    classNameModifier(ComponentClassNames.SliderFieldRoot, size),
     className
   );
 


### PR DESCRIPTION

#### Description of changes

Fix a style regression on SliderField due to classname typos which causes the thumb of vertical slider off its track

#### Issue #, if available

![Screen Shot 2022-05-26 at 11 01 24 AM](https://user-images.githubusercontent.com/40295569/170556794-7b55e871-8aa1-4cac-8aab-d6b5354e597c.png)

#### Description of how you validated changes

Verify it gets fixed in dev env

![Screen Shot 2022-05-26 at 11 58 16 AM](https://user-images.githubusercontent.com/40295569/170557834-dc5edb3e-bd5d-4f52-8efb-630572b10aa0.png)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
