### PR TITLE
fix(ui): update types for ColorModeOverride and BreakpointOverride to allow strings

### DIFF
--- a/.changeset/calm-books-cry.md
+++ b/.changeset/calm-books-cry.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(ui): update types for ColorModeOverride and BreakpointOverride to allow generic strings
+
+Previously, Typescript would show a type error on the theme prop of ThemeProvider (`<ThemeProvider theme={myTheme}>`) if you didn't cast your theme object as a Theme (i.e. `const theme: Theme = {}`). This squashes that error.

--- a/packages/ui/src/theme/types.ts
+++ b/packages/ui/src/theme/types.ts
@@ -39,7 +39,7 @@ interface BaseOverride {
  * ```
  */
 interface BreakpointOverride extends BaseOverride {
-  breakpoint: keyof Breakpoints['values'];
+  breakpoint: keyof Breakpoints['values'] | (string & {});
 }
 
 /**
@@ -86,7 +86,7 @@ type ColorMode = 'light' | 'dark';
  * ```
  */
 export interface ColorModeOverride extends BaseOverride {
-  colorMode: ColorMode;
+  colorMode: ColorMode | (string & {});
 }
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Add `| (string & {})` to ColorModeOverride and BreakpointOverride.

**Context**
Previously, given the following example where a Theme object is created, with overrides for breakpoint and colorMode, without casting the Theme type to it, Typescript would complain (see below). This lets TS chill; you still need to cast as Theme (`const  theme: Theme`) if you want typing suggestions.

<img width="500" alt="Screen Shot 2022-07-28 at 11 27 07 AM" src="https://user-images.githubusercontent.com/376920/181578861-13fb182e-bba7-44c3-a92f-d3ed53291219.png">


```
import { ThemeProvider, Tabs, TabItem } from '@aws-amplify/ui-react';
import '@aws-amplify/ui-react/styles.css';

const theme = {
  name: 'tabs-theme',
  overrides: [
    {
      colorMode: 'dark',
      tokens: {
        colors: {
          border: {
            secondary: { value: 'pink'}
          }
        }
      }
    },
    {
      breakpoint: 'large',
      tokens: {
        space: {
          small: { value: '40px' },
          medium: { value: '80px' },
          large: { value: '120px' },
        },
      },
    },
  ]
};

export default function App() {
  return (
    <ThemeProvider theme={theme}>
      <Tabs>
        <TabItem title="Tab 1">Tab 1 Content</TabItem>
        <TabItem title="Tab 2">Tab 2 Content</TabItem>
      </Tabs>
    </ThemeProvider>
  )
};

```

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
