### PR TITLE
feat(react): add close button component for In-App Messaging

### DIFF
--- a/packages/react/src/components/InAppMessaging/CloseIconButton/CloseIconButton.tsx
+++ b/packages/react/src/components/InAppMessaging/CloseIconButton/CloseIconButton.tsx
@@ -1,19 +1,27 @@
 import * as React from 'react';
 
-import { Link } from '../../../primitives';
+import { Button } from '../../../primitives';
 import { IconClose } from '../../../primitives/Icon/internal';
 
 import { CloseIconButtonProps } from './types';
 
 export function CloseIconButton({
   className,
+  dismissButtonLabel = 'Dismiss message',
   onClick,
   style,
   ...rest
 }: CloseIconButtonProps): JSX.Element {
   return (
-    <Link className={className} onClick={onClick} style={style} {...rest}>
-      <IconClose size="1.5rem" />
-    </Link>
+    <Button
+      ariaLabel={dismissButtonLabel}
+      className={className}
+      onClick={onClick}
+      style={style}
+      variation="link"
+      {...rest}
+    >
+      <IconClose aria-hidden="true" size="1.5rem" />
+    </Button>
   );
 }

--- a/packages/react/src/components/InAppMessaging/CloseIconButton/CloseIconButton.tsx
+++ b/packages/react/src/components/InAppMessaging/CloseIconButton/CloseIconButton.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import { Link } from '../../../primitives';
+import { IconClose } from '../../../primitives/Icon/internal';
+
+import { CloseIconButtonProps } from './types';
+
+export function CloseIconButton({
+  className,
+  onClick,
+  style,
+  ...rest
+}: CloseIconButtonProps): JSX.Element {
+  return (
+    <Link className={className} onClick={onClick} style={style} {...rest}>
+      <IconClose size="1.5rem" />
+    </Link>
+  );
+}

--- a/packages/react/src/components/InAppMessaging/CloseIconButton/__tests__/CloseIconButton.spec.tsx
+++ b/packages/react/src/components/InAppMessaging/CloseIconButton/__tests__/CloseIconButton.spec.tsx
@@ -9,9 +9,7 @@ describe('CloseIconButton component', () => {
   it('should render', async () => {
     render(<CloseIconButton testId={testId} />);
 
-    const closeIconButton = (await screen.findByTestId(
-      testId
-    )) as HTMLAnchorElement;
+    const closeIconButton = await screen.findByTestId(testId);
     expect(closeIconButton.nodeName).toBe('A');
   });
 
@@ -19,9 +17,7 @@ describe('CloseIconButton component', () => {
     const className = 'my-close-button';
     render(<CloseIconButton className={className} testId={testId} />);
 
-    const closeIconButton = (await screen.findByTestId(
-      testId
-    )) as HTMLAnchorElement;
+    const closeIconButton = await screen.findByTestId(testId);
     expect(closeIconButton.className).toContain(className);
   });
 });

--- a/packages/react/src/components/InAppMessaging/CloseIconButton/__tests__/CloseIconButton.spec.tsx
+++ b/packages/react/src/components/InAppMessaging/CloseIconButton/__tests__/CloseIconButton.spec.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { CloseIconButton } from '../CloseIconButton';
+
+const testId = 'closeIconButtonId';
+
+describe('CloseIconButton component', () => {
+  it('should render', async () => {
+    render(<CloseIconButton testId={testId} />);
+
+    const closeIconButton = (await screen.findByTestId(
+      testId
+    )) as HTMLAnchorElement;
+    expect(closeIconButton.nodeName).toBe('A');
+  });
+
+  it('can render a classname', async () => {
+    const className = 'my-close-button';
+    render(<CloseIconButton className={className} testId={testId} />);
+
+    const closeIconButton = (await screen.findByTestId(
+      testId
+    )) as HTMLAnchorElement;
+    expect(closeIconButton.className).toContain(className);
+  });
+});

