### PR TITLE
docs(fix): Add CSP rule for prod env

### DIFF
--- a/docs/src/pages/_document.page.tsx
+++ b/docs/src/pages/_document.page.tsx
@@ -25,7 +25,7 @@ const getCSPContent = (context: Readonly<HtmlProps>) => {
       style-src 'self' 'unsafe-inline';
       font-src 'self' data:;
       frame-src 'self' *.codesandbox.io;
-      img-src 'self' cm.everesttech.net amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net images.unsplash.com;
+      img-src 'self' cm.everesttech.net amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net https://images.unsplash.com;
       connect-src 'self' *.shortbread.aws.dev amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net https://*.algolia.net https://*.algolianet.com;
       script-src 'unsafe-eval' 'self' '${cspInlineScriptHash}' a0.awsstatic.com;
     `;
@@ -36,7 +36,7 @@ const getCSPContent = (context: Readonly<HtmlProps>) => {
     style-src 'self' 'unsafe-inline';
     font-src 'self';
     frame-src 'self' *.codesandbox.io aws.demdex.net;
-    img-src 'self' cm.everesttech.net amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net images.unsplash.com;
+    img-src 'self' cm.everesttech.net amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net https://images.unsplash.com;
     connect-src 'self' *.shortbread.aws.dev amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net https://*.algolia.net https://*.algolianet.com;
     script-src 'self' '${cspInlineScriptHash}' a0.awsstatic.com;
   `;

--- a/docs/src/pages/_document.page.tsx
+++ b/docs/src/pages/_document.page.tsx
@@ -36,7 +36,7 @@ const getCSPContent = (context: Readonly<HtmlProps>) => {
     style-src 'self' 'unsafe-inline';
     font-src 'self';
     frame-src 'self' *.codesandbox.io aws.demdex.net;
-    img-src 'self' cm.everesttech.net amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net;
+    img-src 'self' cm.everesttech.net amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net images.unsplash.com;
     connect-src 'self' *.shortbread.aws.dev amazonwebservices.d2.sc.omtrdc.net dpm.demdex.net https://*.algolia.net https://*.algolianet.com;
     script-src 'self' '${cspInlineScriptHash}' a0.awsstatic.com;
   `;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

I noticed on our [dev docs site](https://dev.ui.docs.amplify.aws/react/getting-started/create-react-app) that the Unsplash images for the CRA tutorial weren't displaying, but they displayed in my dev environment. 

I added the image-src CSP rule to our prod env as well, which should hopefully fix this. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
