### PR TITLE
docs(chore): Image docs update

### DIFF
--- a/docs/src/pages/[platform]/components/image/ImagePropControls.tsx
+++ b/docs/src/pages/[platform]/components/image/ImagePropControls.tsx
@@ -1,17 +1,30 @@
 import * as React from 'react';
-import { Flex, ImageOptions, TextField } from '@aws-amplify/ui-react';
+import {
+  Flex,
+  ImageOptions,
+  BaseStyleProps,
+  TextField,
+  SelectField,
+} from '@aws-amplify/ui-react';
 
 export interface ImagePropControlsProps extends ImageOptions {
   setAlt: (value: React.SetStateAction<ImageOptions['alt']>) => void;
-  setSizes: (value: React.SetStateAction<ImageOptions['sizes']>) => void;
-  setSrc: (value: React.SetStateAction<ImageOptions['src']>) => void;
-  setSrcSet: (value: React.SetStateAction<ImageOptions['srcSet']>) => void;
   setObjectFit: (
     value: React.SetStateAction<ImageOptions['objectFit']>
   ) => void;
   setObjectPosition: (
     value: React.SetStateAction<ImageOptions['objectPosition']>
   ) => void;
+  setBackgroundColor: (
+    value: React.SetStateAction<BaseStyleProps['backgroundColor']>
+  ) => void;
+  setHeight: (value: React.SetStateAction<BaseStyleProps['height']>) => void;
+  setWidth: (value: React.SetStateAction<BaseStyleProps['width']>) => void;
+  setOpacity: (value: React.SetStateAction<BaseStyleProps['opacity']>) => void;
+  backgroundColor: BaseStyleProps['backgroundColor'];
+  height: BaseStyleProps['height'];
+  width: BaseStyleProps['width'];
+  opacity: BaseStyleProps['opacity'];
 }
 
 interface ImagePropControlsInterface {
@@ -20,16 +33,19 @@ interface ImagePropControlsInterface {
 
 export const ImagePropControls: ImagePropControlsInterface = ({
   alt,
-  sizes,
-  src,
-  srcSet,
-  objectFit,
-  objectPosition,
   setAlt,
-  setSizes,
-  setSrcSet,
+  objectFit,
   setObjectFit,
+  objectPosition,
   setObjectPosition,
+  backgroundColor,
+  setBackgroundColor,
+  height,
+  setHeight,
+  width,
+  setWidth,
+  opacity,
+  setOpacity,
 }) => {
   return (
     <Flex direction="column">
@@ -41,30 +57,54 @@ export const ImagePropControls: ImagePropControlsInterface = ({
           setAlt(event.target.value);
         }}
       />
-      <TextField
-        label="sizes"
-        placeholder="Set sizes"
-        value={sizes}
-        onChange={(event: any) => {
-          setSizes(event.target.value);
-        }}
-      />
-      <TextField label="src" placeholder="Set src" value={src} isDisabled />
-      <TextField label="srcSet" placeholder="Set srcSet" value={srcSet} />
-      <TextField
+      <TextField label="src" placeholder="/amplify-logo.svg" isReadOnly />
+      <SelectField
         label="objectFit"
-        placeholder="Set objectFit"
         value={objectFit as string}
-        onChange={(event: any) => {
-          setObjectFit(event.target.value);
-        }}
-      />
+        onChange={(event) => setObjectFit(event.target.value as string)}
+      >
+        <option value="initial">initial</option>
+        <option value="cover">cover</option>
+        <option value="none">none</option>
+      </SelectField>
       <TextField
         label="objectPosition"
         placeholder="Set objectPosition"
         value={objectPosition as string}
         onChange={(event: any) => {
           setObjectPosition(event.target.value);
+        }}
+      />
+      <TextField
+        label="backgroundColor"
+        placeholder="Set backgroundColor"
+        value={backgroundColor as string}
+        onChange={(event: any) => {
+          setBackgroundColor(event.target.value);
+        }}
+      />
+      <TextField
+        label="height"
+        placeholder="Set height"
+        value={height as string}
+        onChange={(event: any) => {
+          setHeight(event.target.value);
+        }}
+      />
+      <TextField
+        label="width"
+        placeholder="Set width"
+        value={width as string}
+        onChange={(event: any) => {
+          setWidth(event.target.value);
+        }}
+      />
+      <TextField
+        label="opacity"
+        placeholder="Set opacity"
+        value={opacity as string}
+        onChange={(event: any) => {
+          setOpacity(event.target.value);
         }}
       />
     </Flex>

--- a/docs/src/pages/[platform]/components/image/demo.tsx
+++ b/docs/src/pages/[platform]/components/image/demo.tsx
@@ -4,106 +4,56 @@ import { Image, ImageProps } from '@aws-amplify/ui-react';
 import { Demo } from '@/components/Demo';
 import { ImagePropControls } from './ImagePropControls';
 import { useImageProps } from './useImageProps';
-import { useStyleProps } from '../shared/useStyleProps';
-import { StylePropControls } from '../shared/StylePropControls';
 import { demoState } from '@/utils/demoState';
 
 const propsToCode = (props) => {
   return `<Image
-  src="${props.src}"
-  srcSet="${props.srcSet}"
-  sizes="${props.sizes}"
   alt="${props.alt}"
+  src="${props.src}"
   objectFit="${props.objectFit}"
   objectPosition="${props.objectPosition}"
   backgroundColor="${props.backgroundColor}"
-  borderRadius="${props.borderRadius}"
-  border="${props.border}"
-  boxShadow="${props.boxShadow}"
-  color="${props.color}"
   height="${props.height}"
-  maxHeight="${props.maxHeight}"
-  maxWidth="${props.maxWidth}"
-  minHeight="${props.minHeight}"
-  minWidth="${props.minWidth}"
-  opacity="${props.opacity}"
-  padding="${props.padding}"
   width="${props.width}"
+  opacity="${props.opacity}"
   onClick={() => alert('📸 Say cheese!')}
 />`;
 };
 
-const defaultStyleProps = {
-  width: '100%',
-  height: '100%',
-  backgroundColor: 'initial',
-  border: 'initial',
-  borderRadius: 'initial',
-  boxShadow: 'initial',
-  color: 'initial',
-  maxHeight: 'initial',
-  maxWidth: 'initial',
-  minHeight: 'initial',
-  minWidth: 'initial',
-  opacity: '100%',
-  padding: '0',
-};
-
 const defaultImageProps = {
-  src: '/amplify-logo.svg',
   alt: 'Amplify logo',
-  objectFit: 'fill',
-  objectPosition: 'initial',
-  onError: () => {},
-  onLoad: () => {},
-  sizes: '',
-  srcSet: '',
+  src: '/amplify-logo.svg',
+  objectFit: 'initial',
+  objectPosition: '50% 50%',
+  width: '75%',
+  height: '75%',
+  backgroundColor: 'initial',
+  opacity: '100%',
 };
 
 export const ImageDemo = () => {
-  const styleProps = useStyleProps(
-    demoState.get(Image.displayName + 'styleProps') || defaultStyleProps
-  );
-
   const imageProps = useImageProps(
     (demoState.get(Image.displayName) as ImageProps) || defaultImageProps
   );
 
   React.useEffect(() => {
-    demoState.set(Image.displayName + 'styleProps', styleProps);
     demoState.set(Image.displayName, imageProps);
-  }, [styleProps, imageProps]);
+  }, [imageProps]);
 
   return (
     <Demo
-      code={propsToCode({ ...styleProps, ...imageProps })}
-      propControls={
-        <>
-          <ImagePropControls {...imageProps} />
-          <StylePropControls {...styleProps} />
-        </>
-      }
+      code={propsToCode({ ...imageProps })}
+      propControls={<ImagePropControls {...imageProps} />}
     >
       <Image
-        src={imageProps.src}
-        srcSet={imageProps.srcSet}
-        sizes={imageProps.sizes}
         alt={imageProps.alt}
+        src={imageProps.src}
         objectFit={imageProps.objectFit}
         objectPosition={imageProps.objectPosition}
-        backgroundColor={styleProps.backgroundColor}
-        borderRadius={styleProps.borderRadius}
-        border={styleProps.border}
-        boxShadow={styleProps.boxShadow}
-        color={styleProps.color}
-        height={styleProps.height}
-        maxHeight={styleProps.maxHeight}
-        maxWidth={styleProps.maxWidth}
-        minHeight={styleProps.minHeight}
-        minWidth={styleProps.minWidth}
-        opacity={styleProps.opacity}
-        padding={styleProps.padding}
-        width={styleProps.width}
+        backgroundColor={imageProps.backgroundColor}
+        height={imageProps.height}
+        width={imageProps.width}
+        opacity={imageProps.opacity}
         onClick={() => alert('📸 Say cheese!')}
       />
     </Demo>

--- a/docs/src/pages/[platform]/components/image/useImageProps.tsx
+++ b/docs/src/pages/[platform]/components/image/useImageProps.tsx
@@ -1,56 +1,70 @@
-import { ImageOptions } from '@aws-amplify/ui-react';
+import { ImageOptions, BaseStyleProps } from '@aws-amplify/ui-react';
 import * as React from 'react';
 
 import { ImagePropControlsProps } from './ImagePropControls';
 
 interface UseImageProps {
-  (initialValues: ImageOptions): ImagePropControlsProps;
+  (initialValues: ImageOptions & BaseStyleProps): ImagePropControlsProps;
 }
 
 export const useImageProps: UseImageProps = (initialValues) => {
   const [alt, setAlt] = React.useState<ImageOptions['alt']>(initialValues.alt);
-  const [sizes, setSizes] = React.useState<ImageOptions['sizes']>(
-    initialValues.sizes
-  );
   const [src, setSrc] = React.useState<ImageOptions['src']>(initialValues.src);
-  const [srcSet, setSrcSet] = React.useState<ImageOptions['srcSet']>(
-    initialValues.srcSet
-  );
   const [objectFit, setObjectFit] = React.useState<ImageOptions['objectFit']>(
     initialValues.objectFit
   );
   const [objectPosition, setObjectPosition] = React.useState<
     ImageOptions['objectPosition']
   >(initialValues.objectPosition);
+  const [backgroundColor, setBackgroundColor] = React.useState<
+    BaseStyleProps['backgroundColor']
+  >(initialValues.backgroundColor);
+  const [height, setHeight] = React.useState<BaseStyleProps['height']>(
+    initialValues.height
+  );
+  const [width, setWidth] = React.useState<BaseStyleProps['width']>(
+    initialValues.width
+  );
+  const [opacity, setOpacity] = React.useState<BaseStyleProps['opacity']>(
+    initialValues.opacity
+  );
 
   return React.useMemo(
     () => ({
       alt,
-      sizes,
-      src,
-      srcSet,
-      objectFit,
-      objectPosition,
       setAlt,
-      setSizes,
+      src,
       setSrc,
-      setSrcSet,
+      objectFit,
       setObjectFit,
+      objectPosition,
       setObjectPosition,
+      backgroundColor,
+      setBackgroundColor,
+      height,
+      setHeight,
+      width,
+      setWidth,
+      opacity,
+      setOpacity,
     }),
     [
       alt,
-      sizes,
-      src,
-      srcSet,
-      objectFit,
-      objectPosition,
       setAlt,
-      setSizes,
+      src,
       setSrc,
-      setSrcSet,
+      objectFit,
       setObjectFit,
+      objectPosition,
       setObjectPosition,
+      backgroundColor,
+      setBackgroundColor,
+      height,
+      setHeight,
+      width,
+      setWidth,
+      opacity,
+      setOpacity,
     ]
   );
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR reduces the number of props in the Image's main demo from 20 to 9, only including props that have a noticeable visual effect on the demo. 

Current demo: https://ui.docs.amplify.aws/react/components/image

Updated demo:

![Screen Shot 2022-06-16 at 5 51 15 PM](https://user-images.githubusercontent.com/48109584/174191117-98311917-d912-4a04-8aa8-9b0716ffd334.png)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the docs locally. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
