### PR TITLE
ci: remove `--no-lockfile` flag in e2e test

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/install-with-retries
         with:
           # only install binary if cypress cache missed
-          no-lockfile: true
+          no-lockfile: false
           skip-cypress-binary: ${{ steps.restore-cypress-cache.outputs.cache-hit }}
       - name: Build ui package
         run: yarn ui build
@@ -132,7 +132,7 @@ jobs:
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: yarn --no-lockfile
+        run: yarn
 
       - name: Build ui package
         if: ${{ steps.restore-ui-cache.outputs.cache-hit != 'true' && matrix.package != 'ui' }}
@@ -239,7 +239,7 @@ jobs:
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
-        run: yarn --no-lockfile
+        run: yarn
 
       - name: Build @aws-amplify/ui package
         if: steps.restore-ui-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -62,7 +62,6 @@ jobs:
         uses: ./.github/actions/install-with-retries
         with:
           # only install binary if cypress cache missed
-          no-lockfile: false
           skip-cypress-binary: ${{ steps.restore-cypress-cache.outputs.cache-hit }}
       - name: Build ui package
         run: yarn ui build
@@ -132,7 +131,7 @@ jobs:
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: yarn
+        uses: ./.github/actions/install-with-retries
 
       - name: Build ui package
         if: ${{ steps.restore-ui-cache.outputs.cache-hit != 'true' && matrix.package != 'ui' }}
@@ -239,7 +238,7 @@ jobs:
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
-        run: yarn
+        uses: ./.github/actions/install-with-retries
 
       - name: Build @aws-amplify/ui package
         if: steps.restore-ui-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Previously in #1174, we added `--no-lockfile` to `yarn install` commands to test against latest dependency. 

But this has been problematic because:
- this creates discrepancy between local dev environment and the ci/cd environment, 
- ci/cd has been breaking to different hoisting structures ([example](https://github.com/aws-amplify/amplify-ui/runs/7548985338?check_suite_focus=true))

#### Minor improvement 
Also updates `reusable-e2e` test to use `install-with-retries` action that I created previously.

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
