### PR TITLE
Adding docs links in intellisense

### DIFF
--- a/docs/src/pages/[platform]/components/icon/index.page.mdx
+++ b/docs/src/pages/[platform]/components/icon/index.page.mdx
@@ -1,6 +1,8 @@
 ---
 title: Icon
 description: The icon component displays simple vector graphics for use in other components like Buttons.
+themeSource: packages/ui/src/theme/tokens/components/icon.ts
+reactSource: packages/react/src/primitives/Icon/Icon.tsx
 supportedFrameworks: react
 ---
 

--- a/docs/src/pages/[platform]/components/image/index.page.mdx
+++ b/docs/src/pages/[platform]/components/image/index.page.mdx
@@ -1,6 +1,8 @@
 ---
 title: Image
 description: The Image primitive can be used to display responsive images.
+themeSource: packages/ui/src/theme/tokens/components/image.ts
+reactSource: packages/react/src/primitives/Image/Image.tsx
 supportedFrameworks: react
 ---
 

--- a/packages/react/src/components/Authenticator/Authenticator.tsx
+++ b/packages/react/src/components/Authenticator/Authenticator.tsx
@@ -38,6 +38,9 @@ function InitMachine({
   return <>{children}</>;
 }
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/authenticator)
+ */
 export function Authenticator({
   children,
   className,

--- a/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
@@ -101,6 +101,9 @@ const useAuthenticatorService = () => {
   return service;
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/authenticator#useauthenticator-hook)
+ */
 export const useAuthenticator = (selector?: Selector) => {
   const service = useAuthenticatorService();
 

--- a/packages/react/src/components/Authenticator/withAuthenticator.tsx
+++ b/packages/react/src/components/Authenticator/withAuthenticator.tsx
@@ -2,6 +2,9 @@ import { Authenticator, AuthenticatorProps } from './Authenticator';
 
 export type WithAuthenticatorOptions = Omit<AuthenticatorProps, 'children'>;
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/authenticator)
+ */
 export function withAuthenticator<Props>(
   Component: (props?: Props) => JSX.Element,
   options: WithAuthenticatorOptions = {}

--- a/packages/react/src/components/Geo/LocationSearch/index.tsx
+++ b/packages/react/src/components/Geo/LocationSearch/index.tsx
@@ -19,7 +19,9 @@ type AmplifyLocationSearch = IControl & {
 };
 
 /**
- * The `<LocationSearch>` component provides location search. See https://ui.docs.amplify.aws/components/geo#geocoder.
+ * The `<LocationSearch>` component provides location search.
+ *
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/geo#location-search)
  *
  * @example
  * // Used as a map control:

--- a/packages/react/src/components/Geo/MapView/index.tsx
+++ b/packages/react/src/components/Geo/MapView/index.tsx
@@ -15,6 +15,8 @@ export type MapViewProps = Omit<MapProps, 'transformRequest'>;
  * [react-map-gl default Map](https://visgl.github.io/react-map-gl/docs/api-reference/map), it accepts the same
  * properties except `transformRequest` which is set by Amplify.
  *
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/geo#mapview)
+ *
  * @example
  * // Basic usage of MapView:
  * function App() {

--- a/packages/react/src/components/ThemeProvider/index.tsx
+++ b/packages/react/src/components/ThemeProvider/index.tsx
@@ -127,4 +127,7 @@ export function AmplifyProvider({
   );
 }
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/theming)
+ */
 export const ThemeProvider = AmplifyProvider;

--- a/packages/react/src/hooks/useBreakpointValue.ts
+++ b/packages/react/src/hooks/useBreakpointValue.ts
@@ -3,6 +3,9 @@ import { getValueAtCurrentBreakpoint } from '../primitives/shared/responsive/uti
 import { useBreakpoint } from '../primitives/shared/responsive/useBreakpoint';
 import { useTheme } from './useTheme';
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/theming/responsive#usebreakpointvalue)
+ */
 export function useBreakpointValue<T>(
   values: Record<string, T> | T[],
   defaultBreakpoint?: Breakpoint

--- a/packages/react/src/hooks/useTheme.ts
+++ b/packages/react/src/hooks/useTheme.ts
@@ -6,6 +6,9 @@ import {
   AmplifyContextType,
 } from '../components/ThemeProvider/AmplifyContext';
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/theming)
+ */
 export const useTheme = (): WebTheme => {
   const context = React.useContext(AmplifyContext);
   return getThemeFromContext(context);

--- a/packages/react/src/primitives/Alert/Alert.tsx
+++ b/packages/react/src/primitives/Alert/Alert.tsx
@@ -69,6 +69,9 @@ const AlertPrimitive: Primitive<AlertProps, typeof Flex> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/alert)
+ */
 export const Alert = React.forwardRef(AlertPrimitive);
 
 Alert.displayName = 'Alert';

--- a/packages/react/src/primitives/Badge/Badge.tsx
+++ b/packages/react/src/primitives/Badge/Badge.tsx
@@ -31,6 +31,9 @@ const BadgePrimitive: Primitive<BadgeProps, 'span'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/badge)
+ */
 export const Badge = React.forwardRef(BadgePrimitive);
 
 Badge.displayName = 'Badge';

--- a/packages/react/src/primitives/Button/Button.tsx
+++ b/packages/react/src/primitives/Button/Button.tsx
@@ -67,6 +67,9 @@ const ButtonPrimitive: Primitive<ButtonProps, 'button'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/button)
+ */
 export const Button = React.forwardRef(ButtonPrimitive);
 
 Button.displayName = 'Button';

--- a/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
@@ -24,6 +24,9 @@ const ButtonGroupPrimitive: Primitive<ButtonGroupProps, typeof Flex> = (
   </Flex>
 );
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/button#buttongroup)
+ */
 export const ButtonGroup = React.forwardRef(ButtonGroupPrimitive);
 
 ButtonGroup.displayName = 'ButtonGroup';

--- a/packages/react/src/primitives/Card/Card.tsx
+++ b/packages/react/src/primitives/Card/Card.tsx
@@ -26,6 +26,9 @@ const CardPrimitive: Primitive<CardProps, 'div'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/card)
+ */
 export const Card = React.forwardRef(CardPrimitive);
 
 Card.displayName = 'Card';

--- a/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
+++ b/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
@@ -47,6 +47,9 @@ const CheckboxFieldPrimitive: Primitive<CheckboxFieldProps, 'input'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/checkboxfield)
+ */
 export const CheckboxField = React.forwardRef(CheckboxFieldPrimitive);
 
 CheckboxField.displayName = 'CheckboxField';

