### PR TITLE
chore: Fix for dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "nth-check": "^2.0.1",
     "prismjs": "^1.25.0",
     "prism-react-renderer": "1.2.1",
+    "shell-quote": "1.7.3",
     "trim": "^0.0.3",
     "ts-jest": "^26.5.6",
     "vscode-vue-languageservice": "0.27.26",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20142,12 +20142,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
-  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
-
-shell-quote@^1.4.2, shell-quote@^1.6.1:
+shell-quote@1.7.2, shell-quote@1.7.3, shell-quote@^1.4.2, shell-quote@^1.6.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Aliases the `shell-quote` dependency to `v1.7.3` to fix [this dependabot alert](https://github.com/aws-amplify/amplify-ui/security/dependabot/44).

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran all unit tests and the Next e2e tests (`shell-quote` is a nested dependency of Next.js). Run `yarn list shell-quote` to verify that 1.7.3 is the only version listed.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated - N/A
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced) - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
