### PR TITLE
chore: update internal type EscapeHatchProps

### DIFF
--- a/.changeset/nasty-tips-eat.md
+++ b/.changeset/nasty-tips-eat.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': minor
+---
+
+Update internal type EscapeHatchProps to accept `unknown`, so that customers can set overrides of any type.

--- a/packages/react/src/primitives/shared/utils.ts
+++ b/packages/react/src/primitives/shared/utils.ts
@@ -78,7 +78,7 @@ export const getOverrideProps = (
 };
 
 export type EscapeHatchProps = {
-  [elementHierarchy: string]: Record<string, string>;
+  [elementHierarchy: string]: Record<string, unknown>;
 };
 
 type VariantValues = { [key: string]: string };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Currently, overrides can only be type `string`. But other types such as `number`, `boolean`, and `React.ReactNode` have their uses. To let customers override any property on any component, we're setting the type to `unknown`.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
