### PR TITLE
docs(fix): Fixed typo in ComponentClassObject

### DIFF
--- a/.changeset/few-rockets-tell.md
+++ b/.changeset/few-rockets-tell.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+docs(fix): Fixed typo in ComponentClassObject for RadioButton

--- a/packages/react/src/primitives/shared/constants.ts
+++ b/packages/react/src/primitives/shared/constants.ts
@@ -276,7 +276,7 @@ export const ComponentClassObject = {
   },
   RadioButton: {
     className: 'amplify-radio__button',
-    compoents: ['RadioGroupField', 'Radio'],
+    components: ['RadioGroupField', 'Radio'],
     description: 'Class applied to the displayed radio button',
   },
   RadioInput: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

While updating the RadioGroupField docs, I was wondering why the Target Classes did not include `amplify-radio__button`. It turns out it was because of a typo in the ComponentClassObject. 

Current:
<img width="942" alt="Screen Shot 2022-06-22 at 6 14 53 PM" src="https://user-images.githubusercontent.com/48109584/175161999-e2829114-1e1d-4e1e-ae2f-158c2735e57a.png">

Updated:
<img width="1165" alt="Screen Shot 2022-06-22 at 6 17 52 PM" src="https://user-images.githubusercontent.com/48109584/175162375-f086b6ae-2303-4728-8431-ace1c1bd957b.png">
<!--

Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
