### PR TITLE
fix(in-app-messaging): Strictly type BannerMessage

### DIFF
--- a/packages/react-core/src/InAppMessaging/types.ts
+++ b/packages/react-core/src/InAppMessaging/types.ts
@@ -54,11 +54,14 @@ export type BannerMessageLayouts =
 
 export type MessageComponentPosition = 'bottom' | 'middle' | 'top';
 
+export type MessageComponentAlignment = 'left' | 'center' | 'right';
+
 // Banner Message requires a `position` prop
 export interface BannerMessageCommonProps<PlatformStyleProps>
   extends MessageCommonProps<PlatformStyleProps>,
     MessageContentProps {
   position?: MessageComponentPosition;
+  alignment?: MessageComponentAlignment;
 }
 
 // Carousel Message nests content props in its `data` prop

--- a/packages/react/src/components/InAppMessaging/BannerMessage/BannerMessage.tsx
+++ b/packages/react/src/components/InAppMessaging/BannerMessage/BannerMessage.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -6,8 +8,9 @@ import { Text } from '../../../primitives/Text';
 import { CloseIconButton } from '../CloseIconButton';
 import { useThemeBreakpoint } from '../../../hooks/useThemeBreakpoint';
 import { useMessageProps } from '../hooks/useMessageProps';
+import { MessageDefaultComponents } from '../InAppMessageDisplay/types';
 
-export default function BannerMessage({
+const BannerMessage: MessageDefaultComponents['BannerMessage'] = ({
   alignment = 'right',
   body,
   container,
@@ -19,7 +22,7 @@ export default function BannerMessage({
   position = 'top',
   primaryButton,
   secondaryButton,
-}): JSX.Element | null {
+}) => {
   const breakpoint = useThemeBreakpoint();
 
   const messageProps = useMessageProps({
@@ -98,4 +101,6 @@ export default function BannerMessage({
       ) : null}
     </Flex>
   );
-}
+};
+
+export default BannerMessage;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This PR fixes react linting issues on `BannerMeessage.tsx` file.

#### Details

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

`yarn react lint` was failing ([workflow](https://github.com/aws-amplify/amplify-ui/runs/7661680933?check_suite_focus=true)) on `in-app-messaging/main` because 

1. `BannerMessage` was not explicitly typed and could not infer which fields are optional (see [workflow](https://github.com/aws-amplify/amplify-ui/runs/7661680933?check_suite_focus=true)),
2. `BannerMessageCommonProps` was missing `alignment` type, and
3. `BannerMessage` was missing `import React from 'react';`

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
