### PR TITLE
docs(fix): Move Pagination to Layout section

### DIFF
--- a/docs/src/data/links.ts
+++ b/docs/src/data/links.ts
@@ -109,12 +109,6 @@ export const feedbackComponents: ComponentNavItem[] = [
     platforms: ['react'],
   },
   {
-    href: '/components/pagination',
-    label: 'Pagination',
-    body: `Pagination provides navigation to allow customers to move between large sets of content that are distributed across multiple pages.`,
-    platforms: ['react'],
-  },
-  {
     href: '/components/placeholder',
     label: 'Placeholder',
     body: `The Placeholder component is used to fill out the interface while content is loaded asynchronously.`,
@@ -244,6 +238,12 @@ export const layoutComponents = [
     href: '/components/expander',
     label: 'Expander',
     body: `The Expander primitive enables users to expand or collapse a set of sections.`,
+    platforms: ['react'],
+  },
+  {
+    href: '/components/pagination',
+    label: 'Pagination',
+    body: `Pagination provides navigation to allow customers to move between large sets of content that are distributed across multiple pages.`,
     platforms: ['react'],
   },
 ].sort(sortByLabel);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR simply moves the Pagination component from the Feedback section to the Layout section. I think this more accurately categorizes the function of Pagination in laying out data for the customer, but I am open to other ideas. 

Current:
![Screen Shot 2022-06-20 at 5 44 10 PM](https://user-images.githubusercontent.com/48109584/174685797-389f61c9-b91a-4a24-9e84-a7b7eb28f205.png)

Updated:
![Screen Shot 2022-06-20 at 5 43 38 PM](https://user-images.githubusercontent.com/48109584/174685749-3e669914-56b0-467c-b357-43932a0e7799.png)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