--- a/packages/react/src/primitives/Collection/Collection.tsx
+++ b/packages/react/src/primitives/Collection/Collection.tsx
@@ -38,6 +38,9 @@ const GridCollection = <Item,>({
   <Grid {...rest}>{Array.isArray(items) ? items.map(children) : null}</Grid>
 );
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/collection)
+ */
 export const Collection = <Item,>({
   className,
   isSearchable,

--- a/packages/react/src/primitives/Divider/Divider.tsx
+++ b/packages/react/src/primitives/Divider/Divider.tsx
@@ -31,6 +31,9 @@ const DividerPrimitive: Primitive<DividerProps, 'hr'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/divider)
+ */
 export const Divider = React.forwardRef(DividerPrimitive);
 
 Divider.displayName = 'Divider';

--- a/packages/react/src/primitives/Expander/Expander.tsx
+++ b/packages/react/src/primitives/Expander/Expander.tsx
@@ -59,6 +59,9 @@ const ExpanderPrimitive: Primitive<ExpanderProps, typeof Root> = (
   return expander;
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/expander)
+ */
 export const Expander = React.forwardRef(ExpanderPrimitive);
 
 Expander.displayName = 'Expander';

--- a/packages/react/src/primitives/Flex/Flex.tsx
+++ b/packages/react/src/primitives/Flex/Flex.tsx
@@ -18,6 +18,9 @@ const FlexPrimitive: Primitive<FlexProps, 'div'> = (
   </View>
 );
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/flex)
+ */
 export const Flex = React.forwardRef(FlexPrimitive);
 
 Flex.displayName = 'Flex';

--- a/packages/react/src/primitives/Grid/Grid.tsx
+++ b/packages/react/src/primitives/Grid/Grid.tsx
@@ -18,6 +18,9 @@ const GridPrimitive: Primitive<GridProps, 'div'> = (
   </View>
 );
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/grid)
+ */
 export const Grid = React.forwardRef(GridPrimitive);
 
 Grid.displayName = 'Grid';

