### PR TITLE
docs: add media attribution page

### DIFF
--- a/docs/src/components/Layout/Footer.tsx
+++ b/docs/src/components/Layout/Footer.tsx
@@ -50,8 +50,9 @@ export const Footer = () => {
           .
         </Text>
         <Text marginBlockStart="medium">
-          Flutter and the related logo are trademarks of Google LLC. We are not
-          endorsed by or affiliated with Google LLC.
+          <Link href="/media-attribution">
+            Brand, logo and media attribution
+          </Link>
         </Text>
       </View>
     </Flex>

--- a/docs/src/pages/media-attribution/index.page.mdx
+++ b/docs/src/pages/media-attribution/index.page.mdx
@@ -1,0 +1,10 @@
+---
+title: Brand, Logo, and Media Attribution
+metaDescription: Brand, logo and media attribution
+hideToc: true
+supportedFrameworks: all
+---
+
+- Flutter and the related logo are trademarks of Google LLC. We are not endorsed by or affiliated with Google LLC.
+- We are not affiliated with Figma.
+- Vercel, the Vercel design, Next.js and related marks, designs and logos are trademarks or registered trademarks of Vercel, Inc. or its affiliates in the US and other countries.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds a new Brand, logo, and media attribution page with a link to it from the footer.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
