### PR TITLE
fix(in-app-messaging): turn off linting for useAuthenticator._state

### DIFF
--- a/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
@@ -182,6 +182,10 @@ export const useAuthenticator = (selector?: Selector): UseAuthenticator => {
   return {
     ...facade,
     /** @deprecated For internal use only */
+    // The current typing of the Authenticator state machine leads to linting issues due to a
+    // return type of `any`. Because this `_state` is marked as deprecated and will be removed,
+    // turn off linting until stricter typing is added (or `_state` is removed)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     _state: service.getSnapshot(),
     /** @deprecated For internal use only */
     _send: send,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Disable linting for the `_state` return value of `useAuthenticator` due to 1) it's deprecated and will be removed 2) fixing the typing is currently out of scope (and `_state` will be removed eventually)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
