### PR TITLE
Fix primitive catalog export

### DIFF
--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -1,4 +1,6 @@
 dist
+# ignore generated primitive catalog ESM
+src/PrimitiveCatalog.ts 
 
 # ignore jest generated coverage directory
 coverage 

--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { PrimitiveCatalog } from '../src/types/catalog';
+import type { PrimitiveCatalogType } from '../src/types/catalog';
 
 // Jest doesn't support `exports` maps, so we have to reference `dist` directly.
 // See: https://github.com/facebook/jest/issues/9771
@@ -142,6 +142,7 @@ describe('@aws-amplify/ui-react/internal', () => {
           "IconCheckCircleOutline",
           "IconFiberManualRecord",
           "IconHighlightOff",
+          "PrimitiveCatalog",
           "createDataStorePredicate",
           "useAuth",
           "useAuthSignOutAction",
@@ -160,13 +161,13 @@ describe('@aws-amplify/ui-react/internal', () => {
   });
 });
 
-const getCatalogJSON = (): PrimitiveCatalog => {
+const getCatalogJSON = (): PrimitiveCatalogType => {
   try {
     const rawJSON = fs
       .readFileSync(path.join(__dirname, '../dist/primitives.json'))
       .toString();
 
-    return JSON.parse(rawJSON) as PrimitiveCatalog;
+    return JSON.parse(rawJSON) as PrimitiveCatalogType;
   } catch (err) {
     console.error('Error reading primitives catalog JSON file:', err);
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
     "prebuild": "rimraf dist",
     "build": "yarn run build:catalog && yarn run build:ts",
     "build:ts": "rollup --config",
-    "build:catalog": "node --require esbuild-register scripts/generatePrimitiveCatalog.ts",
+    "build:catalog": "ts scripts/generatePrimitiveCatalog.ts",
     "dev": "tsup --watch",
     "dev:build": "tsup",
     "update:icons": "node scripts/updateIcons.js",
@@ -52,6 +52,7 @@
     "test:watch": "yarn test:unit:watch",
     "test:unit": "jest",
     "test:unit:watch": "jest --watch",
+    "ts": "node -r esbuild-register",
     "size": "yarn run size-limit"
   },
   "dependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
     "prebuild": "rimraf dist",
     "build": "yarn run build:catalog && yarn run build:ts",
     "build:ts": "rollup --config",
-    "build:catalog": "ts-node scripts/generatePrimitivesCatalog.ts",
+    "build:catalog": "node --require esbuild-register scripts/generatePrimitiveCatalog.ts",
     "dev": "tsup --watch",
     "dev:build": "tsup",
     "update:icons": "node scripts/updateIcons.js",
@@ -97,6 +97,7 @@
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
     "degit": "^2.8.4",
+    "esbuild-register": "^3.3.3",
     "eslint": "^8.13.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
@@ -116,8 +117,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "size-limit": "^7.0.8",
     "ts-jest": "^27.0.3",
-    "ts-morph": "^12.0.0",
-    "ts-node": "^10.2.1"
+    "ts-morph": "^12.0.0"
   },
   "sideEffects": [
     "dist/**/*.css"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,10 +12,6 @@
       "import": "./dist/esm/internal.js",
       "require": "./dist/internal.js"
     },
-    "./internal/primitives-catalog": {
-      "import": "./dist/esm/primitives-catalog.js",
-      "default": null
-    },
     "./legacy": {
       "import": "./dist/esm/legacy.js",
       "require": "./dist/legacy.js"
@@ -42,7 +38,7 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "yarn run build:ts && yarn run build:catalog",
+    "build": "yarn run build:catalog && yarn run build:ts",
     "build:ts": "rollup --config",
     "build:catalog": "ts-node scripts/generatePrimitivesCatalog.ts",
     "dev": "tsup --watch",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
     "prebuild": "rimraf dist",
     "build": "yarn run build:catalog && yarn run build:ts",
     "build:ts": "rollup --config",
-    "build:catalog": "ts scripts/generatePrimitiveCatalog.ts",
+    "build:catalog": "yarn ts scripts/generatePrimitiveCatalog.ts",
     "dev": "tsup --watch",
     "dev:build": "tsup",
     "update:icons": "node scripts/updateIcons.js",

--- a/packages/react/scripts/generatePrimitiveCatalog.ts
+++ b/packages/react/scripts/generatePrimitiveCatalog.ts
@@ -3,10 +3,9 @@ import path from 'path';
 
 import { Node, Project, Symbol, Type, VariableDeclaration } from 'ts-morph';
 import {
-  PrimitiveCatalog,
+  PrimitiveCatalogType,
   PrimitiveCatalogComponentProperties,
   PrimitiveCatalogComponentProperty,
-  PrimitiveCatalogComponentPropertyType,
 } from '../src/types/catalog';
 
 /**
@@ -104,17 +103,17 @@ const getComponentProperties = (type: Type) => {
  */
 const getCatalogComponentProperty = (
   property: Symbol
-): PrimitiveCatalogComponentProperty => {
+): PrimitiveCatalogComponentProperty | undefined => {
   const propType = property.getDeclarations()[0].getType();
 
   if (!propType) {
     return;
   } else if (propType.isBoolean() || propType.isBooleanLiteral()) {
-    return { type: PrimitiveCatalogComponentPropertyType.Boolean };
+    return { type: 'boolean' };
   } else if (propType.isString() || propType.isStringLiteral()) {
-    return { type: PrimitiveCatalogComponentPropertyType.String };
+    return { type: 'string' };
   } else if (propType.isNumber() || propType.isNumberLiteral()) {
-    return { type: PrimitiveCatalogComponentPropertyType.Number };
+    return { type: 'number' };
   } else if (propType.isUnion()) {
     const hasNumber = propType
       .getUnionTypes()
@@ -126,13 +125,13 @@ const getCatalogComponentProperty = (
 
     if (hasNumber) {
       return {
-        type: PrimitiveCatalogComponentPropertyType.Number,
+        type: 'number',
       };
     }
 
     if (hasString) {
       return {
-        type: PrimitiveCatalogComponentPropertyType.String,
+        type: 'string',
       };
     }
   }
@@ -143,7 +142,10 @@ const project = new Project({
 });
 
 const source = project.getSourceFile('src/primitives/components.ts');
-const catalog: PrimitiveCatalog = {};
+const catalog: PrimitiveCatalogType = {};
+if (!source) {
+  throw new Error('Primitives components.ts export file not found');
+}
 
 /**
  * Extract properties from exported React components
@@ -157,10 +159,10 @@ for (const [componentName, [node]] of source.getExportedDeclarations()) {
   } else if (isCallableNode(node)) {
     const [signature] = node.getType().getCallSignatures();
 
-    if (signature && signature.getParameters().length > 0) {
-      properties = getComponentProperties(
-        signature.getParameters()[0].getValueDeclaration().getType()
-      );
+    const signatureParams = signature.getParameters();
+    if (signature && signatureParams[0]) {
+      const type = signatureParams[0].getValueDeclaration()!.getType();
+      properties = getComponentProperties(type);
     }
   }
 
@@ -191,15 +193,18 @@ const jsonString = JSON.stringify(catalog, null, 2);
  * this is being exported under the /internal/primitives-catalog subpath and can be used as
  * import { PrimitiveCatalog } from '@aws-amplify/ui-react/internal/primitives-catalog'
  */
-const exportString = `export const PrimitiveCatalog = ${jsonString};`;
+const exportString = `import { PrimitiveCatalogType } from './types/catalog';
+export const PrimitiveCatalog: PrimitiveCatalogType = ${jsonString};`;
 
 // Generates dist/primitives.js file
-const JSONoutputPath = path.resolve(__dirname, '..', 'dist', 'primitives.json');
+fs.mkdirSync(`${path.resolve(__dirname, '..')}/dist`);
+
+const JSONoutputPath = `${path.resolve(__dirname, '..')}/dist/primitives.json`;
 const internalOutputPath = path.resolve(
   __dirname,
   '..',
-  'dist/esm',
-  'primitives-catalog.js'
+  'src',
+  'PrimitiveCatalog.ts'
 );
-fs.writeFileSync(JSONoutputPath, jsonString);
-fs.writeFileSync(internalOutputPath, exportString);
+fs.writeFileSync(JSONoutputPath, jsonString, { flag: 'w' });
+fs.writeFileSync(internalOutputPath, exportString, { flag: 'w' });

--- a/packages/react/scripts/generatePrimitiveCatalog.ts
+++ b/packages/react/scripts/generatePrimitiveCatalog.ts
@@ -196,8 +196,12 @@ const jsonString = JSON.stringify(catalog, null, 2);
 const exportString = `import { PrimitiveCatalogType } from './types/catalog';
 export const PrimitiveCatalog: PrimitiveCatalogType = ${jsonString};`;
 
-// Generates dist/primitives.js file
-fs.mkdirSync(`${path.resolve(__dirname, '..')}/dist`);
+// Generates dist folder file since it's deleted in `prebuild`
+// NOTE: This line can be removed when we remove primitives.json output
+const distFolderPath = `${path.resolve(__dirname, '..')}/dist`;
+if (!fs.existsSync(distFolderPath)) {
+  fs.mkdirSync(distFolderPath);
+}
 
 const JSONoutputPath = `${path.resolve(__dirname, '..')}/dist/primitives.json`;
 const internalOutputPath = path.resolve(

--- a/packages/react/src/internal.tsx
+++ b/packages/react/src/internal.tsx
@@ -28,3 +28,5 @@ export {
   getOverrideProps,
   mergeVariantsAndOverrides,
 } from './primitives/shared/utils';
+
+export { PrimitiveCatalog } from './PrimitiveCatalog';

--- a/packages/react/src/types/catalog.ts
+++ b/packages/react/src/types/catalog.ts
@@ -1,12 +1,11 @@
-export enum PrimitiveCatalogComponentPropertyType {
-  Boolean = 'boolean',
-  String = 'string',
-  Number = 'number',
-  Any = 'any',
-}
+export type PrimitiveCatalogComponentPropertyType =
+  | 'boolean'
+  | 'string'
+  | 'number';
 
 export type PrimitiveCatalogComponentProperty = {
   type: PrimitiveCatalogComponentPropertyType;
+  priority?: boolean;
 };
 
 export type PrimitiveCatalogComponentProperties = Record<
@@ -18,4 +17,4 @@ export type PrimitiveCatalogComponent = {
   properties: PrimitiveCatalogComponentProperties;
 };
 
-export type PrimitiveCatalog = Record<string, PrimitiveCatalogComponent>;
+export type PrimitiveCatalogType = Record<string, PrimitiveCatalogComponent>;

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,9 +1,4 @@
 {
-  "ts-node": {
-    "compilerOptions": {
-      "module": "CommonJS"
-    }
-  },
   "compilerOptions": {
     "moduleResolution": "node",
     "baseUrl": ".",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5436,7 +5436,7 @@
     "@types/eslint" "*"
     "@types/estree" "*"
 
-"@types/eslint@*", "@types/eslint@8.4.3":
+"@types/eslint@*":
   version "8.4.3"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.3.tgz#5c92815a3838b1985c90034cd85f26f59d9d0ece"
   integrity sha512-YP1S7YJRMPs+7KZKDb9G63n8YejIwW9BALq7a5j2+H4yl6iOv9CB29edho+cuFRrvmJbbaH2yiVChKLJVysDGw==
@@ -10873,6 +10873,11 @@ esbuild-register@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/esbuild-register/-/esbuild-register-3.3.2.tgz#1c3dc7179cabb4c7bd640a393eb916b18b12a223"
   integrity sha512-jceAtTO6zxPmCfSD5cBb3rgIK1vmuqCKYwgylHiS1BF4pq0jJiJb4K2QMuqF4BEw7XDBRatYzip0upyTzfkgsQ==
+
+esbuild-register@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/esbuild-register/-/esbuild-register-3.3.3.tgz#5bd80025c80caf77e6484ced5cc77233b1d39688"
+  integrity sha512-eFHOkutgIMJY5gc8LUp/7c+LLlDqzNi9T6AwCZ2WKKl3HmT+5ef3ZRyPPxDOynInML0fgaC50yszPKfPnjC0NQ==
 
 esbuild-sunos-64@0.14.41:
   version "0.14.41"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR fixes an issue where our ESM export of the PrimitivesCatalog doesn't work correctly and throws a "Cannot find module" error due to the path `/internal/primtives-catalog`. This PR moves the catalog to be built into the source folder and exported alongside the other `internal` exports.

Import error message before this PR:
<img width="946" alt="image" src="https://user-images.githubusercontent.com/6165315/177661329-6a820a6b-3834-41b1-bde5-45bf05fb5697.png">

After this PR:
<img width="680" alt="image" src="https://user-images.githubusercontent.com/6165315/177661471-5ce79a0b-e49d-4590-bf21-c1678e44ca30.png">

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
1. yarn react build
1. cd packages/react && npm pack
1. Opened my studio test app and installed the tarball
1. Observed that the import doesn't throw an error

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
