### PR TITLE
fix(Angular + Vue): Add accessible label to Alert dismiss button Authenticator

### DIFF
--- a/.changeset/late-ducks-divide.md
+++ b/.changeset/late-ducks-divide.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui-angular': patch
+'@aws-amplify/ui-vue': patch
+---
+
+Adds an accessible label for the Alert dismiss button, which is configurable via translation.

--- a/packages/angular/projects/ui-angular/src/lib/primitives/error/error.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/error/error.component.html
@@ -20,7 +20,8 @@
   </div>
   <button
     amplify-button
-    class="amplify-field-group__control"
+    class="amplify-field-group__control amplify-alert__dismiss"
+    [ariaLabel]="dismissAriaLabel"
     variation="link"
     [fullWidth]="false"
     (click)="close()"

--- a/packages/angular/projects/ui-angular/src/lib/primitives/error/error.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/error/error.component.html
@@ -21,7 +21,7 @@
   <button
     amplify-button
     class="amplify-field-group__control amplify-alert__dismiss"
-    [ariaLabel]="dismissAriaLabel"
+    [attr.aria-label]="dismissAriaLabel"
     variation="link"
     [fullWidth]="false"
     (click)="close()"

--- a/packages/angular/projects/ui-angular/src/lib/primitives/error/error.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/error/error.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { translate } from '@aws-amplify/ui';
 
 @Component({
   selector: 'amplify-error',
@@ -6,6 +7,7 @@ import { Component } from '@angular/core';
 })
 export class ErrorComponent {
   public isVisible = true;
+  public dismissAriaLabel = translate('Dismiss alert');
 
   public close() {
     this.isVisible = false;

--- a/packages/vue/src/components/primitives/__tests__/base-alert.spec.ts
+++ b/packages/vue/src/components/primitives/__tests__/base-alert.spec.ts
@@ -2,7 +2,6 @@ import BaseAlert from '../base-alert.vue';
 import { components } from '../../../../global-spec';
 import { render } from '@testing-library/vue';
 
-import { translations } from '@aws-amplify/ui-vue';
 import { I18n } from 'aws-amplify';
 
 describe('Base Alert', () => {

--- a/packages/vue/src/components/primitives/__tests__/base-alert.spec.ts
+++ b/packages/vue/src/components/primitives/__tests__/base-alert.spec.ts
@@ -17,14 +17,14 @@ describe('Base Alert', () => {
   });
 
   it('shows correct default accessible label', () => {
-    const { queryAllByRole } = render(BaseAlert, {
+    const { queryByRole } = render(BaseAlert, {
       global: {
         components,
       },
     });
 
-    const [defaultButton] = queryAllByRole('button');
-    expect(defaultButton.getAttribute('aria-label')).toBe('Dismiss alert');
+    const defaultButton = queryByRole('button');
+    expect(defaultButton?.getAttribute('aria-label')).toBe('Dismiss alert');
   });
   it('shows correct default translated label', () => {
     const translatedAriaLabel = 'Translated dismiss alert';

--- a/packages/vue/src/components/primitives/__tests__/base-alert.spec.ts
+++ b/packages/vue/src/components/primitives/__tests__/base-alert.spec.ts
@@ -1,0 +1,43 @@
+import BaseAlert from '../base-alert.vue';
+import { components } from '../../../../global-spec';
+import { render } from '@testing-library/vue';
+
+import { translations } from '@aws-amplify/ui-vue';
+import { I18n } from 'aws-amplify';
+
+describe('Base Alert', () => {
+  it('Base Alert Exists', () => {
+    const wrapper = render(BaseAlert, {
+      global: {
+        components,
+      },
+    });
+
+    expect(wrapper).toBeTruthy();
+  });
+
+  it('shows correct default accessible label', () => {
+    const { queryAllByRole } = render(BaseAlert, {
+      global: {
+        components,
+      },
+    });
+
+    const [defaultButton] = queryAllByRole('button');
+    expect(defaultButton.getAttribute('aria-label')).toBe('Dismiss alert');
+  });
+  it('shows correct default translated label', () => {
+    const translatedAriaLabel = 'Translated dismiss alert';
+    I18n.putVocabulariesForLanguage('en', {
+      'Dismiss alert': translatedAriaLabel,
+    });
+    const { queryByRole } = render(BaseAlert, {
+      global: {
+        components,
+      },
+    });
+
+    const defaultButton = queryByRole('button');
+    expect(defaultButton?.getAttribute('aria-label')).toBe(translatedAriaLabel);
+  });
+});

--- a/packages/vue/src/components/primitives/base-alert.vue
+++ b/packages/vue/src/components/primitives/base-alert.vue
@@ -1,6 +1,10 @@
 <script setup>
 import { ref } from 'vue';
+import { translate } from '@aws-amplify/ui';
+
 const show = ref(true);
+
+const dismissAriaLabel = translate('Dismiss alert');
 
 function close() {
   show.value = false;
@@ -10,10 +14,7 @@ function close() {
 <template>
   <div
     v-if="show"
-    class="
-      amplify-flex amplify-alert amplify-alert--error
-      amplify-authenticator__base
-    "
+    class="amplify-flex amplify-alert amplify-alert--error amplify-authenticator__base"
     data-variation="error"
     role="alert"
   >
@@ -31,7 +32,8 @@ function close() {
       <div><slot></slot></div>
     </div>
     <amplify-button
-      class="amplify-field-group__control"
+      class="amplify-field-group__control amplify-alert__dismiss"
+      :aria-label="dismissAriaLabel"
       :fullwidth="false"
       :variation="'link'"
       type="button"


### PR DESCRIPTION
#### Description of changes
The alert dismiss button is missing the accessible label for Vue and React Authenticator. This fix will add this text, and also make it translatable, so it can be updated in the future.

#### Issue #, if available

#2284

#### Description of how you validated changes

Validated by manual testing, and Vue test.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
