### PR TITLE
Dial code

### DIFF
--- a/docs/src/pages/[platform]/components/phonenumberfield/react.mdx
+++ b/docs/src/pages/[platform]/components/phonenumberfield/react.mdx
@@ -46,9 +46,6 @@ which will auto-populate the dial code select field.
 
 ### Dial Code Select Properties
 
-<Alert variation="info"  role="none">All `countryCode` fields are being deprecated in favor of the new `dialCode` fields.  If you still have instances of `defaultCountryCode`,
-`countryCodeList`, `countryCodeName`, `countryCodeLabel`, and `onCountryCodeChange` then please update these to the new `dialCode` props listed below.</Alert>
-
 The dial code selector can be customized by setting several properties when using the `PhoneNumberField` primitive. The custom
 properties specific to the dial code selector are the following:
 
@@ -57,8 +54,6 @@ properties specific to the dial code selector are the following:
 - `dialCodeName`: A name used when handling form submission for the dial code selector
 - `dialCodeLabel`: A hidden accessible label for the dial code selector
 - `onDialCodeChange`: A custom change handler for the dial code selector
-
-* If both `defaultDialCode`, `dialCodeList`, `dialCodeName`, `dialCodeLabel`, and `onDialCodeChange` and the corresponding `countryCode` prop are provided, then the value in the `dialCode` prop will be preferred.
 
 <Example>
   <DialCodeSelectExample />
@@ -73,7 +68,7 @@ properties specific to the dial code selector are the following:
 ### Autocomplete - supporting password managers
 
 Use the `autoComplete` prop to tell the browser how to populate the `PhoneNumberField`. By default, the `PhoneNumberField` primitive uses `tel-national`
-as the `autoComplete` property for the text field and `tel-country-code` as the `autoComplete` property for the dial code selector.
+as the `autoComplete` property for the text field and `tel-dial-code` as the `autoComplete` property for the dial code selector.
 
 If the `PhoneNumberField` primitive is intended to be used in a form that is compatible with most password managers, the `autoComplete` property should
 be set to `username` (see [Password Form Styles that Chromium Understands](https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands)).

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.html
@@ -1,10 +1,10 @@
 <div class="amplify-flex amplify-field amplify-authenticator__column">
-  <!-- Country code field -->
+  <!-- Dial code field -->
   <amplify-phone-number-field
     *ngIf="isPhoneField()"
     [name]="name"
     [label]="formField.label"
-    [defaultCountryCode]="formField.dialCode"
+    [defaultDialCode]="formField.dialCode"
     [dialCodeList]="formField.dialCodeList"
     [placeholder]="formField.placeholder"
     [required]="formField.isRequired"

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import {
   translate,
-  countryDialCodes,
+  dialCodes,
   FormFieldOptions,
   getErrors,
 } from '@aws-amplify/ui';
@@ -16,8 +16,8 @@ export class FormFieldComponent {
   @Input() name: string; // name of the input field
   @Input() formField: FormFieldOptions; // form field options for this field
 
-  public defaultCountryCodeValue: string;
-  public countryDialCodesValue = countryDialCodes;
+  public defaultDialCodeValue: string;
+  public dialCodesValue = dialCodes;
   public errorId = nanoid(12);
 
   constructor(private authenticator: AuthenticatorService) {}

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/setup-totp/setup-totp.component.spec.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/setup-totp/setup-totp.component.spec.ts
@@ -13,7 +13,7 @@ import { getTotpCode } from '@aws-amplify/ui';
 
 const mockUser = { username: 'username' };
 const mockContext = {
-  country_code: '100',
+  dial_code: '100',
   formFields: { setupTOTP: { QR: null } },
   user: mockUser,
 };

--- a/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.html
@@ -16,17 +16,17 @@
         amplify-flex
         amplify-field
         amplify-selectfield
-        amplify-countrycodeselect
+        amplify-dialcodeselect
         amplify-dialcodeselect
       "
       style="flex-direction: column"
     >
       <amplify-form-select
-        name="country_code"
-        label="Country Code"
+        name="dial_code"
+        label="Dial Code"
         [id]="selectFieldId"
-        [items]="countryDialCodesValues"
-        [defaultValue]="defaultCountryCode"
+        [items]="dialCodesValues"
+        [defaultValue]="defaultDialCode"
       ></amplify-form-select>
     </div>
   </div>

--- a/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.html
@@ -13,11 +13,7 @@
   <div class="amplify-field-group__outer-start">
     <div
       class="
-        amplify-flex
-        amplify-field
-        amplify-selectfield
-        amplify-dialcodeselect
-        amplify-dialcodeselect
+        amplify-flex amplify-field amplify-selectfield amplify-dialcodeselect
       "
       style="flex-direction: column"
     >

--- a/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostBinding, Input, OnInit } from '@angular/core';
 import { nanoid } from 'nanoid';
