### PR TITLE
fix(e2e): mock Auth.signUp call in totp test

### DIFF
--- a/packages/e2e/features/ui/components/authenticator/sign-in-totp-mfa.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-totp-mfa.feature
@@ -63,6 +63,7 @@ Feature: Sign In with TOTP MFA
     And I type a new "email"
     And I type my password
     And I confirm my password
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-email"
     And I click the "Create Account" button
     Then I see "Confirmation Code"
     And I type a valid confirmation code


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This intercepts and mocks `Auth.signUp` call in totp-mfa test. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
