### PR TITLE
chore(ui-react): lint primitives/utils

### DIFF
--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -71,7 +71,7 @@ module.exports = {
         'src/components/ThemeProvider/**/*',
         'src/helpers/**/*',
         'src/hooks/**/*',
-        'src/primitives/shared/**/*',
+        'src/primitives/+(shared|utils)/**/*',
         // 'src/components/**/*',
         // 'src/primitives/**/*',
       ],

--- a/packages/react/src/primitives/Checkbox/Checkbox.tsx
+++ b/packages/react/src/primitives/Checkbox/Checkbox.tsx
@@ -12,7 +12,7 @@ import { splitPrimitiveProps } from '../shared/styleUtils';
 import { Text } from '../Text';
 import { useCheckbox } from './useCheckbox';
 import { VisuallyHidden } from '../VisuallyHidden';
-import { useTestId } from '../utils/testUtils';
+import { getTestId } from '../utils/testUtils';
 
 const CheckboxPrimitive: Primitive<CheckboxProps, 'input'> = (
   {
@@ -47,9 +47,9 @@ const CheckboxPrimitive: Primitive<CheckboxProps, 'input'> = (
     }
   }, [checked, dataChecked, setDataChecked]);
 
-  const buttonTestId = useTestId(testId, ComponentClassNames.CheckboxButton);
-  const iconTestId = useTestId(testId, ComponentClassNames.CheckboxIcon);
-  const labelTestId = useTestId(testId, ComponentClassNames.CheckboxLabel);
+  const buttonTestId = getTestId(testId, ComponentClassNames.CheckboxButton);
+  const iconTestId = getTestId(testId, ComponentClassNames.CheckboxIcon);
+  const labelTestId = getTestId(testId, ComponentClassNames.CheckboxLabel);
   const flexClasses = classNames(
     ComponentClassNames.CheckboxButton,
     classNameModifierByFlag(

--- a/packages/react/src/primitives/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/react/src/primitives/Checkbox/__tests__/Checkbox.test.tsx
@@ -10,7 +10,6 @@ import {
   testFlexProps,
   expectFlexContainerStyleProps,
 } from '../../Flex/__tests__/Flex.test';
-import { useTestId } from '../../utils/testUtils';
 
 describe('Checkbox test suite', () => {
   const basicProps = {

--- a/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
+++ b/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
@@ -7,7 +7,7 @@ import { CheckboxFieldProps, Primitive } from '../types';
 import { ComponentClassNames } from '../shared';
 import { FieldErrorMessage } from '../Field';
 import { Flex } from '../Flex';
-import { useTestId } from '../utils/testUtils';
+import { getTestId } from '../utils/testUtils';
 
 const CheckboxFieldPrimitive: Primitive<CheckboxFieldProps, 'input'> = (
   {
@@ -22,7 +22,7 @@ const CheckboxFieldPrimitive: Primitive<CheckboxFieldProps, 'input'> = (
   },
   ref
 ) => {
-  const checkboxTestId = useTestId(testId, ComponentClassNames.Checkbox);
+  const checkboxTestId = getTestId(testId, ComponentClassNames.Checkbox);
   return (
     <Flex
       className={classNames(

--- a/packages/react/src/primitives/utils/testUtils.ts
+++ b/packages/react/src/primitives/utils/testUtils.ts
@@ -1,25 +1,23 @@
-import * as React from 'react';
-export const useTestId = (testId: string, component: string) => {
-  const newTestId = React.useMemo(
-    () => (testId && component ? `${testId}-${component}` : undefined),
-    [testId, component]
-  );
-  return newTestId;
-};
+export const getTestId = (testId: string, component: string): string =>
+  testId && component ? `${testId}-${component}` : undefined;
 
-export const errorMessageWrapper = (fn: () => void, message: string) => {
+export const errorMessageWrapper = (
+  fn: () => void,
+  message: string
+): void | Error => {
   try {
     fn();
   } catch (error) {
     // Formatting below is intentional
     // and displays below Jest error message
-    error.message += `
+    (error as Error).message += `
 
 -- Custom Error Message --
 ${message}
 
 `;
+    // eslint-disable-next-line no-console
     console.error(error);
-    throw new Error(error);
+    throw new Error((error as Error).message);
   }
 };

--- a/packages/react/src/primitives/utils/useLayoutEffect.ts
+++ b/packages/react/src/primitives/utils/useLayoutEffect.ts
@@ -8,8 +8,6 @@ import * as React from 'react';
  *
  * See: https://reactjs.org/docs/hooks-reference.html#uselayouteffect
  */
-const useLayoutEffect = Boolean(globalThis?.document)
-  ? React.useLayoutEffect
-  : () => {};
+const useLayoutEffect = globalThis?.document ? React.useLayoutEffect : () => {};
 
 export { useLayoutEffect };

--- a/packages/react/src/primitives/utils/useStableId.ts
+++ b/packages/react/src/primitives/utils/useStableId.ts
@@ -9,10 +9,14 @@ export type UseStableId = (id?: string) => string;
 
 // Create a local version of React.useId which will reference React.useId for React 18
 // and fallback to noop for React 17 and below
-// Note: We `toString()` to prevent bundlers from trying to `import { useId } from 'react';`
+// Note: We use `toString()` to prevent bundlers from trying to `import { useId } from 'react';`
 // since it doesn't exist in React 17 and below (prevents https://github.com/aws-amplify/amplify-ui/issues/1154)
 const useReactId: () => string | (() => undefined) =
-  (React['useId'.toString()] as () => string) || (() => undefined);
+  // disable eslint below to allow usage of casting React to `any`, which ensures that TS
+  // does not get confused about the existence of `useId` in React 17 and below
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  ((React as any)['useId'.toString()] as () => string) || (() => undefined);
+
 let count = 0;
 
 /**

--- a/packages/react/src/primitives/utils/useStableId.ts
+++ b/packages/react/src/primitives/utils/useStableId.ts
@@ -12,7 +12,7 @@ export type UseStableId = (id?: string) => string;
 // Note: We `toString()` to prevent bundlers from trying to `import { useId } from 'react';`
 // since it doesn't exist in React 17 and below (prevents https://github.com/aws-amplify/amplify-ui/issues/1154)
 const useReactId: () => string | (() => undefined) =
-  (React as any)['useId'.toString()] || (() => undefined);
+  (React['useId'.toString()] as () => string) || (() => undefined);
 let count = 0;
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update _primitives/utils_ to pass linting rules
- remove extraneous memoization in `useTestId` and rename to `getTestId` as it no longer requires usage of a React hook internally

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
