### PR TITLE
chore(react): update unit test for Expander for custom title component

### DIFF
--- a/.changeset/mean-eyes-remain.md
+++ b/.changeset/mean-eyes-remain.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+chore(react): update unit tests for Expander, which now supports passing any ReactNode (custom component) as title prop

--- a/docs/src/pages/[platform]/components/expander/examples/CustomTitleComponent.tsx
+++ b/docs/src/pages/[platform]/components/expander/examples/CustomTitleComponent.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+
+import {
+  Expander,
+  ExpanderItem,
+  Flex,
+  View,
+  useTheme,
+} from '@aws-amplify/ui-react';
+
+export const CustomTitle = ({ courseNumber, courseName }) => {
+  const { tokens } = useTheme();
+  return (
+    <Flex gap={tokens.space.small}>
+      <View width={tokens.space.xxxl} color={tokens.colors.teal[80]}>
+        {courseNumber}
+      </View>
+      <View>{courseName}</View>
+    </Flex>
+  );
+};
+
+export const CustomTitleComponent = () => {
+  return (
+    <Expander type="single">
+      <ExpanderItem
+        title={
+          <CustomTitle
+            courseNumber="CS 103"
+            courseName="Mathematical Foundations of Computing"
+          />
+        }
+        value="item-1"
+      >
+        Example content for CS 103
+      </ExpanderItem>
+      <ExpanderItem
+        title={
+          <CustomTitle
+            courseNumber="CS 106A"
+            courseName="Programming Methodology"
+          />
+        }
+        value="item-2"
+      >
+        Example content for CS 106A
+      </ExpanderItem>
+    </Expander>
+  );
+};

--- a/docs/src/pages/[platform]/components/expander/examples/index.ts
+++ b/docs/src/pages/[platform]/components/expander/examples/index.ts
@@ -3,6 +3,7 @@ export { BasicSingleExpander } from './BasicSingleExample';
 export { ClassStylingExpander } from './ClassStylingExample';
 export { CollapsibleExpander } from './CollapsibleExample';
 export { ControlledSingleExpander } from './ControlledSingleExample';
+export { CustomTitleComponent } from './CustomTitleComponent';
 export { DefaultExpanderExample } from './DefaultExpanderExample';
 export { ExpandedByDefaultMultipleExpander } from './ExpandedByDefaultMultipleExample';
 export { StylePropsExpander } from './StylePropsExample';

--- a/docs/src/pages/[platform]/components/expander/react.mdx
+++ b/docs/src/pages/[platform]/components/expander/react.mdx
@@ -6,6 +6,7 @@ import {
   ClassStylingExpander,
   CollapsibleExpander,
   ControlledSingleExpander,
+  CustomTitleComponent,
   DefaultExpanderExample,
   ExpandedByDefaultMultipleExpander,
   StylePropsExpander,
@@ -125,6 +126,22 @@ To use the Expander as controlled component, specify the `value` of the item(s) 
 
   </ExampleCode>
 </Example>
+
+### Custom title component
+
+For more control over the layout or styling of the expander item header, pass a custom component to the `<ExpanderItem>` title prop.
+
+<Example>
+  <View>
+    <CustomTitleComponent />
+  </View>
+  <ExampleCode>
+```jsx file=./examples/CustomTitleComponent.tsx
+
+```
+  </ExampleCode>
+</Example>
+
 
 ## CSS Styling
 

--- a/packages/react/src/primitives/Expander/__tests__/ExpanderItem.test.tsx
+++ b/packages/react/src/primitives/Expander/__tests__/ExpanderItem.test.tsx
@@ -47,7 +47,7 @@ describe('ExpanderItem: ', () => {
     expect(trigger).toHaveClass(ComponentClassNames.ExpanderTrigger);
   });
 
-  it('should pass title', async () => {
+  it('should pass string as title', async () => {
     const title = 'item-title';
     render(
       <Expander type="single" defaultValue="item-value">
@@ -59,6 +59,30 @@ describe('ExpanderItem: ', () => {
 
     const header = await screen.findByTestId(EXPANDER_HEADER_TEST_ID);
     expect(header).toHaveTextContent(title);
+  });
+
+  it('should pass custom component as title', async () => {
+    const titleText = 'item-title';
+    const ExpanderTitle = ({ title }) => {
+      return (
+        <div>
+          <span>{title}</span>
+        </div>
+      );
+    };
+    render(
+      <Expander type="single" defaultValue="item-value">
+        <ExpanderItem
+          title={<ExpanderTitle title={titleText} />}
+          value="item-value"
+        >
+          content
+        </ExpanderItem>
+      </Expander>
+    );
+
+    const header = await screen.findByTestId(EXPANDER_HEADER_TEST_ID);
+    expect(header).toHaveTextContent(titleText);
   });
 
   it('should set aria-controls on trigger and have matching id on content', async () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

We recently updated the ExpanderItem component to accept any ReactNode as a title. 

```
  title?: React.ReactNode;
```
This adds a unit test for passing a custom component to the title prop. It also updates our docs to show an example of using a custom component as the title (screenshot below).

<img width="939" alt="Screen Shot 2022-06-03 at 11 49 33 AM" src="https://user-images.githubusercontent.com/376920/171900803-a8ae5570-6de1-4419-87a7-117b14803474.png">

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran tests locally and verify they pass. Ran docs instance locally to verify new example.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
