### PR TITLE
BREAKING CHANGE: remove ShareText export

### DIFF
--- a/.changeset/eighty-birds-develop.md
+++ b/.changeset/eighty-birds-develop.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": major
+---
+
+BREAKING CHANGE: remove `ShareText` export

--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -21,7 +21,6 @@ describe('@aws-amplify/ui-react', () => {
           "ComponentClassObject",
           "ComponentPropsToStylePropsMap",
           "ComponentPropsToStylePropsMapKeys",
-          "SharedText",
           "View",
           "useTheme",
           "Alert",

--- a/packages/react/src/primitives/shared/constants.ts
+++ b/packages/react/src/primitives/shared/constants.ts
@@ -545,41 +545,6 @@ export const ComponentText = {
   },
 };
 
-/**
- * @deprecated
- * This is supposed to be used internally and will be removed in the next majoy release.
- */
-export const SharedText = {
-  CountryCodeSelect: {
-    ariaLabel: 'Country code',
-  },
-  ShowPasswordButton: {
-    ariaLabel: {
-      showPassword: 'Show password',
-      hidePassword: 'Hide password',
-    },
-  },
-  Fields: {
-    ariaLabel: {
-      clearField: 'Clear search',
-    },
-  },
-  SearchField: {
-    ariaLabel: {
-      search: 'Search',
-    },
-  },
-  StepperField: {
-    ariaLabel: {
-      IncreaseTo: 'Increase to',
-      DecreaseTo: 'Decrease to',
-    },
-  },
-  Collection: {
-    SearchFieldLabel: 'Search',
-  },
-};
-
 type ComponentNames = keyof typeof ComponentClassObject;
 export type ComponentClasses =
   typeof ComponentClassObject[ComponentNames]['className'];

--- a/packages/react/src/primitives/shared/index.ts
+++ b/packages/react/src/primitives/shared/index.ts
@@ -1,5 +1,1 @@
-export {
-  ComponentClassNames,
-  ComponentClassObject,
-  SharedText,
-} from './constants';
+export { ComponentClassNames, ComponentClassObject } from './constants';


### PR DESCRIPTION
#### Description of changes

This PR will remove `SharedText` export as part of 3.0 `BREAKING CHANGE`.

#### Issue #, if available

We want to clean up unintentional exports in 3.0.

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
