### PR TITLE
chore(docs): fix horizontal scroll issue

### DIFF
--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -61,7 +61,6 @@ body {
   padding: 0;
   margin: 0;
   line-height: 1.5;
-  width: 100vw;
 }
 
 a {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Don't need `body { width: 100vw; }`. Apparently browsers handle this differently. On mac scrollbars are overlaid on the page so they take up no space. On windows it affects the browser width so 100vw needs to scroll the width of the vertical scrollbar. Way to go windows. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
