### PR TITLE
add owl selector back to tabs page  content

### DIFF
--- a/docs/src/components/Layout/PageTabLayout.tsx
+++ b/docs/src/components/Layout/PageTabLayout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Tabs, TabItem } from '@aws-amplify/ui-react';
+import { Tabs, TabItem, View } from '@aws-amplify/ui-react';
 import { useCustomRouter } from '@/components/useCustomRouter';
 
 export const PageTabLayout = ({ tabComponents }) => {
@@ -32,7 +32,7 @@ export const PageTabLayout = ({ tabComponents }) => {
     >
       {tabComponents.map(({ title, children }, idx) => (
         <TabItem key={idx} title={title}>
-          {children}
+          <View className="docs-page-tab">{children}</View>
         </TabItem>
       ))}
     </Tabs>

--- a/docs/src/styles/docs/main.scss
+++ b/docs/src/styles/docs/main.scss
@@ -31,3 +31,9 @@
     }
   }
 }
+
+.docs-page-tab {
+  & > * + * {
+    margin-bottom: var(--amplify-space-medium);
+  }
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

**Before**
<img width="845" alt="Screen Shot 2022-06-20 at 3 02 19 PM" src="https://user-images.githubusercontent.com/376920/174666456-459e258d-4045-4b81-aaf6-24df8a146d74.png">

**After**
<img width="859" alt="Screen Shot 2022-06-20 at 3 23 02 PM" src="https://user-images.githubusercontent.com/376920/174666467-d143ea8f-5476-417f-ac25-7424fea27edc.png">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
