### PR TITLE
chore(hosting): Skip cypress binary installation

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -11,6 +11,9 @@ applications:
             - export FLUTTER_HOME=${HOME}/sdks/flutter
             - git clone -b stable --depth 1 https://github.com/flutter/flutter.git ${FLUTTER_HOME}
             - export PATH="$PATH:${FLUTTER_HOME}/bin"
+            # Skip cypress binary installation, as it's unneeded for docs and often fails transiently
+            # https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation
+            - export CYPRESS_INSTALL_BINARY=0 
             - (cd .. && yarn install && yarn build)
         build:
           commands:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Cypress binary installation is unnecessary for docs hosting. Skipping it with `CYPRESS_INSTALL_BINARY=0`.

https://docs.cypress.io/guides/references/advanced-installation#Environment-variables



<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Built docs locally after running that command. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