--- a/packages/react/src/primitives/Heading/Heading.tsx
+++ b/packages/react/src/primitives/Heading/Heading.tsx
@@ -39,6 +39,9 @@ const HeadingPrimitive: Primitive<HeadingProps, HeadingTag> = (
   </View>
 );
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/heading)
+ */
 export const Heading = React.forwardRef(HeadingPrimitive);
 
 Heading.displayName = 'Heading';

--- a/packages/react/src/primitives/Icon/Icon.tsx
+++ b/packages/react/src/primitives/Icon/Icon.tsx
@@ -54,6 +54,9 @@ const IconPrimitive: Primitive<IconProps, 'svg'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/icon)
+ */
 export const Icon = React.forwardRef(IconPrimitive);
 
 Icon.displayName = 'Icon';

--- a/packages/react/src/primitives/Image/Image.tsx
+++ b/packages/react/src/primitives/Image/Image.tsx
@@ -17,6 +17,9 @@ const ImagePrimitive: Primitive<ImageProps, 'img'> = (
   />
 );
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/image)
+ */
 export const Image = React.forwardRef(ImagePrimitive);
 
 Image.displayName = 'Image';

--- a/packages/react/src/primitives/Link/Link.tsx
+++ b/packages/react/src/primitives/Link/Link.tsx
@@ -24,6 +24,9 @@ const LinkPrimitive: Primitive<LinkProps, 'a'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/link)
+ */
 export const Link = React.forwardRef(LinkPrimitive);
 
 Link.displayName = 'Link';

--- a/packages/react/src/primitives/Loader/Loader.tsx
+++ b/packages/react/src/primitives/Loader/Loader.tsx
@@ -145,6 +145,9 @@ const LoaderPrimitive: Primitive<LoaderProps, 'svg'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/loader)
+ */
 export const Loader = React.forwardRef(LoaderPrimitive);
 
 Loader.displayName = 'Loader';

--- a/packages/react/src/primitives/Menu/Menu.tsx
+++ b/packages/react/src/primitives/Menu/Menu.tsx
@@ -60,6 +60,9 @@ const MenuPrimitive: Primitive<MenuProps, 'div'> = (
   </DropdownMenu>
 );
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/menu)
+ */
 export const Menu = React.forwardRef(MenuPrimitive);
 
 Menu.displayName = 'Menu';

--- a/packages/react/src/primitives/Menu/MenuButton.tsx
+++ b/packages/react/src/primitives/Menu/MenuButton.tsx
@@ -7,6 +7,9 @@ import { ButtonProps, PrimitiveProps } from '../types';
 import { ComponentClassNames } from '../shared/constants';
 import { useStyles } from '../shared/styleUtils';
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/menu)
+ */
 export const MenuButton = React.forwardRef<
   HTMLButtonElement,
   PrimitiveProps<ButtonProps, 'button'>

--- a/packages/react/src/primitives/Menu/MenuItem.tsx
+++ b/packages/react/src/primitives/Menu/MenuItem.tsx
@@ -8,6 +8,9 @@ import { MenuItemProps } from '../types';
 
 export const MENU_ITEM_TEST_ID = 'amplify-menu-item-test-id';
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/menu)
+ */
 export const MenuItem = React.forwardRef<HTMLDivElement, MenuItemProps>(
   ({ children, className, variation, ...rest }, ref) => {
     return (

--- a/packages/react/src/primitives/Pagination/Pagination.tsx
+++ b/packages/react/src/primitives/Pagination/Pagination.tsx
@@ -45,6 +45,9 @@ const PaginationPrimitive: Primitive<PaginationProps, 'nav'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/pagination)
+ */
 export const Pagination = React.forwardRef(PaginationPrimitive);
 
 Pagination.displayName = 'Pagination';

--- a/packages/react/src/primitives/PasswordField/PasswordField.tsx
+++ b/packages/react/src/primitives/PasswordField/PasswordField.tsx
@@ -52,6 +52,9 @@ const PasswordFieldPrimitive: Primitive<PasswordFieldProps, 'input'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/passwordfield)
+ */
 export const PasswordField = React.forwardRef(PasswordFieldPrimitive);
 
 PasswordField.displayName = 'PasswordField';

--- a/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
@@ -62,6 +62,9 @@ const PhoneNumberFieldPrimitive: Primitive<PhoneNumberFieldProps, 'input'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/phonenumberfield)
+ */
 export const PhoneNumberField = React.forwardRef(PhoneNumberFieldPrimitive);
 
 PhoneNumberField.displayName = 'PhoneNumberField';

