### PR TITLE
ci(canary): new `install-with-retries` action

### DIFF
--- a/.github/actions/install-with-retries/action.yml
+++ b/.github/actions/install-with-retries/action.yml
@@ -17,7 +17,6 @@ runs:
   using: 'composite'
   steps:
     - name: Run yarn install
-      if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
       shell: bash
       run: ./install-with-retries.sh
       env:

--- a/.github/actions/install-with-retries/action.yml
+++ b/.github/actions/install-with-retries/action.yml
@@ -22,4 +22,4 @@ runs:
       env:
         SKIP_CYPRESS_BINARY: ${{ inputs.skip-cypress-binary }}
         NO_LOCKFILE: ${{ inputs.no-lockfile }}
-      working-directory: ${{ inputs.working-directory }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}

--- a/.github/actions/install-with-retries/action.yml
+++ b/.github/actions/install-with-retries/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Path to run `yarn install` at'
     required: false
     default: './'
+  no-lockfile:
+    description: 'Whether to bypass yarn.lock file'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -18,4 +22,5 @@ runs:
       run: ./install-with-retries.sh
       env:
         SKIP_CYPRESS_BINARY: ${{ inputs.skip-cypress-binary }}
+        NO_LOCKFILE: ${{ inputs.no-lockfile }}
       working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/install-with-retries/action.yml
+++ b/.github/actions/install-with-retries/action.yml
@@ -12,12 +12,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Set environment var to skip cypress binary installation if applicable
-      if: ${{ inputs.working-directory == 'true' }}
-      shell: bash
-      run: echo "CYPRESS_INSTALL_BINARY=0" >> $GITHUB_ENV
     - name: Install cypress with binary
       if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: for n in {1..3}; do yarn install && break || sleep 5; done
+      run: ./install-with-retries.sh
+      env:
+        SKIP_CYPRESS_BINARY: ${{ inputs.skip-cypress-binary }}
       working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/install-with-retries/action.yml
+++ b/.github/actions/install-with-retries/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Run yarn install
       shell: bash
-      run: ./install-with-retries.sh
+      run: ./.github/actions/install-with-retries/install-with-retries.sh
       env:
         SKIP_CYPRESS_BINARY: ${{ inputs.skip-cypress-binary }}
         NO_LOCKFILE: ${{ inputs.no-lockfile }}

--- a/.github/actions/install-with-retries/action.yml
+++ b/.github/actions/install-with-retries/action.yml
@@ -1,0 +1,23 @@
+name: 'Install with retries'
+description: 'Runs yarn install with up to 2 retries'
+inputs:
+  skip-cypress-binary:
+    description: 'Whether to skip binary installation for cypress'
+    required: false
+    default: 'true'
+  working-directory:
+    description: 'Path to run `yarn install` at'
+    required: false
+    default: './'
+runs:
+  using: 'composite'
+  steps:
+    - name: Set environment var to skip cypress binary installation if applicable
+      if: ${{ inputs.working-directory == 'true' }}
+      shell: bash
+      run: echo "CYPRESS_INSTALL_BINARY=0" >> $GITHUB_ENV
+    - name: Install cypress with binary
+      if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: for n in {1..3}; do yarn install && break || sleep 5; done
+      working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/install-with-retries/action.yml
+++ b/.github/actions/install-with-retries/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install cypress with binary
+    - name: Run yarn install
       if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
       shell: bash
       run: ./install-with-retries.sh

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+if [ "$SKIP_CYPRESS_BINARY" = "true" ]; then
+  # Skip cypress binary installation if specified
+  # https://docs.cypress.io/guides/references/advanced-installation#Environment-variables
+  echo "[LOG]: Setting flag to skip cypress binary installation"
+  export CYPRESS_INSTALL_BINARY=0;
+fi
+
+for i in {1..3}; do
+  echo "===================="
+  echo "Attempt $i out of 3:"
+  echo "===================="
+
+  yarn install
+
+  # Check return value and exit early if successful
+  return_value=$?
+  [ $return_value -eq 0 ] && break
+  echo "[ERROR]: yarn install failed with exit code $return_value, waiting to retry..."
+
+  # Sleep 5 seconds before retrying
+  sleep 5
+done

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -26,7 +26,7 @@ for i in {1..3}; do
     echo "[LOG]: Ignoring yarn.lock file"
     yarn install --no-lockfile
   else
-    yarn install
+    yarn installl
   fi
 
   # Check return value and exit early if successful
@@ -38,4 +38,5 @@ for i in {1..3}; do
   sleep 5
 done
 
+# exit 0 if last `yarn install` was successful, non-zero otherwise
 exit $return_value

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -5,7 +5,7 @@
 #   NO_LOCKFILE (boolean): Ignores yarn.lock file if true
 #   WORKING_DIRECTORY (string): Path to run yarn install at
 
