### PR TITLE
fix(docs): dynamically show supported frameworks on each page

### DIFF
--- a/docs/src/components/Layout/FrameworkChooser.tsx
+++ b/docs/src/components/Layout/FrameworkChooser.tsx
@@ -4,16 +4,21 @@ import { capitalize } from 'lodash';
 import { useCustomRouter } from '@/components/useCustomRouter';
 import Link from 'next/link';
 import { FRAMEWORKS } from '@/data/frameworks';
+import metaData from '@/data/pages.preval';
 
 interface FrameworkLinkProps extends FrameworkChooserProps {
   framework: string;
+  isDisabled: boolean;
 }
 
 const platformPath = '[platform]';
 
-const FrameworkLink = ({ framework, onClick }: FrameworkLinkProps) => {
+const FrameworkLink = ({
+  framework,
+  onClick,
+  isDisabled,
+}: FrameworkLinkProps) => {
   const { pathname, query } = useCustomRouter();
-
   const isCurrent = query.platform === framework;
   const classNames = `docs-framework-link ${isCurrent ? 'current' : ''}`;
   const href = pathname.includes(platformPath)
@@ -22,7 +27,12 @@ const FrameworkLink = ({ framework, onClick }: FrameworkLinkProps) => {
 
   return (
     <Link href={href} passHref>
-      <Button as="a" size="small" className={classNames} onClick={onClick}>
+      <Button
+        size="small"
+        className={classNames}
+        onClick={onClick}
+        isDisabled={isDisabled}
+      >
         <Image
           alt={framework}
           height="1.25rem"
@@ -41,7 +51,14 @@ interface FrameworkChooserProps {
 }
 
 export const FrameworkChooser = ({ onClick }: FrameworkChooserProps) => {
+  const { pathname } = useCustomRouter();
   const { tokens } = useTheme();
+  const {
+    frontmatter: { supportedFrameworks = 'react' },
+  } = metaData[pathname];
+  const frameworksOptions =
+    supportedFrameworks === 'all' ? FRAMEWORKS : supportedFrameworks.split('|');
+
   return (
     <Flex direction="column" gap={tokens.space.xs}>
       {FRAMEWORKS.map((framework) => (
@@ -49,6 +66,7 @@ export const FrameworkChooser = ({ onClick }: FrameworkChooserProps) => {
           key={framework}
           framework={framework}
           onClick={onClick}
+          isDisabled={!frameworksOptions.includes(framework)}
         />
       ))}
     </Flex>

--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -11,7 +11,7 @@ import Script from 'next/script';
 import { baseTheme } from '../theme';
 import { capitalizeString } from '../utils/capitalizeString';
 import { useCustomRouter } from '@/components/useCustomRouter';
-import metaData from '../data/pages.preval';
+import metaData from '@/data/pages.preval';
 
 // suppress useLayoutEffect warnings when running outside a browser
 // See: https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85#gistcomment-3886909


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**Issue**: we show all the available frameworks on all pages even though some pages don't support that framework, but the crawler crawl those links

**Fix**: dynamically only show the supported framework options on the switcher

| Before  | After  |
|---|---|
| ![image](https://user-images.githubusercontent.com/11983489/171292715-571e8d07-3500-4c99-95b6-d87e94dae744.png)  |  ![Pasted_Image_5_31_22__15_57](https://user-images.githubusercontent.com/11983489/171297340-d6c6eaf3-037a-4930-b05c-20e7f60dd0bf.png) |
| ![image](https://user-images.githubusercontent.com/11983489/171292847-7d8309cd-bb61-48fc-89c4-439e1af18104.png)  |  ![Pasted_Image_5_31_22__15_55](https://user-images.githubusercontent.com/11983489/171297220-9ad493b5-653f-4a9b-8dea-bae63db9a7d4.png)|








#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202371408638003