### PR TITLE
fix(docs): remove [tab] from sitemap links

### DIFF
--- a/docs/src/utils/getAllPaths.ts
+++ b/docs/src/utils/getAllPaths.ts
@@ -29,7 +29,9 @@ export async function getAllPaths() {
         .replace('/index', '');
 
       return FRAMEWORKS.map((framework) => {
-        const filepath = p.replace('[platform]', framework);
+        const filepath = p
+          .replace('[platform]', framework)
+          .replace('/[tab]', '');
         const supportedFrameworks =
           manifest[p].frontmatter.supportedFrameworks === 'all'
             ? FRAMEWORKS


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Sitemap included `[tab]` links like this:

```
<url>
<loc>https://www.dev.ui.docs.amplify.aws/react/components/alert/[tab]</loc>
<changefreq>weekly</changefreq>
<priority>0.6</priority>
<lastmod>2022-06-28T21:46:57.048Z</lastmod>
</url>
<url>
<loc>https://www.dev.ui.docs.amplify.aws/react/components/badge/[tab]</loc>
<changefreq>weekly</changefreq>
<priority>0.6</priority>
<lastmod>2022-06-28T21:46:57.048Z</lastmod>
</url>
<url>
```

So the search engine crawls wrong links. Remove `[tab]` from the links.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
