### PR TITLE
fix(ui-react): Hide decorative alert icons from screen readers

### DIFF
--- a/.changeset/popular-bats-glow.md
+++ b/.changeset/popular-bats-glow.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+fix(ui-react): Hide decorative alert icons from screen readers.

--- a/packages/react/src/primitives/Alert/Alert.tsx
+++ b/packages/react/src/primitives/Alert/Alert.tsx
@@ -48,7 +48,7 @@ const AlertPrimitive: Primitive<AlertProps, typeof Flex> = (
         ref={ref}
         {...rest}
       >
-        {hasIcon && <AlertIcon variation={variation} />}
+        {hasIcon && <AlertIcon variation={variation} ariaHidden={true} />}
         <View role="alert" flex="1">
           {heading && (
             <View className={ComponentClassNames.AlertHeading}>{heading}</View>
@@ -63,7 +63,7 @@ const AlertPrimitive: Primitive<AlertProps, typeof Flex> = (
             onClick={dismissAlert}
             ref={buttonRef}
           >
-            <IconClose />
+            <IconClose aria-hidden="true" />
           </Button>
         )}
       </Flex>

--- a/packages/react/src/primitives/Alert/AlertIcon.tsx
+++ b/packages/react/src/primitives/Alert/AlertIcon.tsx
@@ -11,18 +11,42 @@ import {
 
 interface AlertIconProps {
   variation: AlertVariations;
+  ariaHidden?: boolean;
 }
 
-export const AlertIcon: React.FC<AlertIconProps> = ({ variation }) => {
+export const AlertIcon: React.FC<AlertIconProps> = ({
+  variation,
+  ariaHidden,
+}) => {
   switch (variation) {
     case 'info':
-      return <IconInfo className={ComponentClassNames.AlertIcon} />;
+      return (
+        <IconInfo
+          aria-hidden={ariaHidden}
+          className={ComponentClassNames.AlertIcon}
+        />
+      );
     case 'error':
-      return <IconError className={ComponentClassNames.AlertIcon} />;
+      return (
+        <IconError
+          aria-hidden={ariaHidden}
+          className={ComponentClassNames.AlertIcon}
+        />
+      );
     case 'warning':
-      return <IconWarning className={ComponentClassNames.AlertIcon} />;
+      return (
+        <IconWarning
+          aria-hidden={ariaHidden}
+          className={ComponentClassNames.AlertIcon}
+        />
+      );
     case 'success':
-      return <IconCheckCircle className={ComponentClassNames.AlertIcon} />;
+      return (
+        <IconCheckCircle
+          aria-hidden="true"
+          className={ComponentClassNames.AlertIcon}
+        />
+      );
     default:
       return null;
   }

--- a/packages/react/src/primitives/Alert/AlertIcon.tsx
+++ b/packages/react/src/primitives/Alert/AlertIcon.tsx
@@ -43,7 +43,7 @@ export const AlertIcon: React.FC<AlertIconProps> = ({
     case 'success':
       return (
         <IconCheckCircle
-          aria-hidden="true"
+          aria-hidden={ariaHidden}
           className={ComponentClassNames.AlertIcon}
         />
       );

--- a/packages/react/src/primitives/Alert/__tests__/Alert.test.tsx
+++ b/packages/react/src/primitives/Alert/__tests__/Alert.test.tsx
@@ -111,6 +111,21 @@ describe('Alert: ', () => {
     expect(isDismissible.childElementCount).toBe(2);
   });
 
+  it('should set aria-hidden to be true on decorative icons', async () => {
+    const { container } = render(
+      <div>
+        <Alert variation="info" isDismissible={true} testId="hasIcon">
+          Has Icon
+        </Alert>
+      </div>
+    );
+    const icons = container.querySelectorAll(`.${ComponentClassNames.Icon}`);
+    expect(icons.length).toEqual(2);
+    icons.forEach((icon) => {
+      expect(icon).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
   it('can configure an accessible label for the dismiss button', async () => {
     const customDismissButtonLabel = 'Testing 123';
     render(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change hides decorative alert icons such that redundant text is not announced by screen readers.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Deployed docs locally and added unit test.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
