### PR TITLE
ci: Handle `in-app-messaging` PR tests separately

### DIFF
--- a/.github/workflows/test-in-app-messaging-prs.yml
+++ b/.github/workflows/test-in-app-messaging-prs.yml
@@ -1,11 +1,12 @@
-# Description: This workflow runs unit + e2e tests on PRs targeting `main` and
-#              other protected branches listed below.
+# Description: This workflow runs unit + e2e tests on PRs targeting
+#   - `in-app-messaging/main`
+#   - `in-app-messaging/release`
 #
 # Triggered by:
-#   (1) Internal PRs: contirubutor pushes a commit to PRs targeting protected branches.
-#   (2) Fork PRs: maintainer adds "run-test" label to PRs targeting protected branches.
+#   (1) Internal PRs: maintainer pushes a commit to PRs targeting those branches.
+#   (2) Fork PRs: maintainer adds "run-test" label to PRs targeting those branches.
 
-name: Test / PRs
+name: Test / in-app-messaging / PRs
 
 concurrency:
   group: e2e-${{ github.event.pull_request.id }}
@@ -13,7 +14,10 @@ concurrency:
 
 on:
   pull_request_target:
-    branches: [main, ui-svelte/main, ui-geo/main, ui-react@v2, studio-release]
+    branches: [
+        in-app-messaging/main
+        in-app-messaging/release,
+      ]
     types: [opened, synchronize, labeled]
 
 permissions:
@@ -40,7 +44,7 @@ jobs:
             const label = 'run-tests';
             github.issues.removeLabel({ owner, repo, issue_number, name: label });
   test:
-    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@main
+    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@in-app-messaging/main
     needs: setup
     with:
       commit: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Summary

Sets up `in-app-messaging` PR CI tests to run the workflow on `@in-app-messaging/main`, instead of one in `main`.

This **only** affects workflows related to in-app-messaging.

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

`in-app-messaging/main` has updated version of CI tests because it tests for `react-native` and `react-core` in addition to preexisting packages.

Now that its CI has diverged, we want to ensure the tests against `in-app-messaging` branches uses the new one.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
