### PR TITLE
fix(ui-react): update withAuthenticator typing

### DIFF
--- a/.changeset/rich-geckos-remain.md
+++ b/.changeset/rich-geckos-remain.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+increase flexibility of `withAuthenticator` typing 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     ]
   },
   "resolutions": {
+    "@types/react": "17.0.47",
     "ansi-regex": "5.0.1",
     "ansi-html": "0.0.8",
     "async": "^3.2.2",

--- a/packages/react/src/components/Authenticator/withAuthenticator.tsx
+++ b/packages/react/src/components/Authenticator/withAuthenticator.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import { Authenticator, AuthenticatorProps } from './Authenticator';
+import { UseAuthenticator } from './hooks/useAuthenticator';
 
 export type WithAuthenticatorOptions = Omit<AuthenticatorProps, 'children'>;
+
+type AuthenticatorHOCProps = Partial<
+  Pick<UseAuthenticator, 'signOut' | 'user'>
+>;
 
 /**
  * [📖 Docs](https://ui.docs.amplify.aws/react/connected-components/authenticator)
  */
-export function withAuthenticator<Props extends object>(
-  Component: (props: Props) => JSX.Element,
+export function withAuthenticator<Props = {}>(
+  Component: React.ComponentType<Props & AuthenticatorHOCProps>,
   options: WithAuthenticatorOptions = {}
 ): (props: Props) => JSX.Element {
   const { variation = 'modal' } = options;
@@ -15,7 +20,9 @@ export function withAuthenticator<Props extends object>(
   return function WrappedWithAuthenticator(props: Props) {
     return (
       <Authenticator variation={variation} {...options}>
-        {(authenticator) => <Component {...props} {...authenticator} />}
+        {(authenticatorHOCProps: AuthenticatorHOCProps) => (
+          <Component {...props} {...authenticatorHOCProps} />
+        )}
       </Authenticator>
     );
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6521,28 +6521,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16", "@types/react@>=16.9.0":
-  version "18.0.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.18.tgz#9f16f33d57bc5d9dca848d12c3572110ff9429ac"
-  integrity sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@17.0.47":
+"@types/react@*", "@types/react@17.0.47", "@types/react@>=16", "@types/react@>=16.9.0", "@types/react@^17", "@types/react@^17.0.2":
   version "17.0.47"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.47.tgz#4ee71aaf4c5a9e290e03aa4d0d313c5d666b3b78"
   integrity sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17", "@types/react@^17.0.2":
-  version "17.0.49"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.49.tgz#df87ba4ca8b7942209c3dc655846724539dc1049"
-  integrity sha512-CCBPMZaPhcKkYUTqFs/hOWqKjPxhTEmnZWjlHHgIMop67DsXywf9B5Os9Hz8KSacjNOgIdnZVJamwl232uxoPg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update `withAuthenticator` typing to allow more flexibility in `Component` argument and expose HOC `props` for render props pattern
- in `withAuthenticator` generic `Props` param, replace `extend object` with a default value of `{}` to closer align with React internal typing patterns
- create `AuthenticatorHOCProps` utility type, use to type render `props` passed to `Component` param
- replace `Component` typing of `(props: Props) => JSX.Element` to more flexible `React.ComponentType` to prevent type errors when user defined `Component` arg is typed as a `React.FC` or is a `Class` component
- add `@types/react@17.0.47` to _package.json_ resolutions due to a conflict between `React.ReactNode` in `@types/react@17` and `@types/react@18` ([more info here](https://github.com/facebook/react/issues/24304))

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manually tested for type safety in sample app:
  - ✅ Functional Component
  - ✅ Functional Component wrapped in `React.forwardRef`
  - ✅ Class Component
- tested `withAuthenticator` typing with `@types/react@18.0.18` to ensure compatibility

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
