### PR TITLE
chore: reorganize migration guides and fix broken link

### DIFF
--- a/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
@@ -87,8 +87,7 @@ Below is an example of how to create an Authenticator.
 
 ## Breaking changes
 
-The latest version of the `Authenticator` component has several differences from earlier versions. It's recommended that you look over the
-[Components](../components) section to get an idea of the new changes. However, here are a few of the major changes that you'll need to look out for.
+The latest version of the `Authenticator` component has several differences from earlier versions. Here are a few of the major changes that you'll need to look out for.
 
 ### Slots
 

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -97,23 +97,22 @@ Amplify.configure(awsExports);
 
 ```
 
-## Breaking changes
+### Authenticator breaking changes (1.x to 2.x)
 
-The latest version of the `Authenticator` component has several differences from earlier versions. It's recommended that you look over the
-[Components](../components) section to get an idea of the new changes. However, here are a few of the major changes that you'll need to look out for.
+The latest version of the `Authenticator` component has several differences from earlier versions. Here are a few of the major changes that you'll need to look out for.
 
-### Slots
+#### Slots
 
 All the slot locations have changed with the latest version of the `Authenticator`. To get a
 sense of the changes please check out the [Headers and Footers](../connected-components/authenticator/customization#headers--footers) section.
 
-### Form Fields
+#### Form Fields
 
 The latest version of the `Authenticator` has a different format for the `formFields` prop. It also no long accepts
 `inputProps` nor `hint`. Instead it's recommended that you use the [Headers and Footers Slots](../connected-components/authenticator/customization#headers--footers) or use the
 [Sign Up Fields customization](../connected-components/authenticator/customization#sign-up-fields). For more information on form field customizations
 please see the [Form Field Customization](../connected-components/authenticator/customization#form-field-customization) section.
 
-### CSS Styling
+#### CSS Styling
 
 The latest version of the `Authenticator` has a completely different set of CSS variables. Please look over the [Amplify CSS Variables](../connected-components/authenticator/customization#styling) section for more information.

--- a/docs/src/pages/[platform]/getting-started/migration/migration.vue.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.vue.mdx
@@ -93,8 +93,7 @@ Below is an example of how to create an Authenticator.
 
 ## Breaking changes
 
-The latest version of the `Authenticator` component has several differences from earlier versions. It's recommended that you look over the
-[Components](../components) section to get an idea of the new changes. However, here are a few of the major changes that you'll need to look out for.
+The latest version of the `Authenticator` component has several differences from earlier versions. Here are a few of the major changes that you'll need to look out for.
 
 ### Slots
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fix broken links on Migration pages for React/Vue/Angular.

<img width="1899" alt="image" src="https://user-images.githubusercontent.com/6165315/190024406-ee87bc8e-faad-4d67-a26d-8ec18e3346d4.png">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-ui/issues/2585
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
ran `yarn docs dev` and smoke tested migration page

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
