### PR TITLE
ci: increase network timeout

### DIFF
--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -24,9 +24,9 @@ for i in {1..3}; do
 
   if [ "$NO_LOCKFILE" = "true" ]; then
     echo "[LOG]: Ignoring yarn.lock file"
-    yarn install --no-lockfile --network-timeout 120000
+    yarn install --no-lockfile --network-timeout 60000
   else
-    yarn install --network-timeout 120000
+    yarn install --network-timeout 60000
   fi
 
   # Check return value and exit early if successful

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -24,9 +24,9 @@ for i in {1..3}; do
 
   if [ "$NO_LOCKFILE" = "true" ]; then
     echo "[LOG]: Ignoring yarn.lock file"
-    yarn install --no-lockfile
+    yarn install --no-lockfile --network-timeout 120000
   else
-    yarn install
+    yarn install --network-timeout 120000
   fi
 
   # Check return value and exit early if successful


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR increases `--network-timeout` on `yarn install` on canary. This is the timeout for network request for each package.

The default is pretty aggressive at [30 seconds](https://github.com/yarnpkg/yarn/blob/3119382885ea373d3c13d6a846de743eca8c914b/src/constants.js#L40), and `yarn install` occasionally failed due to this (issue https://github.com/yarnpkg/yarn/issues/4890#issuecomment-348479446, [workflow run](https://github.com/aws-amplify/amplify-ui/runs/6930774348?check_suite_focus=true)).

This increases the network request to 1 minute. I didn't set it too high, to prevent workflows from waiting >1 minute for already failing network connection. We can revisit this later.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
