### PR TITLE
ci: change v2 branch name to `ui-react@v2`

### DIFF
--- a/.github/workflows/publish-latest-v2.yml
+++ b/.github/workflows/publish-latest-v2.yml
@@ -2,7 +2,7 @@ name: Publish to latest / v2
 
 on:
   push:
-    branches: [v2/react]
+    branches: [ui-react@v2]
 
 permissions:
   contents: write # Used to push tags to GitHub

--- a/.github/workflows/test-deploy-v2.yml
+++ b/.github/workflows/test-deploy-v2.yml
@@ -8,7 +8,7 @@ concurrency:
 
 on:
   push:
-    branches: [v2/react]
+    branches: [ui-react@v2]
 
 jobs:
   test:

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -8,7 +8,7 @@ concurrency:
 
 on:
   pull_request: # not pull_request_target, because v2 is in maintenance mode and will not accept external pull requests
-    branches: [v2/react]
+    branches: [ui-react@v2]
     types: [opened, synchronize, labeled]
 
 permissions:
@@ -35,7 +35,7 @@ jobs:
             const label = 'run-tests';
             github.issues.removeLabel({ owner, repo, issue_number, name: label });
   test:
-    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@v2/react
+    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@ui-react@v2
     needs: setup
     with:
       commit: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/version-packages-v2.yml
+++ b/.github/workflows/version-packages-v2.yml
@@ -2,7 +2,7 @@ name: Version Packages / v2
 
 on:
   push:
-    branches: [v2/react]
+    branches: [ui-react@v2]
 
 permissions:
   contents: write # Used to commit to "Version Packages" PR


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Changing `v2/react` to `ui-react@v2` as discussed. I thought @ is not allowed in branch name, but it is 😋 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
