### PR TITLE
chore(xstate): Set predictableActionArguments to true

### DIFF
--- a/.changeset/pretty-insects-push.md
+++ b/.changeset/pretty-insects-push.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+Set `predictableActionArguments` to true in Authenticator state machine. This is an internal change only.

--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -24,7 +24,7 @@
     "nanoid": "3.1.31",
     "qrcode": "1.5.0",
     "tslib": "2.3.1",
-    "xstate": "^4.33.0"
+    "xstate": "^4.33.6"
   },
   "publishConfig": {
     "directory": "../../dist/ui-angular"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "lodash": "4.17.21",
     "style-dictionary": "3.7.0",
-    "xstate": "^4.33.0",
+    "xstate": "^4.33.6",
     "tslib": "2.4.0"
   },
   "devDependencies": {

--- a/packages/ui/src/machines/authenticator/actors/resetPassword.ts
+++ b/packages/ui/src/machines/authenticator/actors/resetPassword.ts
@@ -25,6 +25,7 @@ export function resetPasswordActor({ services }: ResetPasswordMachineOptions) {
     {
       id: 'resetPasswordActor',
       initial: 'init',
+      predictableActionArguments: true,
       states: {
         init: {
           always: [

--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -60,6 +60,7 @@ export function signInActor({ services }: SignInMachineOptions) {
     {
       initial: 'init',
       id: 'signInActor',
+      predictableActionArguments: true,
       states: {
         init: {
           always: [

--- a/packages/ui/src/machines/authenticator/actors/signOut.ts
+++ b/packages/ui/src/machines/authenticator/actors/signOut.ts
@@ -7,6 +7,7 @@ export const signOutActor = createMachine<SignOutContext, AuthEvent>(
   {
     initial: 'pending',
     id: 'signOutActor',
+    predictableActionArguments: true,
     states: {
       pending: {
         tags: ['pending'],

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -30,6 +30,7 @@ export function createAuthenticatorMachine() {
         actorRef: undefined,
         hasSetup: false,
       },
+      predictableActionArguments: true,
       states: {
         // See: https://xstate.js.org/docs/guides/communication.html#invoking-promises
         idle: {

--- a/packages/ui/src/machines/authenticator/signUp.ts
+++ b/packages/ui/src/machines/authenticator/signUp.ts
@@ -31,6 +31,7 @@ export function createSignUpMachine({ services }: SignUpMachineOptions) {
     {
       id: 'signUpActor',
       initial: 'init',
+      predictableActionArguments: true,
       states: {
         init: {
           always: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -23821,10 +23821,10 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xstate@^4.33.0:
-  version "4.33.5"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.33.5.tgz#eafd193827b173901fac0d99e61bb4e5add6c7c8"
-  integrity sha512-C8WGBeQC+dNMp4MmQX359BUkJCv2VPAH/CGRnhtgri5JZ7wVEX7fsbfcqznAgnKyD0m9Hd3cGhg/wuzIjnfT4A==
+xstate@^4.33.6:
+  version "4.33.6"
+  resolved "https://registry.npmjs.org/xstate/-/xstate-4.33.6.tgz#9e23f78879af106f1de853aba7acb2bc3b1eb950"
+  integrity sha512-A5R4fsVKADWogK2a43ssu8Fz1AF077SfrKP1ZNyDBD8lNa/l4zfR//Luofp5GSWehOQr36Jp0k2z7b+sH2ivyg==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This sets `predictableActionArugments` to `true`, as [suggested](https://xstate.js.org/docs/guides/actions.html) in  `xstate@4.33.0+`:

> It is advised to configure predictableActionArguments: true at the top-level of your machine config.

We tried this in #2468, but we found some regressions with Authenticator usages. Xstate has resolved them now:

- https://github.com/statelyai/xstate/pull/3563
- https://github.com/statelyai/xstate/pull/3549 
- https://github.com/statelyai/xstate/pull/3541

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

See previous PR for technical details: #2468.

#### Description of how you validated changes

E2e test passing this time.

#### Notes

It's worth noting that we have some code that does not follow the best practices (https://github.com/statelyai/xstate/issues/3533#issuecomment-1220663584). That'll be a separate refactor task, but will help prevent these problems in the future.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