--- a/packages/react/src/components/InAppMessaging/CloseIconButton/__tests__/CloseIconButton.spec.tsx
+++ b/packages/react/src/components/InAppMessaging/CloseIconButton/__tests__/CloseIconButton.spec.tsx
@@ -6,18 +6,18 @@ import { CloseIconButton } from '../CloseIconButton';
 const testId = 'closeIconButtonId';
 
 describe('CloseIconButton component', () => {
-  it('should render', async () => {
+  it('should render', () => {
     render(<CloseIconButton testId={testId} />);
 
-    const closeIconButton = await screen.findByTestId(testId);
-    expect(closeIconButton.nodeName).toBe('A');
+    const closeIconButton = screen.getByTestId(testId);
+    expect(closeIconButton.nodeName).toBe('BUTTON');
   });
 
-  it('can render a classname', async () => {
+  it('can render a classname', () => {
     const className = 'my-close-button';
     render(<CloseIconButton className={className} testId={testId} />);
 
-    const closeIconButton = await screen.findByTestId(testId);
+    const closeIconButton = screen.getByTestId(testId);
     expect(closeIconButton.className).toContain(className);
   });
 });

--- a/packages/react/src/components/InAppMessaging/CloseIconButton/index.ts
+++ b/packages/react/src/components/InAppMessaging/CloseIconButton/index.ts
@@ -1,0 +1,1 @@
+export { CloseIconButton } from './CloseIconButton';

--- a/packages/react/src/components/InAppMessaging/CloseIconButton/types.ts
+++ b/packages/react/src/components/InAppMessaging/CloseIconButton/types.ts
@@ -2,7 +2,14 @@ import { LinkProps } from '../../../primitives';
 
 export interface CloseIconButtonProps extends Omit<LinkProps, 'children'> {
   /**
+   * @description
+   * Configures the accessible label for the close iconButton
+   */
+  dismissButtonLabel?: string;
+
+  /**
+   * @description
    * Function called when close iconButton is clicked
    */
-  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }

--- a/packages/react/src/components/InAppMessaging/CloseIconButton/types.ts
+++ b/packages/react/src/components/InAppMessaging/CloseIconButton/types.ts
@@ -1,0 +1,8 @@
+import { LinkProps } from '../../../primitives';
+
+export interface CloseIconButtonProps extends Omit<LinkProps, 'children'> {
+  /**
+   * Function called when close iconButton is clicked
+   */
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+}

--- a/packages/react/src/components/InAppMessaging/CloseIconButton/types.ts
+++ b/packages/react/src/components/InAppMessaging/CloseIconButton/types.ts
@@ -1,15 +1,9 @@
-import { LinkProps } from '../../../primitives';
+import { ButtonProps } from '../../../primitives';
 
-export interface CloseIconButtonProps extends Omit<LinkProps, 'children'> {
+export interface CloseIconButtonProps extends ButtonProps {
   /**
    * @description
    * Configures the accessible label for the close iconButton
    */
   dismissButtonLabel?: string;
-
-  /**
-   * @description
-   * Function called when close iconButton is clicked
-   */
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }

--- a/packages/react/src/primitives/Icon/icons/IconClose.tsx
+++ b/packages/react/src/primitives/Icon/icons/IconClose.tsx
@@ -7,13 +7,13 @@ import { View } from '../../View';
  * @internal For internal Amplify UI use only. May be removed in a future release.
  */
 export const IconClose = (props) => {
-  const { className, ...rest } = props;
+  const { className, size, ...rest } = props;
 
   return (
     <View
       as="span"
-      width="1em"
-      height="1em"
+      width={size || '1em'}
+      height={size || '1em'}
       className={classNames(ComponentClassNames.Icon, className)}
       {...rest}
     >
@@ -23,6 +23,7 @@ export const IconClose = (props) => {
         viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
+        style={size && { width: size, height: size }}
       >
         <path
           d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

This PR adds a CloseIconButton component to be used by the In-App Messaging feature.

<!-- Also, please reference any associated PRs for documentation updates. -->

Tested with a local app and yarn test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
