### PR TITLE
fix: Fix Canary Build

### DIFF
--- a/canary/apps/react/vite3/package.json
+++ b/canary/apps/react/vite3/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "postbuild": "yarn run size-limit",
-    "preview": "vite preview --port 3000"
+    "preview": "vite preview --port 3000",
+    "start": "vite preview --port 3000"
   },
   "dependencies": {
     "@aws-amplify/ui-react": "latest",

--- a/canary/apps/react/vite3/waitOnConfig.json
+++ b/canary/apps/react/vite3/waitOnConfig.json
@@ -1,0 +1,5 @@
+{
+  "headers": {
+    "accept": "text/html"
+  }
+}

--- a/canary/apps/vue/vite3/waitOnConfig.json
+++ b/canary/apps/vue/vite3/waitOnConfig.json
@@ -1,0 +1,5 @@
+{
+  "headers": {
+    "accept": "text/html"
+  }
+}


### PR DESCRIPTION
#### Description of changes
After the recent changes to the canary, we need a new waitOnConfig file to be in the directory for it to run correctly.

#### Issue #, if available

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
