### PR TITLE
fix(ui): update select option to work on dark mode in firefox

### DIFF
--- a/packages/ui/src/theme/css/component/select.scss
+++ b/packages/ui/src/theme/css/component/select.scss
@@ -21,18 +21,19 @@
   padding-inline-end: var(--amplify-components-select-padding-inline-end);
   white-space: var(--amplify-components-select-white-space);
 
+  // For Chrome on Windows, fixes darkmode text color
+  option {
+    color: initial;
+  }
+  
   // for Firefox only, to fix background color in darkmode
   @-moz-document url-prefix() {
     option {
       background-color: var(
         --amplify-components-select-option-background-color
       );
+      color: var(--amplify-components-select-option-color);
     }
-  }
-
-  // For Chrome on Windows, fixes darkmode text color
-  option {
-    color: initial;
   }
 
   &--small {

--- a/packages/ui/src/theme/tokens/components/select.ts
+++ b/packages/ui/src/theme/tokens/components/select.ts
@@ -1,6 +1,7 @@
 import {
   AlignItemsValue,
   BackgroundColorValue,
+  ColorValue,
   CursorValue,
   DesignToken,
   DisplayValue,
@@ -30,6 +31,7 @@ interface SelectIconWrapperTokens {
 
 interface SelectOptionTokens {
   backgroundColor: DesignToken<BackgroundColorValue>;
+  color: DesignToken<ColorValue>;
 }
 
 interface SelectSizeTokens {
@@ -67,6 +69,7 @@ export const select: SelectTokens = {
   // for Firefox only, to fix background color in darkmode
   option: {
     backgroundColor: { value: '{colors.background.primary.value}' },
+    color: { value: '{colors.font.primary.value}' },
   },
   whiteSpace: { value: 'nowrap' },
   minWidth: { value: '6.5rem' },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Added font color to `option` selector for Firefox

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Before:

![CleanShot 2022-06-29 at 15 46 56](https://user-images.githubusercontent.com/321279/176558324-0ef1a4cc-245e-4e7d-8ab8-8ebfd90df4d3.gif)

After:

![CleanShot 2022-06-29 at 15 41 40](https://user-images.githubusercontent.com/321279/176558249-1125051b-954a-4532-a985-73125ab11997.gif)




#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
