### PR TITLE
feat: adding formatValue to allow customizing the value format

### DIFF
--- a/docs/src/pages/[platform]/components/sliderfield/examples/SliderFieldFormatValueExample.tsx
+++ b/docs/src/pages/[platform]/components/sliderfield/examples/SliderFieldFormatValueExample.tsx
@@ -1,0 +1,14 @@
+import { SliderField } from '@aws-amplify/ui-react';
+
+export const SliderFieldFormatValueExample = () => {
+  const formatValue = (value: number) => {
+    return `${value}%`;
+  };
+  return (
+    <SliderField
+      label="SliderField with formatted value"
+      defaultValue={50}
+      formatValue={formatValue}
+    />
+  );
+};

--- a/docs/src/pages/[platform]/components/sliderfield/examples/index.ts
+++ b/docs/src/pages/[platform]/components/sliderfield/examples/index.ts
@@ -1,6 +1,7 @@
 export { DefaultSliderFieldExample } from './DefaultSliderFieldExample';
 export { ControlledSliderFieldExample } from './ControlledSliderFieldExample';
 export { SliderFieldBasicsExample } from './SliderFieldBasicsExample';
+export { SliderFieldFormatValueExample } from './SliderFieldFormatValueExample';
 export { SliderFieldOrientationExample } from './SliderFieldOrientationExample';
 export { SliderFieldAriaExample } from './SliderFieldAriaExample';
 export { SliderFieldIconsExample } from './SliderFieldIconsExample';

--- a/docs/src/pages/[platform]/components/sliderfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/sliderfield/props-table.mdx
@@ -140,6 +140,16 @@ StyleToken<Property.Color>
     </TableRow>
 
     <TableRow>
+      <TableCell className="props-table__tr-name">formatValue</TableCell>
+      <TableCell>
+```jsx
+(value: number) => React.ReactNode
+```
+</TableCell>
+      <TableCell className="props-table__tr-description">Uses to format how the value gets rendered</TableCell>
+    </TableRow>
+
+    <TableRow>
       <TableCell className="props-table__tr-name">hasError</TableCell>
       <TableCell>
 ```jsx

--- a/docs/src/pages/[platform]/components/sliderfield/react.mdx
+++ b/docs/src/pages/[platform]/components/sliderfield/react.mdx
@@ -5,6 +5,7 @@ import {
   DefaultSliderFieldExample,
   ControlledSliderFieldExample,
   SliderFieldBasicsExample,
+  SliderFieldFormatValueExample,
   SliderFieldOrientationExample,
   SliderFieldAriaExample,
   SliderFieldIconsExample,
@@ -135,6 +136,19 @@ To add icons on either side of the SliderField, you may use the `outerStartCompo
   </ExampleCode>
 </Example>
 
+### Format value
+To format how the value looks like, you can pass in a render function to `formatValue` prop.
+
+<Example>
+  <SliderFieldFormatValueExample />
+  <ExampleCode>
+  ```jsx file=./examples/SliderFieldFormatValueExample.tsx
+
+  ```
+
+  </ExampleCode>
+</Example>
+
 ### Validation error
 
 To validate the SliderField input, use the `hasError` and `errorMessage` props.
@@ -187,15 +201,6 @@ To override styling on all SliderField components, you can set the Amplify CSS v
   --amplify-components-sliderfield-range-background-color: var(
     --amplify-colors-orange-60
   );
-}
-```
-
-To replace SliderField styling, unset it:
-
-```css
-.amplify-sliderfield {
-  all: unset;
-  /* Add your styling here*/
 }
 ```
 

--- a/packages/react/src/primitives/SliderField/SliderField.tsx
+++ b/packages/react/src/primitives/SliderField/SliderField.tsx
@@ -29,6 +29,7 @@ const SliderFieldPrimitive: Primitive<SliderFieldProps, typeof Root> = (
     emptyTrackColor,
     errorMessage,
     filledTrackColor,
+    formatValue,
     hasError = false,
     id,
     isDisabled,
@@ -77,6 +78,10 @@ const SliderFieldPrimitive: Primitive<SliderFieldProps, typeof Root> = (
     [onChange]
   );
 
+  const formattedValue = isFunction(formatValue)
+    ? formatValue(currentValue)
+    : null;
+
   const isVertical = orientation === 'vertical';
   const componentClasses = classNames(
     ComponentClassNames.SliderFieldTrack,
@@ -109,7 +114,9 @@ const SliderFieldPrimitive: Primitive<SliderFieldProps, typeof Root> = (
         visuallyHidden={labelHidden}
       >
         <View as="span">{label}</View>
-        {!isValueHidden ? <View as="span">{currentValue}</View> : null}
+        {!isValueHidden
+          ? formattedValue ?? <View as="span">{currentValue}</View>
+          : null}
       </Label>
       <FieldDescription
         id={descriptionId}

--- a/packages/react/src/primitives/SliderField/__tests__/SliderField.test.tsx
+++ b/packages/react/src/primitives/SliderField/__tests__/SliderField.test.tsx
@@ -85,13 +85,28 @@ describe('SliderField: ', () => {
 
     it('should display value if isValueHidden is false', async () => {
       render(<SliderField defaultValue={10} label="slider" />);
-      const value = await screen.queryByText('10');
+      const value = screen.queryByText('10');
+      expect(value).toBeInTheDocument();
+    });
+
+    it('should display formatted value if formatValue is provided', async () => {
+      render(
+        <SliderField
+          defaultValue={10}
+          label="slider"
+          formatValue={(value) => {
+            return `${value}%`;
+          }}
+        />
+      );
+
+      const value = await screen.findByText('10%');
       expect(value).toBeInTheDocument();
     });
 
     it('should not display value if isValueHidden is true', async () => {
       render(<SliderField defaultValue={10} label="slider" isValueHidden />);
-      const value = await screen.queryByText('10');
+      const value = screen.queryByText('10');
       expect(value).not.toBeInTheDocument();
     });
   });
@@ -290,7 +305,7 @@ describe('SliderField: ', () => {
         />
       );
 
-      const errorText = await screen.queryByText(errorMessage);
+      const errorText = screen.queryByText(errorMessage);
       expect(errorText).not.toBeInTheDocument();
     });
 
@@ -303,7 +318,7 @@ describe('SliderField: ', () => {
           hasError
         />
       );
-      const errorText = await screen.queryByText(errorMessage);
+      const errorText = screen.queryByText(errorMessage);
       expect(errorText.innerHTML).toContain(errorMessage);
     });
   });
@@ -318,7 +333,7 @@ describe('SliderField: ', () => {
         />
       );
 
-      const descriptiveText = await screen.queryByText('Description');
+      const descriptiveText = screen.queryByText('Description');
       expect(descriptiveText.innerHTML).toContain('Description');
     });
 

--- a/packages/react/src/primitives/types/sliderField.ts
+++ b/packages/react/src/primitives/types/sliderField.ts
@@ -1,4 +1,5 @@
 import { Property } from 'csstype';
+import React from 'react';
 
 import { StyleToken } from './style';
 import { TextInputFieldProps } from './textField';
@@ -73,6 +74,12 @@ export interface SliderFieldProps extends TextInputFieldProps, ViewProps {
    * Sets the SliderField’s initial value on render
    */
   defaultValue?: number;
+
+  /**
+   * @description
+   * Uses to format how the value gets rendered
+   */
+  formatValue?: (value: number) => React.ReactNode;
 
   /**
    * @description


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adding a new `formatValue` prop to `SliderField` so that the value is allowed to be formatted

#### Issue #, if available

Fixes #2040 

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
