### PR TITLE
fix(docs): Fix UI docs homepage editor interactivity

### DIFF
--- a/docs/src/components/home/HomeEditor.tsx
+++ b/docs/src/components/home/HomeEditor.tsx
@@ -56,7 +56,7 @@ const Error = () => {
 };
 
 const HomeEditor = () => {
-  const [edited, setEdited] = React.useState(0);
+  const [edited, setEdited] = React.useState(false);
   return (
     <LiveProvider
       scope={{ ...AUI }}
@@ -74,24 +74,17 @@ const HomeEditor = () => {
           className="docs-home-editor__code-panel with-lines scrollable"
         >
           <LiveEditor
-            onChange={(e) => {
-              // onChange gets called when it mounts the first time
-              // so we only want to trigger this analytic event
-              // after onChange is called twice
-              if (edited >= 2) {
-                return;
-              }
-              if (edited === 1) {
-                trackClick('HomeCodeEdit');
-              }
-              setEdited(edited + 1);
-            }}
             onKeyDown={(e) => {
-              // This makes sure the editor is not a focus trap
+              // This makes sure the editor is not a focus trap, allowing the customer to 'tab' out of the editor
               if (e.keyCode === 9) {
                 // tab key
                 e.preventDefault();
                 e.target.blur();
+                return;
+              }
+              if (!edited) {
+                trackClick('HomeCodeEdit');
+                setEdited(true);
               }
             }}
           />

--- a/docs/src/components/home/HomeEditor.tsx
+++ b/docs/src/components/home/HomeEditor.tsx
@@ -75,7 +75,7 @@ const HomeEditor = () => {
         >
           <LiveEditor
             onKeyDown={(e) => {
-              // This makes sure the editor is not a focus trap, allowing the customer to 'tab' out of the editor
+              // This makes sure the editor is not a focus trap, allowing customers to 'tab' out of the editor
               if (e.keyCode === 9) {
                 // tab key
                 e.preventDefault();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

There is an issue in the "Take it for a test drive" example on the [UI Docs homepage](https://ui.docs.amplify.aws/) where the live code editor wasn't working. 

To fix:
- Removed the `onChange` event handler and put the click tracking logic inside of `onKeyDown`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the docs locally

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