-if [[ -n "$WORKING_DIRECTORY" ]]; then
+if [ -n "$WORKING_DIRECTORY" ]; then
   echo "[LOG]: Changing directory to $WORKING_DIRECTORY"
   cd $WORKING_DIRECTORY
 fi

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -12,7 +12,11 @@ for i in {1..3}; do
   echo "Attempt $i out of 3:"
   echo "===================="
 
-  yarn install
+  if [ "$NO_LOCKFILE" = "true" ]; then
+    yarn install --no-lockfile
+  else
+    yarn install
+  fi
 
   # Check return value and exit early if successful
   return_value=$?

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -37,3 +37,5 @@ for i in {1..3}; do
   # Sleep 5 seconds before retrying
   sleep 5
 done
+
+exit $return_value

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -26,7 +26,7 @@ for i in {1..3}; do
     echo "[LOG]: Ignoring yarn.lock file"
     yarn install --no-lockfile
   else
-    yarn installl
+    yarn install
   fi
 
   # Check return value and exit early if successful

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -4,7 +4,7 @@
 # - SKIP_CYPRESS_BINARY (boolean): Skips cypress binary installation if true.
 # - NO_LOCKFILE (boolean): Ignores yarn.lock file if true
 
-if [ "$a" = "true" ]; then
+if [ "$SKIP_CYPRESS_BINARY" = "true" ] then
   # Skip cypress binary installation if specified
   # https://docs.cypress.io/guides/references/advanced-installation#Environment-variables
   echo "[LOG]: Setting flag to skip cypress binary installation"

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -1,20 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 
 # Environment variable inputs:
 #   SKIP_CYPRESS_BINARY (boolean): Skips cypress binary installation if true.
 #   NO_LOCKFILE (boolean): Ignores yarn.lock file if true
 #   WORKING_DIRECTORY (string): Path to run yarn install at
 
-if [ $WORKING_DIRECTORY -n ] then
+if [[ -n "$WORKING_DIRECTORY" ]]; then
   echo "[LOG]: Changing directory to $WORKING_DIRECTORY"
   cd $WORKING_DIRECTORY
 fi
 
-if [ "$SKIP_CYPRESS_BINARY" = "true" ] then
+if [ "$SKIP_CYPRESS_BINARY" = "true" ]; then
   # Skip cypress binary installation if specified
   # https://docs.cypress.io/guides/references/advanced-installation#Environment-variables
   echo "[LOG]: Setting flag to skip cypress binary installation"
-  export CYPRESS_INSTALL_BINARY=0;
+  export CYPRESS_INSTALL_BINARY=0
 fi
 
 for i in {1..3}; do

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-if [ "$SKIP_CYPRESS_BINARY" = "true" ]; then
+# Env Variale Inputs
+# - SKIP_CYPRESS_BINARY (boolean): Skips cypress binary installation if true.
+# - NO_LOCKFILE (boolean): Ignores yarn.lock file if true
+
+if [ "$a" = "true" ]; then
   # Skip cypress binary installation if specified
   # https://docs.cypress.io/guides/references/advanced-installation#Environment-variables
   echo "[LOG]: Setting flag to skip cypress binary installation"

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 
-# Env Variale Inputs
-# - SKIP_CYPRESS_BINARY (boolean): Skips cypress binary installation if true.
-# - NO_LOCKFILE (boolean): Ignores yarn.lock file if true
+# Environment variable inputs:
+#   SKIP_CYPRESS_BINARY (boolean): Skips cypress binary installation if true.
+#   NO_LOCKFILE (boolean): Ignores yarn.lock file if true
+#   WORKING_DIRECTORY (string): Path to run yarn install at
+
+if [ $WORKING_DIRECTORY -n ] then
+  echo "[LOG]: Changing directory to $WORKING_DIRECTORY"
+  cd $WORKING_DIRECTORY
+fi
 
 if [ "$SKIP_CYPRESS_BINARY" = "true" ] then
   # Skip cypress binary installation if specified

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -13,6 +13,7 @@ for i in {1..3}; do
   echo "===================="
 
   if [ "$NO_LOCKFILE" = "true" ]; then
+    echo "[LOG]: Ignoring yarn.lock file"
     yarn install --no-lockfile
   else
     yarn install

--- a/.github/workflows/run-and-test-builds.yml
+++ b/.github/workflows/run-and-test-builds.yml
@@ -68,7 +68,7 @@ jobs:
         uses: ./.github/actions/install-with-retries
         with:
           working-directory: ./canary/e2e
