### PR TITLE
feat: adding colors theme key support in style props

### DIFF
--- a/.changeset/dull-pillows-cover.md
+++ b/.changeset/dull-pillows-cover.md
@@ -1,0 +1,15 @@
+---
+"@aws-amplify/ui-react": minor
+"@aws-amplify/ui": patch
+---
+
+feat: adding colors theme key support in style props
+
+***Example code***
+```jsx
+import { View } from '@aws-amplify/ui-react';
+
+export const Demo = () => {
+  return <View backgroundColor="pink.10" color="red.40"/>
+}
+```

--- a/packages/react/src/hooks/useBreakpointValue.ts
+++ b/packages/react/src/hooks/useBreakpointValue.ts
@@ -8,7 +8,8 @@ import { useTheme } from './useTheme';
  */
 export function useBreakpointValue<T>(
   values: Record<string, T> | T[],
-  defaultBreakpoint?: Breakpoint
+  defaultBreakpoint?: Breakpoint,
+  propKey?: string
 ): T | null {
   const {
     breakpoints: { values: breakpoints },
@@ -19,5 +20,5 @@ export function useBreakpointValue<T>(
     defaultBreakpoint,
   });
 
-  return getValueAtCurrentBreakpoint(values, breakpoint, breakpoints);
+  return getValueAtCurrentBreakpoint(values, breakpoint, breakpoints, propKey);
 }

