### PR TITLE
fix: allow heading truncation

### DIFF
--- a/.changeset/wise-terms-travel.md
+++ b/.changeset/wise-terms-travel.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui-react': patch
+'@aws-amplify/ui': patch
+---
+
+fix(ui-react): Fixes an issue where the isTruncated prop of the Heading component was not properly applying a truncation.

--- a/packages/react/src/primitives/Heading/Heading.tsx
+++ b/packages/react/src/primitives/Heading/Heading.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import { classNameModifier } from '../shared/utils';
+import { classNameModifier, classNameModifierByFlag } from '../shared/utils';
 import { ComponentClassNames } from '../shared/constants';
 import { HeadingProps, Primitive } from '../types';
 import { View } from '../View';
@@ -22,7 +22,7 @@ const headingLevels: HeadingLevels = {
 };
 
 const HeadingPrimitive: Primitive<HeadingProps, HeadingTag> = (
-  { className, children, level = 6, ...rest },
+  { className, children, isTruncated, level = 6, ...rest },
   ref
 ) => (
   <View
@@ -30,6 +30,11 @@ const HeadingPrimitive: Primitive<HeadingProps, HeadingTag> = (
     className={classNames(
       ComponentClassNames.Heading,
       classNameModifier(ComponentClassNames.Heading, level),
+      classNameModifierByFlag(
+        ComponentClassNames.Heading,
+        'truncated',
+        isTruncated
+      ),
       className
     )}
     ref={ref}

--- a/packages/react/src/primitives/Heading/__tests__/Heading.test.tsx
+++ b/packages/react/src/primitives/Heading/__tests__/Heading.test.tsx
@@ -128,4 +128,20 @@ describe('Heading: ', () => {
     const heading = await screen.findByTestId('dataTest');
     expect(heading.dataset['demo']).toBe('true');
   });
+
+  it('should render the truncated class on Heading', async () => {
+    render(
+      <div>
+        <Heading testId="truncated" isTruncated={true}>
+          truncated
+        </Heading>
+      </div>
+    );
+
+    const truncated = await screen.findByTestId('truncated');
+
+    expect(truncated.classList).toContain(
+      `${ComponentClassNames['Heading']}--truncated`
+    );
+  });
 });

--- a/packages/ui/src/theme/css/component/heading.scss
+++ b/packages/ui/src/theme/css/component/heading.scss
@@ -2,6 +2,12 @@
   color: var(--amplify-components-heading-color);
   line-height: var(--amplify-components-heading-line-height);
   display: block;
+
+  &--truncated {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .amplify-heading--1 {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

This PR fixes an issue where the `isTruncated` prop of the `<Heading />` component was not properly applying a truncation.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Tested locally in a sample app and `yarn test`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
