### PR TITLE
fix(angular): Use partial ivy compilation mode

### DIFF
--- a/packages/angular/projects/ui-angular/tsconfig.lib.prod.json
+++ b/packages/angular/projects/ui-angular/tsconfig.lib.prod.json
@@ -5,6 +5,6 @@
     "declarationMap": false
   },
   "angularCompilerOptions": {
-    "enableIvy": true
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Sets `angularCompilerOptions` to use partial compilation mode, as suggested in https://angular.io/guide/creating-libraries#ensuring-library-version-compatibility.

This has been blocking publish to `@next`.


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Confirmed NPM publish works with verdaccio:

![Screen Shot 2022-06-08 at 5 58 42 PM](https://user-images.githubusercontent.com/43682783/172742347-734e5ee6-abd9-42a2-b248-1eb5f3704304.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
