### PR TITLE
fix: add isNested prop to ThemeProvider

### DIFF
--- a/.changeset/cold-carrots-explode.md
+++ b/.changeset/cold-carrots-explode.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix: add isNested prop to ThemeProvider

--- a/docs/src/pages/[platform]/components/authenticator/AuthStyle.tsx
+++ b/docs/src/pages/[platform]/components/authenticator/AuthStyle.tsx
@@ -57,7 +57,7 @@ export function AuthStyle() {
   };
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <Authenticator></Authenticator>
     </ThemeProvider>
   );

--- a/docs/src/pages/[platform]/components/authenticator/customization.styling.web.mdx
+++ b/docs/src/pages/[platform]/components/authenticator/customization.styling.web.mdx
@@ -1,4 +1,4 @@
-import { Authenticator, ThemeProvider } from '@aws-amplify/ui-react';
+import { Authenticator } from '@aws-amplify/ui-react';
 import { AuthStyle } from './AuthStyle';
 
 import { Example } from '@/components/Example';

--- a/docs/src/pages/[platform]/components/button/examples/ButtonThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/button/examples/ButtonThemeExample.tsx
@@ -26,7 +26,7 @@ const theme = {
 };
 
 export const ButtonThemeExample = () => (
-  <ThemeProvider theme={theme}>
+  <ThemeProvider theme={theme} isNested>
     <Flex direction="row">
       <Button>Default</Button>
       <Button variation="primary">Primary</Button>

--- a/docs/src/pages/[platform]/components/card/examples/CardThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/card/examples/CardThemeExample.tsx
@@ -21,7 +21,7 @@ const cardTheme = {
 
 export const CardThemeExample = () => {
   return (
-    <ThemeProvider theme={cardTheme}>
+    <ThemeProvider theme={cardTheme} isNested>
       <Flex direction="row">
         <Card>
           <Text>Hello</Text>

--- a/docs/src/pages/[platform]/components/collection/examples/CollectionThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/collection/examples/CollectionThemeExample.tsx
@@ -33,7 +33,7 @@ export const CollectionThemeExample = () => {
     overrides: [defaultDarkModeOverride],
   };
   return (
-    <ThemeProvider theme={theme} colorMode="system">
+    <ThemeProvider theme={theme} colorMode="system" isNested>
       <Collection
         type="grid"
         templateColumns="1fr 1fr 1fr"

--- a/docs/src/pages/[platform]/components/divider/examples/DividerThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/divider/examples/DividerThemeExample.tsx
@@ -18,7 +18,7 @@ const theme = {
 };
 
 export const DividerThemeExample = () => (
-  <ThemeProvider theme={theme}>
+  <ThemeProvider theme={theme} isNested>
     <Flex direction="column">
       <Text>Before</Text>
       <Divider />

--- a/docs/src/pages/[platform]/components/link/examples/LinkThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/link/examples/LinkThemeExample.tsx
@@ -13,7 +13,7 @@ const theme: Theme = {
 };
 export const LinkThemeExample = () => {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <Link>My custom Link</Link>
     </ThemeProvider>
   );

--- a/docs/src/pages/[platform]/components/menu/examples/themeExample.tsx
+++ b/docs/src/pages/[platform]/components/menu/examples/themeExample.tsx
@@ -17,7 +17,7 @@ const theme: Theme = {
 
 export const ThemeExample = () => {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <Menu>
         <MenuItem>Download</MenuItem>
         <MenuItem>Create a Copy</MenuItem>

--- a/docs/src/pages/[platform]/components/pagination/examples/PaginationThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/pagination/examples/PaginationThemeExample.tsx
@@ -27,7 +27,7 @@ export const PaginationThemeExample = () => {
   const paginationProps = usePagination({ totalPages: 6 });
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <Pagination {...paginationProps} />
     </ThemeProvider>
   );

--- a/docs/src/pages/[platform]/components/passwordfield/examples/ThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/passwordfield/examples/ThemeExample.tsx
@@ -18,7 +18,7 @@ const theme = {
 
 export const ThemeExample = () => {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <PasswordField label="password" />
     </ThemeProvider>
   );

--- a/docs/src/pages/[platform]/components/phonenumberfield/examples/ThemingExample.tsx
+++ b/docs/src/pages/[platform]/components/phonenumberfield/examples/ThemingExample.tsx
@@ -13,7 +13,7 @@ const theme: Theme = {
 };
 
 export const ThemingExample = () => (
-  <ThemeProvider theme={theme}>
+  <ThemeProvider theme={theme} isNested>
     <PhoneNumberField label="Themed field" defaultCountryCode="+1" />
   </ThemeProvider>
 );

--- a/docs/src/pages/[platform]/components/placeholder/examples/PlaceholderThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/placeholder/examples/PlaceholderThemeExample.tsx
@@ -14,7 +14,7 @@ const theme: Theme = {
 
 export const PlaceholderThemeExample = () => {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <Placeholder />
     </ThemeProvider>
   );

--- a/docs/src/pages/[platform]/components/radiogroupfield/examples/ThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/radiogroupfield/examples/ThemeExample.tsx
@@ -37,7 +37,7 @@ const theme: Theme = {
 const options = ['html', 'css', 'javascript'];
 
 export const ThemeExample = () => (
-  <ThemeProvider theme={theme}>
+  <ThemeProvider theme={theme} isNested>
     <RadioGroupField label="Language" name="language6" defaultValue="html">
       {options.map((option) => (
         <Radio key={option} value={option}>

--- a/docs/src/pages/[platform]/components/searchfield/examples/SearchFieldThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/searchfield/examples/SearchFieldThemeExample.tsx
@@ -26,7 +26,7 @@ export const SearchFieldThemeExample = () => {
   };
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <SearchField label="search" />
     </ThemeProvider>
   );

--- a/docs/src/pages/[platform]/components/sliderfield/examples/SliderFieldThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/sliderfield/examples/SliderFieldThemeExample.tsx
@@ -24,7 +24,7 @@ const theme: Theme = {
 
 export const SliderFieldThemeExample = () => {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <SliderField label="Themed Slider" defaultValue={50} />
     </ThemeProvider>
   );

--- a/docs/src/pages/[platform]/components/tabs/examples/ThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/tabs/examples/ThemeExample.tsx
@@ -23,7 +23,7 @@ const theme = {
 
 export const ThemeExample = () => {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <Tabs>
         <TabItem title="Tab 1">Tab 1 Content</TabItem>
         <TabItem title="Tab 2">Tab 2 Content</TabItem>

--- a/docs/src/pages/[platform]/components/text/examples/TextTheme.tsx
+++ b/docs/src/pages/[platform]/components/text/examples/TextTheme.tsx
@@ -48,7 +48,7 @@ const theme = {
 };
 
 export const TextThemeExample = () => (
-  <ThemeProvider theme={theme}>
+  <ThemeProvider theme={theme} isNested>
     <Flex wrap="wrap">
       <Text>Default</Text>
       {VARIATIONS_OPTIONS.map((variation) => (

--- a/docs/src/pages/[platform]/getting-started/accessibility/examples/ThemeExample.tsx
+++ b/docs/src/pages/[platform]/getting-started/accessibility/examples/ThemeExample.tsx
@@ -23,7 +23,7 @@ export const ThemeExample = () => {
   };
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <Card variation="outlined">Example Card</Card>
     </ThemeProvider>
   );

--- a/docs/src/pages/[platform]/getting-started/usage/examples/ThemeExampleCode.tsx
+++ b/docs/src/pages/[platform]/getting-started/usage/examples/ThemeExampleCode.tsx
@@ -22,7 +22,7 @@ const theme = {
 
 function App() {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <Button variation="primary">Custom button</Button>
     </ThemeProvider>
   );

--- a/docs/src/pages/[platform]/getting-started/usage/examples/ThemeExampleDemo.tsx
+++ b/docs/src/pages/[platform]/getting-started/usage/examples/ThemeExampleDemo.tsx
@@ -18,7 +18,7 @@ const theme = {
 };
 export const ThemeExampleDemo = () => {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme} isNested>
       <Button variation="primary">Custom button</Button>
     </ThemeProvider>
   );

--- a/docs/src/pages/[platform]/index.page.tsx
+++ b/docs/src/pages/[platform]/index.page.tsx
@@ -63,7 +63,7 @@ const HomePage = ({ colorMode }) => {
   const frameworkInstallScript = installScripts[platform.toString()];
   return (
     <View data-amplify-theme-override={themeOverride}>
-      <ThemeProvider theme={theme} colorMode={colorMode}>
+      <ThemeProvider theme={theme} colorMode={colorMode} isNested>
         <View as="section" className="container">
           <h1 className="docs-home-logo">
             <HomeLogo />

--- a/docs/src/pages/[platform]/theming/dark-mode/examples/CustomDarkMode.tsx
+++ b/docs/src/pages/[platform]/theming/dark-mode/examples/CustomDarkMode.tsx
@@ -42,7 +42,7 @@ export const CustomDarkModeExample = () => {
   return (
     // Note: color mode overrides are scoped to the ThemeProvider
     // if you use multiple providers
-    <ThemeProvider theme={theme} colorMode={colorMode}>
+    <ThemeProvider theme={theme} colorMode={colorMode} isNested>
       <Card>
         <ToggleButtonGroup
           value={colorMode}

--- a/docs/src/pages/[platform]/theming/dark-mode/examples/DefaultDarkMode.tsx
+++ b/docs/src/pages/[platform]/theming/dark-mode/examples/DefaultDarkMode.tsx
@@ -17,7 +17,7 @@ export const DefaultDarkMode = () => {
   };
 
   return (
-    <ThemeProvider theme={theme} colorMode={colorMode}>
+    <ThemeProvider theme={theme} colorMode={colorMode} isNested>
       <Card>
         <ToggleButtonGroup
           value={colorMode}

--- a/docs/src/pages/[platform]/theming/dark-mode/examples/SystemDarkMode.tsx
+++ b/docs/src/pages/[platform]/theming/dark-mode/examples/SystemDarkMode.tsx
@@ -16,7 +16,7 @@ export const SystemDarkModeExample = () => {
   return (
     // Note: color mode overrides are scoped to the ThemeProvider
     // if you use multiple providers
-    <ThemeProvider theme={theme} colorMode="system">
+    <ThemeProvider theme={theme} colorMode="system" isNested>
       <Card>
         <Button>Hello</Button>
         <Text variation="primary">Primary text</Text>

--- a/docs/src/pages/[platform]/theming/dark-mode/react.mdx
+++ b/docs/src/pages/[platform]/theming/dark-mode/react.mdx
@@ -26,7 +26,7 @@ The `ThemeProvider` accepts a `colorMode` prop which can be `light`, `dark`, or 
 
 <Alert variation="warning">
 
-If you have multiple `ThemeProvider`s in your application, make sure to store `colorMode` in the application's state or context and pass it to each `ThemeProvider` or else some parts of your app won't have the right color mode applied. Also, because the theme uses CSS variables which are inherited, your application can have some weird behavior with nested themes and color modes.
+If you have multiple `ThemeProvider`s in your application, make sure to set `isNested` to `true` on nested `ThemeProvider`s other than the root one and store `colorMode` in the application's state or context and pass it to each `ThemeProvider` or else some parts of your app won't have the right color mode applied. Also, because the theme uses CSS variables which are inherited, your application can have some weird behavior with nested themes and color modes.
 
 Multiple `ThemeProvider`s should be avoided if possible because it is more efficient to use a selector override instead. This site uses nested `ThemeProvider`s for demos.
 

--- a/packages/react/src/components/ThemeProvider/__tests__/ThemeProvider.test.tsx
+++ b/packages/react/src/components/ThemeProvider/__tests__/ThemeProvider.test.tsx
@@ -22,7 +22,7 @@ describe('ThemeProvider', () => {
 
   it('wraps the App in [data-amplify-theme="default-theme"]', () => {
     spyOn(global.document.documentElement, 'setAttribute');
-    const { container } = render(
+    render(
       <ThemeProvider>
         <App />
       </ThemeProvider>
@@ -35,8 +35,20 @@ describe('ThemeProvider', () => {
 
     expect(global.document.documentElement.setAttribute).toHaveBeenCalledWith(
       'data-amplify-color-mode',
-      'undefined'
+      undefined
     );
+  });
+
+  it('should not set attributes on root element if isNested is ture', () => {
+    spyOn(global.document.documentElement, 'setAttribute');
+    render(
+      <ThemeProvider isNested>
+        <App />
+      </ThemeProvider>
+    );
+
+    expect(global.document.documentElement.setAttribute).not.toHaveBeenCalled();
+    expect(global.document.documentElement.setAttribute).not.toHaveBeenCalled();
   });
 
   it('filters out XSS attacks which attempt to escape the CSS context', async () => {


### PR DESCRIPTION
#### Description of changes

Add `isNested` prop to `ThemeProvider` so that only the one at top will be able to set attributes on root element versus relying on the cleanup function in `useEffect`, which will not work as expected if there are 2 or more nested providers on the same page.

#### Issue #, if available

A good example I can see is on the [Authenticator page](https://dev.ui.docs.amplify.aws/react/components/authenticator) where 2 ThemeProvider are in use. If you go to that page and then move over to other pages like [Installation](https://dev.ui.docs.amplify.aws/react/getting-started/installation), you will see `data-amplify-theme` attribute on root element is set to a wrong value `Auth Example Theme` instead of the expected original value `amplify-docs`.

#### Description of how you validated changes

Tested it out locally

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
