### PR TITLE
chore(github): rename PublishNPMFailure to PublishLatestFailure

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -89,31 +89,31 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   log-failure-metric:
-    # Send data point 1 to metric PublishNPMFailure, if it's a failure
+    # Send data point 1 to metric PublishLatestFailure, if it's a failure
     runs-on: ubuntu-latest
     environment: ci
     needs: publish
     if: ${{ failure() }}
     steps:
-      - name: Log failure data point to metric PublishNPMFailure
+      - name: Log failure data point to metric PublishLatestFailure
         uses: aws-amplify/amplify-ui/.github/actions/log-metric@main
         with:
-          metric-name: PublishNPMFailure
+          metric-name: PublishLatestFailure
           value: 1
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   log-success-metric:
-    # Send data point 0 to metric PublishNPMFailure, if  it's a success
+    # Send data point 0 to metric PublishLatestFailure, if  it's a success
     runs-on: ubuntu-latest
     environment: ci
     needs: publish
     if: ${{ success() }}
     steps:
-      - name: Log success data point to metric PublishNPMFailure
+      - name: Log success data point to metric PublishLatestFailure
         uses: aws-amplify/amplify-ui/.github/actions/log-metric@main
         with:
-          metric-name: PublishNPMFailure
+          metric-name: PublishLatestFailure
           value: 0
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Since `PublishNext` in `test-deploy-main` workflow also publish to NPM, a.k.a, both `next` and `latest` are tags published to NPM, it's more accurate to name the metric `PublishLatest`.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
