### PR TITLE
feat(in-app-messaging): remove styles prop from InAppMessageDisplay

### DIFF
--- a/examples/next/pages/ui/components/in-app-messaging/override-styling/aws-exports.js
+++ b/examples/next/pages/ui/components/in-app-messaging/override-styling/aws-exports.js
@@ -1,0 +1,8 @@
+// This is a temporary amplify exports file.
+// You must supply the config from your own in-app env.
+// The Demo app will still function without values below,
+// but will throw warnings on some displayMessage calls
+
+const awsmobile = {};
+
+export default awsmobile;

--- a/examples/next/pages/ui/components/in-app-messaging/override-styling/index.page.tsx
+++ b/examples/next/pages/ui/components/in-app-messaging/override-styling/index.page.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback, useEffect } from 'react';
+import { Amplify } from 'aws-amplify';
+import {
+  Button,
+  InAppMessageDisplay,
+  useInAppMessaging,
+  withInAppMessaging,
+} from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+import config from './aws-exports';
+
+Amplify.configure(config);
+
+const CustomModalMessage = (props) => (
+  <InAppMessageDisplay.ModalMessage
+    {...props}
+    style={{ container: { backgroundColor: 'antiquewhite' } }}
+  />
+);
+
+function App() {
+  const { displayMessage } = useInAppMessaging();
+
+  const displayCustomModalMessage = useCallback(
+    () =>
+      displayMessage({
+        content: [{ header: { content: 'Hello World!' } }],
+        id: 'custom message',
+        layout: 'MODAL',
+      }),
+    [displayMessage]
+  );
+
+  // display message component on initial render
+  useEffect(displayCustomModalMessage, [displayCustomModalMessage]);
+
+  return (
+    <Button margin="medium" onClick={displayCustomModalMessage}>
+      Display Custom Modal Message
+    </Button>
+  );
+}
+
+export default withInAppMessaging(App, {
+  components: { ModalMessage: CustomModalMessage },
+});

--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { StyleSheet, View, Text } from 'react-native';
-import { withInAppMessaging } from '@aws-amplify/ui-react-native';
+import {
+  InAppMessageDisplay,
+  withInAppMessaging,
+} from '@aws-amplify/ui-react-native';
 
 const App = () => {
   return (

--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { StyleSheet, View, Text } from 'react-native';
-import {
-  InAppMessageDisplay,
-  withInAppMessaging,
-} from '@aws-amplify/ui-react-native';
+import { withInAppMessaging } from '@aws-amplify/ui-react-native';
 
 const App = () => {
   return (

--- a/packages/react-core/src/InAppMessaging/hooks/useMessage/__tests__/useMessage.spec.ts
+++ b/packages/react-core/src/InAppMessaging/hooks/useMessage/__tests__/useMessage.spec.ts
@@ -41,13 +41,6 @@ const carouselMessage: Partial<Message> = {
   content: [{ header }, { header: { content: 'header two' } }],
   layout: 'CAROUSEL',
 };
-const style = { backgroundColor: 'fuschia' };
-const styles = {
-  bannerMessage: style,
-  carouselMessage: style,
-  fullScreenMessage: style,
-  modalMessage: style,
-};
 
 function BannerMessage() {
   return null;
@@ -98,7 +91,6 @@ describe('useMessage', () => {
           layout,
           onClose: expect.any(Function) as TestMessageProps['onClose'],
           onDisplay: expect.any(Function) as TestMessageProps['onDisplay'],
-          style: undefined,
         })
       );
     }
@@ -119,7 +111,6 @@ describe('useMessage', () => {
         layout: 'CAROUSEL',
         onClose: expect.any(Function) as TestMessageProps['onClose'],
         onDisplay: expect.any(Function) as TestMessageProps['onDisplay'],
-        style: undefined,
       })
     );
   });
@@ -146,24 +137,6 @@ describe('useMessage', () => {
         onDisplay: expect.any(Function) as TestMessageProps['onDisplay'],
       })
     );
