### PR TITLE
fix(docs): table demo syntax highlighting and demo code font size

### DIFF
--- a/docs/src/pages/[platform]/components/table/demo.tsx
+++ b/docs/src/pages/[platform]/components/table/demo.tsx
@@ -10,13 +10,14 @@ import { demoState } from '@/utils/demoState';
 
 const propsToCode = (props) => {
   const { caption, highlightOnHover, size, variation } = props;
-  return `
+  return (
+    `
 <Table
-  caption={${caption}}
-  highlightOnHover={${highlightOnHover}}
-  size={${size}}
-  variation={${variation}}
-  >
+  caption="${caption}"
+  highlightOnHover={${highlightOnHover}}` +
+    (size ? `\n  size="${size}"` : '') +
+    (variation ? `\n  variation="${variation}"` : '') +
+    `>
   <TableHead>
     <TableRow>
       <TableCell as="th">Citrus</TableCell>
@@ -42,7 +43,8 @@ const propsToCode = (props) => {
     </TableRow>
   </TableBody>
 </Table>
-  `;
+  `
+  );
 };
 
 const defaultTableProps = {

--- a/docs/src/styles/docs/code.scss
+++ b/docs/src/styles/docs/code.scss
@@ -3,7 +3,8 @@
  * Based on Atom's One Light theme: https://github.com/atom/atom/tree/master/packages/one-light-syntax
  */
 
-code.prism-code {
+
+.docs-home code.prism-code {
   font-size: inherit;
 }
  


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes the syntax highlighting and uses "" instead of {} for variation and size props for Table component. Also, scopes this css to .docs-home which was making the demo code font size kind of big on component demos. It should match the other code example font sizes on the docs now; home page code examples from new home page design stay the same.

```
.docs-home code.prism-code {
  font-size: inherit;
}
```

**Before (Table)**

<img width="400" alt="Screen Shot 2022-06-27 at 12 51 44 PM" src="https://user-images.githubusercontent.com/376920/175996419-45fb2beb-08dd-4cf0-a801-82cbe334e45e.png">
<img width="400" alt="Screen Shot 2022-06-27 at 12 51 21 PM" src="https://user-images.githubusercontent.com/376920/175996422-cbe971f9-2b61-4420-a229-11832b80cf33.png">

**After (Table)**

<img width="400" alt="Screen Shot 2022-06-27 at 1 01 10 PM" src="https://user-images.githubusercontent.com/376920/175996587-4e10a84c-ff1e-4009-bad9-eb9f5aa6ae03.png">
<img width="400" alt="Screen Shot 2022-06-27 at 1 00 58 PM" src="https://user-images.githubusercontent.com/376920/175996592-100d7057-2926-49a1-9275-4a680307909e.png">

**Before/After (Home)**
No change Before and After, just showing that the font-size is still the same for home page code examples in the new design:

<img width="400" src="https://user-images.githubusercontent.com/376920/175997135-35f22ecf-bde0-40b0-974c-0005b83881b6.png" />
<img width="400" src="https://user-images.githubusercontent.com/376920/175997134-5f73ef57-5ae4-42c1-8e9a-b88009cf7b54.png" />


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
