### PR TITLE
fix(ui-react): Textarea new line in Firefox

### DIFF
--- a/.changeset/gorgeous-pumas-cheat.md
+++ b/.changeset/gorgeous-pumas-cheat.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui': patch
+---
+
+fix(ui-react): Fixes an issue where TextAreaField does not show line breaks properly in Firefox.

--- a/packages/ui/src/theme/css/component/textArea.scss
+++ b/packages/ui/src/theme/css/component/textArea.scss
@@ -5,4 +5,5 @@
   // This only affects Webkit/Chromium-based browsers that implement
   // the property as inherited.
   user-select: text;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes: #2173 

This change fixes an issue where TextAreaField does not show line breaks properly in Firefox.

![Kapture 2022-07-26 at 16 03 16](https://user-images.githubusercontent.com/68251134/181126925-f397c1de-3071-43c7-af00-aec0d0b5c216.gif)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

#2173 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran docs locally and validated in Firefox.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
