### PR TITLE
fix(ui-react): Pagination current item a11y

### DIFF
--- a/.changeset/eighty-snails-push.md
+++ b/.changeset/eighty-snails-push.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(ui-react): Improve accessibility of Pagination current item button

--- a/docs/src/pages/[platform]/components/pagination/react.mdx
+++ b/docs/src/pages/[platform]/components/pagination/react.mdx
@@ -92,7 +92,7 @@ Use the following props to customize these labels:
 
 - **`nextLabel`**: Set the `aria-label` for the next page button (defaults to `Go to next page`)
 
-- **`currentPageLabel`**: Set the `VisuallyHidden` label for current page (defaults to `Current Page:`). This will be used to construct the label text for current page. e.g, `Current Page: 1` if page `1` is the current page.
+- **`currentPageLabel`**: Set the `VisuallyHidden` label for current page (defaults to `Page`). This will be used to construct the label text for current page. e.g, `Page: 1` if page `1` is the current page.
 
 - **`pageLabel`**: Set the label for each page button other than the current page (defaults to `Go to page`). This will be used to construct the `aria-label`. e.g, `Go to page 1` for page `1` button.
 

--- a/packages/react/src/primitives/Pagination/PaginationItem.tsx
+++ b/packages/react/src/primitives/Pagination/PaginationItem.tsx
@@ -60,16 +60,12 @@ export const PaginationItem: React.FC<PaginationItemProps> = ({
         <View as="li">
           {page === currentPage ? (
             <Flex
-              aria-current="true"
+              aria-current="page"
               as="button"
               className={ComponentClassNames.PaginationItemCurrent}
               testId={PAGINATION_CURRENT_TEST_ID}
               {...rest}
             >
-              {/**
-               * Use markup to indicate the current item of a menu, such as the current page on a website, to improve orientation in the menu.
-               * @link https://www.w3.org/WAI/tutorials/menus/structure/#indicate-the-current-item
-               */}
               <VisuallyHidden>{currentPageLabel}:</VisuallyHidden>
               {page}
             </Flex>

--- a/packages/react/src/primitives/Pagination/PaginationItem.tsx
+++ b/packages/react/src/primitives/Pagination/PaginationItem.tsx
@@ -70,7 +70,7 @@ export const PaginationItem: React.FC<PaginationItemProps> = ({
                * Use markup to indicate the current item of a menu, such as the current page on a website, to improve orientation in the menu.
                * @link https://www.w3.org/WAI/tutorials/menus/structure/#indicate-the-current-item
                */}
-              <VisuallyHidden>{currentPageLabel}</VisuallyHidden>
+              <VisuallyHidden>{currentPageLabel}:</VisuallyHidden>
               {page}
             </Flex>
           ) : (

--- a/packages/react/src/primitives/Pagination/PaginationItem.tsx
+++ b/packages/react/src/primitives/Pagination/PaginationItem.tsx
@@ -60,7 +60,8 @@ export const PaginationItem: React.FC<PaginationItemProps> = ({
         <View as="li">
           {page === currentPage ? (
             <Flex
-              as="span"
+              aria-current="true"
+              as="button"
               className={ComponentClassNames.PaginationItemCurrent}
               testId={PAGINATION_CURRENT_TEST_ID}
               {...rest}

--- a/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
@@ -334,7 +334,7 @@ describe('Pagination component: ', () => {
         `${ComponentText.PaginationItem.currentPageLabel}:`
       );
       expect(invisibleLabel).toHaveClass(ComponentClassNames.VisuallyHidden);
-      expect(pageItem.getAttribute('aria-current')).toBe('true');
+      expect(pageItem.getAttribute('aria-current')).toBe('page');
 
       userEvent.click(pageItem);
       expect(mockOnClick).not.toHaveBeenCalled();

--- a/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
@@ -331,7 +331,7 @@ describe('Pagination component: ', () => {
       expect(pageItem.nodeName).toBe('BUTTON');
       expect(pageItem).toHaveClass(ComponentClassNames.PaginationItemCurrent);
       const invisibleLabel = await screen.findByText(
-        ComponentText.PaginationItem.currentPageLabel
+        `${ComponentText.PaginationItem.currentPageLabel}:`
       );
       expect(invisibleLabel).toHaveClass(ComponentClassNames.VisuallyHidden);
       expect(pageItem.getAttribute('aria-current')).toBe('true');

--- a/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
@@ -328,12 +328,13 @@ describe('Pagination component: ', () => {
         />
       );
       const pageItem = await screen.findByText('1');
-      expect(pageItem.nodeName).toBe('SPAN');
+      expect(pageItem.nodeName).toBe('BUTTON');
       expect(pageItem).toHaveClass(ComponentClassNames.PaginationItemCurrent);
       const invisibleLabel = await screen.findByText(
         ComponentText.PaginationItem.currentPageLabel
       );
       expect(invisibleLabel).toHaveClass(ComponentClassNames.VisuallyHidden);
+      expect(pageItem.getAttribute('aria-current')).toBe('true');
 
       userEvent.click(pageItem);
       expect(mockOnClick).not.toHaveBeenCalled();
@@ -353,6 +354,7 @@ describe('Pagination component: ', () => {
       );
       expect(previous.nodeName).toBe('BUTTON');
       expect(previous).not.toBeDisabled();
+      expect(previous.getAttribute('aria-current')).toBe(null);
       userEvent.click(previous);
       expect(mockOnClick).toHaveBeenCalledTimes(1);
       expect(mockOnClick).toHaveBeenCalledWith();
@@ -367,12 +369,14 @@ describe('Pagination component: ', () => {
           onClick={mockOnClick}
         />
       );
-      const previous = await screen.findByLabelText(
+      const next = await screen.findByLabelText(
         ComponentText.PaginationItem.nextLabel
       );
-      expect(previous.nodeName).toBe('BUTTON');
-      expect(previous).not.toBeDisabled();
-      userEvent.click(previous);
+      expect(next.nodeName).toBe('BUTTON');
+      expect(next).not.toBeDisabled();
+      expect(next.getAttribute('aria-current')).toBe(null);
+
+      userEvent.click(next);
       expect(mockOnClick).toHaveBeenCalledTimes(1);
       expect(mockOnClick).toHaveBeenCalledWith();
     });

--- a/packages/react/src/primitives/shared/constants.ts
+++ b/packages/react/src/primitives/shared/constants.ts
@@ -661,7 +661,7 @@ export const ComponentText = {
     clearButtonLabel: 'Clear input',
   },
   PaginationItem: {
-    currentPageLabel: 'Current Page:',
+    currentPageLabel: 'Page',
     nextLabel: 'Go to next page',
     pageLabel: 'Go to page',
     previousLabel: 'Go to previous page',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes: https://github.com/aws-amplify/amplify-ui/issues/1982

To improve the accessibility of the Pagination component:
- current item button is focusable
- screenreader announces if the item is current or not

https://user-images.githubusercontent.com/48109584/180571531-8cb72f58-70c6-4fbf-bb77-2ab775f5a9d0.mov

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/1982

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the docs locally and used a screen reader. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are updated
- [X] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [X] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