-import { countryDialCodes } from '@aws-amplify/ui';
+import { dialCodes } from '@aws-amplify/ui';
 
 @Component({
   selector: 'amplify-phone-number-field',
@@ -9,7 +9,7 @@ import { countryDialCodes } from '@aws-amplify/ui';
 export class PhoneNumberFieldComponent implements OnInit {
   @Input() autocomplete = 'new-password';
   @Input() disabled = false;
-  @Input() defaultCountryCode: string;
+  @Input() defaultDialCode: string;
   @Input() selectFieldId: string = `amplify-field-${nanoid(12)}`;
   @Input() textFieldId: string = `amplify-field-${nanoid(12)}`;
   @Input() initialValue = '';
@@ -25,9 +25,9 @@ export class PhoneNumberFieldComponent implements OnInit {
 
   @HostBinding('style.display') display = 'contents';
 
-  public countryDialCodesValues: Array<string>;
+  public dialCodesValues: Array<string>;
 
   ngOnInit(): void {
-    this.countryDialCodesValues = this.dialCodeList ?? countryDialCodes;
+    this.dialCodesValues = this.dialCodeList ?? dialCodes;
   }
 }

--- a/packages/angular/projects/ui-angular/src/lib/primitives/select/select.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/select/select.component.html
@@ -4,7 +4,7 @@
 <div class="amplify-select__wrapper">
   <select
     class="amplify-select amplify-field-group__control"
-    autocomplete="tel-country-code"
+    autocomplete="tel-dial-code"
     [id]="id"
     [name]="name"
   >

--- a/packages/react/src/components/Authenticator/shared/FormField.tsx
+++ b/packages/react/src/components/Authenticator/shared/FormField.tsx
@@ -40,7 +40,7 @@ export function FormField({
           {...props}
           name={name}
           defaultDialCode={dialCode}
-          dialCodeName="country_code"
+          dialCodeName="dial_code"
           autoComplete={autoComplete}
           hasError={hasError}
           aria-describedby={ariaDescribedBy}

--- a/packages/react/src/primitives/PhoneNumberField/DialCodeSelect.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/DialCodeSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { countryDialCodes } from '@aws-amplify/ui';
+import { dialCodes } from '@aws-amplify/ui';
 
 import { ComponentClassNames } from '../shared/constants';
 import { DialCodeSelectProps, Primitive } from '../types';
@@ -10,7 +10,7 @@ const DialCodeSelectPrimitive: Primitive<DialCodeSelectProps, 'select'> = (
   { className, dialCodeList, isReadOnly, ...props },
   ref
 ) => {
-  const dialList = dialCodeList ?? countryDialCodes;
+  const dialList = dialCodeList ?? dialCodes;
   const dialCodeOptions = React.useMemo(
     () =>
       dialList.map((dialCode) => (
@@ -29,12 +29,8 @@ const DialCodeSelectPrimitive: Primitive<DialCodeSelectProps, 'select'> = (
           so that a screen reader will announce something to the user about the interactivity of the options list ( https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
         */
       aria-disabled={isReadOnly}
-      autoComplete="tel-country-code"
-      className={classNames(
-        ComponentClassNames.CountryCodeSelect,
-        ComponentClassNames.DialCodeSelect,
-        className
-      )}
+      autoComplete="tel-dial-code"
+      className={classNames(ComponentClassNames.DialCodeSelect, className)}
       labelHidden={true}
       ref={ref}
       {...props}
@@ -44,6 +40,6 @@ const DialCodeSelectPrimitive: Primitive<DialCodeSelectProps, 'select'> = (
   );
 };
 
-export const CountryCodeSelect = React.forwardRef(DialCodeSelectPrimitive);
+export const DialCodeSelect = React.forwardRef(DialCodeSelectPrimitive);
 
-CountryCodeSelect.displayName = 'CountryCodeSelect';
+DialCodeSelect.displayName = 'DialCodeSelect';

--- a/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/PhoneNumberField.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ComponentClassNames } from '../shared/constants';
-import { CountryCodeSelect } from './CountryCodeSelect';
+import { DialCodeSelect } from './DialCodeSelect';
 import { PhoneNumberFieldProps, Primitive } from '../types';
 import { ComponentText } from '../shared/constants';
 import { TextField } from '../TextField';
@@ -11,19 +11,14 @@ const PhoneNumberFieldPrimitive: Primitive<PhoneNumberFieldProps, 'input'> = (
   {
     autoComplete = 'tel-national',
     className,
-    countryCodeName,
-    countryCodeLabel = ComponentText.PhoneNumberField.countryCodeLabel,
-    countryCodeRef,
-    defaultCountryCode,
     defaultDialCode,
-    dialCodeLabel = ComponentText.PhoneNumberField.countryCodeLabel,
+    dialCodeLabel = ComponentText.PhoneNumberField.dialCodeLabel,
     dialCodeList,
     dialCodeName,
     dialCodeRef,
     hasError,
     isDisabled,
     isReadOnly,
-    onCountryCodeChange,
     onDialCodeChange,
     onInput,
     size,
@@ -33,27 +28,20 @@ const PhoneNumberFieldPrimitive: Primitive<PhoneNumberFieldProps, 'input'> = (
   },
   ref
 ) => {
-  // Merge all dial/country code values in preparation of countryCode values being removed preferring dial code values
-  const codeName = dialCodeName || countryCodeName;
-  const codeLabel = dialCodeLabel || countryCodeLabel;
-  const defaultCode = defaultDialCode || defaultCountryCode;
-  const onCodeChange = onDialCodeChange || onCountryCodeChange;
-  const codeRef = dialCodeRef || countryCodeRef;
-
   return (
     <TextField
       outerStartComponent={
-        <CountryCodeSelect
-          defaultValue={defaultCode}
+        <DialCodeSelect
+          defaultValue={defaultDialCode}
           dialCodeList={dialCodeList}
           className={className}
           hasError={hasError}
           isDisabled={isDisabled}
           isReadOnly={isReadOnly}
-          label={codeLabel}
-          name={codeName}
-          onChange={onCodeChange}
-          ref={codeRef}
+          label={dialCodeLabel}
+          name={dialCodeName}
+          onChange={onDialCodeChange}
+          ref={dialCodeRef}
           size={size}
           variation={variation}
         />

--- a/packages/react/src/primitives/PhoneNumberField/__tests__/DialCodeSelect.test.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/__tests__/DialCodeSelect.test.tsx
@@ -1,35 +1,35 @@
 import * as React from 'react';
 
 import { render, screen } from '@testing-library/react';
-import { countryDialCodes } from '@aws-amplify/ui';
+import { dialCodes } from '@aws-amplify/ui';
 
-import { CountryCodeSelect } from '../CountryCodeSelect';
+import { DialCodeSelect } from '../DialCodeSelect';
 import { ComponentClassNames } from '../../shared/constants';
 
-describe('CountryCodeSelect', () => {
+describe('DialCodeSelect', () => {
   const setup = async ({
     defaultValue = '+1',
-    label = 'Country Code',
+    label = 'Dial Code',
     ...rest
-  }: Partial<typeof CountryCodeSelect['defaultProps']>) => {
+  }: Partial<typeof DialCodeSelect['defaultProps']>) => {
     render(
-      <CountryCodeSelect label={label} defaultValue={defaultValue} {...rest} />
+      <DialCodeSelect label={label} defaultValue={defaultValue} {...rest} />
     );
 
     return {
-      $countryCodeSelector: await screen.findByRole('combobox'),
+      $dialCodeSelector: await screen.findByRole('combobox'),
     };
   };
 
-  it('should render all country codes as options', async () => {
+  it('should render all dial codes as options', async () => {
     await setup({});
-    const $countryCodeOptions = await screen.findAllByRole('option');
-    const countryCodeOptions = $countryCodeOptions.map(
-      ($countryCodeOption) => $countryCodeOption.textContent
+    const $dialCodeOptions = await screen.findAllByRole('option');
+    const dialCodeOptions = $dialCodeOptions.map(
+      ($dialCodeOption) => $dialCodeOption.textContent
     );
 
-    expect(countryCodeOptions).toMatchInlineSnapshot(
-      countryDialCodes,
+    expect(dialCodeOptions).toMatchInlineSnapshot(
+      dialCodes,
       `
       Array [
         "+1",
@@ -243,30 +243,25 @@ describe('CountryCodeSelect', () => {
     );
   });
 
-  it('should have "tel-country-code" as the default autocomplete attribute', async () => {
-    const { $countryCodeSelector } = await setup({});
+  it('should have "tel-dial-code" as the default autocomplete attribute', async () => {
+    const { $dialCodeSelector } = await setup({});
 
-    expect($countryCodeSelector).toHaveAttribute(
-      'autocomplete',
-      'tel-country-code'
-    );
+    expect($dialCodeSelector).toHaveAttribute('autocomplete', 'tel-dial-code');
   });
 
-  it('should render classname for CountryCodeSelect', async () => {
+  it('should render classname for DialCodeSelect', async () => {
     const className = 'test-class-name';
-    const testId = 'CountryCodeSelectTestId';
+    const testId = 'DialCodeSelectTestId';
     await setup({ className, testId });
-    const $countryCodeSelect = await screen.findByTestId(testId);
+    const $dialCodeSelect = await screen.findByTestId(testId);
 
-    expect($countryCodeSelect).toHaveClass(className);
-    expect($countryCodeSelect).toHaveClass(
-      ComponentClassNames.CountryCodeSelect
-    );
+    expect($dialCodeSelect).toHaveClass(className);
+    expect($dialCodeSelect).toHaveClass(ComponentClassNames.DialCodeSelect);
   });
 
   it('should forward ref to DOM element', async () => {
     const ref = React.createRef<HTMLSelectElement>();
-    const testId = 'CountryCodeSelectTestId';
+    const testId = 'DialCodeSelectTestId';
     await setup({ testId, ref });
 
     await screen.findByTestId(testId);

--- a/packages/react/src/primitives/PhoneNumberField/__tests__/PhoneNumberField.test.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/__tests__/PhoneNumberField.test.tsx
@@ -11,15 +11,17 @@ const originalLog = console.log;
 console.log = jest.fn();
 
 describe('PhoneNumberField primitive', () => {
-  const setup = async ({
-    defaultCountryCode = '+1',
+  const dialCodeSetup = async ({
+    defaultDialCode = '+1',
     label = 'Phone Number',
+    dialCodeLabel = 'dial code',
     ...rest
   }: Partial<typeof PhoneNumberField['defaultProps']>) => {
     render(
       <PhoneNumberField
-        defaultCountryCode={defaultCountryCode}
+        defaultDialCode={defaultDialCode}
         label={label}
+        dialCodeLabel={dialCodeLabel}
         {...rest}
       />
     );
@@ -28,30 +30,30 @@ describe('PhoneNumberField primitive', () => {
       $phoneInput: await screen.findByRole('textbox', {
         name: /phone number/i,
       }),
-      $countryCodeSelector: await screen.findByRole('combobox', {
-        name: /country code/i,
+      $dialCodeSelector: await screen.findByRole('combobox', {
+        name: /dial code/i,
       }),
     };
   };
 
-  const ReadOnlyFormTest = () => {
+  const DialCodeReadOnlyFormTest = () => {
     const inputRef = React.useRef(null);
-    const countryCodeRef = React.useRef(null);
+    const dialCodeRef = React.useRef(null);
 
     const handleSubmit = (e) => {
       e.preventDefault();
-      console.log(`${countryCodeRef.current.value} ${inputRef.current.value}`);
+      console.log(`${dialCodeRef.current.value} ${inputRef.current.value}`);
     };
 
     return (
       <Flex as="form" onSubmit={handleSubmit}>
         <PhoneNumberField
-          defaultCountryCode="+40"
+          defaultDialCode="+40"
           defaultValue="1234567"
           label="Read Only"
           name="read_only_phone"
           ref={inputRef}
-          countryCodeRef={countryCodeRef}
+          dialCodeRef={dialCodeRef}
           isReadOnly
         />
         <Button type="submit">Submit</Button>
@@ -59,56 +61,56 @@ describe('PhoneNumberField primitive', () => {
     );
   };
 
-  it('should forward ref and countryCodeRef to DOM elements', async () => {
+  it('should forward ref and dialCodeRef to DOM elements', async () => {
     const ref = React.createRef<HTMLInputElement>();
-    const countryCodeRef = React.createRef<HTMLSelectElement>();
-    await setup({ ref, countryCodeRef });
+    const dialCodeRef = React.createRef<HTMLSelectElement>();
+    await dialCodeSetup({ ref, dialCodeRef });
 
     await screen.findByRole('textbox');
     expect(ref.current.nodeName).toBe('INPUT');
-    expect(countryCodeRef.current.nodeName).toBe('SELECT');
+    expect(dialCodeRef.current.nodeName).toBe('SELECT');
   });
 
-  it('should render a country code selector with an accessible role', async () => {
-    const { $countryCodeSelector } = await setup({});
+  it('should render a dial code selector with an accessible role', async () => {
+    const { $dialCodeSelector } = await dialCodeSetup({});
 
-    expect($countryCodeSelector).toBeDefined();
+    expect($dialCodeSelector).toBeDefined();
   });
 
-  it('should render a country code selector with an accessible label', async () => {
-    const { $countryCodeSelector } = await setup({});
+  it('should render a dial code selector with an accessible label', async () => {
+    const { $dialCodeSelector } = await dialCodeSetup({});
 
-    expect($countryCodeSelector).toBeDefined();
+    expect($dialCodeSelector).toBeDefined();
   });
 
   it('should render a phone input field with an accessible role', async () => {
-    const { $phoneInput } = await setup({});
+    const { $phoneInput } = await dialCodeSetup({});
 
     expect($phoneInput).toBeDefined();
   });
 
   it('should render a phone input field with an accessible role', async () => {
-    await setup({});
+    await dialCodeSetup({});
     const $phoneInput = await screen.findByLabelText(/phone number/i);
 
     expect($phoneInput).toBeDefined();
   });
 
-  it('should use a specified defaultCountryCode', async () => {
-    const defaultCountryCode = '+7';
-    const { $countryCodeSelector } = await setup({ defaultCountryCode });
+  it('should use a specified defaultDialCode', async () => {
+    const defaultDialCode = '+7';
+    const { $dialCodeSelector } = await dialCodeSetup({ defaultDialCode });
 
-    expect($countryCodeSelector).toHaveValue(defaultCountryCode);
+    expect($dialCodeSelector).toHaveValue(defaultDialCode);
   });
 
   it('should always use type "tel"', async () => {
-    const { $phoneInput } = await setup({});
+    const { $phoneInput } = await dialCodeSetup({});
 
     expect($phoneInput).toHaveAttribute('type', 'tel');
   });
 
   it('should have "tel-national" as the default autocomplete attribute', async () => {
-    const { $phoneInput } = await setup({});
+    const { $phoneInput } = await dialCodeSetup({});
 
     expect($phoneInput).toHaveAttribute('autocomplete', 'tel-national');
   });
@@ -116,7 +118,7 @@ describe('PhoneNumberField primitive', () => {
   it('should render classname for PhoneNumberField', async () => {
     const className = 'test-class-name';
     const testId = 'PhoneNumberFieldTestId';
-    await setup({ className, testId });
+    await dialCodeSetup({ className, testId });
     const $phoneInput = await screen.findByTestId(testId);
 
     expect($phoneInput).toHaveClass(className);
@@ -124,26 +126,26 @@ describe('PhoneNumberField primitive', () => {
   });
 
   it('should be able to set a size', async () => {
-    const { $countryCodeSelector, $phoneInput } = await setup({
+    const { $dialCodeSelector, $phoneInput } = await dialCodeSetup({
       size: 'large',
     });
 
     expect($phoneInput).toHaveAttribute('data-size', 'large');
-    expect($countryCodeSelector).toHaveAttribute('data-size', 'large');
+    expect($dialCodeSelector).toHaveAttribute('data-size', 'large');
   });
 
   it('should be able to set a variation', async () => {
-    const { $countryCodeSelector, $phoneInput } = await setup({
+    const { $dialCodeSelector, $phoneInput } = await dialCodeSetup({
       variation: 'quiet',
     });
 
     expect($phoneInput).toHaveAttribute('data-variation', 'quiet');
-    expect($countryCodeSelector).toHaveAttribute('data-variation', 'quiet');
+    expect($dialCodeSelector).toHaveAttribute('data-variation', 'quiet');
   });
 
   it('should fire onChange handler when phone input field is changed', async () => {
     const onChange = jest.fn();
-    const { $phoneInput } = await setup({ onChange });
+    const { $phoneInput } = await dialCodeSetup({ onChange });
     userEvent.type($phoneInput, '1');
 
     expect(onChange).toHaveBeenCalled();
@@ -151,221 +153,41 @@ describe('PhoneNumberField primitive', () => {
 
   it('should fire onInput handler when phone input field is changed', async () => {
     const onInput = jest.fn();
-    const { $phoneInput } = await setup({ onInput });
+    const { $phoneInput } = await dialCodeSetup({ onInput });
     userEvent.type($phoneInput, '1');
 
     expect(onInput).toHaveBeenCalled();
   });
 
-  it('should fire onCountryCodeChange handler when phone input field is changed', async () => {
-    const onCountryCodeChange = jest.fn();
-    const { $countryCodeSelector } = await setup({ onCountryCodeChange });
-    userEvent.selectOptions($countryCodeSelector, '+7');
+  it('should fire onDialCodeChange handler when phone input field is changed', async () => {
+    const onDialCodeChange = jest.fn();
+    const { $dialCodeSelector } = await dialCodeSetup({ onDialCodeChange });
+    userEvent.selectOptions($dialCodeSelector, '+7');
 
-    expect(onCountryCodeChange).toHaveBeenCalled();
+    expect(onDialCodeChange).toHaveBeenCalled();
   });
 
   /*
-    Since <select> elements do not support the `readonly` html attribute, it is suggested to use the `disabled` html attribute 
-    so that a screen reader will announce something to the user about the interactivity of the options list ( https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
-  */
+      Since <select> elements do not support the `readonly` html attribute, it is suggested to use the `disabled` html attribute 
+      so that a screen reader will announce something to the user about the interactivity of the options list ( https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
+    */
   it('should set aria-disabled="true" when the isReadOnly prop is passed, and disable all the select options', async () => {
-    const { $countryCodeSelector } = await setup({ isReadOnly: true });
+    const { $dialCodeSelector } = await dialCodeSetup({ isReadOnly: true });
 
-    expect($countryCodeSelector).toHaveAttribute('aria-disabled', 'true');
+    expect($dialCodeSelector).toHaveAttribute('aria-disabled', 'true');
 
-    $countryCodeSelector.querySelectorAll('option').forEach((option) => {
+    $dialCodeSelector.querySelectorAll('option').forEach((option) => {
       expect(option).toHaveAttribute('disabled');
     });
   });
 
   it('should still submit the form values when the isReadOnly prop is passed', async () => {
-    const { container } = render(<ReadOnlyFormTest />);
+    const { container } = render(<DialCodeReadOnlyFormTest />);
 
     const button = container.getElementsByTagName('button')[0];
     userEvent.click(button);
     expect(console.log).toHaveBeenCalledWith('+40 1234567');
-  });
 
-  describe('Using Dial Code', () => {
-    const dialCodeSetup = async ({
-      defaultDialCode = '+1',
-      label = 'Phone Number',
-      dialCodeLabel = 'dial code',
-      ...rest
-    }: Partial<typeof PhoneNumberField['defaultProps']>) => {
-      render(
-        <PhoneNumberField
-          defaultDialCode={defaultDialCode}
-          label={label}
-          dialCodeLabel={dialCodeLabel}
-          {...rest}
-        />
-      );
-
-      return {
-        $phoneInput: await screen.findByRole('textbox', {
-          name: /phone number/i,
-        }),
-        $dialCodeSelector: await screen.findByRole('combobox', {
-          name: /dial code/i,
-        }),
-      };
-    };
-
-    const DialCodeReadOnlyFormTest = () => {
-      const inputRef = React.useRef(null);
-      const dialCodeRef = React.useRef(null);
-
-      const handleSubmit = (e) => {
-        e.preventDefault();
-        console.log(`${dialCodeRef.current.value} ${inputRef.current.value}`);
-      };
-
-      return (
-        <Flex as="form" onSubmit={handleSubmit}>
-          <PhoneNumberField
-            defaultDialCode="+40"
-            defaultValue="1234567"
-            label="Read Only"
-            name="read_only_phone"
-            ref={inputRef}
-            dialCodeRef={dialCodeRef}
-            isReadOnly
-          />
-          <Button type="submit">Submit</Button>
-        </Flex>
-      );
-    };
-
-    it('should forward ref and dialCodeRef to DOM elements', async () => {
-      const ref = React.createRef<HTMLInputElement>();
-      const dialCodeRef = React.createRef<HTMLSelectElement>();
-      await dialCodeSetup({ ref, dialCodeRef });
-
-      await screen.findByRole('textbox');
-      expect(ref.current.nodeName).toBe('INPUT');
-      expect(dialCodeRef.current.nodeName).toBe('SELECT');
-    });
-
-    it('should render a country code selector with an accessible role', async () => {
-      const { $dialCodeSelector } = await dialCodeSetup({});
-
-      expect($dialCodeSelector).toBeDefined();
-    });
-
-    it('should render a country code selector with an accessible label', async () => {
-      const { $dialCodeSelector } = await dialCodeSetup({});
-
-      expect($dialCodeSelector).toBeDefined();
-    });
-
-    it('should render a phone input field with an accessible role', async () => {
-      const { $phoneInput } = await dialCodeSetup({});
-
-      expect($phoneInput).toBeDefined();
-    });
-
-    it('should render a phone input field with an accessible role', async () => {
-      await dialCodeSetup({});
-      const $phoneInput = await screen.findByLabelText(/phone number/i);
-
-      expect($phoneInput).toBeDefined();
-    });
-
-    it('should use a specified defaultDialCode', async () => {
-      const defaultDialCode = '+7';
-      const { $dialCodeSelector } = await dialCodeSetup({ defaultDialCode });
-
-      expect($dialCodeSelector).toHaveValue(defaultDialCode);
-    });
-
-    it('should always use type "tel"', async () => {
-      const { $phoneInput } = await dialCodeSetup({});
-
-      expect($phoneInput).toHaveAttribute('type', 'tel');
-    });
-
-    it('should have "tel-national" as the default autocomplete attribute', async () => {
-      const { $phoneInput } = await dialCodeSetup({});
-
-      expect($phoneInput).toHaveAttribute('autocomplete', 'tel-national');
-    });
-
-    it('should render classname for PhoneNumberField', async () => {
-      const className = 'test-class-name';
-      const testId = 'PhoneNumberFieldTestId';
-      await dialCodeSetup({ className, testId });
-      const $phoneInput = await screen.findByTestId(testId);
-
-      expect($phoneInput).toHaveClass(className);
-      expect($phoneInput).toHaveClass(ComponentClassNames.PhoneNumberField);
-    });
-
-    it('should be able to set a size', async () => {
-      const { $dialCodeSelector, $phoneInput } = await dialCodeSetup({
-        size: 'large',
-      });
-
-      expect($phoneInput).toHaveAttribute('data-size', 'large');
-      expect($dialCodeSelector).toHaveAttribute('data-size', 'large');
-    });
-
-    it('should be able to set a variation', async () => {
-      const { $dialCodeSelector, $phoneInput } = await dialCodeSetup({
-        variation: 'quiet',
-      });
-
-      expect($phoneInput).toHaveAttribute('data-variation', 'quiet');
-      expect($dialCodeSelector).toHaveAttribute('data-variation', 'quiet');
-    });
-
-    it('should fire onChange handler when phone input field is changed', async () => {
-      const onChange = jest.fn();
-      const { $phoneInput } = await dialCodeSetup({ onChange });
-      userEvent.type($phoneInput, '1');
-
-      expect(onChange).toHaveBeenCalled();
-    });
-
-    it('should fire onInput handler when phone input field is changed', async () => {
-      const onInput = jest.fn();
-      const { $phoneInput } = await dialCodeSetup({ onInput });
-      userEvent.type($phoneInput, '1');
-
-      expect(onInput).toHaveBeenCalled();
-    });
-
-    it('should fire onDialCodeChange handler when phone input field is changed', async () => {
-      const onDialCodeChange = jest.fn();
-      const { $dialCodeSelector } = await dialCodeSetup({ onDialCodeChange });
-      userEvent.selectOptions($dialCodeSelector, '+7');
-
-      expect(onDialCodeChange).toHaveBeenCalled();
-    });
-
-    /*
-      Since <select> elements do not support the `readonly` html attribute, it is suggested to use the `disabled` html attribute 
-      so that a screen reader will announce something to the user about the interactivity of the options list ( https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
-    */
-    it('should set aria-disabled="true" when the isReadOnly prop is passed, and disable all the select options', async () => {
-      const { $dialCodeSelector } = await dialCodeSetup({ isReadOnly: true });
-
-      expect($dialCodeSelector).toHaveAttribute('aria-disabled', 'true');
-
-      $dialCodeSelector.querySelectorAll('option').forEach((option) => {
-        expect(option).toHaveAttribute('disabled');
-      });
-    });
-
-    it('should still submit the form values when the isReadOnly prop is passed', async () => {
-      const { container } = render(<DialCodeReadOnlyFormTest />);
-
-      const button = container.getElementsByTagName('button')[0];
-      userEvent.click(button);
-      expect(console.log).toHaveBeenCalledWith('+40 1234567');
-
-      console.log = originalLog;
-    });
+    console.log = originalLog;
   });
 });

--- a/packages/react/src/primitives/shared/constants.ts
+++ b/packages/react/src/primitives/shared/constants.ts
@@ -111,12 +111,6 @@ export const ComponentClassObject: ComponentClassNameItems = {
     description:
       'Class applied to the element that wraps the pagination component in a collection',
   },
-  CountryCodeSelect: {
-    className: ComponentClassName.CountryCodeSelect,
-    components: ['PhoneNumberField'],
-    description:
-      'Class applied to the Dial Code Select within the PhoneNumberField primitive',
-  },
   DialCodeSelect: {
     className: ComponentClassName.DialCodeSelect,
     components: ['PhoneNumberField'],
@@ -556,7 +550,6 @@ export const ComponentClassNames: ComponentClassNamesType = {
   CollectionItems: ComponentClassObject.CollectionItems.className,
   CollectionSearch: ComponentClassObject.CollectionSearch.className,
   CollectionPagination: ComponentClassObject.CollectionPagination.className,
-  CountryCodeSelect: ComponentClassObject.CountryCodeSelect.className,
   DialCodeSelect: ComponentClassObject.DialCodeSelect.className,
   Divider: ComponentClassObject.Divider.className,
   DividerLabel: ComponentClassObject.DividerLabel.className,
@@ -675,7 +668,7 @@ export const ComponentText = {
     previousLabel: 'Go to previous page',
   },
   PhoneNumberField: {
-    countryCodeLabel: 'Country code',
+    dialCodeLabel: 'Dial code',
   },
   SearchField: {
     searchButtonLabel: 'Search',

--- a/packages/react/src/primitives/shared/types.ts
+++ b/packages/react/src/primitives/shared/types.ts
@@ -62,7 +62,6 @@ type ComponentClassNameKey =
   | 'CollectionItems'
   | 'CollectionSearch'
   | 'CollectionPagination'
-  | 'CountryCodeSelect'
   | 'DialCodeSelect'
   | 'Divider'
   | 'DividerLabel'
@@ -179,7 +178,6 @@ export enum ComponentClassName {
   CollectionItems = 'amplify-collection-items',
   CollectionSearch = 'amplify-collection-search',
   CollectionPagination = 'amplify-collection-pagination',
-  CountryCodeSelect = 'amplify-countrycodeselect',
   DialCodeSelect = 'amplify-dialcodeselect',
   Divider = 'amplify-divider',
   DividerLabel = 'amplify-divider--label',

--- a/packages/react/src/primitives/types/phoneNumberField.ts
+++ b/packages/react/src/primitives/types/phoneNumberField.ts
@@ -3,9 +3,13 @@ import * as React from 'react';
 import { SelectFieldProps } from './selectField';
 import { TextInputFieldProps } from './textField';
 
-interface optionalPhoneNumberFieldProps
-  extends TextInputFieldProps,
-    CountryCodeFieldProps {
+export interface PhoneNumberFieldProps extends TextInputFieldProps {
+  /**
+   * @description
+   * Sets the default dial code that will be selected on initial render
+   */
+  defaultDialCode: string;
+
   /**
    * @description
    * Sets a hidden and accessible label for the dial code selector
@@ -42,74 +46,6 @@ interface optionalPhoneNumberFieldProps
    */
   dialCodeRef?: React.Ref<HTMLSelectElement>;
 }
-
-interface CountryCodeFieldProps {
-  /**
-   * @description
-   * Sets a hidden and accessible label for the dial code selector
-   * @deprecated
-   * To be removed with next major version release, please use dialCodeLabel
-   */
-  countryCodeLabel?: string;
-
-  /**
-   * @description
-   * Sets the name used when handling form submission for the dial code selector
-   * @deprecated
-   * To be removed with next major version release, please use dialCodeName
-   */
-  countryCodeName?: string;
-
-  /**
-   * @description
-   * Handles change events for the dial code selector
-   * @deprecated
-   * To be removed with next major version release, please use onDialCodeChange
-   */
-  onCountryCodeChange?: React.ChangeEventHandler<HTMLSelectElement>;
-
-  /**
-   * @description
-   * Forwarded ref for access to Country Code select DOM element
-   * @deprecated
-   * To be removed with next major version release, please use dialCodeRef
-   */
-  countryCodeRef?: React.Ref<HTMLSelectElement>;
-}
-
-interface CountryCodeRequired extends optionalPhoneNumberFieldProps {
-  /**
-   * @description
-   * Sets the default dial code that will be selected on initial render
-   * @deprecated
-   * To be removed with next major version release, please use defaultDialCode
-   */
-  defaultCountryCode: string;
-
-  /**
-   * @description
-   * Sets the default dial code that will be selected on initial render
-   */
-  defaultDialCode?: string;
-}
-
-interface DialCodeRequired extends optionalPhoneNumberFieldProps {
-  /**
-   * @description
-   * Sets the default dial code that will be selected on initial render
-   * @deprecated
-   * To be removed with next major version release, please use defaultDialCode
-   */
-  defaultCountryCode?: string;
-
-  /**
-   * @description
-   * Sets the default dial code that will be selected on initial render
-   */
-  defaultDialCode: string;
-}
-
-export type PhoneNumberFieldProps = CountryCodeRequired | DialCodeRequired;
 
 export interface DialCodeSelectProps extends SelectFieldProps {
   defaultValue: string;

--- a/packages/ui/src/helpers/authenticator/constants.ts
+++ b/packages/ui/src/helpers/authenticator/constants.ts
@@ -3,7 +3,7 @@
  */
 
 import { DefaultFormFieldOptions } from '../../types';
-import { countryDialCodes } from '../../i18n';
+import { dialCodes } from '../../i18n';
 
 export const defaultFormFieldOptions: DefaultFormFieldOptions = {
   birthdate: {
@@ -93,7 +93,7 @@ export const defaultFormFieldOptions: DefaultFormFieldOptions = {
     type: 'tel',
     autocomplete: 'tel',
     dialCode: '+1',
-    dialCodeList: countryDialCodes,
+    dialCodeList: dialCodes,
     isRequired: true,
   },
   preferred_username: {

--- a/packages/ui/src/helpers/authenticator/formFields/defaults.ts
+++ b/packages/ui/src/helpers/authenticator/formFields/defaults.ts
@@ -20,12 +20,12 @@ const getDefaultFormField = (
   state: AuthMachineState,
   fieldName: keyof typeof defaultFormFieldOptions
 ) => {
-  const { country_code } = getActorContext(state) as ActorContextWithForms;
+  const { dial_code } = getActorContext(state) as ActorContextWithForms;
   let options: FormFieldOptions = defaultFormFieldOptions[fieldName];
   const { type } = options;
 
   if (type === 'tel') {
-    options = { ...options, dialCode: country_code };
+    options = { ...options, dialCode: dial_code };
   }
 
   return options;

--- a/packages/ui/src/i18n/dial-codes.ts
+++ b/packages/ui/src/i18n/dial-codes.ts
@@ -1,4 +1,4 @@
-export const countryDialCodes = [
+export const dialCodes = [
   '+1',
   '+7',
   '+20',

--- a/packages/ui/src/i18n/index.ts
+++ b/packages/ui/src/i18n/index.ts
@@ -1,2 +1,2 @@
-export * from './country-dial-codes';
+export * from './dial-codes';
 export * from './translations';

--- a/packages/ui/src/machines/authenticator/actions.ts
+++ b/packages/ui/src/machines/authenticator/actions.ts
@@ -107,10 +107,10 @@ export const setUser = assign({
 export const setUsername = assign({
   username: (context: ActorContextWithForms, _) => {
     let {
-      formValues: { username, country_code },
+      formValues: { username, dial_code },
     } = context;
-    if (country_code) {
-      username = `${country_code}${username}`;
+    if (dial_code) {
+      username = `${dial_code}${username}`;
     }
     return username;
   },
@@ -156,7 +156,7 @@ export const handleBlur = assign({
 
 /**
  * This action occurs on the entry to a state where a form submit action
- * occurs. It combines the phone_number and country_code form values, parses
+ * occurs. It combines the phone_number and dial_code form values, parses
  * the result, and updates the form values with the full phone number which is
  * the required format by Cognito for form submission.
  */
@@ -167,18 +167,18 @@ export const parsePhoneNumber = assign({
     if (!context.formValues.phone_number && primaryAlias !== 'phone_number')
       return context.formValues;
 
-    const { formValues, country_code: defaultCountryCode } = context;
+    const { formValues, dial_code: defaultDialCode } = context;
     const phoneAlias = formValues.phone_number ? 'phone_number' : 'username';
 
-    const parsedPhoneNumber = `${
-      formValues.country_code ?? defaultCountryCode
-    }${formValues[phoneAlias]}`.replace(/[^A-Z0-9+]/gi, '');
+    const parsedPhoneNumber = `${formValues.dial_code ?? defaultDialCode}${
+      formValues[phoneAlias]
+    }`.replace(/[^A-Z0-9+]/gi, '');
 
     const updatedFormValues = {
       ...formValues,
       [phoneAlias]: parsedPhoneNumber,
     };
-    delete updatedFormValues.country_code;
+    delete updatedFormValues.dial_code;
 
     return updatedFormValues;
   },

--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -538,19 +538,16 @@ export function signInActor({ services }: SignInMachineOptions) {
         },
         async forceNewPassword(context) {
           const { user, formValues } = context;
-          let {
-            password,
-            confirm_password,
-            phone_number,
-            country_code,
-            ...rest
-          } = formValues;
+          let { password, confirm_password, phone_number, dial_code, ...rest } =
+            formValues;
 
-          let phoneNumberWithCountryCode;
+          let phoneNumberWithDialCode;
           if (phone_number) {
-            phoneNumberWithCountryCode =
-              `${country_code}${phone_number}`.replace(/[^A-Z0-9+]/gi, '');
-            rest = { ...rest, phone_number: phoneNumberWithCountryCode };
+            phoneNumberWithDialCode = `${dial_code}${phone_number}`.replace(
+              /[^A-Z0-9+]/gi,
+              ''
+            );
+            rest = { ...rest, phone_number: phoneNumberWithDialCode };
           }
 
           try {

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -12,7 +12,7 @@ import { resetPasswordActor, signInActor, signOutActor } from './actors';
 import { defaultServices } from './defaultServices';
 import { createSignUpMachine } from './signUp';
 
-const DEFAULT_COUNTRY_CODE = '+1';
+const DEFAULT_DIAL_CODE = '+1';
 
 export type AuthenticatorMachineOptions = AuthContext['config'] & {
   services?: AuthContext['services'];
@@ -297,7 +297,7 @@ export function createAuthenticatorMachine() {
               authAttributes: context.actorDoneData?.authAttributes ?? {},
               user: context.user,
               intent: context.actorDoneData?.intent,
-              country_code: DEFAULT_COUNTRY_CODE,
+              dial_code: DEFAULT_DIAL_CODE,
               formValues: {},
               touched: {},
               validationError: {},
@@ -313,7 +313,7 @@ export function createAuthenticatorMachine() {
             const { services } = context;
             const actor = createSignUpMachine({ services }).withContext({
               authAttributes: context.actorDoneData?.authAttributes ?? {},
-              country_code: DEFAULT_COUNTRY_CODE,
+              dial_code: DEFAULT_DIAL_CODE,
               intent: context.actorDoneData?.intent,
               formValues: {},
               touched: {},

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -256,7 +256,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-copy-tool-tip-bottom: var(--amplify-space-large);
         --amplify-components-copy-tool-tip-color: var(--amplify-colors-teal-100);
         --amplify-components-copy-tool-tip-font-size: var(--amplify-font-sizes-xxs);
-        --amplify-components-countrycodeselect-height: var(--amplify-space-relative-full);
+        --amplify-components-dialcodeselect-height: var(--amplify-space-relative-full);
         --amplify-components-divider-border-style: solid;
         --amplify-components-divider-border-color: var(--amplify-colors-border-primary);
         --amplify-components-divider-border-width: var(--amplify-border-widths-medium);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -290,7 +290,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-copy-tool-tip-bottom: var(--amplify-space-large);
         --amplify-components-copy-tool-tip-color: var(--amplify-colors-teal-100);
         --amplify-components-copy-tool-tip-font-size: var(--amplify-font-sizes-xxs);
-        --amplify-components-countrycodeselect-height: var(--amplify-space-relative-full);
+        --amplify-components-dialcodeselect-height: var(--amplify-space-relative-full);
         --amplify-components-divider-border-style: solid;
         --amplify-components-divider-border-color: var(--amplify-colors-border-primary);
         --amplify-components-divider-border-width: var(--amplify-border-widths-medium);

--- a/packages/ui/src/theme/css/component/dialCodeSelect.scss
+++ b/packages/ui/src/theme/css/component/dialCodeSelect.scss
@@ -1,3 +1,3 @@
 .amplify-dialcodeselect {
-  height: var(--amplify-components-countrycodeselect-height);
+  height: var(--amplify-components-dialcodeselect-height);
 }

--- a/packages/ui/src/theme/tokens/components/index.ts
+++ b/packages/ui/src/theme/tokens/components/index.ts
@@ -55,7 +55,7 @@ export interface ComponentTokens {
   checkboxfield: CheckboxFieldTokens;
   collection: CollectionTokens;
   copy: CopyTokens;
-  countrycodeselect: DialCodeSelectTokens;
+  dialcodeselect: DialCodeSelectTokens;
   divider: DividerTokens;
   expander: ExpanderTokens;
   field: FieldTokens;
@@ -101,7 +101,7 @@ export const components: ComponentTokens = {
   checkboxfield,
   collection,
   copy,
-  countrycodeselect: dialcodeselect, // This to be renamed to dialcodeselect in the next major version
+  dialcodeselect: dialcodeselect,
   divider,
   expander,
   field,

--- a/packages/ui/src/types/authenticator/stateMachine/context.ts
+++ b/packages/ui/src/types/authenticator/stateMachine/context.ts
@@ -70,8 +70,8 @@ interface BaseFormContext {
   passwordSettings?: PasswordSettings;
   /** Denotes where a confirmation code has been sent to */
   codeDeliveryDetails?: CodeDeliveryDetails;
-  /** Default country code for all phone number fields. */
-  country_code?: string; // TODO: this one should be customizable as well
+  /** Default dial code for all phone number fields. */
+  dial_code?: string; // TODO: this one should be customizable as well
 }
 
 // Actor context types

--- a/packages/vue/src/components/alias-control.vue
+++ b/packages/vue/src/components/alias-control.vue
@@ -55,7 +55,7 @@ const randomPhone = Math.floor(Math.random() * 999999);
       <base-wrapper class="amplify-field-group__outer-start">
         <!--select drop down-->
         <base-wrapper
-          class="amplify-flex amplify-field amplify-selectfield amplify-countrycodeselect amplify-dialcodeselect amplify-authenticator__column"
+          class="amplify-flex amplify-field amplify-selectfield amplify-dialcodeselect amplify-authenticator__column"
           v-if="type === 'tel'"
         >
           <base-label
@@ -63,15 +63,15 @@ const randomPhone = Math.floor(Math.random() * 999999);
             class="amplify-label amplify-visually-hidden"
             v-bind="$attrs"
           >
-            {{ 'Country Code' }}
+            {{ 'Dial Code' }}
           </base-label>
           <base-wrapper class="amplify-select__wrapper">
             <base-select
               class="amplify-select amplify-field-group__control"
               :id="'amplify-field-' + randomPhone"
-              autocomplete="tel-country-code"
-              aria-label="country code"
-              name="country_code"
+              autocomplete="tel-dial-code"
+              aria-label="dial code"
+              name="dial_code"
               :options="dialCodeList"
               :select-value="dialCode"
             >


### PR DESCRIPTION
#### Description of changes
This PR completely removes all references to "country code" and replaces them with "dial code".  The references removed include, design tokens, css rules and variables, optional props, uses within authenticator, angular, and vue.

<img width="1116" alt="Screen Shot 2022-09-07 at 3 07 37 AM" src="https://user-images.githubusercontent.com/7351516/188852902-f35b8560-edf0-48f3-bba0-5dcfd9a82cce.png">


<img width="1116" alt="Screen Shot 2022-09-07 at 3 17 54 AM" src="https://user-images.githubusercontent.com/7351516/188854436-993c6703-61da-4077-bce0-6d59e8cd9448.png">


#### Description of how you validated changes
Validated through the docs site and e2e tests.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
