### PR TITLE
fix(ui): max call stack on createTheme

### DIFF
--- a/packages/ui/src/theme/__tests__/createTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/createTheme.test.ts
@@ -1,5 +1,10 @@
 import { createTheme } from '../createTheme';
 
+let consoleWarnSpy: jest.SpyInstance;
+afterEach(() => {
+  consoleWarnSpy?.mockRestore();
+});
+
 describe('@aws-amplify/ui', () => {
   describe('createTheme', () => {
     describe('without a base theme', () => {
@@ -65,6 +70,28 @@ describe('@aws-amplify/ui', () => {
         const { tokens } = newTheme;
         expect(tokens.colors.background.secondary.value).toEqual('#ff9900');
         expect(tokens.colors.background.primary.value).toEqual('#bada55');
+      });
+    });
+
+    describe('error handling', () => {
+      it('should warn the user and not do a max-call stack if given an invalid theme object', () => {
+        consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+        const theme = createTheme({
+          name: 'my-theme',
+          tokens: {
+            colors: {
+              background: {
+                //@ts-expect-error
+                primary: '#f90',
+              },
+            },
+          },
+        });
+        expect(theme.tokens.colors.background.primary).toEqual('#f90');
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn)
+          .toHaveBeenCalledWith(`Non-design token found when creating the theme at path: colors.background.primary
+Did you forget to add '{value:"#f90"}'?`);
       });
     });
   });

--- a/packages/ui/src/theme/createTheme.ts
+++ b/packages/ui/src/theme/createTheme.ts
@@ -39,10 +39,23 @@ function setupTokens(obj: any, path = []) {
 
   if (obj.hasOwnProperty('value')) {
     return setupToken(obj, path);
-  } else {
+  } else if (typeof obj === 'object') {
     for (const name in obj) {
       if (obj.hasOwnProperty(name)) {
-        tokens[name] = setupTokens(obj[name], path.concat(name));
+        // If we get to this point that means there is a 'dangling' part of the theme object
+        // basically some part of the theme object that is not a design token, which is
+        // anything that is not an object with a value attribute
+        if (typeof obj[name] !== 'object') {
+          console.warn(
+            `Non-design token found when creating the theme at path: ${path.join(
+              '.'
+            )}.${name}\nDid you forget to add '{value:"${obj[name]}"}'?`
+          );
+          // Keep the users data there just in case
+          tokens[name] = obj[name];
+        } else {
+          tokens[name] = setupTokens(obj[name], path.concat(name));
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Calling `createTheme` with non-design-token nodes in the object tree will cause a max call stack error. This fixes the error and provides a warning alerting the user what they should do. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
