### PR TITLE
fix: nested theme providers by removing menu's portal

### DIFF
--- a/.changeset/modern-cups-help.md
+++ b/.changeset/modern-cups-help.md
@@ -1,0 +1,8 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+fix: nested theme providers by removing menu's portal. 
+Menu primitive no longer renders in a React Portal which means it properly gets the theme from the nearest ThemeProvider.
+Removing the document element modifications in the ThemeProvider because it is no longer needed. Now the ThemeProvider is much cleaner!

--- a/packages/react/src/components/ThemeProvider/__tests__/ThemeProvider.test.tsx
+++ b/packages/react/src/components/ThemeProvider/__tests__/ThemeProvider.test.tsx
@@ -21,21 +21,15 @@ describe('ThemeProvider', () => {
   });
 
   it('wraps the App in [data-amplify-theme="default-theme"]', () => {
-    jest.spyOn(global.document.documentElement, 'setAttribute');
     const { container } = render(
       <ThemeProvider>
         <App />
       </ThemeProvider>
     );
 
-    expect(global.document.documentElement.setAttribute).toHaveBeenCalledWith(
+    expect(container.querySelector(`[data-amplify-theme]`)).toHaveAttribute(
       'data-amplify-theme',
       'default-theme'
-    );
-
-    expect(global.document.documentElement.setAttribute).toHaveBeenCalledWith(
-      'data-amplify-color-mode',
-      'undefined'
     );
   });
 

--- a/packages/react/src/components/ThemeProvider/index.tsx
+++ b/packages/react/src/components/ThemeProvider/index.tsx
@@ -24,38 +24,6 @@ export function AmplifyProvider({
     theme: { name, cssText },
   } = value;
 
-  // In order for the theme to apply to Portalled elements like our Menu
-  // we need to put the CSS variables we generate from the theme on the
-  // root element. The CSS selector that contains the CSS variables
-  // uses the data attributes present on the root element, and because
-  // the same data attributes are on a div down the DOM tree, the CSS variables
-  // will apply to both.
-  React.useEffect(() => {
-    if (document && document.documentElement) {
-      // Keep original data attributes to reset on unmount
-      const originalName =
-        document.documentElement.getAttribute('data-amplify-theme') ?? name;
-      const originalColorMode =
-        document.documentElement.getAttribute('data-amplify-color-mode') ||
-        colorMode;
-      document.documentElement.setAttribute('data-amplify-theme', name);
-      document.documentElement.setAttribute(
-        'data-amplify-color-mode',
-        colorMode || originalColorMode
-      );
-
-      return function cleanup() {
-        document.documentElement.setAttribute(
-          'data-amplify-theme',
-          originalName
-        );
-        document.documentElement.setAttribute(
-          'data-amplify-color-mode',
-          originalColorMode
-        );
-      };
-    }
-  }, [name, colorMode]);
   return (
     <AmplifyContext.Provider value={value}>
       {/*

--- a/packages/react/src/primitives/Menu/Menu.tsx
+++ b/packages/react/src/primitives/Menu/Menu.tsx
@@ -46,7 +46,7 @@ const MenuPrimitive: Primitive<MenuProps, 'div'> = (
         </MenuButton>
       )}
     </DropdownMenuTrigger>
-    <DropdownMenuContent align={menuAlign}>
+    <DropdownMenuContent align={menuAlign} portalled={false}>
       <ButtonGroup
         className={classNames(ComponentClassNames.MenuContent, className)}
         ref={ref}

--- a/packages/ui/src/theme/css/component/menu.scss
+++ b/packages/ui/src/theme/css/component/menu.scss
@@ -1,3 +1,12 @@
+// Using a ridiculously high z-index so the Radix popover menu
+// will appear above other content when it is NOT in a portal.
+// This is needed so we don't need to do weird stuff in the ThemeProvider
+// to get around the Portal not being part of the ThemeProvider's
+// DOM ancestors.
+[data-radix-popper-content-wrapper] {
+  z-index: 999999;
+}
+
 .amplify-menu-trigger {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

* Menu primitive uses `portalled={false}` now so it no longer renders in a React portal outside the DOM node of the ThemeProvider, meaning it now properly accepts the theme of the nearest ThemeProvider. 
* Removing all the junk in the ThemeProvider to get around that Portal issue. 

Potential alternative: we could make our own Portal (using the ThemeProvider's DOM node) potentially and render the menu content in that. Seems a bit more difficult. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

* Navigated around the docs site, things work fine. Examples with ThemeProvider work.


![CleanShot 2022-06-14 at 11 10 15](https://user-images.githubusercontent.com/321279/173659768-3e370c36-e7ef-41f7-960c-7b00a1a5fada.gif)

![CleanShot 2022-06-14 at 11 10 42](https://user-images.githubusercontent.com/321279/173659844-970ea155-f486-4e7c-a9ac-a5ed26836783.gif)



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
