### PR TITLE
fix(docs): fix margins on stand alone code examples

### DIFF
--- a/docs/src/styles/docs/code.scss
+++ b/docs/src/styles/docs/code.scss
@@ -32,7 +32,6 @@ pre[class*='language-'] *::selection {
 /* Code blocks */
 pre[class*='language-'] {
   padding: var(--amplify-space-medium);
-  margin: 0 0 var(--amplify-space-large) 0;
   overflow: auto;
   border-radius: 0;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes code examples (those not using Example or custom component) that are not getting owl selector margins.

**Before**

<img width="500" alt="Screen Shot 2022-06-29 at 11 49 40 AM" src="https://user-images.githubusercontent.com/376920/176481282-548fda45-1bb1-49a1-819d-250dbbf2e908.png">

**After**
<img width="500" alt="Screen Shot 2022-06-29 at 11 49 48 AM" src="https://user-images.githubusercontent.com/376920/176481315-a52433d8-1df0-41ef-b44f-f886ff5faa4d.png">

No change to home page code examples or Example code:

<img width="500" alt="Screen Shot 2022-06-29 at 11 56 47 AM" src="https://user-images.githubusercontent.com/376920/176481846-63b3e5b4-be2b-4c0d-b64b-ccefbddb1a07.png">


<img width="500" alt="Screen Shot 2022-06-29 at 11 54 42 AM" src="https://user-images.githubusercontent.com/376920/176481655-9d69b003-13a7-4a4d-9088-7e01880961ac.png">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
