### PR TITLE
add design tokens and theme section to textareafield

### DIFF
--- a/docs/src/pages/[platform]/components/textareafield/examples/TextAreaFieldThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/textareafield/examples/TextAreaFieldThemeExample.tsx
@@ -1,0 +1,21 @@
+import { ThemeProvider, TextAreaField } from '@aws-amplify/ui-react';
+
+const theme = {
+  name: 'text-area-theme',
+  tokens: {
+    components: {
+      textareafield: {
+        color: { value: 'red' },
+        _focus: {
+          borderColor: { value: '{colors.brand.primary.40}' },
+        },
+      },
+    },
+  },
+};
+
+export const TextAreaFieldThemeExample = () => (
+  <ThemeProvider theme={theme}>
+    <TextAreaField label="Name" defaultValue="Starting Value" />
+  </ThemeProvider>
+);

--- a/docs/src/pages/[platform]/components/textareafield/examples/index.ts
+++ b/docs/src/pages/[platform]/components/textareafield/examples/index.ts
@@ -8,5 +8,6 @@ export { TextAreaSizeExample } from './TextAreaSizeExample';
 export { TextAreaFieldDescriptiveExample } from './TextAreaFieldDescriptiveExample';
 export { TextAreaFieldStatesExample } from './TextAreaFieldStatesExample';
 export { TextAreaFieldStylePropsExample } from './TextAreaFieldStylePropsExample';
+export { TextAreaFieldThemeExample } from './TextAreaFieldThemeExample';
 export { TextAreaFieldValidationErrorExample } from './TextAreaFieldValidationErrorExample';
 export { TextAreaFieldVariationExample } from './TextAreaFieldVariationExample';

--- a/docs/src/pages/[platform]/components/textareafield/react.mdx
+++ b/docs/src/pages/[platform]/components/textareafield/react.mdx
@@ -12,10 +12,12 @@ import {
   TextAreaFieldDescriptiveExample,
   TextAreaFieldStatesExample,
   TextAreaFieldStylePropsExample,
+  TextAreaFieldThemeExample,
   TextAreaFieldValidationErrorExample,
   TextAreaFieldVariationExample,
 } from './examples';
 import { Example, ExampleCode } from '@/components/Example';
+import { ThemeAlert } from '@/components/ThemeAlert';
 import { Fragment } from '@/components/Fragment';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 
@@ -183,6 +185,24 @@ Use the `hasError` and `errorMessage` fields to mark a `TextAreaField` with a va
 ### Target classes
 
 <ComponentStyleDisplay componentName="TextAreaField" />
+
+### Theme
+
+<ThemeAlert />
+
+You can customize the appearance of all TextAreaFields in your application with a [Theme](/theming).
+
+<Example>
+  <TextAreaFieldThemeExample />
+  
+<ExampleCode>
+
+```tsx file=./examples/TextAreaFieldThemeExample.tsx
+
+```
+
+</ExampleCode>
+</Example>
 
 ### Global styling
 

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -658,6 +658,9 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-text-warning-color: var(--amplify-colors-font-warning);
         --amplify-components-text-success-color: var(--amplify-colors-font-success);
         --amplify-components-text-info-color: var(--amplify-colors-font-info);
+        --amplify-components-textareafield-color: var(--amplify-components-fieldcontrol-color);
+        --amplify-components-textareafield-border-color: var(--amplify-components-fieldcontrol-border-color);
+        --amplify-components-textareafield-focus-border-color: var(--amplify-components-fieldcontrol-focus-border-color);
         --amplify-components-togglebutton-border-color: var(--amplify-colors-border-primary);
         --amplify-components-togglebutton-color: var(--amplify-colors-font-primary);
         --amplify-components-togglebutton-hover-background-color: var(--amplify-colors-overlay-10);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -692,6 +692,9 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-text-warning-color: var(--amplify-colors-font-warning);
         --amplify-components-text-success-color: var(--amplify-colors-font-success);
         --amplify-components-text-info-color: var(--amplify-colors-font-info);
+        --amplify-components-textareafield-color: var(--amplify-components-fieldcontrol-color);
+        --amplify-components-textareafield-border-color: var(--amplify-components-fieldcontrol-border-color);
+        --amplify-components-textareafield-focus-border-color: var(--amplify-components-fieldcontrol-focus-border-color);
         --amplify-components-togglebutton-border-color: var(--amplify-colors-border-primary);
         --amplify-components-togglebutton-color: var(--amplify-colors-font-primary);
         --amplify-components-togglebutton-hover-background-color: var(--amplify-colors-overlay-10);

--- a/packages/ui/src/theme/css/component/textAreaField.scss
+++ b/packages/ui/src/theme/css/component/textAreaField.scss
@@ -1,3 +1,12 @@
 .amplify-textareafield {
   flex-direction: column;
+  --amplify-components-fieldcontrol-color: var(
+    --amplify-components-textareafield-color
+  );
+  --amplify-components-fieldcontrol-border-color: var(
+    --amplify-components-textareafield-border-color
+  );
+  --amplify-components-fieldcontrol-focus-border-color: var(
+    --amplify-components-textareafield-focus-border-color
+  );
 }

--- a/packages/ui/src/theme/tokens/components/index.ts
+++ b/packages/ui/src/theme/tokens/components/index.ts
@@ -37,6 +37,7 @@ import { switchfield, SwitchFieldTokens } from './switchField';
 import { table, TableTokens } from './table';
 import { tabs, TabsTokens } from './tabs';
 import { text, TextTokens } from './text';
+import { textareafield, TextAreaFieldTokens } from './textAreaField';
 import { togglebutton, ToggleButtonTokens } from './toggleButton';
 import {
   togglebuttongroup,
@@ -80,6 +81,7 @@ export interface ComponentTokens {
   table: TableTokens;
   tabs: TabsTokens;
   text: TextTokens;
+  textareafield: TextAreaFieldTokens;
   togglebutton: ToggleButtonTokens;
   togglebuttongroup: ToggleButtonGroupTokens;
 }
@@ -121,6 +123,7 @@ export const components: ComponentTokens = {
   table,
   tabs,
   text,
+  textareafield,
   togglebutton,
   togglebuttongroup,
 };

--- a/packages/ui/src/theme/tokens/components/textAreaField.ts
+++ b/packages/ui/src/theme/tokens/components/textAreaField.ts
@@ -1,0 +1,25 @@
+import {
+  ColorValue,
+  DesignToken,
+  BorderColorValue,
+} from '../types/designToken';
+
+interface TextAreaFieldStateToken {
+  borderColor: DesignToken<BorderColorValue>;
+}
+
+export interface TextAreaFieldTokens {
+  color: DesignToken<ColorValue>;
+  borderColor: DesignToken<BorderColorValue>;
+  _focus: TextAreaFieldStateToken;
+}
+
+export const textareafield: TextAreaFieldTokens = {
+  color: { value: '{components.fieldcontrol.color.value}' },
+  borderColor: { value: '{components.fieldcontrol.borderColor.value}' },
+  _focus: {
+    borderColor: {
+      value: '{components.fieldcontrol._focus.borderColor.value}',
+    },
+  },
+};


### PR DESCRIPTION
#### Description of changes
Add design tokens and theme section to text area field primitive

<img width="1177" alt="Screen Shot 2022-06-13 at 4 25 07 AM" src="https://user-images.githubusercontent.com/7351516/173344115-cd736212-b01d-49cd-a948-2664c050d210.png">


#### Description of how you validated changes
validated on docs site

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
