### PR TITLE
fix(docs): add margin to ThemeAlert

### DIFF
--- a/docs/src/components/ThemeAlert.tsx
+++ b/docs/src/components/ThemeAlert.tsx
@@ -1,8 +1,9 @@
-import { Alert } from '@aws-amplify/ui-react';
+import { Alert, useTheme } from '@aws-amplify/ui-react';
 
 export const ThemeAlert = () => {
+  const { tokens } = useTheme();
   return (
-    <Alert variation="info">
+    <Alert variation="info" marginBottom={tokens.space.medium}>
       AmplifyProvider has been renamed to ThemeProvider. The ThemeProvider
       export is available since version 2.18.3, previous versions must still use
       AmplifyProvider.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds a medium margin bottom to the ThemeAlert component so there is a little spacing between it and content below.

**Before**
<img width="614" alt="Screen Shot 2022-06-13 at 3 51 54 PM" src="https://user-images.githubusercontent.com/376920/173434333-611f3364-d156-444d-bac0-51d2f92ac20d.png">


**After**
<img width="585" alt="Screen Shot 2022-06-13 at 3 51 46 PM" src="https://user-images.githubusercontent.com/376920/173434351-64fd67c3-c477-42c5-ba80-bcf1e67f826e.png">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
