### PR TITLE
fix(ui-react): Add base bg color for the SearchField component button

### DIFF
--- a/.changeset/fast-mirrors-talk.md
+++ b/.changeset/fast-mirrors-talk.md
@@ -1,0 +1,6 @@
+---
+'docs': patch
+'@aws-amplify/ui': patch
+---
+
+This change adds a base background color for the SearchField component's button.

--- a/.changeset/fast-mirrors-talk.md
+++ b/.changeset/fast-mirrors-talk.md
@@ -1,5 +1,4 @@
 ---
-'docs': patch
 '@aws-amplify/ui': patch
 ---
 

--- a/docs/src/pages/[platform]/components/searchfield/examples/SearchFieldThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/searchfield/examples/SearchFieldThemeExample.tsx
@@ -7,6 +7,7 @@ const theme: Theme = {
       searchfield: {
         button: {
           color: { value: '{colors.blue.80}' },
+          backgroundColor: { value: '{colors.blue.20}' },
           _focus: {
             backgroundColor: {
               value: '{colors.blue.60}',

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -529,6 +529,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-rating-empty-color: var(--amplify-colors-background-tertiary);
         --amplify-components-searchfield-color: var(--amplify-components-fieldcontrol-color);
         --amplify-components-searchfield-button-color: var(--amplify-components-button-color);
+        --amplify-components-searchfield-button-background-color: var(--amplify-colors-background-primary);
         --amplify-components-searchfield-button-active-background-color: var(--amplify-components-button-active-background-color);
         --amplify-components-searchfield-button-active-border-color: var(--amplify-components-button-active-border-color);
         --amplify-components-searchfield-button-active-color: var(--amplify-components-button-active-color);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -563,6 +563,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-rating-empty-color: var(--amplify-colors-background-tertiary);
         --amplify-components-searchfield-color: var(--amplify-components-fieldcontrol-color);
         --amplify-components-searchfield-button-color: var(--amplify-components-button-color);
+        --amplify-components-searchfield-button-background-color: var(--amplify-colors-background-primary);
         --amplify-components-searchfield-button-active-background-color: var(--amplify-components-button-active-background-color);
         --amplify-components-searchfield-button-active-border-color: var(--amplify-components-button-active-border-color);
         --amplify-components-searchfield-button-active-color: var(--amplify-components-button-active-color);

--- a/packages/ui/src/theme/css/component/searchField.scss
+++ b/packages/ui/src/theme/css/component/searchField.scss
@@ -4,6 +4,9 @@
   );
   &__search {
     color: var(--amplify-components-searchfield-button-color);
+    background-color: var(
+      --amplify-components-searchfield-button-background-color
+    );
     &:active {
       background-color: var(
         --amplify-components-button-active-background-color

--- a/packages/ui/src/theme/tokens/components/searchField.ts
+++ b/packages/ui/src/theme/tokens/components/searchField.ts
@@ -1,8 +1,13 @@
-import { ColorValue, DesignToken } from '../types/designToken';
+import {
+  BackgroundColorValue,
+  ColorValue,
+  DesignToken,
+} from '../types/designToken';
 import { StateTokens } from './button';
 
 interface SearchTokens {
   color: DesignToken<ColorValue>;
+  backgroundColor: DesignToken<BackgroundColorValue>;
   _active: StateTokens;
   _disabled: StateTokens;
   _focus: StateTokens;
@@ -18,6 +23,7 @@ export const searchfield: SearchFieldTokens = {
   color: { value: '{components.fieldcontrol.color.value}' },
   button: {
     color: { value: '{components.button.color.value}' },
+    backgroundColor: { value: '{colors.background.primary.value}' },
     _active: {
       backgroundColor: {
         value: '{components.button._active.backgroundColor.value}',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adding design token for  SearchField button so that it can be customized. Docs example is updated to showcase usage:

<img width="861" alt="Screen Shot 2022-08-08 at 10 10 58 AM" src="https://user-images.githubusercontent.com/68251134/183475528-841b6775-237b-4805-92e6-7ef61665c6a6.png">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fixes #2412 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
