### PR TITLE
fix(docs): use our Link, not Next Link for CardLink

### DIFF
--- a/docs/src/components/CardLink.tsx
+++ b/docs/src/components/CardLink.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@aws-amplify/ui-react';
 
 interface CardLinkProps {
   href: string;
@@ -9,14 +9,12 @@ interface CardLinkProps {
 
 export function CardLink({ href, title, desc, img }: CardLinkProps) {
   return (
-    <Link href={href}>
-      <a className="docs-cardLink">
-        {img && <div className="docs-cardLink-img">{img}</div>}
-        <div className="docs-cardLink-details">
-          <span className="docs-cardLink-title">{title}</span>
-          <span className="docs-cardLink-desc">{desc}</span>
-        </div>
-      </a>
+    <Link href={href} className="docs-cardLink">
+      {img && <div className="docs-cardLink-img">{img}</div>}
+      <div className="docs-cardLink-details">
+        <span className="docs-cardLink-title">{title}</span>
+        <span className="docs-cardLink-desc">{desc}</span>
+      </div>
     </Link>
   );
 }

--- a/docs/src/pages/[platform]/getting-started/accessibility/accessibility.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/accessibility/accessibility.react.mdx
@@ -74,7 +74,7 @@ The example below shows how to use Theming to supply higher contrast text and bo
 <Grid gap="var(--amplify-space-large)" margin="var(--amplify-space-xl) 0" templateColumns={{ base: '1fr', large: '1fr 1fr' }}>
  <CardLink 
   img={<MdOutlineAutoAwesome />}
-  href="/react/components/textfield#accessibility--label-behavior"
+  href="/react/theming#getting-started"
   title="Theming overview"
   desc="Learn how to make a custom theme" />
 </Grid>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Switch CardLink to use our Link component. It was using next/Link but that breaks smooth scrolling to anchor tags.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Tested in local docs instance. Click  any CardLink on /react/getting-started/accessibility  and it will now smoothly scroll down to the section from the hash.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
