### PR TITLE
fix(ui): toggle button group borders

### DIFF
--- a/packages/ui/src/theme/css/component/toggleButtonGroup.scss
+++ b/packages/ui/src/theme/css/component/toggleButtonGroup.scss
@@ -7,7 +7,8 @@
 
 .amplify-togglebuttongroup {
   .amplify-togglebutton {
-    &:focus {
+    &:focus,
+    &.amplify-togglebutton--pressed {
       z-index: 2;
     }
     

--- a/packages/ui/src/theme/css/component/toggleButtonGroup.scss
+++ b/packages/ui/src/theme/css/component/toggleButtonGroup.scss
@@ -7,7 +7,12 @@
 
 .amplify-togglebuttongroup {
   .amplify-togglebutton {
+    &:focus {
+      z-index: 2;
+    }
+    
     &:not(:first-of-type) {
+      margin-inline-start: calc(-1 * var(--amplify-components-button-border-width));
       border-start-start-radius: 0;
       border-end-start-radius: 0;
       // required for Safari 14 and below
@@ -16,11 +21,8 @@
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
       }
-
-      &:not(:focus) {
-        border-inline-start: 1px solid transparent;
-      }
     }
+    
     &:not(:last-of-type) {
       border-start-end-radius: 0;
       border-end-end-radius: 0;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

* Changed from having a transparent border on one side to overlapping the button borders. This fixes an issue where you see little cut-outs in the top right & left of the border
* Added a z-index on focus so the focused button's border/box-shadow always appears on top

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

| Before | After |
| - | - |
| <img width="434" alt="CleanShot 2022-07-05 at 09 35 22@2x" src="https://user-images.githubusercontent.com/321279/177376108-e2a9a934-0329-492e-a2ff-e8ace02bd5ac.png"> | <img width="430" alt="CleanShot 2022-07-05 at 09 46 21@2x" src="https://user-images.githubusercontent.com/321279/177377045-6adad795-06d3-4728-a646-9d61b39300e6.png"> |
| ![CleanShot 2022-07-05 at 09 36 45](https://user-images.githubusercontent.com/321279/177376115-f4a64ad5-ce48-4618-95ce-be7809af001d.gif) | ![CleanShot 2022-07-05 at 09 37 13](https://user-images.githubusercontent.com/321279/177376121-a8210aad-4a8b-4bcb-88ad-f81f907c5a30.gif) |


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
