### PR TITLE
chore(docs): amplify.yml temp update to fix build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,6 +4,7 @@ applications:
       phases:
         preBuild:
           commands:
+            - rm -rf node_modules
             - nvm install 16.13 # NodeJS 16.13+ is the latest version that Amplify Hosting supports
             - nvm use 16
             - node -v
@@ -22,7 +23,4 @@ applications:
         baseDirectory: .next
         files:
           - '**/*'
-      cache:
-        paths:
-          - node_modules/**/*
     appRoot: docs


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds an `rm -rf node_modules` to amplify.yml build settings and removes node_modules cache setting. We can revert this after the next docs release; we just need to get the proper version of Canvas to build.

Docs builds are failing because of Canvas module. We updated this to a new version in the props-table feature, as well as a new Node version, however it keeps  trying to build the old version (which doesn't build against the newest version of Node we specified). Hosting team suggested an `rm -rf node_modules` and removing the cache setting for node_modules.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
