### PR TITLE
deps: pin @types/react to 17.0.47 in next apps

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/lodash": "^4.14.170",
     "@types/node": "^14.14.31",
-    "@types/react": "^17.0.2",
+    "@types/react": "17.0.47",
     "autoprefixer": "^10.2.4",
     "canvas": "^2.9.1",
     "dotenv-safe": "^8.2.0",

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/node": "^15.12.4",
-    "@types/react": "^17",
+    "@types/react": "17.0.47",
     "eslint": "7.29.0",
     "eslint-config-next": "11.0.1",
     "rimraf": "^3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6127,6 +6127,15 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/react@17.0.47":
+  version "17.0.47"
+  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.47.tgz#4ee71aaf4c5a9e290e03aa4d0d313c5d666b3b78"
+  integrity sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/react@^17", "@types/react@^17.0.2":
   version "17.0.45"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.45.tgz#9b3d5b661fd26365fefef0e766a1c6c30ccf7b3f"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This pins `@types/react` to `17.0.47` in next.js apps, because next.js@11 is incompatible with latest `@types/react@17.0.48`.

See minimal repro: 
- `@types/react@17.0.48` — [fails](https://codesandbox.io/s/next11-with-types-react-17-0-48-vq5fhr?file=/README.md)
- `@types/react@17.0.47` — [works](https://codesandbox.io/s/next11-with-types-react-17-0-47-dgrzuv?file=/README.md)

This has happened a few times before in https://github.com/vercel/next.js/issues/36085 and https://github.com/vercel/next.js/issues/36106, but the fix has been onto `next.js@12` and not 11. We can merge this until we upgrade to better supported version.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
