### PR TITLE
docs: Add Accessibility example to ScrollView

### DIFF
--- a/docs/src/pages/[platform]/components/scrollview/examples/AccessibleScrollViewExample.tsx
+++ b/docs/src/pages/[platform]/components/scrollview/examples/AccessibleScrollViewExample.tsx
@@ -1,0 +1,16 @@
+import { ScrollView, Card } from '@aws-amplify/ui-react';
+
+export const AccessibleScrollViewExample = () => {
+  return (
+    <ScrollView
+      width="400px"
+      maxWidth="100%"
+      tabIndex={0}
+      aria-label="Accessible Scrollview"
+    >
+      <Card width="600px" backgroundColor="neutral.10">
+        This scrollview is keyboard focusable and has an accessible label.
+      </Card>
+    </ScrollView>
+  );
+};

--- a/docs/src/pages/[platform]/components/scrollview/examples/ScrollViewStylePropsExample.tsx
+++ b/docs/src/pages/[platform]/components/scrollview/examples/ScrollViewStylePropsExample.tsx
@@ -1,12 +1,12 @@
-import { ScrollView, useTheme } from '@aws-amplify/ui-react';
+import { ScrollView } from '@aws-amplify/ui-react';
 
 export const ScrollViewStylePropsExample = () => {
-  const { tokens } = useTheme();
   return (
     <ScrollView
       height="100px"
       width="200px"
-      backgroundColor={tokens.colors.blue[40]}
+      padding="medium"
+      backgroundColor="blue.10"
     >
       {
         "Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November weather. As much mud in the streets as if the waters had but newly retired from the face of the earth."

--- a/docs/src/pages/[platform]/components/scrollview/examples/index.ts
+++ b/docs/src/pages/[platform]/components/scrollview/examples/index.ts
@@ -1,3 +1,4 @@
+export { AccessibleScrollViewExample } from './AccessibleScrollViewExample';
 export { DefaultScrollViewExample } from './DefaultScrollViewExample';
 export { ScrollViewHorizontalExample } from './ScrollViewHorizontalExample';
 export { ScrollViewStylePropsExample } from './ScrollViewStylePropsExample';

--- a/docs/src/pages/[platform]/components/scrollview/react.mdx
+++ b/docs/src/pages/[platform]/components/scrollview/react.mdx
@@ -60,9 +60,9 @@ For vertical scrollbars, set the height of the `ScrollView` smaller than the hei
 
 ## Accessibility
 
-For some use cases, for example, if your scrollable content does not have any focusable elements, there are additionial HTML attributes we can add to the ScrollView to make it more friendly to keyboard users. 
+If your scrollable content does not have any focusable elements, there are additional HTML attributes you can add to your ScrollView to make it more friendly to keyboard users. 
 
-To create accessible, scrollable regions, we can add a `tabIndex` to the ScrollView to make it keyboard navigable. Additionally, we can add an accessible title to the ScrollView to give extra context about the scrollable content to screen reader users. In the following example, we've used an `aria-label`.
+To create accessible, scrollable regions, you can add a `tabIndex` to the ScrollView to make it keyboard navigable. Additionally, you can add an accessible label to the ScrollView to give extra context about the scrollable content to screen reader users. In the following example, we've used an `aria-label`.
 
 Read more about <Link isExternal href="https://www.w3.org/WAI/standards-guidelines/act/rules/0ssw9k/proposed/">keyboard friendly, scrollable regions from W3.org</Link>
 

--- a/docs/src/pages/[platform]/components/scrollview/react.mdx
+++ b/docs/src/pages/[platform]/components/scrollview/react.mdx
@@ -1,8 +1,9 @@
 import { Fragment } from '@/components/Fragment'; 
-import { Flex, Image, ScrollView } from '@aws-amplify/ui-react';
+import { Flex, Image, ScrollView, Link } from '@aws-amplify/ui-react';
 
 import { ScrollViewDemo } from './demo';
 import {
+  AccessibleScrollViewExample,
   DefaultScrollViewExample,
   ScrollViewHorizontalExample,
   ScrollViewStylePropsExample,
@@ -57,6 +58,24 @@ For vertical scrollbars, set the height of the `ScrollView` smaller than the hei
   </ExampleCode>
 </Example>
 
+## Accessibility
+
+For some use cases, for example, if your scrollable content does not have any focusable elements, there are additionial HTML attributes we can add to the ScrollView to make it more friendly to keyboard users. 
+
+To create accessible, scrollable regions, we can add a `tabIndex` to the ScrollView to make it keyboard navigable. Additionally, we can add an accessible title to the ScrollView to give extra context about the scrollable content to screen reader users. In the following example, we've used an `aria-label`.
+
+Read more about <Link isExternal href="https://www.w3.org/WAI/standards-guidelines/act/rules/0ssw9k/proposed/">keyboard friendly, scrollable regions from W3.org</Link>
+
+<Example>
+  <AccessibleScrollViewExample />
+  <ExampleCode>
+    ```jsx file=./examples/AccessibleScrollViewExample.tsx
+
+    ```
+
+  </ExampleCode>
+</Example>
+
 ## CSS Styling
 
 ### Target classes
@@ -81,7 +100,8 @@ _Using a class selector:_
   .my-scrollview {
     height: 100px;
     width: 200px;
-    background-color: var(--amplify-colors-blue-40);
+    padding: var(--amplify-space-medium);
+    background-color: var(--amplify-colors-blue-10);
   }
   ```
   </ExampleCode>

--- a/docs/src/styles/primitives/scrollView.css
+++ b/docs/src/styles/primitives/scrollView.css
@@ -1,5 +1,6 @@
 .my-scrollview {
   height: 100px;
   width: 200px;
-  background-color: var(--amplify-colors-blue-40);
+  padding: var(--amplify-space-medium);
+  background-color: var(--amplify-colors-blue-10);
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds section about Accessible scroll views to ScrollView docs.

<img width="936" alt="Screen Shot 2022-07-05 at 12 00 45 AM" src="https://user-images.githubusercontent.com/376920/177247005-8ec7eaa4-0823-478c-97bb-009b69b7faa6.png">

Additionally, updated some styling/styleProps examples to have more contrast-ey backgrounds:

**Before**
<img width="247" alt="Screen Shot 2022-07-02 at 4 31 19 PM" src="https://user-images.githubusercontent.com/376920/177015420-af1853a2-82da-4239-b4c6-f600b15b77dd.png">
**After**
<img width="260" alt="Screen Shot 2022-07-02 at 4 31 38 PM" src="https://user-images.githubusercontent.com/376920/177015419-15d074dd-17fc-41dd-8a67-2a80ecbe9c82.png">



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
