### PR TITLE
fix (docs): Remove redundant alt text

### DIFF
--- a/docs/src/components/Layout/FrameworkChooser.tsx
+++ b/docs/src/components/Layout/FrameworkChooser.tsx
@@ -34,7 +34,7 @@ const FrameworkLink = ({
         isDisabled={isDisabled}
       >
         <Image
-          alt={framework}
+          alt=""
           height="1.25rem"
           width="1.25rem"
           display="block"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Removes some redundant alt text for framework chooser buttons which was causing SR to announce "React React"; we have a text label for them already so we can use an empty alt attribute for the icons.

**Before**

<img width="1112" alt="Screen Shot 2022-06-16 at 12 37 39 PM" src="https://user-images.githubusercontent.com/376920/174121891-6397d6b7-8e57-473c-bea5-c95c7ee27949.png">

**After**

<img width="1105" alt="Screen Shot 2022-06-16 at 12 37 52 PM" src="https://user-images.githubusercontent.com/376920/174122017-17eb70c3-a869-43b2-81bc-5fc15f16706f.png">


#### Issue #, if available

n/a

#### Description of how you validated changes

Local docs instance


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
