### PR TITLE
chore: remove unneeded internal primitives.json output

### DIFF
--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import type { PrimitiveCatalogType } from '../src/types/catalog';
+import { PrimitiveCatalog } from '@aws-amplify/ui-react/internal';
 
 // Jest doesn't support `exports` maps, so we have to reference `dist` directly.
 // See: https://github.com/facebook/jest/issues/9771
@@ -161,24 +162,8 @@ describe('@aws-amplify/ui-react/internal', () => {
   });
 });
 
-const getCatalogJSON = (): PrimitiveCatalogType => {
-  try {
-    const rawJSON = fs
-      .readFileSync(path.join(__dirname, '../dist/primitives.json'))
-      .toString();
-
-    return JSON.parse(rawJSON) as PrimitiveCatalogType;
-  } catch (err) {
-    console.error('Error reading primitives catalog JSON file:', err);
-  }
-
-  return {};
-};
-
 describe('primitive catalog', () => {
-  const catalog = getCatalogJSON();
-
-  it.each(Object.entries(catalog))(
+  it.each(Object.entries(PrimitiveCatalog))(
     'should contain properties for %s primitive',
     (name, primitive) => {
       expect(Object.keys(primitive.properties).length).toBeGreaterThan(0);
@@ -186,7 +171,7 @@ describe('primitive catalog', () => {
   );
 
   it('should match primitives list snapshot', () => {
-    expect(Object.keys(catalog)).toMatchInlineSnapshot(`
+    expect(Object.keys(PrimitiveCatalog)).toMatchInlineSnapshot(`
       Array [
         "Alert",
         "Badge",

--- a/packages/react/scripts/generatePrimitiveCatalog.ts
+++ b/packages/react/scripts/generatePrimitiveCatalog.ts
@@ -182,33 +182,19 @@ for (const [componentName, [node]] of source.getExportedDeclarations()) {
 }
 
 /**
- * Generate the JSON string of the PrimitiveCatalog
- * this is being exported under the /primitives.json subpath and can be used as
- * import PrimitiveCatalog from '@aws-amplify/ui-react/primitives.json'
- */
-const jsonString = JSON.stringify(catalog, null, 2);
-
-/**
  * Generate the es module of the PrimitiveCatalog
  * this is being exported under the /internal/primitives-catalog subpath and can be used as
  * import { PrimitiveCatalog } from '@aws-amplify/ui-react/internal/primitives-catalog'
  */
+const primitiveCatalog = JSON.stringify(catalog, null, 2);
 const exportString = `import { PrimitiveCatalogType } from './types/catalog';
-export const PrimitiveCatalog: PrimitiveCatalogType = ${jsonString};`;
+export const PrimitiveCatalog: PrimitiveCatalogType = ${primitiveCatalog};`;
 
-// Generates dist folder file since it's deleted in `prebuild`
-// NOTE: This line can be removed when we remove primitives.json output
-const distFolderPath = `${path.resolve(__dirname, '..')}/dist`;
-if (!fs.existsSync(distFolderPath)) {
-  fs.mkdirSync(distFolderPath);
-}
-
-const JSONoutputPath = `${path.resolve(__dirname, '..')}/dist/primitives.json`;
 const internalOutputPath = path.resolve(
   __dirname,
   '..',
   'src',
   'PrimitiveCatalog.ts'
 );
-fs.writeFileSync(JSONoutputPath, jsonString, { flag: 'w' });
+
 fs.writeFileSync(internalOutputPath, exportString, { flag: 'w' });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This removes the internally used primitives.json output which represents the Primitive properties for Studio. This file is no longer being used by the UI Builder team; they have migrated over to the ES Module internal export.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
N/A
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
```
// Build a tarball
cd packages/react
npm pack

// navigate to Studio app and tests the import
npm install [tarball path]
npm start
```
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