--- a/packages/react/src/primitives/Placeholder/Placeholder.tsx
+++ b/packages/react/src/primitives/Placeholder/Placeholder.tsx
@@ -28,6 +28,9 @@ const PlaceholderPrimitive: Primitive<PlaceholderProps, 'div'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/placeholder)
+ */
 export const Placeholder = React.forwardRef(PlaceholderPrimitive);
 
 Placeholder.displayName = 'Placeholder';

--- a/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
+++ b/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
@@ -101,6 +101,9 @@ const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/radiogroupfield)
+ */
 export const RadioGroupField = React.forwardRef(RadioGroupFieldPrimitive);
 
 RadioGroupField.displayName = 'RadioGroupField';

--- a/packages/react/src/primitives/Rating/Rating.tsx
+++ b/packages/react/src/primitives/Rating/Rating.tsx
@@ -80,6 +80,9 @@ const RatingPrimitive: Primitive<RatingProps, typeof Flex> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/rating)
+ */
 export const Rating = React.forwardRef(RatingPrimitive);
 
 Rating.displayName = 'Rating';

--- a/packages/react/src/primitives/ScrollView/ScrollView.tsx
+++ b/packages/react/src/primitives/ScrollView/ScrollView.tsx
@@ -24,6 +24,9 @@ const ScrollViewPrimitive: Primitive<ScrollViewProps, 'div'> = (
   </View>
 );
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/scrollview)
+ */
 export const ScrollView = React.forwardRef(ScrollViewPrimitive);
 
 ScrollView.displayName = 'ScrollView';

--- a/packages/react/src/primitives/SearchField/SearchField.tsx
+++ b/packages/react/src/primitives/SearchField/SearchField.tsx
@@ -59,6 +59,9 @@ const SearchFieldPrimitive: Primitive<SearchFieldProps, 'input'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/searchfield)
+ */
 export const SearchField = React.forwardRef(SearchFieldPrimitive);
 
 SearchField.displayName = 'SearchField';

--- a/packages/react/src/primitives/SelectField/SelectField.tsx
+++ b/packages/react/src/primitives/SelectField/SelectField.tsx
@@ -96,6 +96,9 @@ const SelectFieldPrimitive: Primitive<SelectFieldProps, 'select'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/selectfield)
+ */
 export const SelectField = React.forwardRef(SelectFieldPrimitive);
 
 SelectField.displayName = 'SelectField';

--- a/packages/react/src/primitives/SliderField/SliderField.tsx
+++ b/packages/react/src/primitives/SliderField/SliderField.tsx
@@ -171,6 +171,9 @@ const SliderFieldPrimitive: Primitive<SliderFieldProps, typeof Root> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/sliderfield)
+ */
 export const SliderField = React.forwardRef(SliderFieldPrimitive);
 
 SliderField.displayName = 'SliderField';

--- a/packages/react/src/primitives/StepperField/StepperField.tsx
+++ b/packages/react/src/primitives/StepperField/StepperField.tsx
@@ -182,6 +182,9 @@ const StepperFieldPrimitive: Primitive<StepperFieldProps, 'input'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/stepperfield)
+ */
 export const StepperField = React.forwardRef(StepperFieldPrimitive);
 
 StepperField.displayName = 'StepperField';

--- a/packages/react/src/primitives/SwitchField/SwitchField.tsx
+++ b/packages/react/src/primitives/SwitchField/SwitchField.tsx
@@ -128,6 +128,9 @@ const SwitchFieldPrimitive: Primitive<SwitchFieldProps, typeof Flex> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/switchfield)
+ */
 export const SwitchField = React.forwardRef(SwitchFieldPrimitive);
 
 SwitchField.displayName = 'SwitchField';

