### PR TITLE
docs(fix): Add copy button to terminal commands

### DIFF
--- a/docs/src/components/InstallScripts.tsx
+++ b/docs/src/components/InstallScripts.tsx
@@ -6,7 +6,7 @@ type WebFramework = 'react' | 'vue' | 'angular';
 interface TerminalCommandProps {
   framework?: WebFramework;
   packageManager?: 'npm' | 'yarn';
-  terminalCommand?: string;
+  command?: string;
 }
 
 const frameworkInstallScript = (framework, packageManager) =>
@@ -17,25 +17,29 @@ const frameworkInstallScript = (framework, packageManager) =>
 export const TerminalCommand = ({
   framework,
   packageManager,
-  terminalCommand,
+  command,
 }: TerminalCommandProps) => {
-  const command = terminalCommand
-    ? terminalCommand
+  const terminalCommand = command
+    ? command
     : frameworkInstallScript(framework, packageManager);
 
   return (
     <code className="install-code__container">
-      <p className="install-code__content">{command}</p>
+      <p className="install-code__content">{terminalCommand}</p>
       <CopyButton
         className="install-code__button"
-        copyText={command}
+        copyText={terminalCommand}
         variation="link"
       />
     </code>
   );
 };
 
-export const InstallScripts = (framework: WebFramework) => {
+interface InstallScriptsProps {
+  framework: WebFramework;
+}
+
+export const InstallScripts = ({ framework }: InstallScriptsProps) => {
   return (
     <Tabs maxWidth="42rem">
       <TabItem title="npm">

--- a/docs/src/components/InstallScripts.tsx
+++ b/docs/src/components/InstallScripts.tsx
@@ -35,11 +35,7 @@ export const TerminalCommand = ({
   );
 };
 
-interface InstallScriptsProps {
-  framework: WebFramework;
-}
-
-export const InstallScripts = ({ framework }: InstallScriptsProps) => {
+export const InstallScripts = (framework: WebFramework) => {
   return (
     <Tabs maxWidth="42rem">
       <TabItem title="npm">

--- a/docs/src/components/InstallScripts.tsx
+++ b/docs/src/components/InstallScripts.tsx
@@ -2,14 +2,18 @@ import { CopyButton } from '@/components/CopyButton';
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 
 type WebFramework = 'react' | 'vue' | 'angular';
+type PackageManager = 'npm' | 'yarn';
 
 interface TerminalCommandProps {
   framework?: WebFramework;
-  packageManager?: 'npm' | 'yarn';
+  packageManager?: PackageManager;
   command?: string;
 }
 
-const frameworkInstallScript = (framework, packageManager) =>
+const frameworkInstallScript = (
+  framework: WebFramework,
+  packageManager: PackageManager
+) =>
   `${
     packageManager === 'npm' ? 'npm i' : 'yarn add'
   } @aws-amplify/ui-${framework} aws-amplify`;

--- a/docs/src/components/InstallScripts.tsx
+++ b/docs/src/components/InstallScripts.tsx
@@ -4,24 +4,31 @@ import { Tabs, TabItem } from '@aws-amplify/ui-react';
 type WebFramework = 'react' | 'vue' | 'angular';
 
 interface TerminalCommandProps {
-  framework: WebFramework;
-  packageManager: 'npm' | 'yarn';
+  framework?: WebFramework;
+  packageManager?: 'npm' | 'yarn';
+  terminalCommand?: string;
 }
 
-const TerminalCommand = ({
-  framework,
-  packageManager,
-}: TerminalCommandProps) => {
-  const frameworkInstallScript = `${
+const frameworkInstallScript = (framework, packageManager) =>
+  `${
     packageManager === 'npm' ? 'npm i' : 'yarn add'
   } @aws-amplify/ui-${framework} aws-amplify`;
 
+export const TerminalCommand = ({
+  framework,
+  packageManager,
+  terminalCommand,
+}: TerminalCommandProps) => {
+  const command = terminalCommand
+    ? terminalCommand
+    : frameworkInstallScript(framework, packageManager);
+
   return (
     <code className="install-code__container">
-      <p className="install-code__content">{frameworkInstallScript}</p>
+      <p className="install-code__content">{command}</p>
       <CopyButton
         className="install-code__button"
-        copyText={frameworkInstallScript}
+        copyText={command}
         variation="link"
       />
     </code>

--- a/docs/src/pages/[platform]/getting-started/usage/create-react-app/examples/AdvancedExampleCode.tsx
+++ b/docs/src/pages/[platform]/getting-started/usage/create-react-app/examples/AdvancedExampleCode.tsx
@@ -41,7 +41,7 @@ function App() {
 
   return (
     <View width="100%" maxWidth="50rem" padding={{ base: 0, large: '2rem' }}>
-      <Card variation="elevated">
+      <Card variation="outlined">
         <Flex
           direction={{ base: 'column', large: 'row' }}
           justifyContent="space-evenly"

--- a/docs/src/pages/[platform]/getting-started/usage/create-react-app/react.mdx
+++ b/docs/src/pages/[platform]/getting-started/usage/create-react-app/react.mdx
@@ -1,7 +1,7 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
 import { BasicShoppingCard, AdvancedShoppingCard } from '../shared';
-import { InstallScripts } from '@/components/InstallScripts.tsx';
+import { InstallScripts, TerminalCommand } from '@/components/InstallScripts.tsx';
 
 ## Tutorial
 
@@ -11,13 +11,11 @@ In this brief tutorial, we're going to build a basic shopping card component usi
 
 First, execute the command below in your terminal:
 
-```shell
-npx create-react-app amplify-ui-demo
-```
+<TerminalCommand terminalCommand="npx create-react-app amplify-ui-demo && cd amplify-ui-demo" />
 
 This creates a basic React app from scratch named `amplify-ui-demo`. For more information, see the [Create-React-App documentation](https://create-react-app.dev).
 
-If you haven't already, `cd` into the `amplify-ui-demo` folder. Then, install the Amplify UI React package:
+Then, install the Amplify UI React package:
 
 <InstallScripts framework="react" />
 

--- a/docs/src/pages/[platform]/getting-started/usage/create-react-app/react.mdx
+++ b/docs/src/pages/[platform]/getting-started/usage/create-react-app/react.mdx
@@ -11,7 +11,7 @@ In this brief tutorial, we're going to build a basic shopping card component usi
 
 First, execute the command below in your terminal:
 
-<TerminalCommand terminalCommand="npx create-react-app amplify-ui-demo && cd amplify-ui-demo" />
+<TerminalCommand command="npx create-react-app amplify-ui-demo && cd amplify-ui-demo" />
 
 This creates a basic React app from scratch named `amplify-ui-demo`. For more information, see the [Create-React-App documentation](https://create-react-app.dev).
 

--- a/docs/src/pages/[platform]/getting-started/usage/nextjs/examples/AdvancedExampleCode.tsx
+++ b/docs/src/pages/[platform]/getting-started/usage/nextjs/examples/AdvancedExampleCode.tsx
@@ -41,7 +41,7 @@ export default function Home() {
 
   return (
     <View width="100%" maxWidth="50rem" padding={{ base: 0, large: '2rem' }}>
-      <Card variation="elevated">
+      <Card variation="outlined">
         <Flex
           direction={{ base: 'column', large: 'row' }}
           justifyContent="space-evenly"

--- a/docs/src/pages/[platform]/getting-started/usage/nextjs/react.mdx
+++ b/docs/src/pages/[platform]/getting-started/usage/nextjs/react.mdx
@@ -1,7 +1,7 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
 import { BasicShoppingCard, AdvancedShoppingCard } from '../shared';
-import { InstallScripts } from '@/components/InstallScripts.tsx';
+import { InstallScripts, TerminalCommand } from '@/components/InstallScripts.tsx';
 
 ## Tutorial
 
@@ -9,26 +9,18 @@ In this brief tutorial, we're going to build a basic shopping card component usi
 
 ### Setup and Installation
 
-First, execute the command below in your terminal. When prompted for the name of your project, type `amplify-ui-demo`. 
+First, execute the command below in your terminal. When prompted for the name of your project, enter `amplify-ui-demo`. 
 
 <Tabs>
-<TabItem title="npm">
-
-```shell
-npx create-next-app@latest
-```
-
-</TabItem>
-<TabItem title="yarn">
-
-```shell
-yarn create next-app
-```
-
-</TabItem>
+  <TabItem title="npm">
+    <TerminalCommand terminalCommand="npx create-next-app@latest && cd amplify-ui-demo" />
+  </TabItem>
+  <TabItem title="yarn">
+    <TerminalCommand terminalCommand="yarn create next-app && cd amplify-ui-demo" />
+  </TabItem>
 </Tabs>
 
-If you haven't already, `cd` into the `amplify-ui-demo` folder. Then, install the Amplify UI React package:
+Then, install the Amplify UI React package:
 
 <InstallScripts framework="react" />
 

--- a/docs/src/pages/[platform]/getting-started/usage/nextjs/react.mdx
+++ b/docs/src/pages/[platform]/getting-started/usage/nextjs/react.mdx
@@ -13,10 +13,10 @@ First, execute the command below in your terminal. When prompted for the name of
 
 <Tabs>
   <TabItem title="npm">
-    <TerminalCommand terminalCommand="npx create-next-app@latest && cd amplify-ui-demo" />
+    <TerminalCommand command="npx create-next-app@latest && cd amplify-ui-demo" />
   </TabItem>
   <TabItem title="yarn">
-    <TerminalCommand terminalCommand="yarn create next-app && cd amplify-ui-demo" />
+    <TerminalCommand command="yarn create next-app && cd amplify-ui-demo" />
   </TabItem>
 </Tabs>
 

--- a/docs/src/pages/[platform]/getting-started/usage/shared/AdvancedShoppingCard.tsx
+++ b/docs/src/pages/[platform]/getting-started/usage/shared/AdvancedShoppingCard.tsx
@@ -40,7 +40,7 @@ export const AdvancedShoppingCard = () => {
 
   return (
     <View width="100%" maxWidth="50rem" padding={{ base: 0, large: '2rem' }}>
-      <Card variation="elevated">
+      <Card variation="outlined">
         <Flex
           direction={{ base: 'column', large: 'row' }}
           justifyContent="space-evenly"

--- a/docs/src/pages/[platform]/index.page.tsx
+++ b/docs/src/pages/[platform]/index.page.tsx
@@ -19,8 +19,6 @@ import {
   useBreakpointValue,
 } from '@aws-amplify/ui-react';
 import { MdChevronRight } from 'react-icons/md';
-
-import { CopyButton } from '@/components/CopyButton';
 import { Footer } from '@/components/Layout/Footer';
 import { HomeLogo } from '../HomeLogo';
 import { HomePrimitivePreview } from '../HomePrimitivePreview';
@@ -28,6 +26,7 @@ import { theme } from '../../theme';
 import { ThemeButton } from '../ThemeButton';
 import { useCustomRouter } from '@/components/useCustomRouter';
 import { FRAMEWORKS } from '@/data/frameworks';
+import { TerminalCommand } from '@/components/InstallScripts';
 
 // react-live does not work with SSR so we have to load
 // it dynamically and only in the client
@@ -98,16 +97,7 @@ const HomePage = ({ colorMode }) => {
                   Get started
                   <MdChevronRight />
                 </Button>
-                <code className="install-code__container">
-                  <p className="install-code__content">
-                    {frameworkInstallScript}
-                  </p>
-                  <CopyButton
-                    className="install-code__button"
-                    copyText={frameworkInstallScript}
-                    variation="link"
-                  />
-                </code>
+                <TerminalCommand terminalCommand={frameworkInstallScript} />
               </Flex>
             </Card>
             <Flex

--- a/docs/src/pages/[platform]/index.page.tsx
+++ b/docs/src/pages/[platform]/index.page.tsx
@@ -97,7 +97,7 @@ const HomePage = ({ colorMode }) => {
                   Get started
                   <MdChevronRight />
                 </Button>
-                <TerminalCommand terminalCommand={frameworkInstallScript} />
+                <TerminalCommand command={frameworkInstallScript} />
               </Flex>
             </Card>
             <Flex


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR adds a copy button to terminal commands, and applies a few small tweaks to the Getting Started pages. 

Current:
<img width="1145" alt="Screen Shot 2022-06-20 at 12 20 11 PM" src="https://user-images.githubusercontent.com/48109584/174651966-99efb4db-2153-4af6-a3bb-437f691d38da.png">

Updated:
<img width="697" alt="Screen Shot 2022-06-20 at 12 20 34 PM" src="https://user-images.githubusercontent.com/48109584/174652010-be8e5b2a-cf26-4df3-a292-b70408fc36f7.png">

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the docs locally. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
