### PR TITLE
fix(docs): align h4 and make anchor visible on hover

### DIFF
--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -164,13 +164,26 @@ h2[id] {
 }
 
 h2[id] > a,
-h3[id] > a {
+h3[id] > a,
+h4[id] > a {
   position: absolute;
   left: -1.75rem;
   text-decoration: none;
 
   &:hover {
     text-decoration: none;
+  }
+}
+
+h4[id] {
+  position: relative;
+  scroll-margin-block-start: 6rem;
+  > a {
+    left: -1rem;
+    top: -.1rem;
+    .icon-link {
+      font-size: 1.2em;
+    }
   }
 }
 
@@ -186,7 +199,8 @@ h3[id] > a {
 }
 
 h2:hover > a .icon-link,
-h3:hover > a .icon-link {
+h3:hover > a .icon-link,
+h4:hover>  a .icon-link {
   opacity: 1;
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Small fix for alignment of `<h4>` tags. The  anchor link icon was pushing it inward, and the icon wasn't visible.

Before (hovering on "Resizable"):

<img width="410" alt="Screen Shot 2022-06-10 at 11 11 47 AM" src="https://user-images.githubusercontent.com/376920/173096982-a430ec32-845a-46f9-929a-5d874a30ca88.png">

After (hovering on "Resizable")

<img width="401" alt="Screen Shot 2022-06-10 at 11 11 39 AM" src="https://user-images.githubusercontent.com/376920/173097034-7289fe31-14f7-4519-9d61-407ae41a658c.png">

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
