### PR TITLE
docs(fix): Dark mode background color

### DIFF
--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -63,11 +63,11 @@ function MyApp({ Component, pageProps }) {
     const colorModePreference = localStorage.getItem('colorMode') as ColorMode;
     if (colorModePreference) {
       setColorMode(colorModePreference);
-      document.documentElement.setAttribute(
-        'data-amplify-color-mode',
-        colorModePreference
-      );
     }
+    document.documentElement.setAttribute(
+      'data-amplify-color-mode',
+      colorModePreference || 'system'
+    );
   }, []);
 
   configure();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

_Issue (from dev docs bug bash):_
- Dark mode: extra white on bottom, and when you go to landscape mode there are borders to the right and left

![image (1)](https://user-images.githubusercontent.com/48109584/176519475-b251746f-d1d1-4b10-9caf-e51c284b07b5.png)

[Danny's recent PR](https://github.com/aws-amplify/amplify-ui/pull/2212) that added back the `document.documentElement` logic pretty much fixed this issue. 

The only additional change here is slightly adjusting the useEffect logic to ensure that the `data-amplify-color-mode` attribute is set on initial render even if `colorModePreference` is not set in localStorage. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
