### PR TITLE
fix: add tslib as hard dependency in react and ui package

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -71,7 +71,8 @@
     "maplibre-gl-js-amplify": "2.0.2",
     "qrcode": "1.5.0",
     "react-generate-context": "1.0.1",
-    "react-map-gl": "7.0.15"
+    "react-map-gl": "7.0.15",
+    "tslib": "2.4.0"
   },
   "peerDependencies": {
     "aws-amplify": "3.x.x || 4.x.x",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,6 @@
   },
   "files": [
     "dist",
-    "dist/esm/node_modules",
     "legacy",
     "internal",
     "LICENSE"

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "react-jsx",
     "rootDir": "./src",
     "outDir": "./dist",
+    "importHelpers": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "module": "esnext",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,7 +24,6 @@
   },
   "files": [
     "dist",
-    "dist/esm/node_modules",
     "LICENSE"
   ],
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "lodash": "4.17.21",
     "style-dictionary": "3.7.0",
-    "xstate": "^4.30.6"
+    "xstate": "^4.30.6",
+    "tslib": "2.4.0"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.3.1",
@@ -63,7 +64,6 @@
     "sass": "^1.35.2",
     "ts-jest": "^27.0.3",
     "ts-node": "^10.2.1",
-    "tslib": "^2.3.0",
     "type-fest": "^2.3.4"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8747,9 +8747,9 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001032, caniuse-lite@^1.0.30001181, can
   integrity sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==
 
 caniuse-lite@^1.0.30001314:
-  version "1.0.30001373"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz#2dc3bc3bfcb5d5a929bec11300883040d7b4b4be"
-  integrity sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==
+  version "1.0.30001374"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz#3dab138e3f5485ba2e74bd13eca7fe1037ce6f57"
+  integrity sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==
 
 canonical-path@1.0.0:
   version "1.0.0"
@@ -22889,15 +22889,15 @@ tslib@2.3.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@2.4.0, tslib@^2, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tslib@^1.0.0, tslib@^1.10.0, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslint@~6.1.0:
   version "6.1.3"


### PR DESCRIPTION
#### Description of changes

Add `tslib` as hard dependency in both react and ui package so that it will not be included in the bundle but instead it will get pulled down from npm when users install the react/ui package.

#### Issue #, if available

This will fix the weird CI issue where `tslib` is unable to be resolved correctly

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
