### PR TITLE
fix framework focus styles

### DIFF
--- a/docs/src/styles/docs/home.scss
+++ b/docs/src/styles/docs/home.scss
@@ -218,13 +218,16 @@
       border-color: var(--amplify-colors-brand-primary-80);
     }
     
-    
-    
     &:hover .docs-framework-img,
     &.current .docs-framework-img {
       filter: grayscale(0%);
-      
     }
+
+    &:focus {
+      border-color: var(--amplify-components-button-active-border-color);
+      box-shadow: var(--amplify-components-button-focus-box-shadow)
+    }
+
   }
   
   .docs-framework-img {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds focus styles for framework links

<img width="993" alt="Screen Shot 2022-06-18 at 10 02 37 AM" src="https://user-images.githubusercontent.com/376920/174441950-f06b5467-796d-4a6d-92b2-9d126f3d00f4.png">
<img width="1002" alt="Screen Shot 2022-06-18 at 10 02 29 AM" src="https://user-images.githubusercontent.com/376920/174441951-3ccae180-f5ee-4596-8cab-5f78152e6ad4.png">

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
