### PR TITLE
docs(fix): remove react specific code from angular/vue theme page

### DIFF
--- a/docs/src/pages/[platform]/theming/default-theme/cssTokenUsage.mdx
+++ b/docs/src/pages/[platform]/theming/default-theme/cssTokenUsage.mdx
@@ -1,0 +1,11 @@
+import { Link } from '@aws-amplify/ui-react';
+
+The space token definition also gives us an idea of how the CSS custom properties associated with each token are named. Amplify UI uses <Link isExternal href="https://amzn.github.io/style-dictionary/#/">StyleDictionary</Link> to generate the associated CSS custom properties for each token. For the small space token, this would be `--amplify-space-small` and you can use it in your stylesheet as:
+
+```css
+.my-component {
+  margin-bottom: var(--amplify-space-small);
+}
+```
+
+

--- a/docs/src/pages/[platform]/theming/default-theme/tokenUsage.angular.mdx
+++ b/docs/src/pages/[platform]/theming/default-theme/tokenUsage.angular.mdx
@@ -1,0 +1,4 @@
+import { Fragment } from '@/components/Fragment';
+
+<Fragment>{({ platform }) => import(`./cssTokenUsage.mdx`)}</Fragment>
+

--- a/docs/src/pages/[platform]/theming/default-theme/tokenUsage.react.mdx
+++ b/docs/src/pages/[platform]/theming/default-theme/tokenUsage.react.mdx
@@ -1,0 +1,15 @@
+import { Fragment } from '@/components/Fragment';
+
+This structure allows us to reference the small space value as `tokens.space.small` such as in the following example. You can also learn more about [theming](/theming#getting-started) in our getting started guide.
+
+```jsx
+import { useTheme } from '@aws-amplify/ui-react';
+
+const MyComponent = () => {
+  const { tokens } = useTheme();
+  return <View marginBottom={tokens.space.small}>{children}</Text>;
+};
+```
+
+<Fragment>{({ platform }) => import(`./cssTokenUsage.mdx`)}</Fragment>
+

--- a/docs/src/pages/[platform]/theming/default-theme/tokenUsage.react.mdx
+++ b/docs/src/pages/[platform]/theming/default-theme/tokenUsage.react.mdx
@@ -1,13 +1,27 @@
 import { Fragment } from '@/components/Fragment';
 
-This structure allows us to reference the small space value as `tokens.space.small` such as in the following example. You can also learn more about [theming](/theming#getting-started) in our getting started guide.
+This structure allows us to reference the small space value as `space.small` using [Style Props](/react/theming/style-props) like in the following example.
 
 ```jsx
-import { useTheme } from '@aws-amplify/ui-react';
+import { View } from '@aws-amplify/ui-react';
 
 const MyComponent = () => {
-  const { tokens } = useTheme();
-  return <View marginBottom={tokens.space.small}>{children}</Text>;
+  return <View marginBottom="space.small">{children}</View>;
+};
+```
+
+Or we can use the design token to [create a custom theme](/react/theming). 
+
+```javascript
+const theme {
+  name: 'custom-theme',
+  tokens: {
+    components: {
+      card: {
+        padding: { value: '{space.small}' },
+      },
+    },
+  },
 };
 ```
 

--- a/docs/src/pages/[platform]/theming/default-theme/tokenUsage.vue.mdx
+++ b/docs/src/pages/[platform]/theming/default-theme/tokenUsage.vue.mdx
@@ -1,0 +1,4 @@
+import { Fragment } from '@/components/Fragment';
+
+<Fragment>{({ platform }) => import(`./cssTokenUsage.mdx`)}</Fragment>
+

--- a/docs/src/pages/[platform]/theming/default-theme/web.mdx
+++ b/docs/src/pages/[platform]/theming/default-theme/web.mdx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { CardLink } from '@/components/CardLink';
+import { Fragment } from '@/components/Fragment';
 import { Grid, Icon, Link } from '@aws-amplify/ui-react';
 import { ColorsIcon, TypographyIcon, SizesIcon } from './icons';
 import { MdOutlineAutoAwesome } from 'react-icons/md';
@@ -55,29 +56,4 @@ If we use `space` as an example, we'd discover its token definition looks simila
 
 All of our tokens follow this pattern: a top level namespace that is further defined by a scale, each which has their own unique value. In the case of our space design tokens, that scale is based on a size: small, medium, large, etc. Our [color tokens](/react/theming/default-theme/colors#neutral), on the other hand, are further defined by hue (red, blue, yellow, etc), and then by a numerical scale based on lightness (10-100). 
 
-This structure allows us to reference the small space value as `tokens.space.small` such as in the following example. You can also learn more about [theming](/theming#getting-started) in our getting started guide.
-
-```jsx
-import { useTheme } from '@aws-amplify/ui-react';
-
-const MyComponent = () => {
-  const { tokens } = useTheme();
-  return <View marginBottom={tokens.space.small}>{children}</Text>;
-};
-```
-
-The space token definition also gives us an idea of how the CSS custom properties associated with each token are named. Amplify UI uses <Link isExternal href="https://amzn.github.io/style-dictionary/#/">StyleDictionary</Link> to generate the associated CSS custom properties for each token. For the small space token, this would be `--amplify-space-small` and you can use it in your component:
-
-```jsx
-const MyComponent = () => {
-  return <View marginBottom="var(--amplify-space-small)">{children}</Text>;
-};
-```
-
-Or in your own stylesheet:
-
-```css
-.my-component {
-  margin-bottom: var(--amplify-space-small);
-}
-```
+<Fragment>{({ platform }) => import(`./tokenUsage.${platform}.mdx`)}</Fragment>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR re-orders some content on the /theming/default-theme page and removes React specific code that was showing up for Angular/Vue.

#### Issue #, if available

N/A
#### Description of how you validated changes

Local docs instance

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
