### PR TITLE
fix(ui-angular + ui-vue): Hide decorative alert icons from screen readers

### DIFF
--- a/.changeset/weak-pillows-dream.md
+++ b/.changeset/weak-pillows-dream.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui-angular': patch
+'@aws-amplify/ui-vue': patch
+---
+
+Hide decorative alert icons from screen readers.

--- a/packages/angular/projects/ui-angular/src/lib/primitives/error/error.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/error/error.component.html
@@ -9,6 +9,7 @@
     <svg
       xmlns="http://www.w3.org/2000/svg"
       class="amplify-icon"
+      [attr.aria-hidden]="true"
       viewBox="0 0 24 24"
       fill="currentColor"
     >
@@ -29,6 +30,7 @@
     <svg
       xmlns="http://www.w3.org/2000/svg"
       class="amplify-icon"
+      [attr.aria-hidden]="true"
       viewBox="0 0 24 24"
       fill="currentColor"
     >

--- a/packages/vue/src/components/primitives/__tests__/base-alert.spec.ts
+++ b/packages/vue/src/components/primitives/__tests__/base-alert.spec.ts
@@ -1,7 +1,6 @@
 import BaseAlert from '../base-alert.vue';
 import { components } from '../../../../global-spec';
 import { render } from '@testing-library/vue';
-
 import { I18n } from 'aws-amplify';
 
 describe('Base Alert', () => {
@@ -25,6 +24,7 @@ describe('Base Alert', () => {
     const defaultButton = queryByRole('button');
     expect(defaultButton?.getAttribute('aria-label')).toBe('Dismiss alert');
   });
+
   it('shows correct default translated label', () => {
     const translatedAriaLabel = 'Translated dismiss alert';
     I18n.putVocabulariesForLanguage('en', {
@@ -38,5 +38,16 @@ describe('Base Alert', () => {
 
     const defaultButton = queryByRole('button');
     expect(defaultButton?.getAttribute('aria-label')).toBe(translatedAriaLabel);
+  });
+
+  it('should set aria-hidden to be true on dismiss button decorative icon', () => {
+    const { queryByRole } = render(BaseAlert, {
+      global: {
+        components,
+      },
+    });
+    const defaultButton = queryByRole('button');
+    const icon = defaultButton?.children[0];
+    expect(icon?.getAttribute('aria-hidden')).toBe('true');
   });
 });

--- a/packages/vue/src/components/primitives/base-alert.vue
+++ b/packages/vue/src/components/primitives/base-alert.vue
@@ -22,6 +22,7 @@ function close() {
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="amplify-icon"
+        aria-hidden="true"
         viewBox="0 0 24 24"
         fill="currentColor"
       >
@@ -42,6 +43,7 @@ function close() {
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="amplify-icon"
+        aria-hidden="true"
         viewBox="0 0 24 24"
         fill="currentColor"
       >


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change hides decorative alert icons such that redundant text is not announced by screen readers.


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
