### PR TITLE
Revert "fix: pin `@types/eslint` version (#2232)"

### DIFF
--- a/canary/apps/react/cra-ts/package.json
+++ b/canary/apps/react/cra-ts/package.json
@@ -56,8 +56,5 @@
       "path": "build/static/js/main.*.js",
       "limit": "280 kB"
     }
-  ],
-  "resolutions": {
-    "@types/eslint": "8.4.3"
-  }
+  ]
 }

--- a/canary/apps/react/cra/package.json
+++ b/canary/apps/react/cra/package.json
@@ -51,8 +51,5 @@
       "path": "build/static/js/main.*.js",
       "limit": "280 kB"
     }
-  ],
-  "resolutions": {
-    "@types/eslint": "8.4.3"
-  }
+  ]
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -69,8 +69,5 @@
     "globby": "^13.1.1",
     "postcss": "^8.2.6",
     "ts-morph": "^15.1.0"
-  },
-  "resolutions": {
-    "@types/eslint": "8.4.3"
   }
 }

--- a/guides/react/protected-routes/package.json
+++ b/guides/react/protected-routes/package.json
@@ -43,8 +43,5 @@
     "customize-cra": "^1.0.0",
     "react-app-rewired": "^2.2.1",
     "serve": "^13.0.2"
-  },
-  "resolutions": {
-    "@types/eslint": "8.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "cssnano-simple": "3.0.2",
     "cssnano-preset-simple": "4.0.0",
     "eventsource": "~2.0.2",
-    "@types/eslint": "8.4.3",
     "fs-extra": "^10.0.0",
     "glob-parent": "^6.0.2",
     "jest": "^26.6.3",


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This reverts commit f4560d39b3ab4a2666cc9d3feb5c839904e13e6d introduced in https://github.com/aws-amplify/amplify-ui/pull/2232. This change was no longer needed now that npm repo issues publishing tarballs has been fixed.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
