### PR TITLE
docs(chore): Update standard HTML attributes

### DIFF
--- a/docs/scripts/generate-props-tables.ts
+++ b/docs/scripts/generate-props-tables.ts
@@ -1,10 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { globbyStream } from 'globby';
-// refactor this to import all from ./util
-import { getCatalog } from './util/getCatalog';
-import { getAllTypesData } from './util/getAllTypesData';
-import { getStandardHTMLAttributes } from './util/getStandardHTMLAttributes';
+import { getCatalog, getAllTypesData, getStandardHTMLAttributes } from './util';
 import type {
   Catalog,
   Category,
@@ -16,7 +13,6 @@ import { capitalizeString } from '@/utils/capitalizeString';
 
 const catalog = getCatalog();
 const { allTypeFilesInterfaceData } = getAllTypesData();
-// debugger;
 
 createAllPropsTables();
 

--- a/docs/scripts/generate-props-tables.ts
+++ b/docs/scripts/generate-props-tables.ts
@@ -1,8 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import { globbyStream } from 'globby';
+// refactor this to import all from ./util
 import { getCatalog } from './util/getCatalog';
 import { getAllTypesData } from './util/getAllTypesData';
+import { getStandardHTMLAttributes } from './util/getStandardHTMLAttributes';
 import type {
   Catalog,
   Category,
@@ -14,7 +16,7 @@ import { capitalizeString } from '@/utils/capitalizeString';
 
 const catalog = getCatalog();
 const { allTypeFilesInterfaceData } = getAllTypesData();
-debugger;
+// debugger;
 
 createAllPropsTables();
 
@@ -78,9 +80,6 @@ type CategoryProperty = { [key in Category]: Properties };
 type SortedPropertiesByCategory = { [key: string]: Properties }[];
 type PropertiesByCategory = Record<Category, Properties>;
 
-/**
- * @todo After Marketing Launch 2022-06, to update the note under the Props Heading to specify the HTML element's name and MDN link. Ticket: https://app.asana.com/0/1201736086077838/1202477702049308/f
- */
 function Output(displayName, tableAndExpanders) {
   return `
 {/* DO NOT EDIT DIRECTLY */}
@@ -92,7 +91,7 @@ ${tableAndExpanders.join('')}
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The ${displayName} component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+${getStandardHTMLAttributes(displayName)}
 `;
 }
 

--- a/docs/scripts/util/getStandardHTMLAttributes.ts
+++ b/docs/scripts/util/getStandardHTMLAttributes.ts
@@ -59,7 +59,6 @@ const standardHTMLAttributes: StandardHTMLAttributes = {
   Grid: {
     element: 'div',
   },
-  // check this one
   Heading: {
     element: 'h1-h6',
     url: `${baseURL}/Heading_Elements`,
@@ -150,13 +149,11 @@ const standardHTMLAttributes: StandardHTMLAttributes = {
 };
 
 export const getStandardHTMLAttributes = (displayName: string) => {
-  console.log('display name: ', displayName);
-
   const { element, url } = standardHTMLAttributes[displayName];
 
   const MDNlink = `<Link href="${
     url || `${baseURL}/${element}`
   }" isExternal>MDN Documentation</Link>`;
 
-  return `${displayName} will also accept any of the standard HTML attributes that a <code>${element}</code> accepts, which can be found in the ${MDNlink}.`;
+  return `${displayName} will also accept any of the standard HTML attributes that a <code>${element}</code> element accepts, which can be found in the ${MDNlink}.`;
 };

--- a/docs/scripts/util/getStandardHTMLAttributes.ts
+++ b/docs/scripts/util/getStandardHTMLAttributes.ts
@@ -6,12 +6,17 @@ const standardHTMLAttributes = {
   Alert: {
     element: 'div',
   },
+  Badge: {
+    element: 'span',
+  },
 };
 
 // if this still works, can we change it to a .ts file?
 // const codeSnippet = <code></code>;
 
 export const getStandardHTMLAttributes = (displayName: string) => {
+  console.log('display name: ', displayName);
+
   const { element, link } = standardHTMLAttributes[displayName];
 
   const MDNlink = `<Link href="${

--- a/docs/scripts/util/getStandardHTMLAttributes.ts
+++ b/docs/scripts/util/getStandardHTMLAttributes.ts
@@ -1,18 +1,173 @@
-// include type/interface
-// standard url prefix
-// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/
+import type { ComponentName } from '../types/catalog';
 
-const standardHTMLAttributes = {
+type ComponentNames = Exclude<
+  ComponentName,
+  | 'ButtonGroup'
+  | 'ExpanderItem'
+  | 'FieldGroupIcon'
+  | 'FieldGroupIconButton'
+  | 'MenuButton'
+  | 'MenuItem'
+  | 'Radio'
+  | 'TabItem'
+  | 'ToggleButtonGroup'
+  | 'TableBody'
+  | 'TableCell'
+  | 'TableFoot'
+  | 'TableHead'
+  | 'TableRow'
+>;
+
+type StandardHTMLAttributes = {
+  [key in ComponentNames]: {
+    element: string;
+    link?: string;
+  };
+};
+
+const standardHTMLAttributes: StandardHTMLAttributes = {
   Alert: {
     element: 'div',
   },
   Badge: {
     element: 'span',
   },
+  Card: {
+    element: 'div',
+  },
+  Button: {
+    element: '',
+    link: '',
+  },
+  CheckboxField: {
+    element: '',
+    link: '',
+  },
+  Collection: {
+    element: '',
+    link: '',
+  },
+  Divider: {
+    element: '',
+    link: '',
+  },
+  Expander: {
+    element: '',
+    link: '',
+  },
+  Flex: {
+    element: '',
+    link: '',
+  },
+  Grid: {
+    element: '',
+    link: '',
+  },
+  Heading: {
+    element: '',
+    link: '',
+  },
+  Icon: {
+    element: '',
+    link: '',
+  },
+  Image: {
+    element: '',
+    link: '',
+  },
+  Link: {
+    element: '',
+    link: '',
+  },
+  Loader: {
+    element: '',
+    link: '',
+  },
+  Menu: {
+    element: '',
+    link: '',
+  },
+  Pagination: {
+    element: '',
+    link: '',
+  },
+  PasswordField: {
+    element: '',
+    link: '',
+  },
+  PhoneNumberField: {
+    element: '',
+    link: '',
+  },
+  Placeholder: {
+    element: '',
+    link: '',
+  },
+  RadioGroupField: {
+    element: '',
+    link: '',
+  },
+  Rating: {
+    element: '',
+    link: '',
+  },
+  ScrollView: {
+    element: '',
+    link: '',
+  },
+  SearchField: {
+    element: '',
+    link: '',
+  },
+  SelectField: {
+    element: '',
+    link: '',
+  },
+  SliderField: {
+    element: '',
+    link: '',
+  },
+  StepperField: {
+    element: '',
+    link: '',
+  },
+  SwitchField: {
+    element: '',
+    link: '',
+  },
+  Table: {
+    element: '',
+    link: '',
+  },
+  Tabs: {
+    element: '',
+    link: '',
+  },
+  Text: {
+    element: '',
+    link: '',
+  },
+  TextAreaField: {
+    element: '',
+    link: '',
+  },
+  TextField: {
+    element: '',
+    link: '',
+  },
+  ToggleButton: {
+    element: '',
+    link: '',
+  },
+  View: {
+    element: '',
+    link: '',
+  },
+  VisuallyHidden: {
+    element: '',
+    link: '',
+  },
 };
-
-// if this still works, can we change it to a .ts file?
-// const codeSnippet = <code></code>;
 
 export const getStandardHTMLAttributes = (displayName: string) => {
   console.log('display name: ', displayName);

--- a/docs/scripts/util/getStandardHTMLAttributes.ts
+++ b/docs/scripts/util/getStandardHTMLAttributes.ts
@@ -1,5 +1,7 @@
 import type { ComponentName } from '../types/catalog';
 
+const baseURL = `https://developer.mozilla.org/en-US/docs/Web/HTML/Element`;
+
 type ComponentNames = Exclude<
   ComponentName,
   | 'ButtonGroup'
@@ -21,7 +23,7 @@ type ComponentNames = Exclude<
 type StandardHTMLAttributes = {
   [key in ComponentNames]: {
     element: string;
-    link?: string;
+    url?: string;
   };
 };
 
@@ -36,147 +38,124 @@ const standardHTMLAttributes: StandardHTMLAttributes = {
     element: 'div',
   },
   Button: {
-    element: '',
-    link: '',
+    element: 'button',
   },
   CheckboxField: {
-    element: '',
-    link: '',
+    element: 'input',
+    url: `${baseURL}/input/checkbox`,
   },
   Collection: {
-    element: '',
-    link: '',
+    element: 'div',
   },
   Divider: {
-    element: '',
-    link: '',
+    element: 'hr',
   },
   Expander: {
-    element: '',
-    link: '',
+    element: 'div',
   },
   Flex: {
-    element: '',
-    link: '',
+    element: 'div',
   },
   Grid: {
-    element: '',
-    link: '',
+    element: 'div',
   },
+  // check this one
   Heading: {
-    element: '',
-    link: '',
+    element: 'h1-h6',
+    url: `${baseURL}/Heading_Elements`,
   },
   Icon: {
-    element: '',
-    link: '',
+    element: 'svg',
+    url: `https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg`,
   },
   Image: {
-    element: '',
-    link: '',
+    element: 'img',
   },
   Link: {
-    element: '',
-    link: '',
+    element: 'a',
   },
   Loader: {
-    element: '',
-    link: '',
+    element: 'svg',
+    url: `https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg`,
   },
   Menu: {
-    element: '',
-    link: '',
+    element: 'div',
   },
   Pagination: {
-    element: '',
-    link: '',
+    element: 'nav',
   },
   PasswordField: {
-    element: '',
-    link: '',
+    element: 'input',
+    url: `${baseURL}/input/password`,
   },
   PhoneNumberField: {
-    element: '',
-    link: '',
+    element: 'input',
+    url: `${baseURL}/input/tel`,
   },
   Placeholder: {
-    element: '',
-    link: '',
+    element: 'div',
   },
   RadioGroupField: {
-    element: '',
-    link: '',
+    element: 'input',
+    url: `${baseURL}/input/radio`,
   },
   Rating: {
-    element: '',
-    link: '',
+    element: 'div',
   },
   ScrollView: {
-    element: '',
-    link: '',
+    element: 'div',
   },
   SearchField: {
-    element: '',
-    link: '',
+    element: 'input',
+    url: `${baseURL}/input/search`,
   },
   SelectField: {
-    element: '',
-    link: '',
+    element: 'select',
   },
   SliderField: {
-    element: '',
-    link: '',
+    element: 'span',
   },
   StepperField: {
-    element: '',
-    link: '',
+    element: 'input',
+    url: `${baseURL}/input/number`,
   },
   SwitchField: {
-    element: '',
-    link: '',
+    element: 'input',
+    url: `${baseURL}/input/checkbox`,
   },
   Table: {
-    element: '',
-    link: '',
+    element: 'table',
   },
   Tabs: {
-    element: '',
-    link: '',
+    element: 'div',
   },
   Text: {
-    element: '',
-    link: '',
+    element: 'p',
   },
   TextAreaField: {
-    element: '',
-    link: '',
+    element: 'textarea',
   },
   TextField: {
-    element: '',
-    link: '',
+    element: 'textarea',
   },
   ToggleButton: {
-    element: '',
-    link: '',
+    element: 'button',
   },
   View: {
-    element: '',
-    link: '',
+    element: 'div',
   },
   VisuallyHidden: {
-    element: '',
-    link: '',
+    element: 'span',
   },
 };
 
 export const getStandardHTMLAttributes = (displayName: string) => {
   console.log('display name: ', displayName);
 
-  const { element, link } = standardHTMLAttributes[displayName];
+  const { element, url } = standardHTMLAttributes[displayName];
 
   const MDNlink = `<Link href="${
-    link ||
-    `https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${element}`
+    url || `${baseURL}/${element}`
   }" isExternal>MDN Documentation</Link>`;
 
   return `${displayName} will also accept any of the standard HTML attributes that a <code>${element}</code> accepts, which can be found in the ${MDNlink}.`;

--- a/docs/scripts/util/getStandardHTMLAttributes.tsx
+++ b/docs/scripts/util/getStandardHTMLAttributes.tsx
@@ -1,0 +1,23 @@
+// include type/interface
+// standard url prefix
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/
+
+const standardHTMLAttributes = {
+  Alert: {
+    element: 'div',
+  },
+};
+
+// if this still works, can we change it to a .ts file?
+// const codeSnippet = <code></code>;
+
+export const getStandardHTMLAttributes = (displayName: string) => {
+  const { element, link } = standardHTMLAttributes[displayName];
+
+  const MDNlink = `<Link href="${
+    link ||
+    `https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${element}`
+  }" isExternal>MDN Documentation</Link>`;
+
+  return `${displayName} will also accept any of the standard HTML attributes that a <code>${element}</code> accepts, which can be found in the ${MDNlink}.`;
+};

--- a/docs/scripts/util/index.ts
+++ b/docs/scripts/util/index.ts
@@ -1,0 +1,3 @@
+export { getAllTypesData } from './getAllTypesData';
+export { getCatalog } from './getCatalog';
+export { getStandardHTMLAttributes } from './getStandardHTMLAttributes';

--- a/docs/src/components/StandardHTMLAttributes.mdx
+++ b/docs/src/components/StandardHTMLAttributes.mdx
@@ -1,9 +1,0 @@
-import { Link } from '@aws-amplify/ui-react';
-import { Fragment } from '@/components/Fragment';
-
-### Standard HTML attributes
-
-The <code>{props.component}</code> will accept any of the standard HTML attributes that a <code>{props.element}</code> element accepts.
-Standard <code>{props.element}</code> attributes can be found in the <Link isExternal="true" href={`https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${props.link||props.component}#attributes`}>MDN Documentation</Link>
-
-<>{props.children}</>

--- a/docs/src/pages/[platform]/components/alert/props-table.mdx
+++ b/docs/src/pages/[platform]/components/alert/props-table.mdx
@@ -382,4 +382,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Alert will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal={true}>MDN Documentation</Link>
+Alert will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/alert/props-table.mdx
+++ b/docs/src/pages/[platform]/components/alert/props-table.mdx
@@ -382,4 +382,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Alert will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+Alert will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/alert/props-table.mdx
+++ b/docs/src/pages/[platform]/components/alert/props-table.mdx
@@ -382,4 +382,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Alert component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Alert will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal={true}>MDN Documentation</Link>

--- a/docs/src/pages/[platform]/components/badge/props-table.mdx
+++ b/docs/src/pages/[platform]/components/badge/props-table.mdx
@@ -262,4 +262,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Badge component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Badge will also accept any of the standard HTML attributes that a <code>span</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/badge/props-table.mdx
+++ b/docs/src/pages/[platform]/components/badge/props-table.mdx
@@ -262,4 +262,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Badge will also accept any of the standard HTML attributes that a <code>span</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span" isExternal>MDN Documentation</Link>.
+Badge will also accept any of the standard HTML attributes that a <code>span</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/button/props-table.mdx
+++ b/docs/src/pages/[platform]/components/button/props-table.mdx
@@ -492,4 +492,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Button component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Button will also accept any of the standard HTML attributes that a <code>button</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/button/props-table.mdx
+++ b/docs/src/pages/[platform]/components/button/props-table.mdx
@@ -492,4 +492,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Button will also accept any of the standard HTML attributes that a <code>button</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button" isExternal>MDN Documentation</Link>.
+Button will also accept any of the standard HTML attributes that a <code>button</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/button/react.mdx
+++ b/docs/src/pages/[platform]/components/button/react.mdx
@@ -2,7 +2,6 @@ import { Fragment } from '@/components/Fragment';
 import { Button, ButtonGroup, Flex, View } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
 import { ComponentClassTable } from '@/components/ComponentClassTable';
-import StandardHTMLAttributes from '@/components/StandardHTMLAttributes.mdx';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 import ThemeExample from '@/components/ThemeExample.mdx';
 
@@ -247,21 +246,6 @@ import '@aws-amplify/ui-react/styles.css';
 
 </ExampleCode>
 </Example>
-
-<StandardHTMLAttributes component="Button" element="<button>">
-  <Example>
-    <Button name="named">Named</Button>
-
-    <ExampleCode>
-
-    ```jsx
-    <Button name="named">Named</Button>
-    ```
-
-    </ExampleCode>
-
-  </Example>
-</StandardHTMLAttributes>
 
 ## Customization
 

--- a/docs/src/pages/[platform]/components/card/props-table.mdx
+++ b/docs/src/pages/[platform]/components/card/props-table.mdx
@@ -252,4 +252,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Card will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+Card will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/card/props-table.mdx
+++ b/docs/src/pages/[platform]/components/card/props-table.mdx
@@ -252,4 +252,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Card component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Card will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/checkboxfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/checkboxfield/props-table.mdx
@@ -522,4 +522,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-CheckboxField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox" isExternal>MDN Documentation</Link>.
+CheckboxField will also accept any of the standard HTML attributes that a <code>input</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/checkboxfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/checkboxfield/props-table.mdx
@@ -522,4 +522,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The CheckboxField component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+CheckboxField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/checkboxfield/react.mdx
+++ b/docs/src/pages/[platform]/components/checkboxfield/react.mdx
@@ -4,7 +4,6 @@ import { CheckboxDemo } from './demo';
 import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
 import { ComponentClassTable } from '@/components/ComponentClassTable';
-import StandardHTMLAttributes from '@/components/StandardHTMLAttributes.mdx';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 import ThemeExample from '@/components/ThemeExample.mdx';
 
@@ -137,21 +136,6 @@ import { CheckboxField } from '@aws-amplify/ui-react';
     labelHidden={true}
   />
 </Example>
-
-<StandardHTMLAttributes component="CheckboxField" link="input" element="<input>">
-  <Example>
-    <CheckboxField label="Subscribe to our newsletter" name="subscribe" value="yes" />
-
-    <ExampleCode>
-
-    ```jsx
-    <CheckboxField label="Subscribe to our newsletter" name="subscribe" value="yes" />
-    ```
-
-    </ExampleCode>
-
-  </Example>
-</StandardHTMLAttributes>
 
 ## CSS Styling
 

--- a/docs/src/pages/[platform]/components/collection/props-table.mdx
+++ b/docs/src/pages/[platform]/components/collection/props-table.mdx
@@ -402,4 +402,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Collection component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Collection will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/collection/props-table.mdx
+++ b/docs/src/pages/[platform]/components/collection/props-table.mdx
@@ -402,4 +402,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Collection will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+Collection will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/divider/props-table.mdx
+++ b/docs/src/pages/[platform]/components/divider/props-table.mdx
@@ -272,4 +272,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Divider component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Divider will also accept any of the standard HTML attributes that a <code>hr</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/divider/props-table.mdx
+++ b/docs/src/pages/[platform]/components/divider/props-table.mdx
@@ -272,4 +272,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Divider will also accept any of the standard HTML attributes that a <code>hr</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr" isExternal>MDN Documentation</Link>.
+Divider will also accept any of the standard HTML attributes that a <code>hr</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/expander/props-table.mdx
+++ b/docs/src/pages/[platform]/components/expander/props-table.mdx
@@ -575,4 +575,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Expander component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Expander will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/expander/props-table.mdx
+++ b/docs/src/pages/[platform]/components/expander/props-table.mdx
@@ -575,4 +575,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Expander will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+Expander will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/flex/props-table.mdx
+++ b/docs/src/pages/[platform]/components/flex/props-table.mdx
@@ -392,4 +392,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Flex component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Flex will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/flex/props-table.mdx
+++ b/docs/src/pages/[platform]/components/flex/props-table.mdx
@@ -392,4 +392,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Flex will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+Flex will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/grid/props-table.mdx
+++ b/docs/src/pages/[platform]/components/grid/props-table.mdx
@@ -512,4 +512,4 @@ ResponsiveStyle<Property.GridTemplateRows<0 | (string & {})>>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Grid component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Grid will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/grid/props-table.mdx
+++ b/docs/src/pages/[platform]/components/grid/props-table.mdx
@@ -512,4 +512,4 @@ ResponsiveStyle<Property.GridTemplateRows<0 | (string & {})>>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Grid will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+Grid will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/heading/props-table.mdx
+++ b/docs/src/pages/[platform]/components/heading/props-table.mdx
@@ -278,4 +278,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Heading component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Heading will also accept any of the standard HTML attributes that a <code>h1-h6</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/heading/props-table.mdx
+++ b/docs/src/pages/[platform]/components/heading/props-table.mdx
@@ -278,4 +278,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Heading will also accept any of the standard HTML attributes that a <code>h1-h6</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements" isExternal>MDN Documentation</Link>.
+Heading will also accept any of the standard HTML attributes that a <code>h1-h6</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/icon/props-table.mdx
+++ b/docs/src/pages/[platform]/components/icon/props-table.mdx
@@ -307,4 +307,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Icon component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Icon will also accept any of the standard HTML attributes that a <code>svg</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/icon/props-table.mdx
+++ b/docs/src/pages/[platform]/components/icon/props-table.mdx
@@ -307,4 +307,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Icon will also accept any of the standard HTML attributes that a <code>svg</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg" isExternal>MDN Documentation</Link>.
+Icon will also accept any of the standard HTML attributes that a <code>svg</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/image/props-table.mdx
+++ b/docs/src/pages/[platform]/components/image/props-table.mdx
@@ -322,4 +322,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Image will also accept any of the standard HTML attributes that a <code>img</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img" isExternal>MDN Documentation</Link>.
+Image will also accept any of the standard HTML attributes that a <code>img</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/image/props-table.mdx
+++ b/docs/src/pages/[platform]/components/image/props-table.mdx
@@ -322,4 +322,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Image component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Image will also accept any of the standard HTML attributes that a <code>img</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/link/props-table.mdx
+++ b/docs/src/pages/[platform]/components/link/props-table.mdx
@@ -282,4 +282,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Link will also accept any of the standard HTML attributes that a <code>a</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a" isExternal>MDN Documentation</Link>.
+Link will also accept any of the standard HTML attributes that a <code>a</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/link/props-table.mdx
+++ b/docs/src/pages/[platform]/components/link/props-table.mdx
@@ -282,4 +282,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Link component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Link will also accept any of the standard HTML attributes that a <code>a</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/loader/props-table.mdx
+++ b/docs/src/pages/[platform]/components/loader/props-table.mdx
@@ -312,4 +312,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Loader will also accept any of the standard HTML attributes that a <code>svg</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg" isExternal>MDN Documentation</Link>.
+Loader will also accept any of the standard HTML attributes that a <code>svg</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/loader/props-table.mdx
+++ b/docs/src/pages/[platform]/components/loader/props-table.mdx
@@ -312,4 +312,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Loader component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Loader will also accept any of the standard HTML attributes that a <code>svg</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/menu/props-table.mdx
+++ b/docs/src/pages/[platform]/components/menu/props-table.mdx
@@ -1168,4 +1168,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Menu will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+Menu will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/menu/props-table.mdx
+++ b/docs/src/pages/[platform]/components/menu/props-table.mdx
@@ -1168,4 +1168,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Menu component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Menu will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/pagination/props-table.mdx
+++ b/docs/src/pages/[platform]/components/pagination/props-table.mdx
@@ -352,4 +352,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Pagination will also accept any of the standard HTML attributes that a <code>nav</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav" isExternal>MDN Documentation</Link>.
+Pagination will also accept any of the standard HTML attributes that a <code>nav</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/pagination/props-table.mdx
+++ b/docs/src/pages/[platform]/components/pagination/props-table.mdx
@@ -352,4 +352,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Pagination component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Pagination will also accept any of the standard HTML attributes that a <code>nav</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/passwordfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/passwordfield/props-table.mdx
@@ -592,4 +592,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-PasswordField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password" isExternal>MDN Documentation</Link>.
+PasswordField will also accept any of the standard HTML attributes that a <code>input</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/passwordfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/passwordfield/props-table.mdx
@@ -592,4 +592,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The PasswordField component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+PasswordField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/passwordfield/react.mdx
+++ b/docs/src/pages/[platform]/components/passwordfield/react.mdx
@@ -11,7 +11,6 @@ import { PasswordFieldDemo } from './demo';
 import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
 import { ComponentClassTable } from '@/components/ComponentClassTable';
-import StandardHTMLAttributes from '@/components/StandardHTMLAttributes.mdx';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 import ThemeExample from '@/components/ThemeExample.mdx';
 import {
@@ -234,19 +233,6 @@ The following is an example demonstrating use of the `ref` and `showPasswordButt
 
 </ExampleCode>
 </Example>
-
-<StandardHTMLAttributes component="PasswordField" link="input" element="<input>">
-  <Example>
-    <MaxLengthExample />
-    <ExampleCode>
-
-    ```jsx file=./examples/MaxLengthExample.tsx
-    ```
-
-    </ExampleCode>
-
-  </Example>
-</StandardHTMLAttributes>
 
 ## CSS Styling
 

--- a/docs/src/pages/[platform]/components/phonenumberfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/phonenumberfield/props-table.mdx
@@ -612,4 +612,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The PhoneNumberField component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+PhoneNumberField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/phonenumberfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/phonenumberfield/props-table.mdx
@@ -612,4 +612,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-PhoneNumberField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel" isExternal>MDN Documentation</Link>.
+PhoneNumberField will also accept any of the standard HTML attributes that a <code>input</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/phonenumberfield/react.mdx
+++ b/docs/src/pages/[platform]/components/phonenumberfield/react.mdx
@@ -5,7 +5,6 @@ import { PhoneNumberFieldDemo } from './demo';
 import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
 import { ComponentClassTable } from '@/components/ComponentClassTable';
-import StandardHTMLAttributes from '@/components/StandardHTMLAttributes.mdx';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 import ThemeExample from '@/components/ThemeExample.mdx';
 import {
@@ -211,21 +210,6 @@ The following is a contrived example demonstrating use of the `ref` and `country
 
   </ExampleCode>
 </Example>
-
-<StandardHTMLAttributes component="PhoneNumberField" link="input" element="<input>">
-  <Example>
-    <PhoneNumberField label="Phone Number" name="phone"/>
-
-    <ExampleCode>
-
-    ```jsx
-    <PhoneNumberField label="Phone Number" name="phone"/>
-    ```
-
-    </ExampleCode>
-
-  </Example>
-</StandardHTMLAttributes>
 
 ## CSS Styling
 

--- a/docs/src/pages/[platform]/components/placeholder/props-table.mdx
+++ b/docs/src/pages/[platform]/components/placeholder/props-table.mdx
@@ -262,4 +262,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Placeholder will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+Placeholder will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/placeholder/props-table.mdx
+++ b/docs/src/pages/[platform]/components/placeholder/props-table.mdx
@@ -262,4 +262,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Placeholder component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Placeholder will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/radiogroupfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/radiogroupfield/props-table.mdx
@@ -925,4 +925,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The RadioGroupField component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+RadioGroupField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/radiogroupfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/radiogroupfield/props-table.mdx
@@ -925,4 +925,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-RadioGroupField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio" isExternal>MDN Documentation</Link>.
+RadioGroupField will also accept any of the standard HTML attributes that a <code>input</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/rating/props-table.mdx
+++ b/docs/src/pages/[platform]/components/rating/props-table.mdx
@@ -392,4 +392,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Rating component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Rating will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/rating/props-table.mdx
+++ b/docs/src/pages/[platform]/components/rating/props-table.mdx
@@ -392,4 +392,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Rating will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+Rating will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/scrollview/props-table.mdx
+++ b/docs/src/pages/[platform]/components/scrollview/props-table.mdx
@@ -252,4 +252,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-ScrollView will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+ScrollView will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/scrollview/props-table.mdx
+++ b/docs/src/pages/[platform]/components/scrollview/props-table.mdx
@@ -252,4 +252,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The ScrollView component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+ScrollView will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/searchfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/searchfield/props-table.mdx
@@ -592,4 +592,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-SearchField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search" isExternal>MDN Documentation</Link>.
+SearchField will also accept any of the standard HTML attributes that a <code>input</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/searchfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/searchfield/props-table.mdx
@@ -592,4 +592,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The SearchField component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+SearchField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/searchfield/react.mdx
+++ b/docs/src/pages/[platform]/components/searchfield/react.mdx
@@ -3,7 +3,6 @@ import { SearchField, Flex, View } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
 import { ComponentClassTable } from '@/components/ComponentClassTable';
-import StandardHTMLAttributes from '@/components/StandardHTMLAttributes.mdx';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 import ThemeExample from '@/components/ThemeExample.mdx';
 import { SearchFieldDemo } from './demo';
@@ -120,21 +119,6 @@ The following is a contrived example demonstrating use of the ref props:
 
 </ExampleCode>
 </Example>
-
-<StandardHTMLAttributes component="SearchField" link="input" element="<input>">
-  <Example>
-    <SearchField label="Search" name="search"/>
-
-    <ExampleCode>
-
-    ```jsx
-    <SearchField label="Search" name="search"/>
-    ```
-
-    </ExampleCode>
-
-  </Example>
-</StandardHTMLAttributes>
 
 ## CSS Styling
 

--- a/docs/src/pages/[platform]/components/selectfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/selectfield/props-table.mdx
@@ -492,4 +492,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The SelectField component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+SelectField will also accept any of the standard HTML attributes that a <code>select</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/selectfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/selectfield/props-table.mdx
@@ -492,4 +492,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-SelectField will also accept any of the standard HTML attributes that a <code>select</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select" isExternal>MDN Documentation</Link>.
+SelectField will also accept any of the standard HTML attributes that a <code>select</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/selectfield/react.mdx
+++ b/docs/src/pages/[platform]/components/selectfield/react.mdx
@@ -3,7 +3,6 @@ import { SelectField, Flex, IconArrowDropDown } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
 import { ComponentClassTable } from '@/components/ComponentClassTable';
-import StandardHTMLAttributes from '@/components/StandardHTMLAttributes.mdx';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 import ThemeExample from '@/components/ThemeExample.mdx';
 import { SelectFieldDemo, ControlledSelect } from './demo.tsx';
@@ -188,29 +187,6 @@ Use the `hasError` and `errorMessage` props to mark a SelectField as having a va
 
   </ExampleCode>
 </Example>
-
-<StandardHTMLAttributes component="SelectField" link="select" element="<select>">
-  <Example>
-    <SelectField label="Fruit" name="fruit">
-      <option value="apple">Apple</option>
-      <option value="banana">Banana</option>
-      <option value="orange">Orange</option>
-    </SelectField>
-
-    <ExampleCode>
-
-    ```jsx
-    <SelectField label="Fruit" name="fruit">
-      <option value="apple">Apple</option>
-      <option value="banana">Banana</option>
-      <option value="orange">Orange</option>
-    </SelectField>
-    ```
-
-    </ExampleCode>
-
-  </Example>
-</StandardHTMLAttributes>
 
 ## CSS Styling
 

--- a/docs/src/pages/[platform]/components/sliderfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/sliderfield/props-table.mdx
@@ -692,4 +692,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The SliderField component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+SliderField will also accept any of the standard HTML attributes that a <code>span</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/sliderfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/sliderfield/props-table.mdx
@@ -692,4 +692,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-SliderField will also accept any of the standard HTML attributes that a <code>span</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span" isExternal>MDN Documentation</Link>.
+SliderField will also accept any of the standard HTML attributes that a <code>span</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/stepperfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/stepperfield/props-table.mdx
@@ -632,4 +632,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The StepperField component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+StepperField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/stepperfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/stepperfield/props-table.mdx
@@ -632,4 +632,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-StepperField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number" isExternal>MDN Documentation</Link>.
+StepperField will also accept any of the standard HTML attributes that a <code>input</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/stepperfield/react.mdx
+++ b/docs/src/pages/[platform]/components/stepperfield/react.mdx
@@ -14,7 +14,6 @@ import {
 import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
 import { ComponentClassTable } from '@/components/ComponentClassTable';
-import StandardHTMLAttributes from '@/components/StandardHTMLAttributes.mdx';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 import ThemeExample from '@/components/ThemeExample.mdx';
 
@@ -122,33 +121,6 @@ Use the `hasError` and `errorMessage` props to mark a StepperField as having an 
 
   </ExampleCode>
 </Example>
-
-<StandardHTMLAttributes component="StepperField" link="input" element="<input>">
-  <Example>
-    <StepperField
-      label="Stepper"
-      min={0}
-      max={10}
-      step={1}
-      name="stepper"
-    />
-
-    <ExampleCode>
-
-    ```jsx
-    <StepperField
-      label="Stepper"
-      min={0}
-      max={10}
-      step={1}
-      name="stepper"
-    />
-    ```
-
-    </ExampleCode>
-
-  </Example>
-</StandardHTMLAttributes>
 
 ## CSS Styling
 

--- a/docs/src/pages/[platform]/components/switchfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/switchfield/props-table.mdx
@@ -582,4 +582,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The SwitchField component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+SwitchField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/switchfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/switchfield/props-table.mdx
@@ -582,4 +582,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-SwitchField will also accept any of the standard HTML attributes that a <code>input</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox" isExternal>MDN Documentation</Link>.
+SwitchField will also accept any of the standard HTML attributes that a <code>input</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/table/props-table.mdx
+++ b/docs/src/pages/[platform]/components/table/props-table.mdx
@@ -1497,4 +1497,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Table component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Table will also accept any of the standard HTML attributes that a <code>table</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/table/props-table.mdx
+++ b/docs/src/pages/[platform]/components/table/props-table.mdx
@@ -1497,4 +1497,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Table will also accept any of the standard HTML attributes that a <code>table</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table" isExternal>MDN Documentation</Link>.
+Table will also accept any of the standard HTML attributes that a <code>table</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/table/react.mdx
+++ b/docs/src/pages/[platform]/components/table/react.mdx
@@ -20,7 +20,6 @@ import {
 import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
 import { ComponentClassTable } from '@/components/ComponentClassTable';
-import StandardHTMLAttributes from '@/components/StandardHTMLAttributes.mdx';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 import ThemeExample from '@/components/ThemeExample.mdx';
 
@@ -113,61 +112,6 @@ respectively. This is similar to how the HTML native `th` and `td` elements are 
 
   </ExampleCode>
 </Example>
-
-<StandardHTMLAttributes component="Table" element="<table>">
-  <Example>
-    <Table title="Table">
-      <TableHead>
-        <TableRow>
-          <TableCell as="th">Citrus</TableCell>
-          <TableCell as="th">Stone Fruit</TableCell>
-          <TableCell as="th">Berry</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        <TableRow>
-          <TableCell>Orange</TableCell>
-          <TableCell>Nectarine</TableCell>
-          <TableCell>Raspberry</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>Grapefruit</TableCell>
-          <TableCell>Apricot</TableCell>
-          <TableCell>Blueberry</TableCell>
-        </TableRow>
-      </TableBody>
-    </Table>
-
-    <ExampleCode>
-
-    ```jsx
-    <Table title="Table">
-      <TableHead>
-        <TableRow>
-          <TableCell as="th">Citrus</TableCell>
-          <TableCell as="th">Stone Fruit</TableCell>
-          <TableCell as="th">Berry</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        <TableRow>
-          <TableCell>Orange</TableCell>
-          <TableCell>Nectarine</TableCell>
-          <TableCell>Raspberry</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>Grapefruit</TableCell>
-          <TableCell>Apricot</TableCell>
-          <TableCell>Blueberry</TableCell>
-        </TableRow>
-      </TableBody>
-    </Table>
-    ```
-
-    </ExampleCode>
-
-  </Example>
-</StandardHTMLAttributes>
 
 ## CSS Styling
 

--- a/docs/src/pages/[platform]/components/tabs/props-table.mdx
+++ b/docs/src/pages/[platform]/components/tabs/props-table.mdx
@@ -615,4 +615,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Tabs will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+Tabs will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/tabs/props-table.mdx
+++ b/docs/src/pages/[platform]/components/tabs/props-table.mdx
@@ -615,4 +615,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Tabs component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Tabs will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/text/props-table.mdx
+++ b/docs/src/pages/[platform]/components/text/props-table.mdx
@@ -268,4 +268,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-Text will also accept any of the standard HTML attributes that a <code>p</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p" isExternal>MDN Documentation</Link>.
+Text will also accept any of the standard HTML attributes that a <code>p</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/text/props-table.mdx
+++ b/docs/src/pages/[platform]/components/text/props-table.mdx
@@ -268,4 +268,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The Text component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+Text will also accept any of the standard HTML attributes that a <code>p</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/textareafield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/textareafield/props-table.mdx
@@ -492,4 +492,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The TextAreaField component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+TextAreaField will also accept any of the standard HTML attributes that a <code>textarea</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/textareafield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/textareafield/props-table.mdx
@@ -492,4 +492,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-TextAreaField will also accept any of the standard HTML attributes that a <code>textarea</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea" isExternal>MDN Documentation</Link>.
+TextAreaField will also accept any of the standard HTML attributes that a <code>textarea</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/textfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/textfield/props-table.mdx
@@ -636,4 +636,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-TextField will also accept any of the standard HTML attributes that a <code>textarea</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea" isExternal>MDN Documentation</Link>.
+TextField will also accept any of the standard HTML attributes that a <code>textarea</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/textfield/props-table.mdx
+++ b/docs/src/pages/[platform]/components/textfield/props-table.mdx
@@ -636,4 +636,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The TextField component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+TextField will also accept any of the standard HTML attributes that a <code>textarea</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/textfield/react.mdx
+++ b/docs/src/pages/[platform]/components/textfield/react.mdx
@@ -25,7 +25,6 @@ import {
 import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
 import { ComponentClassTable } from '@/components/ComponentClassTable';
-import StandardHTMLAttributes from '@/components/StandardHTMLAttributes.mdx';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 import ThemeExample from '@/components/ThemeExample.mdx';
 
@@ -276,29 +275,6 @@ Use the `hasError` and `errorMessage` fields to mark a TextField as having an va
 
   </ExampleCode>
 </Example>
-
-<StandardHTMLAttributes component="TextField" link="input" element="<input>">
-  <Example>
-    <TextField
-      label="Name"
-      placeholder="Galadriel"
-      name="name"
-    />
-
-    <ExampleCode>
-
-    ```jsx
-    <TextField
-      label="Name"
-      placeholder="Galadriel"
-      name="name"
-    />
-    ```
-
-    </ExampleCode>
-
-  </Example>
-</StandardHTMLAttributes>
 
 ## CSS Styling
 

--- a/docs/src/pages/[platform]/components/togglebutton/props-table.mdx
+++ b/docs/src/pages/[platform]/components/togglebutton/props-table.mdx
@@ -815,4 +815,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The ToggleButton component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+ToggleButton will also accept any of the standard HTML attributes that a <code>button</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/togglebutton/props-table.mdx
+++ b/docs/src/pages/[platform]/components/togglebutton/props-table.mdx
@@ -815,4 +815,4 @@ ResponsiveStyle<Property.FlexWrap>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-ToggleButton will also accept any of the standard HTML attributes that a <code>button</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button" isExternal>MDN Documentation</Link>.
+ToggleButton will also accept any of the standard HTML attributes that a <code>button</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/togglebutton/react.mdx
+++ b/docs/src/pages/[platform]/components/togglebutton/react.mdx
@@ -3,7 +3,6 @@ import { Flex, ToggleButton } from '@aws-amplify/ui-react';
 
 import { Example, ExampleCode } from '@/components/Example';
 import { ComponentClassTable } from '@/components/ComponentClassTable';
-import StandardHTMLAttributes from '@/components/StandardHTMLAttributes.mdx';
 import ThemeExample from '@/components/ThemeExample.mdx';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 import { ToggleButtonDemo } from './demo';
@@ -130,21 +129,6 @@ In cases where you need to have at least one option on, you can set the `isSelec
 
   </ExampleCode>
 </Example>
-
-<StandardHTMLAttributes component="ToggleButton" link="button" element="<button>">
-  <Example>
-    <ToggleButton name="button">Press me!</ToggleButton>
-
-    <ExampleCode>
-
-    ```jsx
-    <ToggleButton name="button">Press me!</ToggleButton>
-    ```
-
-    </ExampleCode>
-
-  </Example>
-</StandardHTMLAttributes>
 
 ## CSS Styling
 

--- a/docs/src/pages/[platform]/components/view/props-table.mdx
+++ b/docs/src/pages/[platform]/components/view/props-table.mdx
@@ -831,4 +831,4 @@ PropertyType
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The View component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+View will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/view/props-table.mdx
+++ b/docs/src/pages/[platform]/components/view/props-table.mdx
@@ -831,4 +831,4 @@ PropertyType
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-View will also accept any of the standard HTML attributes that a <code>div</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.
+View will also accept any of the standard HTML attributes that a <code>div</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/visuallyhidden/props-table.mdx
+++ b/docs/src/pages/[platform]/components/visuallyhidden/props-table.mdx
@@ -242,4 +242,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-The VisuallyHidden component will accept any of the standard HTML attributes that a HTML element accepts. Standard element attributes can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" isExternal={true}>MDN Documentation</Link>.
+VisuallyHidden will also accept any of the standard HTML attributes that a <code>span</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span" isExternal>MDN Documentation</Link>.

--- a/docs/src/pages/[platform]/components/visuallyhidden/props-table.mdx
+++ b/docs/src/pages/[platform]/components/visuallyhidden/props-table.mdx
@@ -242,4 +242,4 @@ ResponsiveStyle<Property.FlexShrink>
 
 See [Style Props](/react/theming/style-props) for all supported style and layout properties.
 
-VisuallyHidden will also accept any of the standard HTML attributes that a <code>span</code> accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span" isExternal>MDN Documentation</Link>.
+VisuallyHidden will also accept any of the standard HTML attributes that a <code>span</code> element accepts, which can be found in the <Link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span" isExternal>MDN Documentation</Link>.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

_Asana task:_ 
Docs Props table: update the note under the Props Heading to specify the HTML element's name and MDN link.

The only file which really needs to be reviewed is [docs/scripts/util/getStandardHTMLAttributes.ts](https://github.com/aws-amplify/amplify-ui/pull/2278/files#diff-775549019f5b84073383458867d8ce7a2c313f2cf034a458c30bbb0029b2090b)

![Screen Shot 2022-07-11 at 5 00 00 PM](https://user-images.githubusercontent.com/48109584/178366045-55bc9050-427a-4af4-9647-03d07a6c433b.png)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the docs locally, checked each page to make sure the MDN links work. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
