### PR TITLE
add textfield design tokens

### DIFF
--- a/.changeset/mighty-impalas-fail.md
+++ b/.changeset/mighty-impalas-fail.md
@@ -1,0 +1,11 @@
+---
+"@aws-amplify/ui": minor
+---
+
+add textfield design tokens
+
+```
+--amplify-components-textfield-color: var(--amplify-components-fieldcontrol-color);
+--amplify-components-textfield-border-color: var(--amplify-components-fieldcontrol-border-color);
+--amplify-components-textfield-focus-border-color: var(--amplify-components-fieldcontrol-focus-border-color);
+```

--- a/docs/src/pages/[platform]/components/textfield/examples/TextFieldThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/textfield/examples/TextFieldThemeExample.tsx
@@ -1,0 +1,21 @@
+import { ThemeProvider, TextField } from '@aws-amplify/ui-react';
+
+const theme = {
+  name: 'text-theme',
+  tokens: {
+    components: {
+      textfield: {
+        color: { value: 'red' },
+        _focus: {
+          borderColor: { value: '{colors.brand.primary.40}' },
+        },
+      },
+    },
+  },
+};
+
+export const TextFieldThemeExample = () => (
+  <ThemeProvider theme={theme}>
+    <TextField label="Name" />
+  </ThemeProvider>
+);

--- a/docs/src/pages/[platform]/components/textfield/examples/index.ts
+++ b/docs/src/pages/[platform]/components/textfield/examples/index.ts
@@ -14,5 +14,6 @@ export { TextFieldOuterComponentsExample } from './TextFieldOuterComponentsExamp
 export { TextFieldSizeExample } from './TextFieldSizeExample';
 export { TextFieldStatesExample } from './TextFieldStatesExample';
 export { TextFieldStylePropsExample } from './TextFieldStylePropsExample';
+export { TextFieldThemeExample } from './TextFieldThemeExample';
 export { TextFieldValidationErrorExample } from './TextFieldValidationErrorExample';
 export { TextFieldVariationExample } from './TextFieldVariationExample';

--- a/docs/src/pages/[platform]/components/textfield/react.mdx
+++ b/docs/src/pages/[platform]/components/textfield/react.mdx
@@ -1,6 +1,7 @@
 import { Alert, Link, TextField } from '@aws-amplify/ui-react';
 
 import { TextFieldDemo } from './demo';
