### PR TITLE
docs: next steps in getting started sections

### DIFF
--- a/docs/src/components/CardLink.tsx
+++ b/docs/src/components/CardLink.tsx
@@ -43,11 +43,13 @@ interface CardLinkGroupProps {
   children: React.ReactNode;
   templateColumns?: string | object;
   gap?: string;
+  headingLevel?: 1 | 2 | 3 | 4 | 6;
 }
 
 export function CardLinkGroup({
   title,
   children,
+  headingLevel = 2,
   templateColumns = { base: '1fr', large: '1fr 1fr' },
   id,
   gap = 'large',
@@ -55,7 +57,11 @@ export function CardLinkGroup({
   return (
     <>
       {title ? (
-        <Heading id={id} className="docs-cardLinkGroup-title" level={2}>
+        <Heading
+          id={id}
+          className="docs-cardLinkGroup-title"
+          level={headingLevel}
+        >
           {
             /* Assuming you added an id for this to show in the ToC,
              * we'll add the utility hover anchor link here */

--- a/docs/src/pages/[platform]/getting-started/installation/dependencies.flutter.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/dependencies.flutter.mdx
@@ -8,13 +8,3 @@ dependencies:
   amplify_auth_cognito: ^0.5.0
   amplify_authenticator: ^0.1.0
 ```
-
-<Alert variation="info">
-  <Text color="inherit">
-    The authenticator component is currently the only supported component for
-    flutter.
-  </Text>
-  <Link href="/flutter/components/authenticator">
-    View Authenticator Component docs
-  </Link>
-</Alert>

--- a/docs/src/pages/[platform]/getting-started/installation/index.page.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/index.page.mdx
@@ -22,3 +22,7 @@ import { Fragment } from '@/components/Fragment';
 <Fragment platforms={['web']} useCommonWebContent>
   {({ platform }) => import(`./fonts.${platform}.mdx`)}
 </Fragment>
+
+<Fragment>
+  {({ platform }) => import(`./nextSteps.${platform}.mdx`)}
+</Fragment>

--- a/docs/src/pages/[platform]/getting-started/installation/nextSteps.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/nextSteps.angular.mdx
@@ -1,0 +1,11 @@
+import { CardLink, CardLinkGroup } from '@/components/CardLink';
+import { MdLogin } from 'react-icons/md';
+
+<CardLinkGroup id="nextSteps" title="Next steps">
+  <CardLink 
+    title="Adding the Authenticator"
+    desc="Learn how to setup the Authenticator component for Angular"
+    href="/angular/connected-components/authenticator"
+    icon={<MdLogin />}
+  />
+</CardLinkGroup>

--- a/docs/src/pages/[platform]/getting-started/installation/nextSteps.flutter.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/nextSteps.flutter.mdx
@@ -1,0 +1,11 @@
+import { CardLink, CardLinkGroup } from '@/components/CardLink';
+import { MdLogin } from 'react-icons/md';
+
+<CardLinkGroup id="nextSteps" title="Next steps">
+  <CardLink 
+    title="Adding the Authenticator"
+    desc="Learn how to setup the Authenticator component for Flutter"
+    href="/vue/connected-components/authenticator"
+    icon={<MdLogin />}
+  />
+</CardLinkGroup>

--- a/docs/src/pages/[platform]/getting-started/installation/nextSteps.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/nextSteps.react.mdx
@@ -1,0 +1,11 @@
+import { CardLink, CardLinkGroup } from '@/components/CardLink';
+import { ReactIcon } from '@/components/Icons';
+
+<CardLinkGroup id="nextSteps" title="Next steps">
+  <CardLink 
+    title="Usage"
+    desc="Learn the basics of setting up a React app with Amplify UI"
+    href="/react/getting-started/usage"
+    icon={<ReactIcon />}
+  />
+</CardLinkGroup>

--- a/docs/src/pages/[platform]/getting-started/installation/nextSteps.vue.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/nextSteps.vue.mdx
@@ -1,0 +1,11 @@
+import { CardLink, CardLinkGroup } from '@/components/CardLink';
+import { MdLogin } from 'react-icons/md';
+
+<CardLinkGroup id="nextSteps" title="Next steps">
+  <CardLink 
+    title="Adding the Authenticator"
+    desc="Learn how to setup the Authenticator component for Vue"
+    href="/vue/connected-components/authenticator"
+    icon={<MdLogin />}
+  />
+</CardLinkGroup>

--- a/docs/src/pages/[platform]/getting-started/usage/usage.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/usage/usage.react.mdx
@@ -1,23 +1,25 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
 import { InstallScripts } from '@/components/InstallScripts.tsx';
+import { CardLink, CardLinkGroup } from '@/components/CardLink';
+import { ReactIcon } from '@/components/Icons';
+import { SiNextdotjs } from 'react-icons/si';
+import { MdOutlineWidgets, MdOutlineAutoAwesome } from 'react-icons/md';
 import {
   ComponentExampleDemo,
   ReactExampleDemo,
   ThemeExampleDemo,
 } from './examples';
 
-## React and Amplify UI
+Amplify UI is designed to integrate seamlessly with the React library so you can get started in no time. 
 
-Amplify UI is designed to integrate seamlessly with the React framework so you can get started in no time. 
-
-### Installation
+## Installation
 
 If you haven't already, install `@aws-amplify/ui-react` with [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/):
 
 <InstallScripts framework="react" />
 
-### Quick start
+## Quick start
 
 Here's all you need to get up and running:
 
@@ -31,7 +33,22 @@ Copy/paste the code above into your React app, start the app, and look at that l
 
 <ReactExampleDemo />
 
-### Components
+<CardLinkGroup id="frameworkGuides" headingLevel="3" title="Looking for framework specific guides?">
+  <CardLink 
+    title="Create React App"
+    desc="Learn how to use Amplify UI components with CRA"
+    href="/react/getting-started/usage/create-react-app"
+    icon={<ReactIcon />}
+  />
+  <CardLink 
+    title="Next.js"
+    desc="Learn how to use Amplify UI components with Next.js"
+    href="/react/getting-started/usage/create-react-app"
+    icon={<SiNextdotjs />}
+  />
+</CardLinkGroup>
+
+## Components
 
 You can use all of Amplify UI's primitive components (e.g., `Button`, `Tabs`, `Flex`) right out-of-the-box. These are the same components we use to build our connected components such as the [Authenticator](/react/connected-components/authenticator). Please refer to each component's [documentation](/react/components/button) to see how they should be imported, configured and styled.
 
@@ -44,7 +61,7 @@ You can use all of Amplify UI's primitive components (e.g., `Button`, `Tabs`, `F
   </ExampleCode>
 </Example>
 
-### Theming
+## Theming
 
 Amplify UI ships with a default [theme](/react/theming) that you can customize to match the look and feel of your project. Remember to load the default styling by importing our CSS at the entry-point to your application (e.g., `src/App.js`).
 
@@ -62,3 +79,19 @@ To learn how to customize the appearance of all components in your application w
 ```
   </ExampleCode>
 </Example>
+
+<CardLinkGroup id="nextSteps" title="Next Steps">
+  <CardLink 
+    title="Browse components"
+    desc="Amplify UI has over 40 components to build with"
+    href="/react/getting-started/usage/create-react-app"
+    icon={<MdOutlineWidgets />}
+  />
+  <CardLink 
+    title="Theming"
+    desc="Learn how to customize the style of your application"
+    href="/react/getting-started/usage/create-react-app"
+    icon={<MdOutlineAutoAwesome />}
+  />
+  
+</CardLinkGroup>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Sprinkling some more "Next steps" sections around in the Getting Started docs. Also, made it so CardLinkGroup can accept a `headingLevel` so its Heading can follow proper nesting if you need it to be an h3.

**Installation (React, end of page, links to Usage)**
<img width="400" alt="Screen Shot 2022-07-06 at 10 53 49 PM" src="https://user-images.githubusercontent.com/376920/177680620-73c179f2-9ff2-4d88-8bfe-c6848b367b0a.png">


**Installation (Angular, similar for Vue and Flutter, links to Authenticator)**
<img width="400" alt="Screen Shot 2022-07-06 at 10 54 47 PM" src="https://user-images.githubusercontent.com/376920/177680732-5456a99a-e7fe-431a-a7ff-7b7e8ae92e67.png">

**Usage (React,  in Quick Start section and at end of page)**
<img width="400" src="https://user-images.githubusercontent.com/376920/177679611-82dfb7f6-bcd3-4cd0-8533-691db452e599.png" />

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
