### PR TITLE
fix: username undefined with autoconfirmed lambda

### DIFF
--- a/.changeset/nervous-clocks-reply.md
+++ b/.changeset/nervous-clocks-reply.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui': patch
+---
+
+Fixed issue when customer is using auto confirmed lambda. Now it will work again.

--- a/.changeset/nervous-clocks-reply.md
+++ b/.changeset/nervous-clocks-reply.md
@@ -2,4 +2,4 @@
 '@aws-amplify/ui': patch
 ---
 
-Fixed issue when customer is using auto confirmed lambda. Now it will work again.
+Fixed bug that displayed "usernamed undefined" when using a lambda that autoconfirms the user during sign up. The sign up would fail and redirect the user to sign in with the "username undefined" error. The user then would have to sign in again. This patch will now assign the correct credentials during sign up for users that are auto confirmed. 

--- a/packages/e2e/cypress/fixtures/sign-up-with-email-with-lambda-trigger.json
+++ b/packages/e2e/cypress/fixtures/sign-up-with-email-with-lambda-trigger.json
@@ -1,9 +1,4 @@
 {
-  "CodeDeliveryDetails": {
-    "AttributeName": "email",
-    "DeliveryMedium": "EMAIL",
-    "Destination": "a***@e***.com"
-  },
   "UserConfirmed": true,
   "UserSub": "••••••-••••-••••-••••-•••••••••••••"
 }

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -7,6 +7,7 @@ import { get, escapeRegExp } from 'lodash';
 
 let language = 'en-US';
 let window = null;
+let stub = null;
 
 /**
  * Given dot delimited paths to a method (e.g. Amplify.Auth.signIn) on window,
@@ -105,10 +106,15 @@ Given(
 
     cy.fixture(fixture).then((result) => {
       console.info('`%s` mocked with %o', path, result);
-      cy.stub(obj, method).returns(result);
+      stub = cy.stub(obj, method);
+      stub.returns(result);
     });
   }
 );
+
+When('Sign in was called with {string}', (username: string) => {
+  expect(stub.calledWith(username, Cypress.env('VALID_PASSWORD'))).to.be.true;
+});
 
 When('I type an invalid password', () => {
   cy.findInputField('Password').type('invalidpass');

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -113,7 +113,9 @@ Given(
 );
 
 When('Sign in was called with {string}', (username: string) => {
-  expect(stub.calledWith(username, Cypress.env('VALID_PASSWORD'))).to.be.true;
+  let tempStub = stub.calledWith(username, Cypress.env('VALID_PASSWORD'));
+  stub = null;
+  expect(tempStub).to.be.true;
 });
 
 When('I type an invalid password', () => {

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-email-with-lambda-trigger.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-email-with-lambda-trigger.feature
@@ -22,3 +22,14 @@ Feature: Sign Up with Email with Pre Sign Up Lambda Trigger for Auto Confirmatio
     And I mock 'Amplify.Auth.currentAuthenticatedUser' with fixture "Auth.currentAuthenticatedUser-verified-email"
     And I click the "Create Account" button
     Then I see "Sign out"
+
+  @angular @react @vue  
+  Scenario: Sign up with an email & password and verify it was called correctly
+    When I type a new "email" with value 'TEST@example.com'
+    And I type my password
+    And I confirm my password
+    And I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-email-with-lambda-trigger"
+    And I mock 'Amplify.Auth.signIn' with fixture "sign-up-with-email-with-lambda-trigger"
+    And I click the "Create Account" button
+    And I see "Sign out"
+    Then Sign in was called with 'TEST@example.com'

--- a/packages/ui/src/machines/authenticator/signUp.ts
+++ b/packages/ui/src/machines/authenticator/signUp.ts
@@ -114,7 +114,7 @@ export function createSignUpMachine({ services }: SignUpMachineOptions) {
                       {
                         cond: 'shouldSkipConfirm',
                         target: 'skipConfirm',
-                        actions: ['setUser'],
+                        actions: ['setUser', 'setCredentials'],
                       },
                       {
                         target: 'resolved',


### PR DESCRIPTION
#### Description of changes
When using auto confirmed lambda an error will show that the `username is not defined`

This PR sets the correct credentials, so the sign in can occur correctly. This was caused by a regression that no longer
set the credentials when you skip the confirmed page.

#### Issue #, if available

#2235 

#### Description of how you validated changes

Created new test to check values being sent to SignIn

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
