### PR TITLE
docs: Add callout for MapView margin reset

### DIFF
--- a/docs/src/pages/[platform]/connected-components/geo/fragments/margin-reset.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/geo/fragments/margin-reset.react.mdx
@@ -1,0 +1,5 @@
+```css
+body {
+  margin: 0;
+}
+```

--- a/docs/src/pages/[platform]/connected-components/geo/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/geo/react.mdx
@@ -1,6 +1,6 @@
 import { Example } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
-import { Tabs, TabItem } from '@aws-amplify/ui-react';
+import { Alert, Tabs, TabItem } from '@aws-amplify/ui-react';
 
 Amplify UI Geo is powered by
 [Geo APIs](https://docs.amplify.aws/lib/geo/getting-started/q/platform/js/) and
@@ -28,6 +28,13 @@ additional configuration.
 <Fragment platforms={['react']}>
   {({ platform }) => import(`./fragments/map-quick-start.${platform}.mdx`)}
 </Fragment>
+
+<Alert role="none" variation="info">
+  If the map isn't taking up the entire screen, try resetting your browser's default CSS body margins:
+  <Fragment platforms={['react']}>
+    {({ platform }) => import(`./fragments/margin-reset.${platform}.mdx`)}
+  </Fragment>
+</Alert>
 
 ### Setting Initial Viewport
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
When using the `<MapView>` component, the map will sometimes not take up the entire viewport of the browser and the attribution footer will be cut off. To address this, users will need to reset the default `body` CSS margins. This pull request adds an info callout to reset css `body` margins.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

### Without margin reset (notice attribution lower right)
<img width="1792" alt="Screen Shot 2022-08-02 at 11 38 32" src="https://user-images.githubusercontent.com/26472139/182449359-4bd14b82-da4d-4f7d-b185-57ca458d7452.png">

### With margin reset
<img width="1791" alt="Screen Shot 2022-08-02 at 11 36 52" src="https://user-images.githubusercontent.com/26472139/182448942-76cf32c3-df6f-48da-b94e-599793358d80.png">


#### Issue #, if available
N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
