### PR TITLE
fix(docs): translations causing scroll on auth docs

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
@@ -29,14 +29,14 @@ The list of available keys are available [here](https://github.com/aws-amplify/a
 The confirm sign up page has a few specialized strings that can be translated.
 These include:
 
-```
-Your code is on the way. To log in, enter the code we emailed to
+```js
+`Your code is on the way. To log in, enter the code we emailed to`
 
-Your code is on the way. To log in, enter the code we texted to
+`Your code is on the way. To log in, enter the code we texted to`
 
-Your code is on the way. To log in, enter the code we sent you. It may take a minute to arrive.
+`Your code is on the way. To log in, enter the code we sent you. It may take a minute to arrive.`
 
-It may take a minute to arrive.
+`It may take a minute to arrive.`
 ```
 
 <Alert variation="info" heading="Translations Needed 📖">


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes [some translation text](https://ui.docs.amplify.aws/react/connected-components/authenticator/customization#confirm-sign-up-page-translations) that was causing a horizontal scroll on the Authenticator docs on smaller viewports.

Note: There is also a table causing a larger horizontal scroll on this page but that should be fixed with [this PR](https://github.com/aws-amplify/amplify-ui/pull/2243) where the markdown table is converted to a ResponsiveTable

**Before**
<img width="682" alt="Screen Shot 2022-07-05 at 10 58 32 AM" src="https://user-images.githubusercontent.com/376920/177358518-6b5da77d-8403-4553-838e-dda6c2c9b752.png">

**After**
<img width="675" alt="Screen Shot 2022-07-05 at 11 00 01 AM" src="https://user-images.githubusercontent.com/376920/177358589-2fbeb631-c773-4e23-b897-298473d2889d.png">

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
