### PR TITLE
chore(in-app-messaging): update React web BannerMessage typing

### DIFF
--- a/packages/react-core/src/InAppMessaging/types.ts
+++ b/packages/react-core/src/InAppMessaging/types.ts
@@ -54,14 +54,11 @@ export type BannerMessageLayouts =
 
 export type MessageComponentPosition = 'bottom' | 'middle' | 'top';
 
-export type MessageComponentAlignment = 'left' | 'center' | 'right';
-
 // Banner Message requires a `position` prop
 export interface BannerMessageCommonProps<PlatformStyleProps>
   extends MessageCommonProps<PlatformStyleProps>,
     MessageContentProps {
   position?: MessageComponentPosition;
-  alignment?: MessageComponentAlignment;
 }
 
 // Carousel Message nests content props in its `data` prop

--- a/packages/react/src/components/InAppMessaging/BannerMessage/BannerMessage.tsx
+++ b/packages/react/src/components/InAppMessaging/BannerMessage/BannerMessage.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 
+import { useThemeBreakpoint } from '../../../hooks/useThemeBreakpoint';
 import { Button } from '../../../primitives/Button';
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
 import { Image } from '../../../primitives/Image';
 import { Text } from '../../../primitives/Text';
-import { CloseIconButton } from '../CloseIconButton';
-import { useThemeBreakpoint } from '../../../hooks/useThemeBreakpoint';
-import { useMessageProps } from '../hooks/useMessageProps';
-import { MessageDefaultComponents } from '../InAppMessageDisplay/types';
 
-const BannerMessage: MessageDefaultComponents['BannerMessage'] = ({
+import { CloseIconButton } from '../CloseIconButton';
+import { useMessageProps } from '../hooks/useMessageProps';
+
+import { BannerMessageProps } from './types';
+
+export default function BannerMessage({
   alignment = 'right',
   body,
   container,
@@ -22,7 +24,7 @@ const BannerMessage: MessageDefaultComponents['BannerMessage'] = ({
   position = 'top',
   primaryButton,
   secondaryButton,
-}) => {
+}: BannerMessageProps): JSX.Element {
   const breakpoint = useThemeBreakpoint();
 
   const messageProps = useMessageProps({
@@ -101,6 +103,4 @@ const BannerMessage: MessageDefaultComponents['BannerMessage'] = ({
       ) : null}
     </Flex>
   );
-};
-
-export default BannerMessage;
+}

--- a/packages/react/src/components/InAppMessaging/BannerMessage/index.ts
+++ b/packages/react/src/components/InAppMessaging/BannerMessage/index.ts
@@ -1,1 +1,2 @@
 export { default as BannerMessage } from './BannerMessage';
+export { BannerMessageProps } from './types';

--- a/packages/react/src/components/InAppMessaging/BannerMessage/types.ts
+++ b/packages/react/src/components/InAppMessaging/BannerMessage/types.ts
@@ -1,0 +1,9 @@
+import { BannerMessageCommonProps } from '@aws-amplify/ui-react-core';
+import { MessageOverrideStyle } from '../hooks';
+
+type BannerMessageAlignment = 'left' | 'center' | 'right';
+
+export interface BannerMessageProps
+  extends BannerMessageCommonProps<MessageOverrideStyle | undefined> {
+  alignment?: BannerMessageAlignment;
+}

--- a/packages/react/src/components/InAppMessaging/FullScreenMessage/index.ts
+++ b/packages/react/src/components/InAppMessaging/FullScreenMessage/index.ts
@@ -1,1 +1,2 @@
 export { FullScreenMessage } from './FullScreenMessage';
+export { FullScreenMessageProps } from './types';

--- a/packages/react/src/components/InAppMessaging/InAppMessageDisplay/types.ts
+++ b/packages/react/src/components/InAppMessaging/InAppMessageDisplay/types.ts
@@ -5,10 +5,13 @@ import {
   ModalMessageComponent,
 } from '@aws-amplify/ui-react-core';
 
+import { BannerMessageProps } from '../BannerMessage';
+import { FullScreenMessageProps } from '../FullScreenMessage';
+
 // TODO: replace these incrementally as they become available
-type BannerStyle = any;
+type BannerStyle = BannerMessageProps['style'];
 type CarouselStyle = any;
-type FullScreenStyle = any;
+type FullScreenStyle = FullScreenMessageProps['style'];
 type ModalStyle = any;
 
 export interface MessageDefaultComponents {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Updates the typing of the React web `BannerMessage` to follow patterns used by other In-App Messaging components, in addition move `alignment` prop to React web only (does not exist in React Native component)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`yarn react lint && yarn build`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
