### PR TITLE
fix(docs): Update sign up fields link

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/configuration/index.page.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/configuration/index.page.mdx
@@ -65,7 +65,7 @@ but can be explicitly defined as seen below.
 </Alert>
 
 The Authenticator automatically renders _most_ [Cognito User Pools attributes](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html),
-with the exception of `address`, `gender`, `locale`, `picture`, `updated_at`, and `zoneinfo`. Because these are often app-specific, they can be customized via [Sign Up fields](#sign-up-fields).
+with the exception of `address`, `gender`, `locale`, `picture`, `updated_at`, and `zoneinfo`. Because these are often app-specific, they can be customized via [Sign Up fields](customization#sign-up-fields).
 
 <Tabs>
   <TabItem title="Verification Attributes">


### PR DESCRIPTION
#### Description of changes
The link in the configuration sign up attributes points to the configuration section. This should point to the customization section, otherwise the link does not work after clicking it.

#### Description of how you validated changes
Manually

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
