### PR TITLE
fix: Fix docs error messages for Authenticator demo

### DIFF
--- a/docs/src/components/SocialProviderDemo.tsx
+++ b/docs/src/components/SocialProviderDemo.tsx
@@ -1,0 +1,35 @@
+import { translations } from '@aws-amplify/ui';
+import { Authenticator } from '@aws-amplify/ui-react';
+
+import { I18n } from 'aws-amplify';
+import * as React from 'react';
+
+type SocialProps = {
+  components: Record<string, string>;
+};
+
+export function SocialProviderDemo({ components = {} }: SocialProps) {
+  React.useEffect(() => {
+    const errorText = 'This example is for demo purposes only!';
+    I18n.putVocabulariesForLanguage('en', {
+      // Errors
+      'Federation requires either a User Pool or Identity Pool in config':
+        errorText,
+      'Configuration error (see console) – please contact the administrator':
+        errorText,
+    });
+
+    return () => {
+      I18n.putVocabulariesForLanguage('en', translations['en']);
+    };
+  }, []);
+
+  return (
+    <Authenticator.Provider>
+      <Authenticator
+        components={components}
+        socialProviders={['amazon', 'apple', 'facebook', 'google']}
+      />
+    </Authenticator.Provider>
+  );
+}

--- a/docs/src/pages/[platform]/components/authenticator/configuration/socialProviders.web.mdx
+++ b/docs/src/pages/[platform]/components/authenticator/configuration/socialProviders.web.mdx
@@ -1,6 +1,8 @@
-import { Alert, Authenticator } from '@aws-amplify/ui-react';
+import { Alert } from '@aws-amplify/ui-react';
 import { Example } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
+import {SocialProviderDemo} from "@/components/SocialProviderDemo";
+
 
 <Alert heading="Zero Configuration">
 
