### PR TITLE
fix(docs): hide empty Primitives expander for non-react platforms

### DIFF
--- a/docs/src/components/Layout/Sidebar.tsx
+++ b/docs/src/components/Layout/Sidebar.tsx
@@ -50,7 +50,13 @@ const NavLinks = ({
   </Collection>
 );
 
-const NavLink = ({ href, children, onClick, tertiary, platforms = [] }) => {
+const NavLink = ({
+  href,
+  children,
+  onClick,
+  tertiary = false,
+  platforms = [],
+}) => {
   const {
     query: { platform = 'react' },
     pathname,
@@ -129,7 +135,7 @@ const ExpanderTitle = ({ Icon, text }) => {
 // TODO: clean up this logic
 const SecondaryNav = (props) => {
   const { pathname } = useCustomRouter();
-
+  const { platform } = props;
   // Extract section from URL (/section/... => section)
   let section = pathname.split('/')[2];
   // NOTE: Remove this logic when we update the URLs for these sections.
@@ -169,21 +175,27 @@ const SecondaryNav = (props) => {
           </NavLink>
         ))}
       </ExpanderItem>
-      <ExpanderItem
-        title={
-          <ExpanderTitle Icon={MdOutlineWidgets} text="Primitive components" />
-        }
-        value="components"
-      >
-        {primitiveComponents.map(({ heading, components }) => (
-          <NavLinkComponentsSection
-            {...props}
-            key={heading}
-            heading={heading}
-            components={components}
-          />
-        ))}
-      </ExpanderItem>
+      {platform === 'react' ? (
+        <ExpanderItem
+          title={
+            <ExpanderTitle
+              Icon={MdOutlineWidgets}
+              text="Primitive components"
+            />
+          }
+          value="components"
+        >
+          {primitiveComponents.map(({ heading, components }) => (
+            <NavLinkComponentsSection
+              {...props}
+              key={heading}
+              heading={heading}
+              components={components}
+            />
+          ))}
+        </ExpanderItem>
+      ) : null}
+
       <ExpanderItem
         title={<ExpanderTitle Icon={MdWebAssetOff} text="Legacy components" />}
         value="legacy-components"
@@ -240,7 +252,7 @@ export const Sidebar = ({ expanded, setExpanded, platform }) => {
 
           <FrameworkChooser onClick={onClick} />
 
-          <SecondaryNav onClick={onClick} />
+          <SecondaryNav onClick={onClick} platform={platform} />
 
           <Divider size="small" />
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Hides the Primitives expander for Vue, Angular, Flutter in the sidebar.

**Before, empty Expander**

<img width="310" alt="Screen Shot 2022-06-20 at 2 00 59 PM" src="https://user-images.githubusercontent.com/376920/174656972-d1d80d2f-bd88-47e0-87a5-4c40d1489bcd.png">

**After**

<img width="305" alt="Screen Shot 2022-06-20 at 2 00 03 PM" src="https://user-images.githubusercontent.com/376920/174656993-9b0f0da7-9122-40c2-b940-fc7cb76da400.png">

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