-          skip-cypress-binary: steps.restore-cypress-cache.outputs.cache-hit
+          skip-cypress-binary: ${{ steps.restore-cypress-cache.outputs.cache-hit }}
       - name: Cache cypress runner
         if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v2

--- a/.github/workflows/run-and-test-builds.yml
+++ b/.github/workflows/run-and-test-builds.yml
@@ -32,9 +32,11 @@ jobs:
           cache: 'yarn'
       - name: Ignore monorepo postcss.config.js
         run: mv postcss.config.js _postcss.config.js
-      - name: Install packages
-        run: for n in {1..3}; do yarn install --no-lockfile && break || sleep 5; done
-        working-directory: ./canary/apps/${{ matrix.path }}
+      - name: Install e2e packages
+        uses: ./.github/actions/install-with-retries
+        with:
+          no-lockfile: true
+          working-directory: ./canary/apps/${{ matrix.path }}
       - name: Add Amplify CLI
         run: yarn global add @aws-amplify/cli
       - name: Get CLI versions

--- a/.github/workflows/run-and-test-builds.yml
+++ b/.github/workflows/run-and-test-builds.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Build example app
         run: yarn build
         working-directory: ./canary/apps/${{ matrix.path }}
+      # This steps attempts to restore cypress runner. It will not create any new
+      # cache entries however, because cypress runner isn't available yet.
       - name: Restore cypress runner from Cache
         uses: actions/cache@v2
         id: restore-cypress-cache
@@ -68,7 +70,12 @@ jobs:
         uses: ./.github/actions/install-with-retries
         with:
           working-directory: ./canary/e2e
+          # If we got a cache hit on cypress runner, then we will skip cypress binary
+          # installation. Otherwise, it will install cypress binary.
           skip-cypress-binary: ${{ steps.restore-cypress-cache.outputs.cache-hit }}
+      # If cypress cache was missed, then we need to create new cache entry and upload it.
+      # At this point, cypress runner should've been installed from the previous installation
+      # step, so we go ahead and update the cache entry.
       - name: Cache cypress runner
         if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v2

--- a/.github/workflows/run-and-test-builds.yml
+++ b/.github/workflows/run-and-test-builds.yml
@@ -56,9 +56,23 @@ jobs:
       - name: Build example app
         run: yarn build
         working-directory: ./canary/apps/${{ matrix.path }}
-      - name: Install cypress
-        run: for n in {1..3}; do yarn install --no-lockfile && break || sleep 5; done
-        working-directory: ./canary/e2e
+      - name: Restore cypress runner from Cache
+        uses: actions/cache@v2
+        id: restore-cypress-cache
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-canary-cypress-${{ hashFiles('canary/e2e/yarn.lock') }}
+      - name: Install e2e packages
+        uses: ./.github/actions/install-with-retries
+        with:
+          working-directory: ./canary/e2e
+          skip-cypress-binary: steps.restore-cypress-cache.outputs.cache-hit
+      - name: Cache cypress runner
+        if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-canary-cypress-${{ hashFiles('canary/e2e/yarn.lock') }}
       - name: Start ${{ matrix.example }} example
         run: yarn start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000
         working-directory: ./canary/apps/${{ matrix.path }}

--- a/.github/workflows/run-and-test-builds.yml
+++ b/.github/workflows/run-and-test-builds.yml
@@ -32,7 +32,7 @@ jobs:
           cache: 'yarn'
       - name: Ignore monorepo postcss.config.js
         run: mv postcss.config.js _postcss.config.js
-      - name: Install e2e packages
+      - name: Install canary package
         uses: ./.github/actions/install-with-retries
         with:
           no-lockfile: true


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR adds new `install-with-retries` action that will try `yarn install` up to 3 times. This can be reused in other PRs, but I scoped it to just canary workflow because that's where `yarn install` failed the most. 

#### Bug Fix
This fixed a bug where `yarn install` failed silently after it failed all three retries. See "Install Cypress" step in this [workflow](https://github.com/aws-amplify/amplify-ui/runs/6914109019?check_suite_focus=true) for example.

#### Optimization
`install-with-retries` optionally accepts `skip-cypress-binary` argument. If this is set to true, it'll skip cypress binary installation step, which has [been really flimsy](https://github.com/aws-amplify/amplify-ui/runs/6914109019?check_suite_focus=true) recently.

Instead of installing cypress binary every time, canaries will cache cypress binary and share it across jobs. It'll only install the binary on cache misses.


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

POC'd on #2122

- First run (cache miss): https://github.com/aws-amplify/amplify-ui/runs/6914131760?check_suite_focus=true
- Second run (cache hit): https://github.com/aws-amplify/amplify-ui/runs/6914184443?check_suite_focus=true

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] New workflow files do not accept any user inputs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
