### PR TITLE
chore(rwa): convert AuthChallengeNames enum to string union

### DIFF
--- a/.changeset/gentle-ads-hang.md
+++ b/.changeset/gentle-ads-hang.md
@@ -1,0 +1,9 @@
+---
+"amplify-ui-angular-mono": patch
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-vue": patch
+"@aws-amplify/ui-angular": patch
+---
+
+chore(rwa): convert AuthChallengeNames enum to string union

--- a/.changeset/gentle-ads-hang.md
+++ b/.changeset/gentle-ads-hang.md
@@ -1,5 +1,4 @@
 ---
-"amplify-ui-angular-mono": patch
 "@aws-amplify/ui-react": patch
 "@aws-amplify/ui": patch
 "@aws-amplify/ui-vue": patch

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-in/confirm-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-in/confirm-sign-in.component.ts
@@ -1,7 +1,6 @@
 import { Component, HostBinding, OnInit } from '@angular/core';
 import { Logger } from 'aws-amplify';
 import {
-  AuthChallengeNames,
   FormFieldsArray,
   getActorContext,
   getFormDataFromEvent,
@@ -40,10 +39,10 @@ export class ConfirmSignInComponent implements OnInit {
     const actorContext = getActorContext(state) as SignInContext;
     const { challengeName } = actorContext;
     switch (challengeName) {
-      case AuthChallengeNames.SOFTWARE_TOKEN_MFA:
+      case 'SOFTWARE_TOKEN_MFA':
         this.headerText = translate('Confirm TOTP Code');
         break;
-      case AuthChallengeNames.SMS_MFA:
+      case 'SMS_MFA':
         this.headerText = translate('Confirm SMS Code');
         break;
       default:

--- a/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react/src/components/Authenticator/ConfirmSignIn/ConfirmSignIn.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AuthChallengeNames, getActorState, translate } from '@aws-amplify/ui';
+import { getActorState, translate } from '@aws-amplify/ui';
 
 import { Flex } from '../../../primitives/Flex';
 import { Heading } from '../../../primitives/Heading';
@@ -61,10 +61,10 @@ function Header() {
   let headerText: string;
 
   switch (challengeName) {
-    case AuthChallengeNames.SMS_MFA:
+    case 'SMS_MFA':
       headerText = translate('Confirm SMS Code');
       break;
-    case AuthChallengeNames.SOFTWARE_TOKEN_MFA:
+    case 'SOFTWARE_TOKEN_MFA':
       headerText = translate('Confirm TOTP Code');
       break;
     default:

--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -2,7 +2,7 @@ import { Auth } from 'aws-amplify';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import { createMachine, sendUpdate } from 'xstate';
-import { AuthChallengeNames, AuthEvent, SignInContext } from '../../../types';
+import { AuthEvent, SignInContext } from '../../../types';
 import { runValidators } from '../../../validators';
 import {
   clearAttributeToVerify,
@@ -462,10 +462,7 @@ export function signInActor({ services }: SignInMachineOptions) {
       guards: {
         shouldConfirmSignIn: (_, event): boolean => {
           const challengeName = get(event, 'data.challengeName');
-          const validChallengeNames = [
-            AuthChallengeNames.SMS_MFA,
-            AuthChallengeNames.SOFTWARE_TOKEN_MFA,
-          ];
+          const validChallengeNames = ['SMS_MFA', 'SOFTWARE_TOKEN_MFA'];
 
           return validChallengeNames.includes(challengeName);
         },
@@ -481,12 +478,12 @@ export function signInActor({ services }: SignInMachineOptions) {
         shouldSetupTOTP: (_, event): boolean => {
           const challengeName = get(event, 'data.challengeName');
 
-          return challengeName === AuthChallengeNames.MFA_SETUP;
+          return challengeName === 'MFA_SETUP';
         },
         shouldForceChangePassword: (_, event): boolean => {
           const challengeName = get(event, 'data.challengeName');
 
-          return challengeName === AuthChallengeNames.NEW_PASSWORD_REQUIRED;
+          return challengeName === 'NEW_PASSWORD_REQUIRED';
         },
         shouldRequestVerification: (_, event): boolean => {
           const { unverified, verified } = event.data;
@@ -517,8 +514,8 @@ export function signInActor({ services }: SignInMachineOptions) {
 
           let mfaType;
           if (
-            challengeName === AuthChallengeNames.SMS_MFA ||
-            challengeName === AuthChallengeNames.SOFTWARE_TOKEN_MFA
+            challengeName === 'SMS_MFA' ||
+            challengeName === 'SOFTWARE_TOKEN_MFA'
           ) {
             mfaType = challengeName;
           }

--- a/packages/ui/src/machines/authenticator/defaultServices.ts
+++ b/packages/ui/src/machines/authenticator/defaultServices.ts
@@ -1,7 +1,12 @@
 import { Amplify, Auth } from 'aws-amplify';
 import { hasSpecialChars } from '../../helpers';
 
-import { PasswordSettings, SignInResult, ValidatorResult } from '../../types';
+import {
+  AuthChallengeName,
+  PasswordSettings,
+  SignInResult,
+  ValidatorResult,
+} from '../../types';
 
 export const defaultServices = {
   async getAmplifyConfig() {
@@ -31,9 +36,14 @@ export const defaultServices = {
   }: {
     user: any;
     code: string;
-    mfaType: 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA';
+    mfaType: AuthChallengeName;
   }): Promise<any> {
-    return Auth.confirmSignIn(user, code, mfaType);
+    return Auth.confirmSignIn(
+      user,
+      code,
+      // cast due to restrictive typing of Auth.confirmSignIn
+      mfaType as 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA'
+    );
   },
   async handleConfirmSignUp({
     username,

--- a/packages/ui/src/machines/authenticator/defaultServices.ts
+++ b/packages/ui/src/machines/authenticator/defaultServices.ts
@@ -1,12 +1,7 @@
 import { Amplify, Auth } from 'aws-amplify';
 import { hasSpecialChars } from '../../helpers';
 
-import {
-  AuthChallengeNames,
-  PasswordSettings,
-  SignInResult,
-  ValidatorResult,
-} from '../../types';
+import { PasswordSettings, SignInResult, ValidatorResult } from '../../types';
 
 export const defaultServices = {
   async getAmplifyConfig() {
@@ -36,7 +31,7 @@ export const defaultServices = {
   }: {
     user: any;
     code: string;
-    mfaType: AuthChallengeNames.SMS_MFA | AuthChallengeNames.SOFTWARE_TOKEN_MFA;
+    mfaType: 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA';
   }): Promise<any> {
     return Auth.confirmSignIn(user, code, mfaType);
   },

--- a/packages/ui/src/types/authenticator/stateMachine/context.ts
+++ b/packages/ui/src/types/authenticator/stateMachine/context.ts
@@ -1,6 +1,6 @@
 import { ValidationError } from '../validator';
 import { AuthFormData, AuthFormFields } from '../form';
-import { AuthChallengeNames, CognitoUserAmplify } from '../user';
+import { AuthChallengeName, CognitoUserAmplify } from '../user';
 import { CodeDeliveryDetails as CognitoCodeDeliveryDetails } from 'amazon-cognito-identity-js';
 import { LoginMechanism, SignUpAttribute, SocialProvider } from '../attributes';
 import { defaultServices } from '../../../machines/authenticator/defaultServices';
@@ -37,7 +37,7 @@ export interface AuthContext {
   username?: string;
   password?: string;
   code?: string;
-  mfaType?: AuthChallengeNames.SMS_MFA | AuthChallengeNames.SOFTWARE_TOKEN_MFA;
+  mfaType?: 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA';
   actorDoneData?: Omit<ActorDoneData, 'user'>; // data returned from actors when they finish and reach their final state
   hasSetup?: boolean;
 }
@@ -51,7 +51,7 @@ interface BaseFormContext {
   /** Any user attributes set that needs to persist between states */
   authAttributes?: Record<string, any>;
   /** Current challengeName issued by Cognnito */
-  challengeName?: AuthChallengeNames;
+  challengeName?: AuthChallengeName;
   /** Required attributes for form submission */
   requiredAttributes?: Array<string>;
   /** Maps each input name to tis value */
@@ -98,7 +98,7 @@ export interface ResetPasswordContext extends BaseFormContext {
 
 export interface SignOutContext {
   authAttributes?: Record<string, any>;
-  challengeName?: AuthChallengeNames;
+  challengeName?: AuthChallengeName;
   unverifiedAttributes?: Record<string, string>;
   user?: CognitoUserAmplify;
   formFields?: AuthFormFields;

--- a/packages/ui/src/types/authenticator/user.ts
+++ b/packages/ui/src/types/authenticator/user.ts
@@ -1,13 +1,7 @@
-import { CognitoUser } from 'amazon-cognito-identity-js';
+import { ChallengeName, CognitoUser } from 'amazon-cognito-identity-js';
 
-/** Enum of known challenge names */
-export enum AuthChallengeNames {
-  SMS_MFA = 'SMS_MFA',
-  SOFTWARE_TOKEN_MFA = 'SOFTWARE_TOKEN_MFA',
-  NEW_PASSWORD_REQUIRED = 'NEW_PASSWORD_REQUIRED',
-  RESET_REQUIRED = 'RESET_REQUIRED',
-  MFA_SETUP = 'MFA_SETUP',
-}
+/** Known challenge names */
+export type AuthChallengeName = ChallengeName;
 
 /** Contact destinations that we can send user confirmation code to */
 export type ContactMethod = 'Email' | 'Phone Number';

--- a/packages/ui/src/types/authenticator/validator.ts
+++ b/packages/ui/src/types/authenticator/validator.ts
@@ -1,6 +1,5 @@
 import { PasswordSettings } from '.';
 import { AuthFormData } from './form';
-import { AuthChallengeNames } from './user';
 
 /**
  * Maps each input to its validation error, if any
@@ -22,9 +21,3 @@ export type Validator = (
   touchData?: AuthFormData,
   passwordSettings?: PasswordSettings
 ) => ValidatorResult | Promise<ValidatorResult>;
-
-export type SignInTypes = (
-  user: string,
-  code: string,
-  mfaType: AuthChallengeNames.SMS_MFA | AuthChallengeNames.SOFTWARE_TOKEN_MFA
-) => SignInResult | Promise<SignInResult>;

--- a/packages/vue/src/components/confirm-sign-in.vue
+++ b/packages/vue/src/components/confirm-sign-in.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import {
-  AuthChallengeNames,
   getActorState,
   getFormDataFromEvent,
   SignInState,
@@ -27,7 +26,7 @@ const challengeName = actorState.value.context.challengeName;
 
 let mfaType = 'SMS';
 
-if (challengeName === AuthChallengeNames.SOFTWARE_TOKEN_MFA) {
+if (challengeName === 'SOFTWARE_TOKEN_MFA') {
   mfaType = 'TOTP';
 }
 const confirmSignInHeading = `Confirm ${mfaType} Code`;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Replace `AuthChallengeNames` enum with `AuthChallengeName` string union (set to the value of Cognito supplied `ChallengeName`) to prevent type conflicts between `CognitoUserAmplify['challengeName']` and usage of `AuthChallengeName` in utils

Additionally, added some typed `challengeName` utils in _packages/ui/src/machines/authenticator/actors/signIn.ts_

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
