### PR TITLE
Fix canary builds due to NPMJS errors

### DIFF
--- a/canary/apps/angular/angularcli/package.json
+++ b/canary/apps/angular/angularcli/package.json
@@ -45,5 +45,8 @@
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
     "typescript": "~4.1.5"
+  },
+  "resolutions": {
+    "caniuse-lite": "1.0.30001393"
   }
 }

--- a/canary/apps/react/cra-ts/package.json
+++ b/canary/apps/react/cra-ts/package.json
@@ -56,5 +56,8 @@
       "path": "build/static/js/main.*.js",
       "limit": "280 kB"
     }
-  ]
+  ],
+  "resolutions": {
+    "caniuse-lite": "1.0.30001393"
+  }
 }

--- a/canary/apps/react/cra/package.json
+++ b/canary/apps/react/cra/package.json
@@ -53,6 +53,7 @@
     }
   ],
   "overrides": {
-    "caniuse-lite": "1.0.30001393"
+    "caniuse-lite": "1.0.30001393",
+    "autoprefixer": "10.4.8"
   }
 }

--- a/canary/apps/react/cra/package.json
+++ b/canary/apps/react/cra/package.json
@@ -51,5 +51,8 @@
       "path": "build/static/js/main.*.js",
       "limit": "280 kB"
     }
-  ]
+  ],
+  "overrides": {
+    "caniuse-lite": "1.0.30001393"
+  }
 }

--- a/canary/apps/react/next/package.json
+++ b/canary/apps/react/next/package.json
@@ -26,5 +26,8 @@
       "path": ".next/static/**/*.js",
       "limit": "350 kB"
     }
-  ]
+  ],
+  "resolutions": {
+    "caniuse-lite": "1.0.30001393"
+  }
 }

--- a/canary/apps/react/next/package.json
+++ b/canary/apps/react/next/package.json
@@ -19,7 +19,8 @@
     "@size-limit/preset-app": "^7.0.8",
     "eslint": "8.8.0",
     "eslint-config-next": "12.0.10",
-    "size-limit": "^7.0.8"
+    "size-limit": "^7.0.8",
+    "autoprefixer": "10.4.8"
   },
   "size-limit": [
     {

--- a/canary/apps/vue/vuecli/package.json
+++ b/canary/apps/vue/vuecli/package.json
@@ -42,5 +42,8 @@
     "> 1%",
     "last 2 versions",
     "not dead"
-  ]
+  ],
+  "resolutions": {
+    "caniuse-lite": "1.0.30001393"
+  }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Canary Build tests are failing with following errors:

```
 Cannot find module 'caniuse-lite/data/features/css-unicode-bidi'
```
and

```
Error: Cannot find module 'autoprefixer'
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated change
```bash
cd canary
yarn install
yarn build
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
