### PR TITLE
fix(ui-react): directly return children from Authenticator

### DIFF
--- a/.changeset/slow-dragons-deny.md
+++ b/.changeset/slow-dragons-deny.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(ui-react): directly return children from Authenticator

--- a/packages/react/src/components/Authenticator/Authenticator.tsx
+++ b/packages/react/src/components/Authenticator/Authenticator.tsx
@@ -51,7 +51,7 @@ function useInitMachine(data: AuthenticatorMachineOptions) {
 
 // `AuthenticatorInternal` exists to give access to the context returned via `useAuthenticator`,
 // which allows the `Authenticator` to just return `children` if a user is authenticated.
-// Once the `Provider` is removed from the `Authentcator` component and exported as
+// Once the `Provider` is removed from the `Authenticator` component and exported as
 // `AuthenticatorProvider`, this component should be renamed to `Authenticator`.
 export function AuthenticatorInternal({
   children,

--- a/packages/react/src/components/Authenticator/Authenticator.tsx
+++ b/packages/react/src/components/Authenticator/Authenticator.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
-import { AuthenticatorMachineOptions } from '@aws-amplify/ui';
+import {
+  AuthenticatorMachineOptions,
+  CognitoUserAmplify,
+} from '@aws-amplify/ui';
 
-import { Provider, useAuthenticator } from './hooks/useAuthenticator';
+import {
+  Provider,
+  useAuthenticator,
+  UseAuthenticator,
+} from './hooks/useAuthenticator';
 import {
   CustomComponentsContext,
   ComponentsProviderProps,
@@ -15,14 +22,20 @@ import { ResetPassword } from './ResetPassword';
 import { defaultComponents } from './hooks/useCustomComponents/defaultComponents';
 
 export type AuthenticatorProps = Partial<
-  AuthenticatorMachineOptions & ComponentsProviderProps & RouterProps
+  AuthenticatorMachineOptions &
+    ComponentsProviderProps &
+    RouterProps & {
+      children:
+        | React.ReactNode
+        | ((props: {
+            signOut?: UseAuthenticator['signOut'];
+            user?: CognitoUserAmplify;
+          }) => JSX.Element);
+    }
 >;
 
-// Helper component that sends init event to the parent provider
-function InitMachine({
-  children,
-  ...data
-}: AuthenticatorMachineOptions & { children: React.ReactNode }) {
+// Utility hook that sends init event to the parent provider
+function useInitMachine(data: AuthenticatorMachineOptions) {
   // TODO: `INIT` event should be removed so that `_send` doesn't need to be extracted
   const { _send, route } = useAuthenticator(({ route }) => [route]);
 
@@ -34,14 +47,13 @@ function InitMachine({
       hasInitialized.current = true;
     }
   }, [_send, route, data]);
-
-  return <>{children}</>;
 }
 
-/**
- * [📖 Docs](https://ui.docs.amplify.aws/react/connected-components/authenticator)
- */
-export function Authenticator({
+// `AuthenticatorInternal` exists to give access to the context returned via `useAuthenticator`,
+// which allows the `Authenticator` to just return `children` if a user is authenticated.
+// Once the `Provider` is removed from the `Authentcator` component and exported as
+// `AuthenticatorProvider`, this component should be renamed to `Authenticator`.
+export function AuthenticatorInternal({
   children,
   className,
   components: customComponents,
@@ -54,31 +66,58 @@ export function Authenticator({
   socialProviders,
   variation,
 }: AuthenticatorProps): JSX.Element {
-  const value = React.useMemo(
-    () => ({ components: { ...defaultComponents, ...customComponents } }),
-    [customComponents]
+  const { route, signOut, user } = useAuthenticator(
+    ({ route, signOut, user }) => [route, signOut, user]
   );
-  const machineProps = {
+
+  useInitMachine({
     initialState,
     loginMechanisms,
     services,
     signUpAttributes,
     socialProviders,
     formFields,
-  };
+  });
+
+  const value = React.useMemo(
+    () => ({ components: { ...defaultComponents, ...customComponents } }),
+    [customComponents]
+  );
+
+  const isAuthenticatedRoute = route === 'authenticated' || route === 'signOut';
+  if (isAuthenticatedRoute) {
+    // `Authenticator` might not have user defined `children` for non SPA use cases.
+    if (!children) {
+      return null;
+    }
+
+    return (
+      <>
+        {typeof children === 'function'
+          ? children({ signOut, user }) // children is a render prop
+          : children}
+      </>
+    );
+  }
+
+  return (
+    <CustomComponentsContext.Provider value={value}>
+      <Router
+        className={className}
+        hideSignUp={hideSignUp}
+        variation={variation}
+      />
+    </CustomComponentsContext.Provider>
+  );
+}
+
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/connected-components/authenticator)
+ */
+export function Authenticator(props: AuthenticatorProps): JSX.Element {
   return (
     <Provider>
-      <CustomComponentsContext.Provider value={value}>
-        <InitMachine {...machineProps}>
-          <Router
-            className={className}
-            hideSignUp={hideSignUp}
-            variation={variation}
-          >
-            {children}
-          </Router>
-        </InitMachine>
-      </CustomComponentsContext.Provider>
+      <AuthenticatorInternal {...props} />
     </Provider>
   );
 }

--- a/packages/react/src/components/Authenticator/Router/Router.tsx
+++ b/packages/react/src/components/Authenticator/Router/Router.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useMemo } from 'react';
 
 import { useAuthenticator } from '../hooks/useAuthenticator';
 import { ConfirmSignUp } from '../ConfirmSignUp';
@@ -52,42 +52,13 @@ const getRouteComponent = (route: string): RouteComponent => {
   }
 };
 
-export function useRouterChildren(
-  children: RouterProps['children']
-): RouteComponent {
-  const { route, signOut, user } = useAuthenticator(
-    ({ route, signOut, user }) => [route, signOut, user]
-  );
-
-  return React.useMemo(() => {
-    const isUnauthenticatedRoute = !(
-      route === 'authenticated' || route === 'signOut'
-    );
-
-    if (isUnauthenticatedRoute) {
-      return getRouteComponent(route);
-    }
-
-    // `Authenticator` might not have user defined `children` for non SPA use cases.
-    if (!children) {
-      return RenderNothing;
-    }
-
-    return () =>
-      (typeof children === 'function'
-        ? children({ signOut, user }) // children is a render prop
-        : children) as JSX.Element;
-  }, [children, route, signOut, user]);
-}
-
 export function Router({
-  children,
   className,
   hideSignUp,
   variation,
 }: RouterProps): JSX.Element {
   const { route } = useAuthenticator(({ route }) => [route]);
-  const RouterChildren = useRouterChildren(children);
+  const RouterChildren = useMemo(() => getRouteComponent(route), [route]);
 
   return (
     <RouterChildren

--- a/packages/react/src/components/Authenticator/Router/types.ts
+++ b/packages/react/src/components/Authenticator/Router/types.ts
@@ -1,15 +1,3 @@
-import * as React from 'react';
-import { CognitoUserAmplify } from '@aws-amplify/ui';
 import { RouteProps } from '../RouteContainer';
 
-import { UseAuthenticator } from '../hooks/useAuthenticator';
-
-export type RouterProps = {
-  children:
-    | React.ReactNode
-    | ((props: {
-        signOut?: UseAuthenticator['signOut'];
-        user?: CognitoUserAmplify;
-      }) => React.ReactNode);
-  hideSignUp: boolean;
-} & RouteProps;
+export type RouterProps = { hideSignUp: boolean } & RouteProps;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
In `Authenticator`, directly return user defined `children` argument when user is authenticated. Currently, `children` is rendered from within the `Router` component, which may be remounted due to `Authenticator` life cycle events.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Potentially fixes https://github.com/aws-amplify/amplify-ui/issues/2191

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual testing, ran integ tests

#### Checklist
NA
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
