### PR TITLE
remove deprecation console warning from countryCodeSelect usage

### DIFF
--- a/.changeset/brave-emus-ring.md
+++ b/.changeset/brave-emus-ring.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+remove deprecation console warning from countryCode prop usage

--- a/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
@@ -6,7 +6,6 @@ import { CountryCodeSelect } from './CountryCodeSelect';
 import { PhoneNumberFieldProps, Primitive } from '../types';
 import { ComponentText } from '../shared/constants';
 import { TextField } from '../TextField';
-import { useDeprecationWarning } from '../../hooks/useDeprecationWarning';
 
 const PhoneNumberFieldPrimitive: Primitive<PhoneNumberFieldProps, 'input'> = (
   {
@@ -40,20 +39,6 @@ const PhoneNumberFieldPrimitive: Primitive<PhoneNumberFieldProps, 'input'> = (
   const defaultCode = defaultDialCode || defaultCountryCode;
   const onCodeChange = onDialCodeChange || onCountryCodeChange;
   const codeRef = dialCodeRef || countryCodeRef;
-
-  const deprecationMessage =
-    'The PhoneNumberField component props: countryCodeName, countryCodeLabel, defaultCountryCode, onCountryCodeChange, and countryCodeRef props are deprecated and will be removed in the next major release of @aws-amplify/ui-react. Please update to dialCodeName, dialCodeLabel, defaultDialCode, onDialCodeChange, and dialCodeRef respectively.';
-  const shouldWarn =
-    countryCodeName ||
-    countryCodeLabel !== ComponentText.PhoneNumberField.countryCodeLabel ||
-    defaultCountryCode ||
-    onCountryCodeChange ||
-    countryCodeRef;
-
-  useDeprecationWarning({
-    shouldWarn: !!shouldWarn,
-    message: deprecationMessage,
-  });
 
   return (
     <TextField


### PR DESCRIPTION
#### Description of changes
Removing the deprecation console warning from the countryCode props usage.  The countryCode props are being deprecated but because these props are used in the UI Builder phoneNumberField the deprecation message is being removed to give UI Builder a chance to migrate over to the dialCode props.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
