### PR TITLE
fix: issue where npm v8.8+ doesn't include tslib

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,6 +35,7 @@
   },
   "files": [
     "dist",
+    "dist/esm/node_modules",
     "legacy",
     "internal",
     "LICENSE"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "dist",
+    "dist/esm/node_modules",
     "LICENSE"
   ],
   "scripts": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fixes an issue where `npm pack` or `npm publish` in npm version 8.8+ no longer includes the `dist/esm/node_modules/tslib` folder. This folder includes a file `tslib.es6.js` which polyfills a few ES6 features. The fix is to tell npm to always include this folder by adding it to `files`. 

Runtime error seen when `dist/esm/node_modules/tslib` folder is missing
```bash
ERROR in ./node_modules/@aws-amplify/ui-react/dist/esm/primitives/VisuallyHidden/VisuallyHidden.js 1:0-68
Module not found: Error: Can't resolve '../../node_modules/tslib/tslib.es6.js'
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
