### PR TITLE
feat(in-app-messaging): add React web useMessageImage

### DIFF
--- a/packages/react-native/src/InAppMessaging/hooks/useMessageImage/useMessageImage.ts
+++ b/packages/react-native/src/InAppMessaging/hooks/useMessageImage/useMessageImage.ts
@@ -12,11 +12,10 @@ const logger = new Logger('Notifications.InAppMessaging');
 /**
  * Handles prefetching and dimension setting for message images
  *
- * @param {MessageImage} image - contains image source
- * @param {MessageLayout} layout - message layout
- * @returns {UseMessageImage} message image dimensions and rendering related booleans
+ * @param image contains image source
+ * @param layout message layout
+ * @returns message image dimensions and rendering related booleans
  */
-
 export default function useMessageImage(
   image: MessageImage | undefined,
   layout: MessageLayout

--- a/packages/react/src/components/InAppMessaging/hooks/index.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useMessageImage } from './useMessageImage';

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
@@ -1,0 +1,110 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
+
+import useMessageImage from '../useMessageImage';
+
+type ImageConstructor = new (
+  width?: number | undefined,
+  height?: number | undefined
+) => HTMLImageElement;
+
+// use empty mockImplementation to turn off console output
+const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+const src = 'https://test.jpeg';
+const image = { src };
+
+describe('useMessageImage', () => {
+  const original = global.Image;
+  afterAll(() => {
+    // restore Image
+    global.Image = original;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('handles loading an image in the happy path as expected', async () => {
+    // set Image to mock succesful load
+    global.Image = class {
+      onload = jest.fn();
+      constructor() {
+        setTimeout(() => {
+          this.onload();
+        }, 50);
+      }
+    } as unknown as ImageConstructor;
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useMessageImage(image)
+    );
+
+    expect(result.current.hasRenderableImage).toBe(false);
+    expect(result.current.isImageFetching).toBe(true);
+
+    await waitForNextUpdate();
+
+    expect(result.current.hasRenderableImage).toBe(true);
+    expect(result.current.isImageFetching).toBe(false);
+  });
+
+  it('handles an image load error event as expected', async () => {
+    // set Image to mock error
+    global.Image = class {
+      onerror = jest.fn();
+      constructor() {
+        setTimeout(() => {
+          this.onerror();
+        }, 50);
+      }
+    } as unknown as ImageConstructor;
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useMessageImage(image)
+    );
+
+    expect(result.current.hasRenderableImage).toBe(false);
+    expect(result.current.isImageFetching).toBe(true);
+
+    await waitForNextUpdate();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(`Image failed to load: ${src}`);
+    expect(result.current.hasRenderableImage).toBe(false);
+    expect(result.current.isImageFetching).toBe(false);
+  });
+
+  it('handles an image load abort event as expected', async () => {
+    // set Image to mock abort
+    global.Image = class {
+      onabort = jest.fn();
+      constructor() {
+        setTimeout(() => {
+          this.onabort();
+        }, 50);
+      }
+    } as unknown as ImageConstructor;
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useMessageImage(image)
+    );
+
+    expect(result.current.hasRenderableImage).toBe(false);
+    expect(result.current.isImageFetching).toBe(true);
+
+    await waitForNextUpdate();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(`Image load aborted: ${src}`);
+    expect(result.current.hasRenderableImage).toBe(false);
+    expect(result.current.isImageFetching).toBe(false);
+  });
+
+  it('handles an undefined argument as expected', () => {
+    const { result } = renderHook(() => useMessageImage(undefined));
+
+    expect(result.current.hasRenderableImage).toBe(false);
+    expect(result.current.isImageFetching).toBe(false);
+  });
+});

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
@@ -32,7 +32,7 @@ describe('useMessageImage', () => {
       constructor() {
         setTimeout(() => {
           this.onload();
-        }, 50);
+        }, 0);
       }
     } as unknown as ImageConstructor;
 
@@ -56,7 +56,7 @@ describe('useMessageImage', () => {
       constructor() {
         setTimeout(() => {
           this.onerror();
-        }, 50);
+        }, 0);
       }
     } as unknown as ImageConstructor;
 
@@ -82,7 +82,7 @@ describe('useMessageImage', () => {
       constructor() {
         setTimeout(() => {
           this.onabort();
-        }, 50);
+        }, 0);
       }
     } as unknown as ImageConstructor;
 

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
@@ -32,7 +32,7 @@ describe('useMessageImage', () => {
       constructor() {
         setTimeout(() => {
           this.onload();
-        }, 0);
+        });
       }
     } as unknown as ImageConstructor;
 
@@ -56,7 +56,7 @@ describe('useMessageImage', () => {
       constructor() {
         setTimeout(() => {
           this.onerror();
-        }, 0);
+        });
       }
     } as unknown as ImageConstructor;
 
@@ -82,7 +82,7 @@ describe('useMessageImage', () => {
       constructor() {
         setTimeout(() => {
           this.onabort();
-        }, 0);
+        });
       }
     } as unknown as ImageConstructor;
 

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageImage/index.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageImage/index.ts
@@ -1,0 +1,1 @@
+export { default as useMessageImage } from './useMessageImage';

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageImage/types.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageImage/types.ts
@@ -1,11 +1,5 @@
-export type ImageDimensions = {
-  height: number | undefined;
-  width: number | undefined;
-};
-
-export type ImageLoadingState = 'loaded' | 'failed';
-
 export enum ImagePrefetchStatus {
+  Aborted = 'ABORTED',
   Failure = 'FAILURE',
   Fetching = 'FETCHING',
   Success = 'SUCCESS',
@@ -13,6 +7,5 @@ export enum ImagePrefetchStatus {
 
 export type UseMessageImage = {
   hasRenderableImage: boolean;
-  imageDimensions: ImageDimensions;
   isImageFetching: boolean;
 };

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageImage/useMessageImage.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageImage/useMessageImage.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { MessageImage } from '@aws-amplify/ui-react-core';
+
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
+
+import { ImagePrefetchStatus, UseMessageImage } from './types';
+
+const logger = new Logger('Notifications.InAppMessaging');
+
+/**
+ * Handles prefetching for message images
+ *
+ * @param image contains image source
+ * @returns message image dimensions and fetching related booleans
+ */
+export default function useMessageImage(
+  image: MessageImage | undefined
+): UseMessageImage {
+  const { src } = image ?? {};
+  const shouldPrefetch = !!src;
+
+  // set initial status to fetching if prefetch is required
+  const [prefetchStatus, setPrefetchStatus] =
+    useState<ImagePrefetchStatus | null>(
+      shouldPrefetch ? ImagePrefetchStatus.Fetching : null
+    );
+
+  const isImageFetching = prefetchStatus === ImagePrefetchStatus.Fetching;
+  const hasRenderableImage = prefetchStatus === ImagePrefetchStatus.Success;
+
+  useEffect(() => {
+    const img = new Image();
+
+    img.onload = () => {
+      setPrefetchStatus(ImagePrefetchStatus.Success);
+    };
+
+    img.onabort = () => {
+      logger.error(`Image load aborted: ${src}`);
+      setPrefetchStatus(ImagePrefetchStatus.Aborted);
+    };
+
+    img.onerror = () => {
+      logger.error(`Image failed to load: ${src}`);
+      setPrefetchStatus(ImagePrefetchStatus.Failure);
+    };
+
+    img.src = src;
+  }, [src]);
+
+  return { hasRenderableImage, isImageFetching };
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add React Web `useMessageImage` hook for prefetching message images
- remove an unused enum value in the React Native version
- align the docs between the React Native and React Web versions

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested in sample app
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