@@ -16,7 +18,7 @@ For your [configured social providers](https://docs.amplify.aws/lib/auth/social/
 </Fragment>
 
 <Example>
-  <Authenticator socialProviders={['amazon', 'apple', 'facebook', 'google']} />
+  <SocialProviderDemo/>
 </Example>
 
 _[Step by step video](https://youtu.be/8KwZNn56F78) on setting up social providers._

--- a/docs/src/pages/[platform]/components/authenticator/customization/LabelsAndTextDemo.tsx
+++ b/docs/src/pages/[platform]/components/authenticator/customization/LabelsAndTextDemo.tsx
@@ -5,19 +5,16 @@ import {
   useAuthenticator,
   View,
 } from '@aws-amplify/ui-react';
+
 import { I18n } from 'aws-amplify';
 import * as React from 'react';
 
 type ScreenProps = {
-  Component:
-    | Authenticator.SignIn
-    | Authenticator.SignUp
-    | Authenticator.SetupTOTP;
+  Component: JSX.Element;
 };
 
 function Screen({ Component }: ScreenProps) {
   // Used to render the component when side-effects happen
-  const [version, setVersion] = React.useState(0);
   const { route } = useAuthenticator();
 
   React.useEffect(() => {
@@ -50,8 +47,6 @@ function Screen({ Component }: ScreenProps) {
       // 'Back to Sign In': 'Back to Login', # Already set
     });
 
-    setVersion(version + 1);
-
     return () => {
       I18n.putVocabulariesForLanguage('en', translations['en']);
     };
@@ -67,37 +62,19 @@ function Screen({ Component }: ScreenProps) {
     );
   }
 
-  return <Component key={version} />;
+  return Component;
 }
 
 export function LabelsAndTextDemo({ Component }: ScreenProps) {
-  const OnMachineInit = ({ children }) => {
-    /**
-     * This waits for Authenticator machine to init before its inner components
-     * start consuming machine context.
-     */
-    const { route, _send } = useAuthenticator();
-    React.useEffect(() => {
-      if (route === 'idle') {
-        _send('INIT', { data: {} });
-      }
-    }, []);
-    if (!route || route === 'idle' || route === 'setup') return null;
-
-    return <>{children}</>;
-  };
-
   return (
     <Authenticator.Provider>
-      <OnMachineInit>
-        <View data-amplify-authenticator="">
-          <View data-amplify-container="">
-            <View data-amplify-body>
-              <Screen Component={Component} />
-            </View>
+      <View data-amplify-authenticator="">
+        <View data-amplify-container="">
+          <View data-amplify-body>
+            <Screen Component={Component} />
           </View>
         </View>
-      </OnMachineInit>
+      </View>
     </Authenticator.Provider>
   );
 }

--- a/docs/src/pages/[platform]/components/authenticator/customization/customization.headers-and-footers.web.mdx
+++ b/docs/src/pages/[platform]/components/authenticator/customization/customization.headers-and-footers.web.mdx
@@ -11,6 +11,7 @@ import {
 
 import { Example } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
+import {SocialProviderDemo} from '@/components/SocialProviderDemo' 
 
 ## Headers & Footers
 
@@ -32,9 +33,7 @@ The following example customizes these slots with:
 </Fragment>
 
 <Example>
-  <Authenticator
-    socialProviders={['amazon', 'apple', 'facebook', 'google']}
-    components={{
+  <SocialProviderDemo components={{
       Header() {
         const { tokens } = useTheme();
         return (
@@ -125,8 +124,7 @@ The following example customizes these slots with:
           },
         },
       },
-      /*
-       */
-    }}
+
+  }}/>
   />
 </Example>

--- a/docs/src/pages/[platform]/components/authenticator/customization/customization.labels-and-text.web.mdx
+++ b/docs/src/pages/[platform]/components/authenticator/customization/customization.labels-and-text.web.mdx
@@ -32,7 +32,7 @@ Using the same techniques as [Internationalization (I18n)](#internationalization
     ```
 
     <Example>
-      <LabelsAndTextDemo Component={Authenticator.SignIn} />
+      <LabelsAndTextDemo Component={<Authenticator initialState="signIn"/>} />
     </Example>
 
   </ExpanderItem>
@@ -49,7 +49,7 @@ Using the same techniques as [Internationalization (I18n)](#internationalization
     ```
 
     <Example>
-      <LabelsAndTextDemo Component={Authenticator.SignUp} />
+      <LabelsAndTextDemo Component={<Authenticator initialState="signUp"/>} />
     </Example>
 
   </ExpanderItem>
@@ -65,7 +65,7 @@ Using the same techniques as [Internationalization (I18n)](#internationalization
     ```
 
     <Example>
-      <LabelsAndTextDemo Component={Authenticator.ResetPassword} />
+      <LabelsAndTextDemo Component={<Authenticator initialState="resetPassword"/>} />
     </Example>
 
   </ExpanderItem>
@@ -79,10 +79,6 @@ Using the same techniques as [Internationalization (I18n)](#internationalization
       'Back to Sign In': 'Back to Login',
     });
     ```
-
-    <Example>
-      <LabelsAndTextDemo Component={Authenticator.SetupTOTP} />
-    </Example>
 
   </ExpanderItem>
 </Expander>


### PR DESCRIPTION
#### Description of changes
Fix docs error messages when people click buttons in the authenticator in the docs.

<img width="603" alt="image" src="https://user-images.githubusercontent.com/65630/173945930-31775175-bcba-40b4-85cb-0541fb7a9ffb.png">

<img width="1388" alt="image" src="https://user-images.githubusercontent.com/65630/173949087-c67625ab-67f1-4369-89dd-457ddbff6652.png">

Also fixed broken translation accordion.

Before:

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/65630/173947850-61e41e31-7c25-4233-a1c0-57bde393fbb6.png">


After:

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/65630/173946846-6ad1f985-bf70-43e2-8d1f-723c58839b46.png">


#### Issue #, if available

Fixes #2066  

#### Description of how you validated changes
Manually tested

#### Checklist


- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
