### PR TITLE
docs(fix): Add missing prop descriptions

### DIFF
--- a/.changeset/pretty-parents-add.md
+++ b/.changeset/pretty-parents-add.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+docs(fix): Add missing prop descriptions for `as`, `isDisabled` and `style`

--- a/packages/react/src/primitives/types/view.ts
+++ b/packages/react/src/primitives/types/view.ts
@@ -39,6 +39,10 @@ export type PrimitiveProps<
   Element extends ElementType
 > = MergeProps<
   Omit<Props, 'as'> & {
+    /**
+     * @description
+     * Changes the type of HTML element rendered
+     */
     as?: Element | Props['as'];
   },
   Omit<ElementProps<Element>, 'ref'> // exclude `ref?: LegacyRef` included in DetailedHTMLProps
@@ -73,7 +77,17 @@ export interface ViewProps
    */
   as?: ElementType;
 
+  /**
+   * @description
+   * Sets the Boolean `disabled` HTML attribute, which, when present, makes the element not mutable, focusable, or even submitted with the form
+   */
   isDisabled?: boolean;
 
+  /**
+   * @description
+   * Accepts a JavaScript object with camelCased properties rather than a CSS string.
+   * This is consistent with the DOM style JavaScript property, is more efficient, and prevents XSS security holes.
+   * [React docs]{@link https://reactjs.org/docs/dom-elements.html#style}
+   */
   style?: React.CSSProperties;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

To help with [MJ's props table PR](https://github.com/aws-amplify/amplify-ui/pull/2090), this PR adds a few prop descriptions which are missing from each primitive page:
- `isDisabled`
- `style`
- `as` 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
