### PR TITLE
update authenticator to use the new dial code props

### DIFF
--- a/.changeset/gold-tips-punch.md
+++ b/.changeset/gold-tips-punch.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+update authenticator to use the new dial code props

--- a/packages/react/src/components/Authenticator/shared/FormField.tsx
+++ b/packages/react/src/components/Authenticator/shared/FormField.tsx
@@ -39,8 +39,8 @@ export function FormField({
         <PhoneNumberField
           {...props}
           name={name}
-          defaultCountryCode={dialCode}
-          countryCodeName="country_code"
+          defaultDialCode={dialCode}
+          dialCodeName="country_code"
           autoComplete={autoComplete}
           hasError={hasError}
           aria-describedby={ariaDescribedBy}


### PR DESCRIPTION
#### Description of changes
Update the react authenticator component to use the dialCode props instead of the countryCode versions.

This is part of the effort being made to deprecate all of the countryCode props and migrate over to dialCode instead.  The dialCode props were added in this [PR](https://github.com/aws-amplify/amplify-ui/pull/2459) alongside the countryCode props.  Currently either prop can be used and if both are provided the dialCode versions will be preferred.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