--- a/packages/react/src/primitives/Table/Table.tsx
+++ b/packages/react/src/primitives/Table/Table.tsx
@@ -45,6 +45,9 @@ const TablePrimitive: Primitive<TableProps, 'table'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/table)
+ */
 export const Table = React.forwardRef(TablePrimitive);
 
 Table.displayName = 'Table';

--- a/packages/react/src/primitives/Tabs/Tabs.tsx
+++ b/packages/react/src/primitives/Tabs/Tabs.tsx
@@ -107,6 +107,9 @@ const TabItemPrimitive: Primitive<TabItemProps, 'button'> = (
   </View>
 );
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/tabs)
+ */
 export const Tabs = React.forwardRef(TabsPrimitive);
 export const TabItem = React.forwardRef(TabItemPrimitive);
 

--- a/packages/react/src/primitives/Text/Text.tsx
+++ b/packages/react/src/primitives/Text/Text.tsx
@@ -31,6 +31,9 @@ const TextPrimitive: Primitive<TextProps, 'p'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/text)
+ */
 export const Text = React.forwardRef(TextPrimitive);
 
 Text.displayName = 'Text';

--- a/packages/react/src/primitives/TextAreaField/TextAreaField.tsx
+++ b/packages/react/src/primitives/TextAreaField/TextAreaField.tsx
@@ -90,6 +90,9 @@ const TextAreaFieldPrimitive: Primitive<TextAreaFieldProps, 'textarea'> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/textareafield)
+ */
 export const TextAreaField = React.forwardRef(TextAreaFieldPrimitive);
 
 TextAreaField.displayName = 'TextAreaField';

--- a/packages/react/src/primitives/TextField/TextField.tsx
+++ b/packages/react/src/primitives/TextField/TextField.tsx
@@ -144,6 +144,9 @@ const TextFieldPrimitive = <Multiline extends boolean>(
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/textfield)
+ */
 export const TextField = React.forwardRef(TextFieldPrimitive) as <
   Multiline extends boolean
 >(

--- a/packages/react/src/primitives/ToggleButton/ToggleButton.tsx
+++ b/packages/react/src/primitives/ToggleButton/ToggleButton.tsx
@@ -58,6 +58,9 @@ const ToggleButtonPrimitive: Primitive<ToggleButtonProps, typeof Button> = (
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/togglebutton)
+ */
 export const ToggleButton = React.forwardRef(ToggleButtonPrimitive);
 
 ToggleButton.displayName = 'ToggleButton';

--- a/packages/react/src/primitives/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react/src/primitives/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -54,6 +54,9 @@ const ToggleButtonGroupPrimitive: Primitive<
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/togglebutton#togglebuttongroup)
+ */
 export const ToggleButtonGroup = React.forwardRef(ToggleButtonGroupPrimitive);
 
 ToggleButtonGroup.displayName = 'ToggleButtonGroup';

--- a/packages/react/src/primitives/View/View.tsx
+++ b/packages/react/src/primitives/View/View.tsx
@@ -35,6 +35,9 @@ const ViewPrimitive = <Element extends ElementType = 'div'>(
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/view)
+ */
 export const View = React.forwardRef(ViewPrimitive);
 
 View.displayName = 'View';

--- a/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/primitives/VisuallyHidden/VisuallyHidden.tsx
@@ -19,6 +19,9 @@ const VisuallyHiddenPrimitive: Primitive<VisuallyHiddenProps, 'span'> = (
   </View>
 );
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/visuallyhidden)
+ */
 export const VisuallyHidden = React.forwardRef(VisuallyHiddenPrimitive);
 
 VisuallyHidden.displayName = 'VisuallyHidden';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Added JSDoc comment blocks on the primitives with a link to their documentation page. I think this is a nice little DX improvement especially since our types look really weird in VSCode's intellisense popover. In the future I would like to see how we can clean up with the intellisense popover shows because the type definition it shows is not super helpful. I would like to see the component's prop types

TODO:
[] Authenticator for all frameworks

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes


![CleanShot 2022-06-02 at 10 03 04](https://user-images.githubusercontent.com/321279/171684995-6e85cee1-3cdb-4a65-8350-d2af3751dc7b.gif)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
