### PR TITLE
docs: use named import to import `aws-amplify`

### DIFF
--- a/docs/src/pages/[platform]/components/authenticator/formfields/dialcode/form-fields.angular.mdx
+++ b/docs/src/pages/[platform]/components/authenticator/formfields/dialcode/form-fields.angular.mdx
@@ -17,7 +17,7 @@ _app.component.ts_
 
 ```js
 import { Component } from '@angular/core';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 
 import awsExports from './aws-exports';
 

--- a/docs/src/pages/[platform]/components/authenticator/formfields/dialcodelist/form-fields.angular.mdx
+++ b/docs/src/pages/[platform]/components/authenticator/formfields/dialcodelist/form-fields.angular.mdx
@@ -17,7 +17,7 @@ _app.component.ts_
 
 ```js
 import { Component } from '@angular/core';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 
 import awsExports from './aws-exports';
 

--- a/docs/src/pages/[platform]/components/authenticator/formfields/form-fields.angular.mdx
+++ b/docs/src/pages/[platform]/components/authenticator/formfields/form-fields.angular.mdx
@@ -17,7 +17,7 @@ _app.component.ts_
 
 ```js
 import { Component } from '@angular/core';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 
 import awsExports from './aws-exports';
 

--- a/docs/src/pages/[platform]/components/authenticator/formfields/orderformfields/form-fields.angular.mdx
+++ b/docs/src/pages/[platform]/components/authenticator/formfields/orderformfields/form-fields.angular.mdx
@@ -17,7 +17,7 @@ _app.component.ts_
 
 ```js
 import { Component } from '@angular/core';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 
 import awsExports from './aws-exports';
 

--- a/docs/src/pages/[platform]/components/authenticator/formfields/qrcode/form-fields.angular.mdx
+++ b/docs/src/pages/[platform]/components/authenticator/formfields/qrcode/form-fields.angular.mdx
@@ -17,7 +17,7 @@ _app.component.ts_
 
 ```js
 import { Component } from '@angular/core';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 
 import awsExports from './aws-exports';
 

--- a/docs/src/pages/[platform]/components/authenticator/overrides/username.vue.mdx
+++ b/docs/src/pages/[platform]/components/authenticator/overrides/username.vue.mdx
@@ -1,6 +1,6 @@
 ```html
 <script setup lang="ts">
-  import Amplify, { Auth } from 'aws-amplify';
+  import { Amplify, Auth } from 'aws-amplify';
   import { Authenticator } from '@aws-amplify/ui-vue';
   import '@aws-amplify/ui-vue/styles.css';
   import aws_exports from './aws-exports';

--- a/docs/src/pages/[platform]/components/authenticator/quick-start-example.vue.mdx
+++ b/docs/src/pages/[platform]/components/authenticator/quick-start-example.vue.mdx
@@ -7,7 +7,7 @@ For Vue 3, import the `Authenticator` and the `styles.css` into your single file
   import { Authenticator } from "@aws-amplify/ui-vue";
   import "@aws-amplify/ui-vue/styles.css";
 
-  import Amplify from 'aws-amplify';
+  import { Amplify } from 'aws-amplify';
   import awsconfig from './aws-exports';
 
   Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/chatbot/migration.vue.mdx
+++ b/docs/src/pages/[platform]/components/chatbot/migration.vue.mdx
@@ -15,7 +15,7 @@ import App from "./App.vue";
 +   applyPolyfills,
 +   defineCustomElements,
 + } from '@aws-amplify/ui-components/loader';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/chatbot/usage.angular.mdx
+++ b/docs/src/pages/[platform]/components/chatbot/usage.angular.mdx
@@ -6,7 +6,7 @@ import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 - import { AmplifyAngularModule, AmplifyService } from 'aws-amplify-angular';
 + import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular/legacy';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/chatbot/usage.react.mdx
+++ b/docs/src/pages/[platform]/components/chatbot/usage.react.mdx
@@ -1,6 +1,6 @@
 ```jsx
 import * as React from 'react';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import { AmplifyChatbot } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';
 

--- a/docs/src/pages/[platform]/components/chatbot/usage.vue.mdx
+++ b/docs/src/pages/[platform]/components/chatbot/usage.vue.mdx
@@ -15,7 +15,7 @@ import {
   defineCustomElements,
 } from '@aws-amplify/ui-components/loader';
 
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 Amplify.configure(awsconfig);
 
@@ -39,7 +39,7 @@ import {
   defineCustomElements,
 } from '@aws-amplify/ui-components/loader';
 
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3album/migration.angular.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3album/migration.angular.mdx
@@ -15,7 +15,7 @@ import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 - import { AmplifyAngularModule, AmplifyService } from 'aws-amplify-angular';
 + import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular/legacy';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3album/migration.vue.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3album/migration.vue.mdx
@@ -12,7 +12,7 @@ import App from "./App.vue";
 +   applyPolyfills,
 +   defineCustomElements,
 + } from '@aws-amplify/ui-components/loader';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3album/usage.angular.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3album/usage.angular.mdx
@@ -6,7 +6,7 @@ import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 
 import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular/legacy';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from '../aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3album/usage.react.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3album/usage.react.mdx
@@ -1,6 +1,6 @@
 ```jsx
 import * as React from 'react';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import { AmplifyS3Album } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';
 

--- a/docs/src/pages/[platform]/components/storage/s3album/usage.vue.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3album/usage.vue.mdx
@@ -10,7 +10,7 @@ import {
   defineCustomElements,
 } from '@aws-amplify/ui-components/loader';
 
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 Amplify.configure(awsconfig);
 

