### PR TITLE
docs(fix): hide tertiary pages on /components page

### DIFF
--- a/docs/src/pages/[platform]/components/ComponentsGrid.tsx
+++ b/docs/src/pages/[platform]/components/ComponentsGrid.tsx
@@ -41,7 +41,7 @@ const ComponentGridSection = ({ heading, components }) => {
 
   const platformComponents = components.filter((component) => {
     if (component.platforms) {
-      return component.platforms.includes(platform);
+      return component.platforms.includes(platform) && !component.tertiary;
     }
     return true;
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Hides the tertiary pages on the /components page. We don't currently link to this in the menu, but the new home page will.

**Before**
<img width="1249" alt="Screen Shot 2022-06-21 at 2 54 54 PM" src="https://user-images.githubusercontent.com/376920/174877067-8634ecd8-a9d6-4a50-90e2-cb0c261cb77f.png">

**After**
<img width="1267" alt="Screen Shot 2022-06-21 at 2 54 47 PM" src="https://user-images.githubusercontent.com/376920/174877098-f8b321b7-8997-4bc7-a3ab-2fbd074f03b7.png">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Local docs instance

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
