### PR TITLE
chore(ci): cleanup environment secrets 

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -77,7 +77,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    environment: ci
+    environment: deployment
     needs: build-test
     if: ${{ needs.setup.outputs.has-changesets != 'true' }}
     steps:

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -17,7 +17,6 @@ permissions:
 jobs:
   version:
     runs-on: ubuntu-latest
-    environment: deployment
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Background
We have two environments for GitHub Actions workflow: `CI`, and `deployment`. 

- `CI` holds secrets that are required to run e2e tests, and 
- `deployments` holds secrets related to publishing.

#### Description of changes

This PR cleans up the environment usage so that workflow references the correct environment, and only when they need it.

This also fixes a problem where `NPM_TOKEN` was duplicated between the two environments. Going onward, we will only rely on `deployment` environment to get `NPM_TOKEN` and remove the duplicated one on `CI`.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
