### PR TITLE
fix: docs table of contents with no headings

### DIFF
--- a/docs/src/components/Layout/index.tsx
+++ b/docs/src/components/Layout/index.tsx
@@ -120,9 +120,9 @@ export default function Page({
         <Footer />
       </main>
 
-      {!hideToc && headings.length && (
+      {!hideToc && headings.length ? (
         <TableOfContents title="Contents" headings={headings} />
-      )}
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Using `&&` for conditional rendering in React should be avoided because you might get weird cases like this where the ToC will show `0` because `headings.length` is 0. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
