### PR TITLE
feat: add alert for publishing @next version

### DIFF
--- a/.github/workflows/run-and-test-builds.yml
+++ b/.github/workflows/run-and-test-builds.yml
@@ -96,8 +96,8 @@ jobs:
           NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
           VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
 
-  trigger-failure-alarm:
-    # Triggers an alarm if any of builds failed.
+  log-failure-metric:
+    # Send data point 1 to metric RunTimeTestsFailure, if failure
     runs-on: ubuntu-latest
     environment: ci
     needs: build
@@ -111,8 +111,8 @@ jobs:
           aws-region: us-east-1
       - run: aws cloudwatch put-metric-data --metric-name RunTimeTestsFailure --namespace GithubCanaryApps --value 1
 
-  trigger-success-alarm:
-    # Triggers an alarm if all the builds succeed
+  log-success-metric:
+    # Send data point 0 to metric RunTimeTestsFailure, if success
     runs-on: ubuntu-latest
     environment: ci
     needs: build
@@ -124,4 +124,4 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      - run: aws cloudwatch put-metric-data --metric-name RunTimeTestsSuccess --namespace GithubCanaryApps --value 0
+      - run: aws cloudwatch put-metric-data --metric-name RunTimeTestsFailure --namespace GithubCanaryApps --value 0

--- a/.github/workflows/run-and-test-builds.yml
+++ b/.github/workflows/run-and-test-builds.yml
@@ -111,7 +111,7 @@ jobs:
           aws-region: us-east-1
       - run: aws cloudwatch put-metric-data --metric-name RunTimeTestsFailure --namespace GithubCanaryApps --value 1
 
-  trigger-sucess-alarm:
+  trigger-success-alarm:
     # Triggers an alarm if all the builds succeed
     runs-on: ubuntu-latest
     environment: ci
@@ -124,4 +124,4 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      - run: aws cloudwatch put-metric-data --metric-name RunTimeTestsFailure --namespace GithubCanaryApps --value 0
+      - run: aws cloudwatch put-metric-data --metric-name RunTimeTestsSuccess --namespace GithubCanaryApps --value 0

--- a/.github/workflows/test-deploy-main.yml
+++ b/.github/workflows/test-deploy-main.yml
@@ -168,8 +168,8 @@ jobs:
         run: yarn build
         working-directory: ./canary
 
-  put-failure-metric:
-    # Triggers an alarm if any of builds failed.
+  log-failure-metric:
+    # Send data point 1 to metric RunTimeTestsFailure, if success
     runs-on: ubuntu-latest
     environment: ci
     needs: build
@@ -182,3 +182,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - run: aws cloudwatch put-metric-data --metric-name publishFailure --namespace GithubCanaryApps --value 1
+
+  log-success-metric:
+    # Send data point 0 to metric RunTimeTestsFailure, if success
+    runs-on: ubuntu-latest
+    environment: ci
+    needs: build
+    if: ${{ success() }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - run: aws cloudwatch put-metric-data --metric-name publishFailure --namespace GithubCanaryApps --value 0

--- a/.github/workflows/test-deploy-main.yml
+++ b/.github/workflows/test-deploy-main.yml
@@ -168,7 +168,7 @@ jobs:
         run: yarn build
         working-directory: ./canary
 
-  trigger-failure-alarm:
+  put-failure-metric:
     # Triggers an alarm if any of builds failed.
     runs-on: ubuntu-latest
     environment: ci

--- a/.github/workflows/test-deploy-main.yml
+++ b/.github/workflows/test-deploy-main.yml
@@ -182,18 +182,3 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - run: aws cloudwatch put-metric-data --metric-name publishFailure --namespace GithubCanaryApps --value 1
-
-  trigger-success-alarm:
-    # Triggers an alarm if all the builds succeed
-    runs-on: ubuntu-latest
-    environment: ci
-    needs: build
-    if: ${{ success() }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - run: aws cloudwatch put-metric-data --metric-name publishSuccess --namespace GithubCanaryApps --value 0

--- a/.github/workflows/test-deploy-main.yml
+++ b/.github/workflows/test-deploy-main.yml
@@ -167,3 +167,33 @@ jobs:
       - name: Run yarn build on each sample app
         run: yarn build
         working-directory: ./canary
+
+  trigger-failure-alarm:
+    # Triggers an alarm if any of builds failed.
+    runs-on: ubuntu-latest
+    environment: ci
+    needs: build
+    if: ${{ failure() }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - run: aws cloudwatch put-metric-data --metric-name publishFailure --namespace GithubCanaryApps --value 1
+
+  trigger-success-alarm:
+    # Triggers an alarm if all the builds succeed
+    runs-on: ubuntu-latest
+    environment: ci
+    needs: build
+    if: ${{ success() }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - run: aws cloudwatch put-metric-data --metric-name publishSuccess --namespace GithubCanaryApps --value 0


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
https://app.asana.com/0/1201736086077862/1201914591116096/f

#### Description of how you validated changes

This PR add metrics for success and failures of the after merge next tag publishing events in Prod account.

TODO:
- manually create an alarm to trigger Sev3 tickets
- Ideally, we need to migrate the metrics and alarms to CDK and deploy them to the canary accounts

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
