### PR TITLE
docs(chore): Add copy button to installation fragment

### DIFF
--- a/docs/src/components/InstallScripts.tsx
+++ b/docs/src/components/InstallScripts.tsx
@@ -1,19 +1,12 @@
 import { CopyButton } from '@/components/CopyButton';
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 
-type Framework = 'react' | 'vue' | 'angular' | 'flutter';
-type PackageManager = 'npm' | 'yarn';
+type WebFramework = 'react' | 'vue' | 'angular';
 
 interface TerminalCommandProps {
-  framework: Framework;
-  packageManager: PackageManager;
+  framework: WebFramework;
+  packageManager: 'npm' | 'yarn';
 }
-
-interface InstallScriptsProps {
-  framework: Framework;
-}
-
-const flutterInstallScript = 'flutter pub add amplify_authenticator';
 
 const TerminalCommand = ({
   framework,
@@ -35,8 +28,12 @@ const TerminalCommand = ({
   );
 };
 
+interface InstallScriptsProps {
+  framework: WebFramework;
+}
+
 export const InstallScripts = ({ framework }: InstallScriptsProps) => {
-  return framework !== 'flutter' ? (
+  return (
     <Tabs maxWidth="42rem">
       <TabItem title="npm">
         <TerminalCommand framework={framework} packageManager="npm" />
@@ -45,16 +42,5 @@ export const InstallScripts = ({ framework }: InstallScriptsProps) => {
         <TerminalCommand framework={framework} packageManager="yarn" />
       </TabItem>
     </Tabs>
-  ) : (
-    <code className="install-code__container">
-      <p className="install-code__content install-code__script">
-        {flutterInstallScript}
-      </p>
-      <CopyButton
-        className="install-code__button"
-        copyText={flutterInstallScript}
-        variation="link"
-      />
-    </code>
   );
 };

--- a/docs/src/components/InstallScripts.tsx
+++ b/docs/src/components/InstallScripts.tsx
@@ -1,0 +1,60 @@
+import { CopyButton } from '@/components/CopyButton';
+import { Tabs, TabItem } from '@aws-amplify/ui-react';
+
+type Framework = 'react' | 'vue' | 'angular' | 'flutter';
+type PackageManager = 'npm' | 'yarn';
+
+interface TerminalCommandProps {
+  framework: Framework;
+  packageManager: PackageManager;
+}
+
+interface InstallScriptsProps {
+  framework: Framework;
+}
+
+const flutterInstallScript = 'flutter pub add amplify_authenticator';
+
+const TerminalCommand = ({
+  framework,
+  packageManager,
+}: TerminalCommandProps) => {
+  const frameworkInstallScript = `${
+    packageManager === 'npm' ? 'npm i' : 'yarn add'
+  } @aws-amplify/ui-${framework} aws-amplify`;
+
+  return (
+    <code className="install-code__container">
+      <p className="install-code__content">{frameworkInstallScript}</p>
+      <CopyButton
+        className="install-code__button"
+        copyText={frameworkInstallScript}
+        variation="link"
+      />
+    </code>
+  );
+};
+
+export const InstallScripts = ({ framework }: InstallScriptsProps) => {
+  return framework !== 'flutter' ? (
+    <Tabs maxWidth="42rem">
+      <TabItem title="npm">
+        <TerminalCommand framework={framework} packageManager="npm" />
+      </TabItem>
+      <TabItem title="yarn">
+        <TerminalCommand framework={framework} packageManager="yarn" />
+      </TabItem>
+    </Tabs>
+  ) : (
+    <code className="install-code__container">
+      <p className="install-code__content install-code__script">
+        {flutterInstallScript}
+      </p>
+      <CopyButton
+        className="install-code__button"
+        copyText={flutterInstallScript}
+        variation="link"
+      />
+    </code>
+  );
+};

--- a/docs/src/pages/[platform]/getting-started/installation/dependencies.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/dependencies.angular.mdx
@@ -1,20 +1,6 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
+import { InstallScripts } from '@/components/InstallScripts.tsx';
 
 Install `@aws-amplify/ui-angular` with [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/):
 
-<Tabs>
-<TabItem title="npm">
-
-```shell
-npm install aws-amplify @aws-amplify/ui-angular
-```
-
-</TabItem>
-<TabItem title="yarn">
-
-```shell
-yarn add @aws-amplify/ui-angular
-```
-
-</TabItem>
-</Tabs>
+<InstallScripts framework="angular" />

--- a/docs/src/pages/[platform]/getting-started/installation/dependencies.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/dependencies.react.mdx
@@ -1,22 +1,8 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
+import { InstallScripts } from '@/components/InstallScripts.tsx';
 
 Install `@aws-amplify/ui-react` with [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/):
 
-<Tabs>
-<TabItem title="npm">
-
-```shell
-npm install aws-amplify @aws-amplify/ui-react
-```
-
-</TabItem>
-<TabItem title="yarn">
-
-```shell
-yarn add aws-amplify @aws-amplify/ui-react
-```
-
-</TabItem>
-</Tabs>
+<InstallScripts framework="react" />
 
 After adding the `aws-amplify` and `@aws-amplify/ui-react` dependencies you are now ready to add any of our [components](../components) to your application.

--- a/docs/src/pages/[platform]/getting-started/installation/dependencies.vue.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/dependencies.vue.mdx
@@ -1,24 +1,10 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 import { Alert } from '@aws-amplify/ui-react';
+import { InstallScripts } from '@/components/InstallScripts.tsx';
 
 For Vue 3 install `@aws-amplify/ui-vue` with [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/):
 
-<Tabs>
-<TabItem title="npm">
-
-```shell
-npm install aws-amplify @aws-amplify/ui-vue
-```
-
-</TabItem>
-<TabItem title="yarn">
-
-```shell
-yarn add aws-amplify @aws-amplify/ui-vue
-```
-
-</TabItem>
-</Tabs>
+<InstallScripts framework="vue" />
 
 <Alert variation="info" heading="Vue 2">
   If you're looking for the [Vue 2

--- a/docs/src/pages/[platform]/getting-started/usage/create-react-app/react.mdx
+++ b/docs/src/pages/[platform]/getting-started/usage/create-react-app/react.mdx
@@ -1,6 +1,7 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
 import { BasicShoppingCard, AdvancedShoppingCard } from '../shared';
+import { InstallScripts } from '@/components/InstallScripts.tsx';
 
 ## Tutorial
 
@@ -18,22 +19,7 @@ This creates a basic React app from scratch named `amplify-ui-demo`. For more in
 
 If you haven't already, `cd` into the `amplify-ui-demo` folder. Then, install the Amplify UI React package:
 
-<Tabs>
-<TabItem title="npm">
-
-```shell
-npm install aws-amplify @aws-amplify/ui-react
-```
-
-</TabItem>
-<TabItem title="yarn">
-
-```shell
-yarn add aws-amplify @aws-amplify/ui-react
-```
-
-</TabItem>
-</Tabs>
+<InstallScripts framework="react" />
 
 ### Basic Demo
 

--- a/docs/src/pages/[platform]/getting-started/usage/nextjs/react.mdx
+++ b/docs/src/pages/[platform]/getting-started/usage/nextjs/react.mdx
@@ -1,6 +1,7 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
 import { BasicShoppingCard, AdvancedShoppingCard } from '../shared';
+import { InstallScripts } from '@/components/InstallScripts.tsx';
 
 ## Tutorial
 
@@ -29,22 +30,7 @@ yarn create next-app
 
 If you haven't already, `cd` into the `amplify-ui-demo` folder. Then, install the Amplify UI React package:
 
-<Tabs>
-<TabItem title="npm">
-
-```shell
-npm install aws-amplify @aws-amplify/ui-react
-```
-
-</TabItem>
-<TabItem title="yarn">
-
-```shell
-yarn add aws-amplify @aws-amplify/ui-react
-```
-
-</TabItem>
-</Tabs>
+<InstallScripts framework="react" />
 
 ### Basic Demo
 

--- a/docs/src/pages/[platform]/getting-started/usage/usage.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/usage/usage.react.mdx
@@ -1,5 +1,6 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
+import { InstallScripts } from '@/components/InstallScripts.tsx';
 import {
   ComponentExampleDemo,
   ReactExampleDemo,
@@ -14,22 +15,7 @@ Amplify UI is designed to integrate seamlessly with the React framework so you c
 
 If you haven't already, install `@aws-amplify/ui-react` with [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/):
 
-<Tabs>
-<TabItem title="npm">
-
-```shell
-npm install aws-amplify @aws-amplify/ui-react
-```
-
-</TabItem>
-<TabItem title="yarn">
-
-```shell
-yarn add aws-amplify @aws-amplify/ui-react
-```
-
-</TabItem>
-</Tabs>
+<InstallScripts framework="react" />
 
 ### Quick start
 

--- a/docs/src/styles/docs/home.scss
+++ b/docs/src/styles/docs/home.scss
@@ -33,6 +33,7 @@
 .install-code__container {
   flex-grow: 1;
   display: flex;
+  max-width: 42rem;
 }
 
 .install-code__content {
@@ -84,7 +85,8 @@
 }
 
 .docs-home-editor {
-  border-right: var(--amplify-border-widths-small) solid var(--amplify-colors-border-primary);
+  border-right: var(--amplify-border-widths-small) solid
+    var(--amplify-colors-border-primary);
   max-height: 30rem;
   overflow-y: auto;
   font-size: var(--amplify-font-sizes-medium);

--- a/docs/src/styles/docs/home.scss
+++ b/docs/src/styles/docs/home.scss
@@ -37,14 +37,16 @@
 }
 
 .install-code__content {
-  margin: auto;
+  margin: var(--amplify-space-small);
   overflow-x: auto;
   white-space: normal;
+  &:before {
+    content: '$ ';
+  }
 }
 
 .install-code__button {
-  place-self: end;
-  align-self: center;
+  margin-left: auto;
   // Hiding on smaller screens
   // because there's not enough space
   @media (max-width: 480px) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR creates a reusable `<InstallScripts />` component, which reduces some redundant code across the Getting Started section. It also includes a "Copy" button for improved UX. 

Current:
<img width="1151" alt="Screen Shot 2022-06-17 at 9 00 01 PM" src="https://user-images.githubusercontent.com/48109584/174418186-29ed6074-4989-47e9-a476-171664752170.png">

Updated:
<img width="694" alt="Screen Shot 2022-06-18 at 12 20 06 PM" src="https://user-images.githubusercontent.com/48109584/174449582-36ecbbdc-5a97-4e01-aa1b-ff3371127f0e.png">

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the docs locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