--- a/packages/react/src/primitives/Alert/__tests__/Alert.test.tsx
+++ b/packages/react/src/primitives/Alert/__tests__/Alert.test.tsx
@@ -118,16 +118,10 @@ describe('Alert: ', () => {
       </Alert>
     );
     const alert = await screen.findByTestId('alertId');
-    expect(
-      alert.style.getPropertyValue(
-        kebabCase(ComponentPropsToStylePropsMap.backgroundColor)
-      )
-    ).toBe('white');
-    expect(
-      alert.style.getPropertyValue(
-        kebabCase(ComponentPropsToStylePropsMap.fontStyle)
-      )
-    ).toBe('italic');
+    expect(alert).toHaveStyle({
+      backgroundColor: 'var(--amplify-colors-white)',
+      fontStyle: 'italic',
+    });
   });
 
   it('can apply a custom className', async () => {

--- a/packages/react/src/primitives/shared/__tests__/utils.test.tsx
+++ b/packages/react/src/primitives/shared/__tests__/utils.test.tsx
@@ -8,6 +8,7 @@ import {
   EscapeHatchProps,
   classNameModifier,
   classNameModifierByFlag,
+  getCSSVariableIfValueIsThemeKey,
 } from '../utils';
 import { ComponentClassNames } from '../constants';
 
@@ -367,5 +368,19 @@ describe('classNameModifierByFlag', () => {
 
   it('should return null with a false flag value passed in', () => {
     expect(classNameModifierByFlag(myClass, modifier, false)).toEqual(null);
+  });
+});
+
+describe('getCSSVariableIfValueIsThemeKey', () => {
+  it('should return CSS variable if value is a theme key', () => {
+    expect(getCSSVariableIfValueIsThemeKey('backgroundColor', 'red.10')).toBe(
+      'var(--amplify-colors-red-10)'
+    );
+  });
+
+  it('should return value directly if it is not a theme key', () => {
+    expect(getCSSVariableIfValueIsThemeKey('backgroundColor', 'red')).toBe(
+      'red'
+    );
   });
 });

--- a/packages/react/src/primitives/shared/responsive/__tests__/utils.test.ts
+++ b/packages/react/src/primitives/shared/responsive/__tests__/utils.test.ts
@@ -1,4 +1,7 @@
-import { Breakpoints } from 'src/primitives/types/responsive';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useTheme } from '../../../../hooks/useTheme';
+import { Breakpoints } from '../../../types/responsive';
 import { getValueAtCurrentBreakpoint } from '../utils';
 
 const breakpoints: Breakpoints = {
@@ -15,8 +18,31 @@ describe('getValueAtCurrentBreakpoint', () => {
     const result = getValueAtCurrentBreakpoint('20px', 'base', breakpoints);
     expect(result).toBe('20px');
   });
+
+  it('should return number values directly', () => {
+    const result = getValueAtCurrentBreakpoint(0, 'base', breakpoints);
+    expect(result).toBe(0);
+  });
+
+  it('should return design token toString vaule directly', () => {
+    const { result } = renderHook(() => useTheme());
+    const { tokens } = result.current;
+    const value = getValueAtCurrentBreakpoint(
+      tokens.colors.red[10],
+      'base',
+      breakpoints
+    );
+    expect(value).toBe(tokens.colors.red[10].toString());
+  });
+
   it('should support object values syntax', () => {
-    const values = { base: '20px', medium: '40px' };
+    const { result } = renderHook(() => useTheme());
+    const { tokens } = result.current;
+    const values = {
+      base: 'red',
+      medium: tokens.colors.red[10],
+      large: 'red.60',
+    };
 
     const baseResult = getValueAtCurrentBreakpoint(values, 'base', breakpoints);
     const smallResult = getValueAtCurrentBreakpoint(
@@ -29,14 +55,24 @@ describe('getValueAtCurrentBreakpoint', () => {
       'medium',
       breakpoints
     );
+    const largeResult = getValueAtCurrentBreakpoint(
+      values,
+      'large',
+      breakpoints,
+      'backgroundColor'
+    );
+
     expect(baseResult).toBe(values.base);
     // "small" breakpoint not specified, so should fallback to "base" value
     expect(smallResult).toBe(values.base);
-    expect(mediumResult).toBe(values.medium);
+    expect(mediumResult).toBe(values.medium.toString());
+    expect(largeResult).toBe('var(--amplify-colors-red-60)');
   });
 
   it('should support array values syntax', () => {
-    const values = ['20px', '40px', '30px'];
+    const { result } = renderHook(() => useTheme());
+    const { tokens } = result.current;
+    const values = ['pink', tokens.colors.pink[60], 'pink.80'];
 
     const baseResult = getValueAtCurrentBreakpoint(values, 'base', breakpoints);
     const smallResult = getValueAtCurrentBreakpoint(
@@ -47,10 +83,18 @@ describe('getValueAtCurrentBreakpoint', () => {
     const mediumResult = getValueAtCurrentBreakpoint(
       values,
       'medium',
-      breakpoints
+      breakpoints,
+      'backgroundColor'
+    );
+    const largeResult = getValueAtCurrentBreakpoint(
+      values,
+      'large',
+      breakpoints,
+      'backgroundColor'
     );
     expect(baseResult).toBe(values[0]);
-    expect(smallResult).toBe(values[1]);
-    expect(mediumResult).toBe(values[2]);
+    expect(smallResult).toBe(values[1].toString());
+    expect(mediumResult).toBe('var(--amplify-colors-pink-80)');
+    expect(largeResult).toBe('var(--amplify-colors-pink-80)');
   });
 });

--- a/packages/react/src/primitives/shared/responsive/__tests__/utils.test.ts
+++ b/packages/react/src/primitives/shared/responsive/__tests__/utils.test.ts
@@ -24,7 +24,7 @@ describe('getValueAtCurrentBreakpoint', () => {
     expect(result).toBe(0);
   });
 
-  it('should return design token toString vaule directly', () => {
+  it('should return design token toString value directly', () => {
     const { result } = renderHook(() => useTheme());
     const { tokens } = result.current;
     const value = getValueAtCurrentBreakpoint(

--- a/packages/react/src/primitives/shared/styleUtils.ts
+++ b/packages/react/src/primitives/shared/styleUtils.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { isDesignToken } from '@aws-amplify/ui';
 
 import {
   BaseStyleProps,
@@ -133,12 +132,13 @@ export const convertStylePropsToStyleObj: ConvertStylePropsToStyleObj = ({
         nonStyleProps[propKey] = props[propKey];
       } else if (!isEmptyString(props[propKey])) {
         let value = props[propKey];
-        // if styleProp is a DesignToken use its toString()
-        if (isDesignToken(value)) {
-          value = value.toString();
-        } else {
-          value = getValueAtCurrentBreakpoint(value, breakpoint, breakpoints);
-        }
+        value = getValueAtCurrentBreakpoint(
+          value,
+          breakpoint,
+          breakpoints,
+          propKey
+        );
+
         const reactStyleProp = ComponentPropsToStylePropsMap[propKey];
         style = { ...style, [reactStyleProp]: value };
       }

--- a/packages/react/src/primitives/shared/utils.ts
+++ b/packages/react/src/primitives/shared/utils.ts
@@ -1,4 +1,7 @@
+import { cssNameTransform, defaultTheme, isDesignToken } from '@aws-amplify/ui';
+
 import { ComponentClasses } from './constants';
+import { stylePropsToThemeKeys } from '../types/theme';
 
 export const strHasLength = (str: unknown): str is string =>
   typeof str === 'string' && str.length > 0;
@@ -192,4 +195,28 @@ export const classNameModifierByFlag = (
   flag: boolean
 ): string => {
   return flag ? `${base}--${modifier}` : null;
+};
+
+export const getCSSVariableIfValueIsThemeKey = (
+  propKey: string,
+  value: string | number
+) => {
+  if (typeof value === 'number') {
+    return value;
+  }
+  const path = value.split('.');
+  let { tokens } = defaultTheme;
+  tokens = tokens[stylePropsToThemeKeys[propKey]];
+  for (let i = 0; i < path.length; i++) {
+    if (tokens) {
+      tokens = tokens[path[i]];
+      continue;
+    }
+    break;
+  }
+  return isDesignToken(tokens)
+    ? `var(--${cssNameTransform({
+        path: [stylePropsToThemeKeys[propKey], ...path],
+      })})`
+    : value;
 };

--- a/packages/react/src/primitives/types/style.ts
+++ b/packages/react/src/primitives/types/style.ts
@@ -1,6 +1,7 @@
 import { Property } from 'csstype';
 import { WebDesignToken } from '@aws-amplify/ui';
 
+import type { ColorKeys } from './theme';
 import { FlexItemStyleProps, FlexContainerStyleProps } from './flex';
 import { GridItemStyleProps, GridContainerStyleProps } from './grid';
 import { ImageStyleProps } from './image';
@@ -41,13 +42,15 @@ export type ResponsiveStyle<PropertyType> =
 
 export interface BaseStyleProps extends FlexItemStyleProps, GridItemStyleProps {
   alignSelf?: ResponsiveStyle<StyleToken<Property.AlignSelf>>;
-  backgroundColor?: ResponsiveStyle<StyleToken<Property.BackgroundColor>>;
+  backgroundColor?: ResponsiveStyle<
+    ColorKeys<StyleToken<Property.BackgroundColor>>
+  >;
   backgroundImage?: ResponsiveStyle<StyleToken<Property.BackgroundImage>>;
   border?: ResponsiveStyle<StyleToken<Property.Border>>;
   borderRadius?: ResponsiveStyle<StyleToken<Property.BorderRadius>>;
   bottom?: ResponsiveStyle<StyleToken<Property.Bottom>>;
   boxShadow?: ResponsiveStyle<StyleToken<Property.BoxShadow>>;
-  color?: ResponsiveStyle<StyleToken<Property.Color>>;
+  color?: ResponsiveStyle<ColorKeys<StyleToken<Property.Color>>>;
   display?: ResponsiveStyle<StyleToken<Property.Display>>;
   fontFamily?: ResponsiveStyle<StyleToken<Property.FontFamily>>;
   fontSize?: ResponsiveStyle<StyleToken<Property.FontSize>>;

--- a/packages/react/src/primitives/types/theme.ts
+++ b/packages/react/src/primitives/types/theme.ts
@@ -1,0 +1,183 @@
+/**
+ * Token keys for colors
+ *
+ * Though both 'white' and 'black' are valid CSS values
+ * We still want to define them as keys here and convert them into CSS variable reference afterwards
+ * This will make the default dark mode override work, where we flip these two
+ */
+type WhiteKey = 'white';
+
+type BlackKey = 'black';
+
+type RedKeys =
+  | 'red.10'
+  | 'red.20'
+  | 'red.40'
+  | 'red.60'
+  | 'red.80'
+  | 'red.90'
+  | 'red.100';
+
+type OrangeKeys =
+  | 'orange.10'
+  | 'orange.20'
+  | 'orange.40'
+  | 'orange.60'
+  | 'orange.80'
+  | 'orange.90'
+  | 'orange.100';
+
+type YellowKeys =
+  | 'yellow.10'
+  | 'yellow.20'
+  | 'yellow.40'
+  | 'yellow.60'
+  | 'yellow.80'
+  | 'yellow.90'
+  | 'yellow.100';
+
+type GreenKeys =
+  | 'green.10'
+  | 'green.20'
+  | 'green.40'
+  | 'green.60'
+  | 'green.80'
+  | 'green.90'
+  | 'green.100';
+
+type TealKeys =
+  | 'teal.10'
+  | 'teal.20'
+  | 'teal.40'
+  | 'teal.60'
+  | 'teal.80'
+  | 'teal.90'
+  | 'teal.100';
+
+type BlueKeys =
+  | 'blue.10'
+  | 'blue.20'
+  | 'blue.40'
+  | 'blue.60'
+  | 'blue.80'
+  | 'blue.90'
+  | 'blue.100';
+
+type PurpleKeys =
+  | 'purple.10'
+  | 'purple.20'
+  | 'purple.40'
+  | 'purple.60'
+  | 'purple.80'
+  | 'purple.90'
+  | 'purple.100';
+
+type PinkKeys =
+  | 'pink.10'
+  | 'pink.20'
+  | 'pink.40'
+  | 'pink.60'
+  | 'pink.80'
+  | 'pink.90'
+  | 'pink.100';
+
+type NeutralKeys =
+  | 'neutral.10'
+  | 'neutral.20'
+  | 'neutral.40'
+  | 'neutral.60'
+  | 'neutral.80'
+  | 'neutral.90'
+  | 'neutral.100';
+
+type OverlayKeys =
+  | 'overlay.10'
+  | 'overlay.20'
+  | 'overlay.30'
+  | 'overlay.40'
+  | 'overlay.50'
+  | 'overlay.60'
+  | 'overlay.70'
+  | 'overlay.80'
+  | 'overlay.90';
+
+type BrandColorKeys =
+  | 'brand.primary.10'
+  | 'brand.primary.20'
+  | 'brand.primary.40'
+  | 'brand.primary.60'
+  | 'brand.primary.80'
+  | 'brand.primary.90'
+  | 'brand.primary.100'
+  | 'brand.secondary.10'
+  | 'brand.secondary.20'
+  | 'brand.secondary.40'
+  | 'brand.secondary.60'
+  | 'brand.secondary.80'
+  | 'brand.secondary.90'
+  | 'brand.secondary.100';
+
+type FontColorKeys =
+  | 'font.primary'
+  | 'font.secondary'
+  | 'font.tertiary'
+  | 'font.disabled'
+  | 'font.inverse'
+  | 'font.interactive'
+  | 'font.hover'
+  | 'font.focus'
+  | 'font.active'
+  | 'font.success'
+  | 'font.info'
+  | 'font.warning'
+  | 'font.error';
+
+type BackgroundColorKeys =
+  | 'background.primary'
+  | 'background.secondary'
+  | 'background.tertiary'
+  | 'background.quaternary'
+  | 'background.disabled'
+  | 'background.success'
+  | 'background.info'
+  | 'background.warning'
+  | 'background.error';
+
+type BorderColorKeys =
+  | 'border.primary'
+  | 'border.secondary'
+  | 'border.tertiary'
+  | 'border.disabled'
+  | 'border.focus'
+  | 'border.pressed'
+  | 'border.error';
+
+type ShadowColorKeys =
+  | 'shadow.primary'
+  | 'shadow.secondary'
+  | 'shadow.tertiary';
+
+export type ColorKeys<PropertyType> =
+  | PropertyType
+  | WhiteKey
+  | BlackKey
+  | RedKeys
+  | OrangeKeys
+  | YellowKeys
+  | GreenKeys
+  | TealKeys
+  | BlueKeys
+  | PurpleKeys
+  | PinkKeys
+  | NeutralKeys
+  | OverlayKeys
+  | BrandColorKeys
+  | FontColorKeys
+  | BackgroundColorKeys
+  | BorderColorKeys
+  | ShadowColorKeys;
+
+export const stylePropsToThemeKeys = {
+  backgroundColor: 'colors',
+  color: 'colors',
+};

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -2,3 +2,4 @@ export { createTheme } from './createTheme';
 export { defaultTheme } from './defaultTheme';
 export { defaultDarkModeOverride } from './defaultDarkModeOverride';
 export * from './types';
+export { cssNameTransform } from './utils';


### PR DESCRIPTION
#### Description of changes

This PR will be adding colors theme key support in style props. Styling with theme key right away and it will be converted into CSS variable reference under the hood. Responsive value support as well. No need to call `useTheme` hook to get the tokens first anymore!

**Example Code**

```jsx
import { View } from '@aws-amplify/ui-react';

export const Demo = () => {
  return <View backgroundColor="pink.10" color="red.40"/>
}
```

For more colors, please reference [here](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/theme/tokens/colors.ts#L100-L283).

![Kapture 2022-06-08 at 14 45 06](https://user-images.githubusercontent.com/40295569/172726163-7dd8f92e-0bdd-4e8c-ac99-84e6a5a21dcd.gif)

![Kapture 2022-06-08 at 14 38 28](https://user-images.githubusercontent.com/40295569/172726175-9255fca1-1fa3-4ff4-9c5e-95233e28feb0.gif)




#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