--- a/docs/src/pages/[platform]/components/storage/s3image/migration.angular.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3image/migration.angular.mdx
@@ -15,7 +15,7 @@ import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 - import { AmplifyAngularModule, AmplifyService } from 'aws-amplify-angular';
 + import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular/legacy';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3image/migration.vue.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3image/migration.vue.mdx
@@ -12,7 +12,7 @@ import App from "./App.vue";
 +   applyPolyfills,
 +   defineCustomElements,
 + } from '@aws-amplify/ui-components/loader';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3image/usage.angular.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3image/usage.angular.mdx
@@ -6,7 +6,7 @@ import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 
 import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular/legacy';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from '../aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3image/usage.react.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3image/usage.react.mdx
@@ -1,6 +1,6 @@
 ```jsx
 import * as React from 'react';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import { AmplifyS3Image } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';
 

--- a/docs/src/pages/[platform]/components/storage/s3image/usage.vue.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3image/usage.vue.mdx
@@ -10,7 +10,7 @@ import {
   defineCustomElements,
 } from '@aws-amplify/ui-components/loader';
 
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 Amplify.configure(awsconfig);
 

--- a/docs/src/pages/[platform]/components/storage/s3imagepicker/migration.angular.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3imagepicker/migration.angular.mdx
@@ -15,7 +15,7 @@ import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 - import { AmplifyAngularModule, AmplifyService } from 'aws-amplify-angular';
 + import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular/legacy';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3imagepicker/migration.vue.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3imagepicker/migration.vue.mdx
@@ -12,7 +12,7 @@ import App from "./App.vue";
 +   applyPolyfills,
 +   defineCustomElements,
 + } from '@aws-amplify/ui-components/loader';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3imagepicker/usage.angular.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3imagepicker/usage.angular.mdx
@@ -6,7 +6,7 @@ import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 
 import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular/legacy';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from '../aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3imagepicker/usage.react.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3imagepicker/usage.react.mdx
@@ -1,6 +1,6 @@
 ```jsx
 import * as React from 'react';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import { AmplifyS3ImagePicker } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';
 

--- a/docs/src/pages/[platform]/components/storage/s3imagepicker/usage.vue.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3imagepicker/usage.vue.mdx
@@ -10,7 +10,7 @@ import {
   defineCustomElements,
 } from '@aws-amplify/ui-components/loader';
 
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 Amplify.configure(awsconfig);
 

--- a/docs/src/pages/[platform]/components/storage/s3text/migration.angular.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3text/migration.angular.mdx
@@ -15,7 +15,7 @@ import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 - import { AmplifyAngularModule, AmplifyService } from 'aws-amplify-angular';
 + import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular/legacy';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3text/migration.vue.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3text/migration.vue.mdx
@@ -12,7 +12,7 @@ import App from "./App.vue";
 +   applyPolyfills,
 +   defineCustomElements,
 + } from '@aws-amplify/ui-components/loader';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3text/usage.angular.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3text/usage.angular.mdx
@@ -6,7 +6,7 @@ import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 
 import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular/legacy';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from '../aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3text/usage.react.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3text/usage.react.mdx
@@ -1,6 +1,6 @@
 ```jsx
 import * as React from 'react';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import { AmplifyS3Text } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';
 

--- a/docs/src/pages/[platform]/components/storage/s3text/usage.vue.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3text/usage.vue.mdx
@@ -10,7 +10,7 @@ import {
   defineCustomElements,
 } from '@aws-amplify/ui-components/loader';
 
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 Amplify.configure(awsconfig);
 

--- a/docs/src/pages/[platform]/components/storage/s3textpicker/migration.angular.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3textpicker/migration.angular.mdx
@@ -15,7 +15,7 @@ import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 - import { AmplifyAngularModule, AmplifyService } from 'aws-amplify-angular';
 + import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular/legacy';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3textpicker/migration.vue.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3textpicker/migration.vue.mdx
@@ -12,7 +12,7 @@ import App from "./App.vue";
 +   applyPolyfills,
 +   defineCustomElements,
 + } from '@aws-amplify/ui-components/loader';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3textpicker/usage.angular.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3textpicker/usage.angular.mdx
@@ -6,7 +6,7 @@ import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 
 import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular/legacy';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from '../aws-exports';
 
 Amplify.configure(awsconfig);

--- a/docs/src/pages/[platform]/components/storage/s3textpicker/usage.react.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3textpicker/usage.react.mdx
@@ -1,6 +1,6 @@
 ```jsx
 import * as React from 'react';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import { AmplifyS3TextPicker } from '@aws-amplify/ui-react/legacy';
 import awsconfig from './aws-exports';
 

--- a/docs/src/pages/[platform]/components/storage/s3textpicker/usage.vue.mdx
+++ b/docs/src/pages/[platform]/components/storage/s3textpicker/usage.vue.mdx
@@ -10,7 +10,7 @@ import {
   defineCustomElements,
 } from '@aws-amplify/ui-components/loader';
 
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 Amplify.configure(awsconfig);
 

--- a/docs/src/pages/[platform]/getting-started/migration/migration.vue.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.vue.mdx
@@ -50,7 +50,7 @@ Update the **main.js** file and remove the references to the older `ui-component
 - app.mount('#app');
 
 import App from "./App.vue";
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 import { createApp } from 'vue';
 + import '@aws-amplify/ui-vue/styles.css';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

`import Amplify from 'aws-amplify'` is [deprecated](https://github.com/aws-amplify/amplify-js/blob/bcb7fa67a6ba5662989465f6c96ead1706ee1f40/packages/aws-amplify/src/index.ts#L65-L67) in favor of `import { Amplify } from 'aws-amplify'`. Updating docs to reflect it.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
