### PR TITLE
chore(ci): split `yarn environment pull` call in workflows 

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -72,7 +72,7 @@ jobs:
         run: echo "::set-output name=version::$(amplify --version)"
       - name: Pull down AWS environments
         if: steps.environments-cache.outputs.cache-hit != 'true'
-        run: yarn environments pull
+        run: yarn environments auth pull
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -262,9 +262,23 @@ jobs:
           path: environments/**/aws-exports.js
           key: ${{ runner.os }}-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('environments/**/amplify/**') }}
 
-      - name: Pull down AWS environments on cache miss
+      - name: Pull down Auth AWS environments, on cache miss
         if: steps.environments-cache.outputs.cache-hit != 'true'
-        run: yarn environments pull
+        run: yarn environments auth pull
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Pull down Geo AWS environments, on cache miss
+        if: steps.environments-cache.outputs.cache-hit != 'true'
+        run: yarn environments geo pull
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Pull down Datastore AWS environments, on cache miss
+        if: steps.environments-cache.outputs.cache-hit != 'true'
+        run: yarn environments datastore pull
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Instead of running `yarn environments pull` to pull all environments altogether, this PR splits them off to just pull the environments they need (`auth`, `datastore`,  or `geo`).

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

#2517 is running e2e + guide test. I disabled cache this time 😅 
- e2e: [workflow](https://github.com/aws-amplify/amplify-ui/runs/8022933916)
- guides: [workflow](https://github.com/aws-amplify/amplify-ui/actions/workflows/poc-test-guide.yml)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
