### PR TITLE
remove extra spacing around theme example elements

### DIFF
--- a/docs/src/components/ThemeExample.mdx
+++ b/docs/src/components/ThemeExample.mdx
@@ -8,24 +8,18 @@ import { DesignTokenIcon } from '@/components/Icons';
 
 <ThemeAlert />
 
-<br />
-
 You can customize the appearance of all {props.component} components in your application with a [Theme](/theming).
 
-<Flex>
-  <Link
-    className="docs-component-link"
-    href={`${GITHUB_REPO_FILE}packages/ui/src/theme/tokens/components/${
-      props.link ||
-      props.component.charAt(0).toLowerCase() + props.component.slice(1)
-    }.ts`}
-    isExternal
-  >
-    <DesignTokenIcon ariaLabel="theme-source" marginInlineEnd="0.5rem" />
-    {props.component} Theme Source
-  </Link>
-</Flex>
-
-<br />
+<Link
+  className="docs-component-link"
+  href={`${GITHUB_REPO_FILE}packages/ui/src/theme/tokens/components/${
+    props.link ||
+    props.component.charAt(0).toLowerCase() + props.component.slice(1)
+  }.ts`}
+  isExternal
+>
+  <DesignTokenIcon ariaLabel="theme-source" marginInlineEnd="0.5rem" />
+  {props.component} Theme Source
+</Link>
 
 <View backgroundColor="white">{props.children}</View>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Removes some of the extra margins/spacing around elements in the ThemeExample

**Before**
<img width="500" alt="Screen Shot 2022-06-18 at 8 55 00 AM" src="https://user-images.githubusercontent.com/376920/174438590-6f3feacb-8e38-491e-b710-3ececf7d181b.png">

**After**
<img width="500" alt="Screen Shot 2022-06-18 at 8 53 57 AM" src="https://user-images.githubusercontent.com/376920/174438570-7c8876a9-dcc4-4d6f-b9f4-346ab14ff79f.png">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