-  });
-
-  it.each([
-    'BOTTOM_BANNER',
-    'CAROUSEL',
-    'FULL_SCREEN',
-    'MIDDLE_BANNER',
-    'TOP_BANNER',
-    'MODAL',
-  ])('handles custom style props for a %s layout', (layout) => {
-    mockUseInAppMessaging.mockReturnValueOnce({
-      components,
-      message: { ...baseMessage, layout },
-    });
-
-    const { props } = useMessage({ components, onMessageAction, styles });
-
-    expect(props.style).toBe(style);
   });
 
   it('returns the expected values of Component and props when message is null', () => {

--- a/packages/react-core/src/InAppMessaging/hooks/useMessage/types.ts
+++ b/packages/react-core/src/InAppMessaging/hooks/useMessage/types.ts
@@ -17,17 +17,9 @@ interface Components<PlatformStyleProps> {
   ModalMessage: ModalMessageComponent<PlatformStyleProps>;
 }
 
-interface Styles<PlatformStyleProps> {
-  bannerMessage?: PlatformStyleProps;
-  carouselMessage?: PlatformStyleProps;
-  fullScreenMessage?: PlatformStyleProps;
-  modalMessage?: PlatformStyleProps;
-}
-
 export interface UseMessageParams<PlatformStyleProps> {
   components: Components<PlatformStyleProps>;
   onMessageAction: OnMessageAction;
-  styles?: Styles<PlatformStyleProps>;
 }
 
 type MessageComponent<PlatformStyleProps> =

--- a/packages/react-core/src/InAppMessaging/hooks/useMessage/useMessage.ts
+++ b/packages/react-core/src/InAppMessaging/hooks/useMessage/useMessage.ts
@@ -25,7 +25,6 @@ const { InAppMessaging } = Notifications;
 export default function useMessage<PlatformStyleProps>({
   components,
   onMessageAction,
-  styles,
 }: UseMessageParams<PlatformStyleProps>): UseMessage<PlatformStyleProps> {
   const { clearMessage, message } = useInAppMessaging();
   const { BannerMessage, CarouselMessage, FullScreenMessage, ModalMessage } =
@@ -73,7 +72,6 @@ export default function useMessage<PlatformStyleProps>({
         onClose,
         onDisplay,
         position: getPositionProp(layout),
-        style: styles?.bannerMessage,
       };
       return { Component: BannerMessage, props };
     }
@@ -85,7 +83,6 @@ export default function useMessage<PlatformStyleProps>({
         layout,
         onClose,
         onDisplay,
-        style: styles?.carouselMessage,
       };
       return { Component: CarouselMessage, props };
     }
@@ -95,7 +92,6 @@ export default function useMessage<PlatformStyleProps>({
         layout,
         onClose,
         onDisplay,
-        style: styles?.fullScreenMessage,
       };
       return { Component: FullScreenMessage, props };
     }
@@ -105,7 +101,6 @@ export default function useMessage<PlatformStyleProps>({
         layout,
         onClose,
         onDisplay,
-        style: styles?.modalMessage,
       };
       return { Component: ModalMessage, props };
     }

--- a/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/InAppMessageDisplay.tsx
+++ b/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/InAppMessageDisplay.tsx
@@ -27,7 +27,6 @@ const onMessageAction: OnMessageAction = ({ action, url }) => {
 
 function InAppMessageDisplay({
   components: overrideComponents,
-  styles,
 }: InAppMessageDisplayProps): JSX.Element | null {
   const components = React.useMemo(
     () => ({ ...platformComponents, ...overrideComponents }),
@@ -36,10 +35,14 @@ function InAppMessageDisplay({
   const { Component, props } = useMessage({
     components,
     onMessageAction,
-    styles,
   });
 
   return <Component {...props} />;
 }
+
+InAppMessageDisplay.BannerMessage = BannerMessage;
+InAppMessageDisplay.CarouselMessage = CarouselMessage;
+InAppMessageDisplay.FullScreenMessage = FullScreenMessage;
+InAppMessageDisplay.ModalMessage = ModalMessage;
 
 export default InAppMessageDisplay;

--- a/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/index.ts
+++ b/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/index.ts
@@ -1,2 +1,2 @@
 export { default as InAppMessageDisplay } from './InAppMessageDisplay';
-export { MessageComponents, MessageStyles } from './types';
+export { MessageComponents } from './types';

--- a/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/types.ts
+++ b/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/types.ts
@@ -24,21 +24,9 @@ export interface MessageDefaultComponents {
 
 export interface MessageComponents extends Partial<MessageDefaultComponents> {}
 
-export interface MessageStyles {
-  bannerMessage?: BannerStyle;
-  carouselMessage?: CarouselStyle;
-  fullScreenMessage?: FullScreenStyle;
-  modalMessage?: ModalStyle;
-}
-
 export interface InAppMessageDisplayProps {
   /**
    * Message override UI components
    */
   components?: MessageComponents;
-
-  /**
-   *  Message override styles
-   */
-  styles?: MessageStyles;
 }

--- a/packages/react-native/src/InAppMessaging/components/index.ts
+++ b/packages/react-native/src/InAppMessaging/components/index.ts
@@ -1,6 +1,6 @@
-export {
-  InAppMessageDisplay,
-  MessageComponents,
-  MessageStyles,
-} from './InAppMessageDisplay';
+export { BannerMessageProps } from './BannerMessage';
+export { CarouselMessageProps } from './CarouselMessage';
+export { FullScreenMessageProps } from './FullScreenMessage';
+export { InAppMessageDisplay, MessageComponents } from './InAppMessageDisplay';
+export { ModalMessageProps } from './ModalMessage';
 export { withInAppMessaging } from './withInAppMessaging';

--- a/packages/react-native/src/InAppMessaging/components/withInAppMessaging/withInAppMessaging.tsx
+++ b/packages/react-native/src/InAppMessaging/components/withInAppMessaging/withInAppMessaging.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 import { InAppMessagingProvider } from '@aws-amplify/ui-react-core';
 
-import {
-  InAppMessageDisplay,
-  MessageComponents,
-  MessageStyles,
-} from '../InAppMessageDisplay';
+import { InAppMessageDisplay, MessageComponents } from '../InAppMessageDisplay';
 
 export default function withInAppMessaging<Props>(
   Component: (props: Props) => JSX.Element,
-  options?: { components?: MessageComponents; styles?: MessageStyles }
+  options?: { components?: MessageComponents }
 ): (props: Props) => JSX.Element {
   return function WrappedWithInAppMessaging(props: Props) {
     return (

--- a/packages/react-native/src/InAppMessaging/index.ts
+++ b/packages/react-native/src/InAppMessaging/index.ts
@@ -1,6 +1,14 @@
 export {
+  InAppMessagingProvider,
+  useInAppMessaging,
+} from '@aws-amplify/ui-react-core';
+
+export {
+  BannerMessageProps,
+  CarouselMessageProps,
+  FullScreenMessageProps,
+  ModalMessageProps,
   InAppMessageDisplay,
   MessageComponents,
-  MessageStyles,
   withInAppMessaging,
 } from './components';

--- a/packages/react-native/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/react-native/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@aws-amplify/ui-react-native exports should match snapshot 1`] = `
+Array [
+  "BannerMessageProps",
+  "CarouselMessageProps",
+  "FullScreenMessageProps",
+  "InAppMessageDisplay",
+  "InAppMessagingProvider",
+  "MessageComponents",
+  "ModalMessageProps",
+  "useInAppMessaging",
+  "withInAppMessaging",
+]
+`;

--- a/packages/react-native/src/__tests__/index.spec.ts
+++ b/packages/react-native/src/__tests__/index.spec.ts
@@ -1,0 +1,8 @@
+import * as exported from '..';
+
+describe('@aws-amplify/ui-react-native', () => {
+  it('exports should match snapshot', () => {
+    const exportedKeys = Object.keys(exported);
+    expect(exportedKeys).toMatchSnapshot();
+  });
+});

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,5 +1,1 @@
-export { InAppMessageDisplay, withInAppMessaging } from './InAppMessaging';
-export {
-  InAppMessagingProvider,
-  useInAppMessaging,
-} from '@aws-amplify/ui-react-core';
+export * from './InAppMessaging';

--- a/packages/react/__tests__/exports.ts
+++ b/packages/react/__tests__/exports.ts
@@ -1,7 +1,5 @@
 import { PrimitiveCatalog } from '@aws-amplify/ui-react/internal';
 
-// Jest doesn't support `exports` maps, so we have to reference `dist` directly.
-// See: https://github.com/facebook/jest/issues/9771
 import * as exported from '../src';
 import * as legacy from '../src/legacy';
 import * as internal from '../src/internal';

--- a/packages/react/src/components/InAppMessaging/InAppMessageDisplay/InAppMessageDisplay.tsx
+++ b/packages/react/src/components/InAppMessaging/InAppMessageDisplay/InAppMessageDisplay.tsx
@@ -33,9 +33,8 @@ const onMessageAction: OnMessageAction = ({ action, url }) => {
   });
 };
 
-export default function InAppMessageDisplay({
+function InAppMessageDisplay({
   components: overrideComponents,
-  styles,
 }: InAppMessageDisplayProps): JSX.Element {
   const components = React.useMemo(
     () => ({ ...platformComponents, ...overrideComponents }),
@@ -44,8 +43,14 @@ export default function InAppMessageDisplay({
   const { Component, props } = useMessage({
     components,
     onMessageAction,
-    styles,
   });
 
   return <Component {...props} />;
 }
+
+InAppMessageDisplay.BannerMessage = BannerMessage;
+InAppMessageDisplay.CarouselMessage = CarouselMessage;
+InAppMessageDisplay.FullScreenMessage = FullScreenMessage;
+InAppMessageDisplay.ModalMessage = ModalMessage;
+
+export default InAppMessageDisplay;

--- a/packages/react/src/components/InAppMessaging/InAppMessageDisplay/index.ts
+++ b/packages/react/src/components/InAppMessaging/InAppMessageDisplay/index.ts
@@ -1,2 +1,2 @@
 export { default as InAppMessageDisplay } from './InAppMessageDisplay';
-export { MessageComponents, MessageStyles } from './types';
+export { MessageComponents } from './types';

--- a/packages/react/src/components/InAppMessaging/InAppMessageDisplay/types.ts
+++ b/packages/react/src/components/InAppMessaging/InAppMessageDisplay/types.ts
@@ -24,21 +24,9 @@ export interface MessageDefaultComponents {
 
 export interface MessageComponents extends Partial<MessageDefaultComponents> {}
 
-export interface MessageStyles {
-  bannerMessage?: BannerStyle;
-  carouselMessage?: CarouselStyle;
-  fullScreenMessage?: FullScreenStyle;
-  modalMessage?: ModalStyle;
-}
-
 export interface InAppMessageDisplayProps {
   /**
    * Message override UI components
    */
   components?: MessageComponents;
-
-  /**
-   *  Message override styles
-   */
-  styles?: MessageStyles;
 }

--- a/packages/react/src/components/InAppMessaging/index.ts
+++ b/packages/react/src/components/InAppMessaging/index.ts
@@ -3,9 +3,8 @@ export {
   useInAppMessaging,
 } from '@aws-amplify/ui-react-core';
 
-export {
-  InAppMessageDisplay,
-  MessageComponents,
-  MessageStyles,
-} from './InAppMessageDisplay';
+export { BannerMessageProps } from './BannerMessage';
+export { FullScreenMessageProps } from './FullScreenMessage';
+export { InAppMessageDisplay, MessageComponents } from './InAppMessageDisplay';
+export { ModalMessageProps } from './ModalMessage';
 export { withInAppMessaging } from './withInAppMessaging';

--- a/packages/react/src/components/InAppMessaging/withInAppMessaging/withInAppMessaging.tsx
+++ b/packages/react/src/components/InAppMessaging/withInAppMessaging/withInAppMessaging.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 import { InAppMessagingProvider } from '@aws-amplify/ui-react-core';
 
-import {
-  InAppMessageDisplay,
-  MessageComponents,
-  MessageStyles,
-} from '../InAppMessageDisplay';
+import { InAppMessageDisplay, MessageComponents } from '../InAppMessageDisplay';
 
 export default function withInAppMessaging<Props>(
   Component: (props: Props) => JSX.Element,
-  options?: { components?: MessageComponents; styles?: MessageStyles }
+  options?: { components?: MessageComponents }
 ): (props: Props) => JSX.Element {
   return function WrappedWithInAppMessaging(props: Props) {
     return (


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- remove `styles` prop from `InAppMessageDisplay` components and related types
- add InApp components as properties of `inAppMessageDisplay` components
- add "exports" snapshot test for `@aws-amplify/ui-react-native`
- add NextJS example app for custom styling of InApp UI components

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
