### PR TITLE
fix(authenticator): explicitly filter special characters allowed by Cognito

### DIFF
--- a/.changeset/healthy-actors-relate.md
+++ b/.changeset/healthy-actors-relate.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(authenticator): explicitly filter special characters allowed by Cognito

--- a/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
+++ b/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
@@ -58,7 +58,7 @@ describe('validateFormPassword', () => {
     });
   });
 
-  it('validates as expected with invalid password and strict password policy', async () => {
+  it('validates as expected with invalid password (fails all requirements) and strict password policy', async () => {
     // is too short, and does not meet any of character requirements
     const password3 = 'short';
     const result3 = await validateFormPassword(

--- a/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
+++ b/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
@@ -1,0 +1,105 @@
+import { PasswordSettings } from '../../../types';
+import { defaultServices } from '../defaultServices';
+
+const { validateFormPassword } = defaultServices;
+
+const untouched = { password: false };
+const touched = { password: true };
+
+const strictPasswordPolicy: PasswordSettings = {
+  passwordPolicyCharacters: [
+    'REQUIRES_LOWERCASE',
+    'REQUIRES_NUMBERS',
+    'REQUIRES_UPPERCASE',
+    'REQUIRES_SYMBOLS',
+  ],
+  passwordPolicyMinLength: 8,
+};
+
+const lenientPasswordPolicy: PasswordSettings = {
+  passwordPolicyCharacters: [],
+  passwordPolicyMinLength: 4,
+};
+
+describe('validateFormPassword', () => {
+  it('happy case with valid password and strict password policy', async () => {
+    const password = 'UnitTest_Password1';
+    const result = await validateFormPassword({ password }, touched, {
+      passwordPolicyCharacters: ['REQUIRES_SYMBOLS'],
+      passwordPolicyMinLength: 1,
+    });
+    expect(result).toBe(null);
+  });
+
+  it('unhappy cases with invalid passwords and strict password policy', async () => {
+    // has special character not recognized by Cognito
+    const password1 = 'UnitTestㄱPassword1';
+    const result1 = await validateFormPassword(
+      { password: password1 },
+      touched,
+      strictPasswordPolicy
+    );
+    expect(result1).toStrictEqual({
+      password: ['Password must have special characters'],
+    });
+
+    // does not have special character
+    const password2 = 'UnitTestPassword1';
+    const result2 = await validateFormPassword(
+      { password: password2 },
+      touched,
+      strictPasswordPolicy
+    );
+    expect(result2).toStrictEqual({
+      password: ['Password must have special characters'],
+    });
+
+    // is too short, and does not meet character requirements
+    const password3 = 'short';
+    const result3 = await validateFormPassword(
+      { password: password3 },
+      touched,
+      strictPasswordPolicy
+    );
+    expect(result3).toStrictEqual({
+      password: [
+        'Password must have at least 8 characters',
+        'Password must have numbers',
+        'Password must have upper case letters',
+        'Password must have special characters',
+      ],
+    });
+  });
+
+  it('happy case with valid password and lenient password policy', async () => {
+    const password = 'legitpassword123';
+    const result = await validateFormPassword(
+      { password: password },
+      touched,
+      lenientPasswordPolicy
+    );
+    expect(result).toBe(null);
+  });
+
+  it('unhappy case with valid password and lenient password policy', async () => {
+    const password = '123';
+    const result = await validateFormPassword(
+      { password: password },
+      touched,
+      lenientPasswordPolicy
+    );
+    expect(result).toStrictEqual({
+      password: ['Password must have at least 4 characters'],
+    });
+  });
+
+  it('validation is skipped if inputs are not touched', async () => {
+    const password = '';
+    const result = await validateFormPassword(
+      { password: password },
+      untouched,
+      strictPasswordPolicy
+    );
+    expect(result).toBe(null);
+  });
+});

--- a/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
+++ b/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
@@ -98,7 +98,7 @@ describe('validateFormPassword', () => {
     });
   });
 
-  it('validation is skipped if inputs are not touched', async () => {
+  it('skips validation if inputs are not touched', async () => {
     const password = '';
     const result = await validateFormPassword(
       { password: password },

--- a/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
+++ b/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
@@ -32,7 +32,7 @@ describe('validateFormPassword', () => {
     expect(result).toBe(null);
   });
 
-  it('validates as expected with invalid password (has unknown special character) on strict password policy', async () => {
+  it('validates as expected with invalid password (has unknown special character) and strict password policy', async () => {
     // has special character not recognized by Cognito
     const password = 'UnitTestㄱPassword1';
     const result = await validateFormPassword(
@@ -45,7 +45,7 @@ describe('validateFormPassword', () => {
     });
   });
 
-  it('validates as expected with invalid password (no special characters) on strict password policy', async () => {
+  it('validates as expected with invalid password (no special characters) and strict password policy', async () => {
     // does not have special character
     const password = 'UnitTestPassword1';
     const result = await validateFormPassword(
@@ -58,7 +58,7 @@ describe('validateFormPassword', () => {
     });
   });
 
-  it('validates as expected with invalid password on strict password policy', async () => {
+  it('validates as expected with invalid password and strict password policy', async () => {
     // is too short, and does not meet any of character requirements
     const password3 = 'short';
     const result3 = await validateFormPassword(

--- a/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
+++ b/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
@@ -24,10 +24,11 @@ const lenientPasswordPolicy: PasswordSettings = {
 describe('validateFormPassword', () => {
   it('happy case with valid password and strict password policy', async () => {
     const password = 'UnitTest_Password1';
-    const result = await validateFormPassword({ password }, touched, {
-      passwordPolicyCharacters: ['REQUIRES_SYMBOLS'],
-      passwordPolicyMinLength: 1,
-    });
+    const result = await validateFormPassword(
+      { password },
+      touched,
+      strictPasswordPolicy
+    );
     expect(result).toBe(null);
   });
 

--- a/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
+++ b/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
@@ -76,7 +76,7 @@ describe('validateFormPassword', () => {
     });
   });
 
-  it('happy case with valid password and lenient password policy', async () => {
+  it('validates as expected with valid password and lenient password policy', async () => {
     const password = 'legitpassword123';
     const result = await validateFormPassword(
       { password },
@@ -86,7 +86,7 @@ describe('validateFormPassword', () => {
     expect(result).toBe(null);
   });
 
-  it('unhappy case with valid password and lenient password policy', async () => {
+  it('validates as expected with invalid password and lenient password policy', async () => {
     const password = '123';
     const result = await validateFormPassword(
       { password },

--- a/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
+++ b/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
@@ -22,7 +22,7 @@ const lenientPasswordPolicy: PasswordSettings = {
 };
 
 describe('validateFormPassword', () => {
-  it('happy case with valid password and strict password policy', async () => {
+  it('validates as expected with valid password and strict password policy', async () => {
     const password = 'UnitTest_Password1';
     const result = await validateFormPassword(
       { password },
@@ -32,30 +32,34 @@ describe('validateFormPassword', () => {
     expect(result).toBe(null);
   });
 
-  it('unhappy cases with invalid passwords and strict password policy', async () => {
+  it('validates as expected with invalid password (has unknown special character) on strict password policy', async () => {
     // has special character not recognized by Cognito
-    const password1 = 'UnitTestㄱPassword1';
-    const result1 = await validateFormPassword(
-      { password: password1 },
+    const password = 'UnitTestㄱPassword1';
+    const result = await validateFormPassword(
+      { password: password },
       touched,
       strictPasswordPolicy
     );
-    expect(result1).toStrictEqual({
+    expect(result).toStrictEqual({
       password: ['Password must have special characters'],
     });
+  });
 
+  it('validates as expected with invalid password (no special characters) on strict password policy', async () => {
     // does not have special character
-    const password2 = 'UnitTestPassword1';
-    const result2 = await validateFormPassword(
-      { password: password2 },
+    const password = 'UnitTestPassword1';
+    const result = await validateFormPassword(
+      { password: password },
       touched,
       strictPasswordPolicy
     );
-    expect(result2).toStrictEqual({
+    expect(result).toStrictEqual({
       password: ['Password must have special characters'],
     });
+  });
 
-    // is too short, and does not meet character requirements
+  it('validates as expected with invalid password on strict password policy', async () => {
+    // is too short, and does not meet any of character requirements
     const password3 = 'short';
     const result3 = await validateFormPassword(
       { password: password3 },

--- a/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
+++ b/packages/ui/src/machines/authenticator/__tests__/defaultService.test.ts
@@ -49,7 +49,7 @@ describe('validateFormPassword', () => {
     // does not have special character
     const password = 'UnitTestPassword1';
     const result = await validateFormPassword(
-      { password: password },
+      { password },
       touched,
       strictPasswordPolicy
     );
@@ -60,13 +60,13 @@ describe('validateFormPassword', () => {
 
   it('validates as expected with invalid password (fails all requirements) and strict password policy', async () => {
     // is too short, and does not meet any of character requirements
-    const password3 = 'short';
-    const result3 = await validateFormPassword(
-      { password: password3 },
+    const password = 'short';
+    const result = await validateFormPassword(
+      { password },
       touched,
       strictPasswordPolicy
     );
-    expect(result3).toStrictEqual({
+    expect(result).toStrictEqual({
       password: [
         'Password must have at least 8 characters',
         'Password must have numbers',
@@ -79,7 +79,7 @@ describe('validateFormPassword', () => {
   it('happy case with valid password and lenient password policy', async () => {
     const password = 'legitpassword123';
     const result = await validateFormPassword(
-      { password: password },
+      { password },
       touched,
       lenientPasswordPolicy
     );
@@ -89,7 +89,7 @@ describe('validateFormPassword', () => {
   it('unhappy case with valid password and lenient password policy', async () => {
     const password = '123';
     const result = await validateFormPassword(
-      { password: password },
+      { password },
       touched,
       lenientPasswordPolicy
     );

--- a/packages/ui/src/machines/authenticator/defaultServices.ts
+++ b/packages/ui/src/machines/authenticator/defaultServices.ts
@@ -106,6 +106,7 @@ export const defaultServices = {
             password_complexity.push('Password must have numbers');
           break;
         case 'REQUIRES_SYMBOLS':
+          // https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html
           if (!/[\^$*.[\]{}()?"!@#%&\/\\,><':;|_~`=+\-\ ]/.test(password))
             password_complexity.push('Password must have special characters');
           break;

--- a/packages/ui/src/machines/authenticator/defaultServices.ts
+++ b/packages/ui/src/machines/authenticator/defaultServices.ts
@@ -106,7 +106,7 @@ export const defaultServices = {
             password_complexity.push('Password must have numbers');
           break;
         case 'REQUIRES_SYMBOLS':
-          if (!/[\W]/.test(password))
+          if (!/[\^$*.[\]{}()?"!@#%&\/\\,><':;|_~`=+\-\ ]/.test(password))
             password_complexity.push('Password must have special characters');
           break;
         default:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Previously in our password validation util, we were matching special characters with `\W`, which matches all non-word character **except underscore**. 

https://github.com/aws-amplify/amplify-ui/blob/5b713ad3f5ddaf24583f7589138c1545a26f6c3a/packages/ui/src/machines/authenticator/defaultServices.ts#L109

This was not sufficient because underscore is a valid special character. Instead, this PR makes password rules more explicit by directly matching [special characters allowed by Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html). 




<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fixes #2052

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

New unit test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
