### PR TITLE
docs: remove tab in props control panel

### DIFF
--- a/docs/src/components/Demo.tsx
+++ b/docs/src/components/Demo.tsx
@@ -1,14 +1,6 @@
 import * as React from 'react';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
 import Highlight, { defaultProps } from 'prism-react-renderer';
-import {
-  Tabs,
-  TabItem,
-  Flex,
-  View,
-  Button,
-  useTheme,
-} from '@aws-amplify/ui-react';
+import { Divider, Flex, View, useTheme } from '@aws-amplify/ui-react';
 import { CopyButton } from './CopyButton';
 
 interface DemoProps {
@@ -50,16 +42,17 @@ export const Demo = ({
           <View overflow="auto" padding="5px">
             {children}
           </View>
+          <Divider
+            label="Props"
+            margin="20px 0 0"
+            border={`2px solid ${tokens.colors.brand.primary[80]}`}
+            style={{
+              '--amplify-components-divider-label-color':
+                tokens.colors.brand.primary[80],
+            }}
+          />
           {propControls && (
-            <Tabs>
-              <TabItem title="Props">
-                <View padding={`${tokens.space.medium} 0`}>{propControls}</View>
-              </TabItem>
-              {/* Temporarily removing the Theme tab until we figure out a way 
-                to let customers dynamically edit a theme object in the demos 
-            */}
-              {/* {themeControls ? <TabItem title="Theme">{themeControls}</TabItem> : null} */}
-            </Tabs>
+            <View padding={`${tokens.space.medium} 0`}>{propControls}</View>
           )}
         </Flex>
         <View

--- a/docs/src/components/Demo.tsx
+++ b/docs/src/components/Demo.tsx
@@ -43,13 +43,8 @@ export const Demo = ({
             {children}
           </View>
           <Divider
-            label="Props"
             margin="20px 0 0"
-            border={`2px solid ${tokens.colors.brand.primary[80]}`}
-            style={{
-              '--amplify-components-divider-label-color':
-                tokens.colors.brand.primary[80],
-            }}
+            border={`2px solid ${tokens.colors.border.secondary}`}
           />
           {propControls && (
             <View padding={`${tokens.space.medium} 0`}>{propControls}</View>


### PR DESCRIPTION
#### Description of changes

Remove props tab in demo control panel to reduce unneeded noise for SR users and keyboard users. We can add it back in once we have a theme section

![Screen Shot 2022-08-09 at 1 39 20 PM](https://user-images.githubusercontent.com/40295569/183759403-97b8e2d6-5b9a-4d25-aeea-e6a37d81cabf.png)

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
