### PR TITLE
fix: remove headless usage page from flutter

### DIFF
--- a/docs/src/data/links.tsx
+++ b/docs/src/data/links.tsx
@@ -126,7 +126,7 @@ export const connectedComponents = [
   {
     href: '/connected-components/authenticator/headless',
     label: 'Headless Usage',
-    platforms: ['react', 'vue', 'angular', 'flutter'],
+    platforms: ['react', 'vue', 'angular'],
     tertiary: true,
   },
   {

--- a/docs/src/pages/[platform]/connected-components/authenticator/headless/headless-usage.flutter.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/headless/headless-usage.flutter.mdx
@@ -1,7 +1,0 @@
-import { Alert, Text } from '@aws-amplify/ui-react';
-
-<Alert role="none" variation="info" marginBottom="1rem">
-  <Text>Flutter does not support headless usage</Text>
-</Alert>
-
-Please view the [Flutter Authenticator](/flutter/components/authenticator) documentation to begin.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Remove "Headless Usage" Page from Flutter, since it doesn't exist.

|  Before  | After  |
|---|---|
| ![image](https://user-images.githubusercontent.com/11983489/183782373-156a217e-eebc-4c0e-a3c1-a24a9ed15a6d.png) | ![image](https://user-images.githubusercontent.com/11983489/183782398-9159f6b9-759f-4f4a-b364-b75438fcefb0.png)  |



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- Verified in local. See the screenshot above
- Manually checked sitemap which is not affact

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202729371496839