### PR TITLE
ci(in-app-messaging): use absolute path to reference reusable workflow

### DIFF
--- a/.github/workflows/test-in-app-messaging.yml
+++ b/.github/workflows/test-in-app-messaging.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    uses: ./.github/workflows/reusable-e2e.yml
+    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@in-app-messaging/main
     with:
       commit: ${{ github.sha }}
       repository: ${{ github.repository }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This adjusts `test-in-app-messaging.yml` to reference the reusable e2e file with absolute path. This is generally considered safer when combined with `pull_request_target`. 

(To be precise, it doens't change the threat model in this case because `in-app-messaging/main` is protected and only maintainers can push onto it, but it's a good practice).

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

This only changes the path so I'm comfortable with manually verifying after merge.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
