### PR TITLE
chore: update cra canary app to use npm install

### DIFF
--- a/canary/apps/.gitignore
+++ b/canary/apps/.gitignore
@@ -1,1 +1,2 @@
 yarn.lock
+package-lock.json

--- a/canary/package.json
+++ b/canary/package.json
@@ -18,7 +18,7 @@
     "angular": "yarn angularcli",
     "angular:install": "yarn angularcli:install",
     "cra": "yarn --cwd apps/react/cra build ",
-    "cra:install": "echo 'NOTE: Testing using npm install instead of yarn' && npm install apps/react/cra install",
+    "cra:install": "echo 'NOTE: Testing using npm install instead of yarn' && npm install --prefix apps/react/cra",
     "cra-ts": "yarn --cwd apps/react/cra-ts build ",
     "cra-ts:install": "yarn --cwd apps/react/cra-ts install",
     "next": "yarn --cwd apps/react/next build ",

--- a/canary/package.json
+++ b/canary/package.json
@@ -18,7 +18,7 @@
     "angular": "yarn angularcli",
     "angular:install": "yarn angularcli:install",
     "cra": "yarn --cwd apps/react/cra build ",
-    "cra:install": "echo 'NOTE: Testing using npm install instead of yarn \n' && npm install apps/react/cra install",
+    "cra:install": "echo 'NOTE: Testing using npm install instead of yarn' && npm install apps/react/cra install",
     "cra-ts": "yarn --cwd apps/react/cra-ts build ",
     "cra-ts:install": "yarn --cwd apps/react/cra-ts install",
     "next": "yarn --cwd apps/react/next build ",

--- a/canary/package.json
+++ b/canary/package.json
@@ -18,7 +18,7 @@
     "angular": "yarn angularcli",
     "angular:install": "yarn angularcli:install",
     "cra": "yarn --cwd apps/react/cra build ",
-    "cra:install": "yarn --cwd apps/react/cra install",
+    "cra:install": "echo 'NOTE: Testing using npm install instead of yarn \n' && npm install apps/react/cra install",
     "cra-ts": "yarn --cwd apps/react/cra-ts build ",
     "cra-ts:install": "yarn --cwd apps/react/cra-ts install",
     "next": "yarn --cwd apps/react/next build ",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This updates one of our canary apps to be installed with `npm install` in order to catch differences between `npm install` and `yarn install`. This is inspired by a problem where `npm install` went into an infinite loop on our package but it wasn't caught by canary apps because they only use `yarn install`.

**Tested `yarn react:install` triggers `npm install` for the CRA app:**
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/6165315/178040509-951ed3f0-d49d-4375-8a7b-0cc73ff8cf7d.png">

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
