### PR TITLE
Fix Vue-CLI canary from failing to build

### DIFF
--- a/canary/apps/vue/vuecli/package.json
+++ b/canary/apps/vue/vuecli/package.json
@@ -24,6 +24,9 @@
     "eslint-plugin-vue": "^7.0.0",
     "serve": "^13.0.2"
   },
+  "resolutions": {
+    "error-stack-parser": "2.0.7"
+  },
   "eslintConfig": {
     "root": true,
     "env": {


### PR DESCRIPTION
#### Description of changes

Fix Vue CLI from this [bug](https://github.com/stacktracejs/error-stack-parser/issues/80).

Can remove when bug is fixed if needed.

Fixes #2038 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
