### PR TITLE
chore(docs): fix search color styles

### DIFF
--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -55,12 +55,18 @@ function MyApp({ Component, pageProps }) {
     } else {
       localStorage.removeItem('colorMode');
     }
+    // Algolia search renders in a Portal so we need to do this
+    document.documentElement.setAttribute('data-amplify-color-mode', colorMode);
   };
 
   React.useEffect(() => {
     const colorModePreference = localStorage.getItem('colorMode') as ColorMode;
     if (colorModePreference) {
       setColorMode(colorModePreference);
+      document.documentElement.setAttribute(
+        'data-amplify-color-mode',
+        colorModePreference
+      );
     }
   }, []);
 

--- a/docs/src/pages/_document.page.tsx
+++ b/docs/src/pages/_document.page.tsx
@@ -83,7 +83,7 @@ const getCSPContent = (context: Readonly<HtmlProps>) => {
 class MyDocument extends Document {
   render() {
     return (
-      <Html lang="en-us">
+      <Html lang="en-us" data-amplify-theme="amplify-docs">
         <Head>
           <meta
             httpEquiv="Content-Security-Policy"

--- a/docs/src/styles/docs/algolia.scss
+++ b/docs/src/styles/docs/algolia.scss
@@ -52,11 +52,8 @@
   }
 
   .DocSearch-Button-Key {
-    background: var(--amplify-colors-overlay-20);
-    color: inherit;
     height: var(--amplify-font-sizes-medium);
     font-family: var(--docs-font-mono);
-    box-shadow: none;
     padding: 0;
     margin-right: var(--amplify-space-xxs);
     &:last-of-type {
@@ -72,16 +69,10 @@
 
 // Modal
 .DocSearch-Container .DocSearch-Modal {
-  background: var(--amplify-colors-background-secondary);
-  color: var(--amplify-colors-font-primary);
   position: fixed;
 
   @media (min-width: $breakpoint-small) {
     position: relative;
-  }
-
-  .DocSearch-Hit-source {
-    background: var(--amplify-colors-background-secondary);
   }
 
   .DocSearch-Input {
@@ -92,38 +83,18 @@
     outline: revert;
   }
 
-  .DocSearch-MagnifierLabel,
   .DocSearch-Hit-source,
-  .DocSearch-Hits mark,
   .DocSearch-Logo svg {
-    color: var(--amplify-colors-brand-primary-60);
+    color: var(--amplify-colors-font-tertiary);
   }
-
-  .DocSearch-Form {
-    box-shadow: inset 0 0 0 2px var(--amplify-colors-brand-primary-60);
-    background: var(--amplify-colors-background-secondary);
+  
+  .DocSearch-MagnifierLabel {
+    color: var(--amplify-colors-font-disabled);
   }
-
-  .DocSearch-Hit-Container {
-    color: var(--amplify-colors-font-primary);
-  }
-
-  .DocSearch-Hit a {
-    background: var(--amplify-colors-background-primary);
-  }
-
-  .DocSearch-Hit[aria-selected='true'] a {
-    background-color: var(--amplify-colors-brand-primary-60);
-  }
-
-  .DocSearch-Footer {
-    background: var(--amplify-colors-background-primary);
-  }
-
-  .DocSearch-Commands-Key {
-    background: inherit;
-    box-shadow: inset 0 -2px 0 0 #cdcde6, inset 0 0 1px 1px #fff,
-      0 1px 2px 1px var(--amplify-colors-shadow-primary);
+  
+  .DocSearch-Hit {
+    border-radius: var(--amplify-radii-small);
+    padding-block-end: var(--amplify-space-small);
   }
 
   .DocSearch-Cancel {

--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -234,6 +234,20 @@ h4:hover>  a .icon-link {
   monospace;
   --docs-horizontal-padding: var(--amplify-space-medium);
   
+  // Algolia customizations
+  --docsearch-modal-background: var(--amplify-colors-background-primary);
+  --docsearch-modal-shadow: var(--amplify-shadows-small);
+  --docsearch-footer-background: var(--amplify-colors-background-primary);
+  --docsearch-footer-shadow: none;
+  --docsearch-hit-shadow: none;
+  --docsearch-hit-background: var(--amplify-colors-background-secondary);
+  --docsearch-hit-color: var(--amplify-colors-font-primary);
+  --docsearch-key-gradient: var(--amplify-colors-overlay-10);
+  --docsearch-key-shadow: none;
+  --docsearch-muted-color: var(--amplify-colors-font-tertiary);
+  --docsearch-searchbox-focus-background: transparent;
+  --docsearch-icon-color: var(--amplify-colors-font-disabled);
+  
   @media (min-width: $breakpoint-medium) {
     --docs-horizontal-padding: var(--amplify-space-xl);
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

We removed the `document.documentElement` stuff from the `ThemeProvider`, it broke the color modes for search in the docs site because it renders outside the provider DOM tree. 

* Added the document.documentElement logic into the docs color mode switching logic
* Cleaned up some algolia styles, moved some customizations to algolia's CSS vars

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
