### PR TITLE
fix(docs): Broken Authenticator link

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.react.mdx
@@ -27,7 +27,7 @@ const App = () => {
 
 ## Authenticator Provider
 
-In advanced use cases where usage of the [`useAuthenticator` hook](headless#useauthenticator-hook) outside the scope of the [`Authenticator`](../components/authenticator) is needed, wrap your application inside an `Authenticator.Provider`. The `Authenticator.Provider` guarantees that the [useAuthenticator hook](headless#useauthenticator-hook) is available throughout your application. You can see an example of this pattern in the [Protected Routes Guide.](../../guides/auth-protected)
+In advanced use cases where usage of the [`useAuthenticator` hook](headless#useauthenticator-hook) outside the scope of the [`Authenticator`](../authenticator) is needed, wrap your application inside an `Authenticator.Provider`. The `Authenticator.Provider` guarantees that the [useAuthenticator hook](headless#useauthenticator-hook) is available throughout your application. You can see an example of this pattern in the [Protected Routes Guide.](../../guides/auth-protected)
 
 <Tabs>
 <TabItem title="Create React App">


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes a broken link on the React Authenticator [Headless Usage](https://ui.docs.amplify.aws/react/connected-components/authenticator/headless#authenticator-provider) page in the 'Authenticator Provider' section.

Fixes: https://github.com/aws-amplify/amplify-ui/issues/2531

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/2531

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
