### PR TITLE
fix(vue): Turn on declaration for tsconfig

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -11,7 +11,7 @@
   "browser": {
     "./styles.css": "./dist/style.css"
   },
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -5,7 +5,7 @@
     "strict": true,
     "jsx": "preserve",
     "importHelpers": true,
-    "declaration": true,
+    "declaration": false, // this is overriden in the vite.config.ts typescript2 settings
     "moduleResolution": "node",
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -5,7 +5,7 @@
     "strict": true,
     "jsx": "preserve",
     "importHelpers": true,
-    "declaration": false, // this is overriden in the vite.config.ts typescript2 settings
+    "declaration": true,
     "moduleResolution": "node",
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
#### Description of changes
When testing the latest version of Vue with Vite, I noticed types were broken for `@aws-amplify/ui-vue` declaration. 

<img width="777" alt="image" src="https://user-images.githubusercontent.com/65630/179098241-6519993c-ebfb-47ca-8861-044119e67dc3.png">

This is a regression caused from #2184 

#### Issue #, if available

#### Description of how you validated changes
Pointed to correct definition file. 

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
