### PR TITLE
fix(amplifyprovider): prevent original values from being null

### DIFF
--- a/.changeset/calm-hornets-care.md
+++ b/.changeset/calm-hornets-care.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+fix ThemeProvider original value

--- a/packages/react/src/components/ThemeProvider/__tests__/ThemeProvider.test.tsx
+++ b/packages/react/src/components/ThemeProvider/__tests__/ThemeProvider.test.tsx
@@ -35,7 +35,7 @@ describe('ThemeProvider', () => {
 
     expect(global.document.documentElement.setAttribute).toHaveBeenCalledWith(
       'data-amplify-color-mode',
-      ''
+      'undefined'
     );
   });
 

--- a/packages/react/src/components/ThemeProvider/index.tsx
+++ b/packages/react/src/components/ThemeProvider/index.tsx
@@ -32,14 +32,14 @@ export function AmplifyProvider({
     if (document && document.documentElement) {
       // Keep original data attributes to reset on unmount
       const originalName =
-        document.documentElement.getAttribute('data-amplify-theme');
-      const originalColorMode = document.documentElement.getAttribute(
-        'data-amplify-color-mode'
-      );
+        document.documentElement.getAttribute('data-amplify-theme') ?? name;
+      const originalColorMode =
+        document.documentElement.getAttribute('data-amplify-color-mode') ||
+        colorMode;
       document.documentElement.setAttribute('data-amplify-theme', name);
       document.documentElement.setAttribute(
         'data-amplify-color-mode',
-        colorMode || ''
+        colorMode || originalColorMode
       );
 
       return function cleanup() {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**Issue**: when changing page, `data-amplify-theme` and `data-amplify-color-mode` sometimes are `null`, which caused issue for the search modal https://github.com/aws-amplify/amplify-ui/pull/1775/. If the system mode is changed dark, the modal doesn't change accordingly. It might cause similar issue to the customers.


https://user-images.githubusercontent.com/11983489/170784598-a4c92b2e-3fd6-4def-98bf-64b2ab99d7fe.mov



https://user-images.githubusercontent.com/11983489/170784640-6a8c59df-1f3a-42f4-a5f9-76fee272cffc.mov


**Fix**: set default value if query value from the empty `html` tag


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

locally tested

https://fix-amplifyprovider.dnxy4amiz00i4.amplifyapp.com/

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