+import { ThemeAlert } from '@/components/ThemeAlert';
 import {
   DefaultRequiredTextFieldExample,
   DefaultTextAreaExample,
@@ -18,6 +19,7 @@ import {
   TextFieldSizeExample,
   TextFieldStatesExample,
   TextFieldStylePropsExample,
+  TextFieldThemeExample,
   TextFieldValidationErrorExample,
   TextFieldVariationExample,
 } from './examples';
@@ -303,6 +305,24 @@ Use the `hasError` and `errorMessage` fields to mark a TextField as having an va
 ### Target classes
 
 <ComponentStyleDisplay componentName="TextField" />
+
+### Theme
+
+<ThemeAlert />
+
+You can customize the appearance of all TextFields in your application with a [Theme](/theming).
+
+<Example>
+  <TextFieldThemeExample />
+  
+<ExampleCode>
+
+```tsx file=./examples/TextFieldThemeExample.tsx
+
+```
+
+</ExampleCode>
+</Example>
 
 ### Global styling
 

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -658,6 +658,9 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-text-warning-color: var(--amplify-colors-font-warning);
         --amplify-components-text-success-color: var(--amplify-colors-font-success);
         --amplify-components-text-info-color: var(--amplify-colors-font-info);
+        --amplify-components-textfield-color: var(--amplify-components-fieldcontrol-color);
+        --amplify-components-textfield-border-color: var(--amplify-components-fieldcontrol-border-color);
+        --amplify-components-textfield-focus-border-color: var(--amplify-components-fieldcontrol-focus-border-color);
         --amplify-components-togglebutton-border-color: var(--amplify-colors-border-primary);
         --amplify-components-togglebutton-color: var(--amplify-colors-font-primary);
         --amplify-components-togglebutton-hover-background-color: var(--amplify-colors-overlay-10);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -692,6 +692,9 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-text-warning-color: var(--amplify-colors-font-warning);
         --amplify-components-text-success-color: var(--amplify-colors-font-success);
         --amplify-components-text-info-color: var(--amplify-colors-font-info);
+        --amplify-components-textfield-color: var(--amplify-components-fieldcontrol-color);
+        --amplify-components-textfield-border-color: var(--amplify-components-fieldcontrol-border-color);
+        --amplify-components-textfield-focus-border-color: var(--amplify-components-fieldcontrol-focus-border-color);
         --amplify-components-togglebutton-border-color: var(--amplify-colors-border-primary);
         --amplify-components-togglebutton-color: var(--amplify-colors-font-primary);
         --amplify-components-togglebutton-hover-background-color: var(--amplify-colors-overlay-10);

--- a/packages/ui/src/theme/css/component/textField.scss
+++ b/packages/ui/src/theme/css/component/textField.scss
@@ -1,3 +1,12 @@
 .amplify-textfield {
   flex-direction: column;
+  --amplify-components-fieldcontrol-color: var(
+    --amplify-components-textfield-color
+  );
+  --amplify-components-fieldcontrol-border-color: var(
+    --amplify-components-textfield-border-color
+  );
+  --amplify-components-fieldcontrol-focus-border-color: var(
+    --amplify-components-textfield-focus-border-color
+  );
 }

--- a/packages/ui/src/theme/tokens/components/index.ts
+++ b/packages/ui/src/theme/tokens/components/index.ts
@@ -37,6 +37,7 @@ import { switchfield, SwitchFieldTokens } from './switchField';
 import { table, TableTokens } from './table';
 import { tabs, TabsTokens } from './tabs';
 import { text, TextTokens } from './text';
+import { textfield, TextFieldTokens } from './textField';
 import { togglebutton, ToggleButtonTokens } from './toggleButton';
 import {
   togglebuttongroup,
@@ -80,6 +81,7 @@ export interface ComponentTokens {
   table: TableTokens;
   tabs: TabsTokens;
   text: TextTokens;
+  textfield: TextFieldTokens;
   togglebutton: ToggleButtonTokens;
   togglebuttongroup: ToggleButtonGroupTokens;
 }
@@ -121,6 +123,7 @@ export const components: ComponentTokens = {
   table,
   tabs,
   text,
+  textfield,
   togglebutton,
   togglebuttongroup,
 };

--- a/packages/ui/src/theme/tokens/components/textField.ts
+++ b/packages/ui/src/theme/tokens/components/textField.ts
@@ -1,0 +1,25 @@
+import {
+  ColorValue,
+  DesignToken,
+  BorderColorValue,
+} from '../types/designToken';
+
+interface TextFieldStateToken {
+  borderColor: DesignToken<BorderColorValue>;
+}
+
+export interface TextFieldTokens {
+  color: DesignToken<ColorValue>;
+  borderColor: DesignToken<BorderColorValue>;
+  _focus: TextFieldStateToken;
+}
+
+export const textfield: TextFieldTokens = {
+  color: { value: '{components.fieldcontrol.color.value}' },
+  borderColor: { value: '{components.fieldcontrol.borderColor.value}' },
+  _focus: {
+    borderColor: {
+      value: '{components.fieldcontrol._focus.borderColor.value}',
+    },
+  },
+};


### PR DESCRIPTION
#### Description of changes
Add Design Tokens and Theme section to textfield

<img width="1177" alt="Screen Shot 2022-06-13 at 4 31 00 AM" src="https://user-images.githubusercontent.com/7351516/173345176-5e133c04-b920-4590-8b86-bf3fe7b9ef02.png">


#### Description of how you validated changes
validated on docs site

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
