### PR TITLE
fix(docs): make high-contrast example readable in darkmode

### DIFF
--- a/docs/src/pages/[platform]/getting-started/accessibility/accessibility.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/accessibility/accessibility.react.mdx
@@ -1,4 +1,4 @@
-import { Grid } from '@aws-amplify/ui-react';
+import { View, Grid } from '@aws-amplify/ui-react';
 import { CardLink } from '@/components/CardLink';
 import { Fragment } from '@/components/Fragment';
 import { Example, ExampleCode } from '@/components/Example';
@@ -62,6 +62,7 @@ Amplify UI uses design tokens for the color palette, which makes modifying the t
 
 The example below shows how to use Theming to supply higher contrast text and border styles.
 
+<View backgroundColor="white" color="black">
 <Example>
   <ThemeExample />
   <ExampleCode>
@@ -70,6 +71,7 @@ The example below shows how to use Theming to supply higher contrast text and bo
 ```
   </ExampleCode>
 </Example>
+</View>
 
 <Grid gap="var(--amplify-space-large)" margin="var(--amplify-space-xl) 0" templateColumns={{ base: '1fr', large: '1fr 1fr' }}>
  <CardLink 

--- a/docs/src/pages/[platform]/getting-started/accessibility/examples/ThemeExample.tsx
+++ b/docs/src/pages/[platform]/getting-started/accessibility/examples/ThemeExample.tsx
@@ -1,21 +1,19 @@
-import { ThemeProvider, Card, useTheme, Theme } from '@aws-amplify/ui-react';
+import { ThemeProvider, Card } from '@aws-amplify/ui-react';
 
 export const ThemeExample = () => {
-  const { tokens } = useTheme();
-
-  const theme: Theme = {
+  const theme = {
     name: 'high-contrast',
     tokens: {
       colors: {
         font: {
-          primary: { value: '#000' },
+          primary: { value: '{colors.black}' },
         },
       },
       components: {
         card: {
           outlined: {
-            borderWidth: tokens.borderWidths.large,
-            borderColor: { value: '#000' },
+            borderWidth: { value: '{borderWidths.large}' },
+            borderColor: { value: '{colors.black}' },
           },
         },
       },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

Dark mode made the high contrast mode on the accessibility introduction page weird. I had to hardcode some values using style props on a View wrapping the example because the color was getting overridden by our dark mode colors (even when putting colorMode="light" in the example code. Also updated some values to use token names instead of hex colors.

**Before**
<img width="931" alt="Screen Shot 2022-06-20 at 12 28 15 PM" src="https://user-images.githubusercontent.com/376920/174645072-c8772948-e655-4eff-b46b-3d116091a59f.png">


**After**

<img width="948" alt="Screen Shot 2022-06-20 at 12 17 48 PM" src="https://user-images.githubusercontent.com/376920/174645099-6507a33d-5590-446b-8613-3c459946ad07.png">

Light colorMode is unaffected.
<img width="928" alt="Screen Shot 2022-06-20 at 12 29 29 PM" src="https://user-images.githubusercontent.com/376920/174645285-f467a10e-38b8-47a5-9c29-65829d103462.png">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
