### PR TITLE
Authenticator removes focus from input after Authenticated

### DIFF
--- a/.changeset/small-suns-trade.md
+++ b/.changeset/small-suns-trade.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Fixed bug that was causing logged in users to lose focus on their inputs.

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component.html
@@ -28,6 +28,7 @@
     let-user="user"
     let-signOut="signOut"
   >
+    <input name="textInput" type="text" />
     <h2>Welcome, {{ user.username }}!</h2>
     <button (click)="signOut()">Sign Out</button>
   </ng-template>

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
@@ -1,9 +1,10 @@
 import { Amplify } from 'aws-amplify';
+import { useState } from 'react';
 
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
-import { Heading, Text, useTheme } from '@aws-amplify/ui-react';
+import { Heading, Text, useTheme, TextField } from '@aws-amplify/ui-react';
 
 import awsExports from './aws-exports';
 Amplify.configure(awsExports);
@@ -56,6 +57,7 @@ const components = {
 };
 
 export default function App() {
+  const [text, setText] = useState('');
   return (
     <Authenticator
       formFields={formFields}
@@ -64,6 +66,13 @@ export default function App() {
     >
       {({ signOut, user }) => (
         <main>
+          <TextField
+            name="testInput"
+            type="text"
+            label="myInput"
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+          />
           <h1>Hello {user.username}</h1>
           <button onClick={signOut}>Sign out</button>
         </main>

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import Amplify, { Auth } from 'aws-amplify';
-import { Authenticator } from '@aws-amplify/ui-vue';
+import { Amplify } from 'aws-amplify';
+import { Authenticator, AmplifyTextField } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from './aws-exports';
 
@@ -20,6 +20,7 @@ const formFields = {
 <template>
   <authenticator :form-fields="formFields" :hide-sign-up="true">
     <template v-slot="{ user, signOut }">
+      <amplify-text-field name="testInput" type="text" label="myInput" />
       <h1>Hello {{ user.username }}!</h1>
       <button @click="signOut">Sign Out</button>
     </template>

--- a/packages/e2e/cypress/integration/common/sign-in.ts
+++ b/packages/e2e/cypress/integration/common/sign-in.ts
@@ -34,6 +34,14 @@ When(
   }
 );
 
+When('I type {string} in the input field', (text: string) => {
+  cy.get('input').type(text);
+});
+
+When('I see input text {string}', (text: string) => {
+  cy.get('input').should('have.value', text);
+});
+
 When('I type my password', () => {
   cy.findInputField('Password').type(Cypress.env('VALID_PASSWORD'));
 });

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
@@ -18,6 +18,15 @@ Feature: Sign In with Email
     Then I see "User does not exist"
 
   @angular @react @vue
+  Scenario: Sign in with confirmed credentials and verify inputs are working
+    When I type my "email" with status "CONFIRMED"
+    And I type my password
+    And I click the "Sign in" button
+    Then I see "Sign out"
+    And I type "test" in the input field
+    Then I see input text "test"
+
+  @angular @react @vue
   Scenario: Sign in with unconfirmed credentials
 
   If you sign in with an unconfirmed account, Authenticator will redirect you to `confirmSignUp` route.
@@ -34,6 +43,8 @@ Feature: Sign In with Email
     And I mock 'Amplify.Auth.currentAuthenticatedUser' with fixture "Auth.currentAuthenticatedUser-verified-email"
     And I click the "Confirm" button
     Then I see "Sign out"
+
+
 
 
   @angular @react @vue

--- a/packages/react/src/components/Authenticator/Router/Router.tsx
+++ b/packages/react/src/components/Authenticator/Router/Router.tsx
@@ -45,17 +45,17 @@ const getRouteComponent = (route: string) => {
   }
 };
 
-export function useRouterChildren(
-  children: RouterProps['children']
-): (props?: Omit<RouterProps, 'children'>) => JSX.Element {
+const isUnauthenticatedRoute = (route: string): boolean => {
+  return !(route === 'authenticated' || route === 'signOut');
+};
+
+export function useRouterChildren(): (
+  props?: Omit<RouterProps, 'children'>
+) => JSX.Element {
   const { route } = useAuthenticator(({ route }) => [route]);
 
   return React.useMemo(() => {
-    const isUnauthenticatedRoute = !(
-      route === 'authenticated' || route === 'signOut'
-    );
-
-    if (isUnauthenticatedRoute) {
+    if (isUnauthenticatedRoute(route)) {
       return getRouteComponent(route);
     }
   }, [route]);
@@ -70,10 +70,10 @@ export function Router({
   const { route, signOut, user } = useAuthenticator(
     ({ route, signOut, user }) => [route, signOut, user]
   );
-  const RouterChildren = useRouterChildren(children);
+  const RouterChildren = useRouterChildren();
 
   // `Authenticator` might not have user defined `children` for non SPA use cases.
-  if (route === 'authenticated' || route === 'signOut') {
+  if (!isUnauthenticatedRoute(route)) {
     if (!children) {
       return null;
     }

--- a/packages/react/src/components/Authenticator/Router/Router.tsx
+++ b/packages/react/src/components/Authenticator/Router/Router.tsx
@@ -48,9 +48,7 @@ const getRouteComponent = (route: string) => {
 export function useRouterChildren(
   children: RouterProps['children']
 ): (props?: Omit<RouterProps, 'children'>) => JSX.Element {
-  const { route, signOut, user } = useAuthenticator(
-    ({ route, signOut, user }) => [route, signOut, user]
-  );
+  const { route } = useAuthenticator(({ route }) => [route]);
 
   return React.useMemo(() => {
     const isUnauthenticatedRoute = !(

--- a/packages/react/src/components/Authenticator/Router/Router.tsx
+++ b/packages/react/src/components/Authenticator/Router/Router.tsx
@@ -60,17 +60,7 @@ export function useRouterChildren(
     if (isUnauthenticatedRoute) {
       return getRouteComponent(route);
     }
-
-    // `Authenticator` might not have user defined `children` for non SPA use cases.
-    if (!children) {
-      return () => null;
-    }
-
-    return () =>
-      typeof children === 'function'
-        ? children({ signOut, user }) // children is a render prop
-        : children;
-  }, [children, route, signOut, user]);
+  }, [route]);
 }
 
 export function Router({
@@ -79,8 +69,21 @@ export function Router({
   hideSignUp,
   variation,
 }: RouterProps) {
-  const { route } = useAuthenticator(({ route }) => [route]);
+  const { route, signOut, user } = useAuthenticator(
+    ({ route, signOut, user }) => [route, signOut, user]
+  );
   const RouterChildren = useRouterChildren(children);
+
+  // `Authenticator` might not have user defined `children` for non SPA use cases.
+  if (route === 'authenticated' || route === 'signOut') {
+    if (!children) {
+      return null;
+    }
+
+    return typeof children === 'function'
+      ? children({ signOut, user }) // children is a render prop
+      : children;
+  }
 
   return (
     <RouterChildren


### PR DESCRIPTION
#### Description of changes
When users are following the Authenticator [getting started guide](https://docs.amplify.aws/start/getting-started/auth/q/integration/react/) in the official docs, they get stuck on the `Add authentication` page. Every typing in the input, it loses focus after every letter.

It seems to be related to #1451 

#### Issue #, if available
[#4306](https://github.com/aws-amplify/docs/issues/4306)

#### Description of how you validated changes
Wrote test

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
