### PR TITLE
feat(environments): Add CLI options to pull-environments.sh

### DIFF
--- a/.github/workflows/poc-test-environments.yml
+++ b/.github/workflows/poc-test-environments.yml
@@ -44,3 +44,16 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_DATASTORE }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DATASTORE }}
+
+      # new pull-environments.sh tests
+      - name: Pull phone environments only
+        run: yarn environments auth pull:phone
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Pull all auth environments except phone
+        run: yarn environments auth pull:non-phone
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/environments/auth/package.json
+++ b/environments/auth/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "pull": "../pull-environments.sh -r us-east-1",
-    "pull:phone": "../pull-environments.sh -r us-east-1 -i \"\\./auth-with-((phone-and-sms-mfa)|(phone-number)|(totp-and-sms-mfa))\"",
-    "pull:non-phone": "../pull-environments.sh -r us-east-1 -e \"\\./auth-with-((phone-and-sms-mfa)|(phone-number)|(totp-and-sms-mfa))\""
+    "pull:phone": "yarn pull -i \"\\./auth-with-((phone-and-sms-mfa)|(phone-number)|(totp-and-sms-mfa))\"",
+    "pull:non-phone": "yarn pull -e \"\\./auth-with-((phone-and-sms-mfa)|(phone-number)|(totp-and-sms-mfa))\""
   }
 }

--- a/environments/auth/package.json
+++ b/environments/auth/package.json
@@ -3,6 +3,8 @@
   "name": "environments-auth",
   "version": "0.0.1",
   "scripts": {
-    "pull": "../pull-environments.sh"
+    "pull": "../pull-environments.sh -r us-east-1",
+    "pull:phone": "../pull-environments.sh -r us-east-1 -i \"\\./auth-with-((phone-and-sms-mfa)|(phone-number)|(totp-and-sms-mfa))\"",
+    "pull:non-phone": "../pull-environments.sh -r us-east-1 -e \"\\./auth-with-((phone-and-sms-mfa)|(phone-number)|(totp-and-sms-mfa))\""
   }
 }

--- a/environments/datastore/package.json
+++ b/environments/datastore/package.json
@@ -3,6 +3,6 @@
   "name": "environments-datastore",
   "version": "0.0.1",
   "scripts": {
-    "pull": "../pull-environments.sh"
+    "pull": "../pull-environments.sh -r us-east-2"
   }
 }

--- a/environments/geo/package.json
+++ b/environments/geo/package.json
@@ -3,6 +3,6 @@
   "name": "environments-geo",
   "version": "0.0.1",
   "scripts": {
-    "pull": "../pull-environments.sh"
+    "pull": "../pull-environments.sh -r us-east-2"
   }
 }

--- a/environments/pull-environment.sh
+++ b/environments/pull-environment.sh
@@ -6,6 +6,8 @@ IFS='|'
 dir=$1
 region=$2
 
+echo find -regextype help
+
 # In development, AWS_PROFILE should be set. In CI, it's not.
 [ "$AWS_PROFILE" ] && useProfile="true" || useProfile="false"
 

--- a/environments/pull-environment.sh
+++ b/environments/pull-environment.sh
@@ -3,8 +3,8 @@ set -e
 IFS='|'
 
 # Get args
-dir=$1;
-region=$2;
+dir=$1
+region=$2
 
 # In development, AWS_PROFILE should be set. In CI, it's not.
 [ "$AWS_PROFILE" ] && useProfile="true" || useProfile="false"

--- a/environments/pull-environment.sh
+++ b/environments/pull-environment.sh
@@ -6,8 +6,6 @@ IFS='|'
 dir=$1
 region=$2
 
-find -regextype help
-
 # In development, AWS_PROFILE should be set. In CI, it's not.
 [ "$AWS_PROFILE" ] && useProfile="true" || useProfile="false"
 

--- a/environments/pull-environment.sh
+++ b/environments/pull-environment.sh
@@ -2,8 +2,12 @@
 set -e
 IFS='|'
 
+# Get args
+dir=$1;
+region=$2;
+
 # In development, AWS_PROFILE should be set. In CI, it's not.
-[ "$AWS_PROFILE" ] && useProfile="true" || useProfile="false";
+[ "$AWS_PROFILE" ] && useProfile="true" || useProfile="false"
 
 FRONTENDCONFIG="{\
 \"SourceDir\":\"src\",\
@@ -14,8 +18,7 @@ FRONTENDCONFIG="{\
 FRONTEND="{\
 \"frontend\":\"javascript\",\
 \"framework\":\"none\",\
-\"config\":$FRONTENDCONFIG\
-}"
+\"config\":$FRONTENDCONFIG}"
 AMPLIFY="{\
 \"defaultEditor\":\"code\",\
 }"
@@ -25,12 +28,12 @@ AWSCLOUDFORMATIONCONFIG="{\
 \"profileName\":\"$AWS_PROFILE\",\
 \"accessKeyId\":\"$AWS_ACCESS_KEY_ID\",\
 \"secretAccessKey\":\"$AWS_SECRET_ACCESS_KEY\",\
-\"region\":\"us-east-2\"\
+\"region\":\""$region\""\
 }"
 PROVIDERS="{\
-\"awscloudformation\":$AWSCLOUDFORMATIONCONFIG\
-}"
+\"awscloudformation\":$AWSCLOUDFORMATIONCONFIG}"
 
-cd $1
+cd $dir
+echo $region
 
 echo y | yarn pull --amplify $AMPLIFY --frontend $FRONTEND --providers $PROVIDERS

--- a/environments/pull-environment.sh
+++ b/environments/pull-environment.sh
@@ -34,6 +34,5 @@ PROVIDERS="{\
 \"awscloudformation\":$AWSCLOUDFORMATIONCONFIG}"
 
 cd $dir
-echo $region
 
 echo y | yarn pull --amplify $AMPLIFY --frontend $FRONTEND --providers $PROVIDERS

--- a/environments/pull-environment.sh
+++ b/environments/pull-environment.sh
@@ -6,7 +6,7 @@ IFS='|'
 dir=$1
 region=$2
 
-echo find -regextype help
+find -regextype help
 
 # In development, AWS_PROFILE should be set. In CI, it's not.
 [ "$AWS_PROFILE" ] && useProfile="true" || useProfile="false"

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -54,7 +54,6 @@ regexMatch=""
 if [[ "$uname" == "Darwin" ]]; then
   # macOS has find syntax `find -E . [...]`.
   if [ -z "$exclude" ]; then
-    echo "find -E . -regex "$include""
     regexMatch=$(find -E . -regex "$include")
   else
     regexMatch=$(find -E . -regex "$include" -not -regex "$exclude")

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -43,25 +43,29 @@ done
 # Check OS, because `find` implementation is slightly different between OS.
 uname="$(uname)"
 
-# find has different syntax to allow extended regex on Linux vs MacOS.
-# findFlags will be assigned to the right flag for the correspondingOS.
-findFlags=""
-
-if [[ "$uname" == "Darwin" ]]; then
-  # On macOS, we do `find -E . -type d [...]`
-  findFlags="-E . -type d"
-elif [[ "$uname" == "Linux" ]]; then
-  # On Linux, we do `find . -regextype posix-extended  -type d`
-  findFlags=". -regextype posix-extended"
-else
-  echo "ERROR: unknown os: "$uname". Please open an issue with this log."
+# We only support macOS and Linux.
+# TODO: We should rewrite this script in node.js for better cross-os support.
+if [[ "$uname" != "Darwin" && "$uname" != 'Linux' ]]; then
+  echo "ERROR: Unknown os: "$uname""
+  exit 1
 fi
 
 regexMatch=""
-if ! [ -z "$exclude" ]; then
-  regexMatch=$(find $findFlags -regex "$include" -not -regex "$exclude")
+if [[ "$uname" == "Darwin" ]]; then
+  # on MacOS
+  if [ -z "$exclude" ]; then
+    echo "find -E . -regex "$include""
+    regexMatch=$(find -E . -regex "$include")
+  else
+    regexMatch=$(find -E . -regex "$include" -not -regex "$exclude")
+  fi
 else
-  regexMatch=$(find $findFlags -regex "$include")
+  # on Linux
+  if [ -z "$exclude" ]; then
+    regexMatch=$(find . -regextype posix-extended -regex "$include")
+  else
+    regexMatch=$(find . -regextype posix-extended -regex "$include" -not -regex "$exclude")
+  fi
 fi
 
 if [ -z "$regexMatch" ]; then

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -1,11 +1,53 @@
 #!/bin/bash
 # using bin/bash for macOS and Linux compatibility
-set -e
-IFS='|'
 
 dirs=""
-# Pull the backend for each environment
-for dir in ./*/ ; do
+
+# Get Options from CLI
+
+# Options:
+#  -r (region): Specifies aws region to pull environments from. Defaults to us-east-2.
+#  -i (include): Regex pattern that matches environment folders to pull from.
+#  -e (exclude): Regex pattern that matches environment folders to ignore.
+# If both -i and -e are specified, it'll match all dirs that match -i but not -e.
+
+# Examples:
+# - Include only sms/phone environments:
+#   ./pull-environments.sh -r us-east-2 -i "\./auth/auth-with-((phone-and-sms-mfa)|(phone-number)|(totp-and-sms-mfa))"
+
+while getopts ':r:i:e:' OPTION; do
+
+  case "$OPTION" in
+  r)
+    region="$OPTARG"
+    ;;
+  i)
+    include=$OPTARG
+    ;;
+
+  e)
+    exclude="$OPTARG"
+    ;;
+
+  ?)
+    echo "Usage: $(basename $0) [-r region] [-i include] [-e exclude]"
+    exit 1
+    ;;
+  esac
+
+done
+
+[ -z "$region" ] && region="us-east-2"        # default to us-east-2
+[ -z "$include" ] && include="\./[a-zA-Z\-]*" # default to all folders in cwd
+
+regexMatch=""
+if ! [ -z "$regexMatch" ]; then
+  regexMatch=$(find -E . -type d -regex "$include" -not -regex "$exclude")
+else
+  regexMatch=$(find -E . -type d -regex "$include")
+fi
+
+for dir in $regexMatch; do
   if ! [ -f "$dir/package.json" ]; then
     echo "If $dir is an environment, ensure the a package.json file exists with a \"pull\" command that pulls the environment (see the README)."
     continue
@@ -16,22 +58,22 @@ for dir in ./*/ ; do
 done
 
 # max number of parallel tasks at a time
-numParallelTasks=8; # Future improvement: could set this to # of logical cores in localdevice
+numParallelTasks=8 # Future improvement: could set this to # of logical cores in localdevice
 
 if [ "$NODE_ENV" = "test" ]; then
-  numParallelTasks=1; # GitHub actions has trouble handling parallel executions
+  numParallelTasks=1 # GitHub actions has trouble handling parallel executions
 fi
 
 # Get the path to this shell file relative to cwd
 # (1) bash_source[0] contains the filename of this shell relative to cwd
 #     (e.g. `../pull-environments.sh`)
-# (2) dirname gets rid of filename and returns the relative path to the 
+# (2) dirname gets rid of filename and returns the relative path to the
 #     directory is in (e.g. ..)
 #
 # source: https://stackoverflow.com/a/24112741
 shell_path="$(dirname "${BASH_SOURCE[0]}")" # under normal use, this points to `../`
 
+printf $dirs
 # Pull environments in parallel
 # Note that printf is used because echo dosn't handle `\n` by default in bash.
-printf $dirs | xargs -P $numParallelTasks -I {} sh -c ""$shell_path"/pull-environment.sh {}";
-
+printf $dirs | xargs -P $numParallelTasks -I {} sh -c ""$shell_path"/pull-environment.sh {} "$region""

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -73,7 +73,6 @@ fi
 # source: https://stackoverflow.com/a/24112741
 shell_path="$(dirname "${BASH_SOURCE[0]}")" # under normal use, this points to `../`
 
-printf $dirs
 # Pull environments in parallel
 # Note that printf is used because echo dosn't handle `\n` by default in bash.
 printf $dirs | xargs -P $numParallelTasks -I {} sh -c ""$shell_path"/pull-environment.sh {} "$region""

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -40,31 +40,28 @@ done
 [ -z "$region" ] && region="us-east-2"        # default to us-east-2
 [ -z "$include" ] && include="\./[a-zA-Z\-]*" # default to all folders in cwd
 
-# Check OS, as `find` implementation is slightly different between OS.
+# Check OS, because `find` implementation is slightly different between OS.
 uname="$(uname)"
-# find takes primary flag, and then secondary flag:
-#   `find [PRIMARY_FLAG] [PATH] [SECONDARY_FLAG]`
-# We'll assign the right flag that corresponds to the right OS.
-primaryFlag=""
-secondaryFlag=""
 
 # find has different syntax to allow extended regex on Linux vs MacOS.
+# findFlags will be assigned to the right flag for the correspondingOS.
+findFlags=""
+
 if [[ "$uname" == "Darwin" ]]; then
-  # On macOS, we do `find -E . [...]`, ie. only has primary Flag
-  primaryFlag="-E"
-  # space padding is added because find is really picky on spaces around flags.
+  # On macOS, we do `find -E . -type d [...]`
+  findFlags="-E . -type d"
 elif [[ "$uname" == "Linux" ]]; then
-  # On Linux, we do `find . -regextype posix-extended`, ie. only has secondary flag.
-  secondartyFlag="-regextype posix-extended"
+  # On Linux, we do `find . -regextype posix-extended  -type d`
+  findFlags=". -regextype posix-extended"
 else
   echo "ERROR: unknown os: "$uname". Please open an issue with this log."
 fi
 
 regexMatch=""
 if ! [ -z "$exclude" ]; then
-  regexMatch=$(find "$primaryFlag" . $secondaryFlag -regex "$include" -not -regex "$exclude")
+  regexMatch=$(find $findFlags -regex "$include" -not -regex "$exclude")
 else
-  regexMatch=$(find "$primaryFlag" . $secondaryFlag -regex "$include")
+  regexMatch=$(find $findFlags -regex "$include")
 fi
 
 if [ -z "$regexMatch" ]; then

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -37,14 +37,21 @@ while getopts ':r:i:e:' OPTION; do
 
 done
 
+find -regextype help
+
 [ -z "$region" ] && region="us-east-2"        # default to us-east-2
 [ -z "$include" ] && include="\./[a-zA-Z\-]*" # default to all folders in cwd
 
 regexMatch=""
-if ! [ -z "$regexMatch" ]; then
-  regexMatch=$(find -E . -type d -regex "$include" -not -regex "$exclude")
+if ! [ -z "$exclude" ]; then
+  regexMatch=$(find . -type d -regex "$include" -not -regex "$exclude")
 else
-  regexMatch=$(find -E . -type d -regex "$include")
+  regexMatch=$(find . -type d -regex "$include")
+fi
+
+if [ -z "$regexMatch" ]; then
+  echo "ERROR: no directory matches given regex."
+  exit 1
 fi
 
 for dir in $regexMatch; do

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -52,7 +52,7 @@ fi
 
 regexMatch=""
 if [[ "$uname" == "Darwin" ]]; then
-  # on MacOS
+  # macOS has find syntax `find -E . [...]`.
   if [ -z "$exclude" ]; then
     echo "find -E . -regex "$include""
     regexMatch=$(find -E . -regex "$include")
@@ -60,7 +60,7 @@ if [[ "$uname" == "Darwin" ]]; then
     regexMatch=$(find -E . -regex "$include" -not -regex "$exclude")
   fi
 else
-  # on Linux
+  # Linux has find syntax `find -E . [...]`.
   if [ -z "$exclude" ]; then
     regexMatch=$(find . -regextype posix-extended -regex "$include")
   else
@@ -84,10 +84,10 @@ for dir in $regexMatch; do
 done
 
 # max number of parallel tasks at a time
-numParallelTasks=8 # Future improvement: could set this to # of logical cores in localdevice
+numParallelTasks=1 # Future improvement: could set this to # of logical cores in localdevice
 
 if [ "$NODE_ENV" = "test" ]; then
-  numParallelTasks=1 # GitHub actions has trouble handling parallel executions
+  numParallelTasks=8 # GitHub actions has trouble handling parallel executions
 fi
 
 # Get the path to this shell file relative to cwd

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -24,7 +24,6 @@ while getopts ':r:i:e:' OPTION; do
   i)
     include=$OPTARG
     ;;
-
   e)
     exclude="$OPTARG"
     ;;
@@ -39,16 +38,28 @@ done
 
 find -regextype help
 
-uname
-
+# Apply defaults
 [ -z "$region" ] && region="us-east-2"        # default to us-east-2
 [ -z "$include" ] && include="\./[a-zA-Z\-]*" # default to all folders in cwd
 
+# Check OS, and assign right flag to use for `find` exec/
+uname="$(uname)"
+regexTypeFlag="" # this flag should indicate the regex type.
+
+# find has different flag spec on Linux vs MacOS.
+if [[ "$uname" == "Darwin" ]]; then
+  regexTypeFlag="-E" # Extended regex type flag
+elif [[ "$uname" == "Linux" ]]; then
+  regexTypeFlag="-regextype posix-extended"
+else
+  echo "ERROR: unknown os: "$uname". Please open an issue with this log."
+fi
+
 regexMatch=""
 if ! [ -z "$exclude" ]; then
-  regexMatch=$(find . -type d -regex "$include" -not -regex "$exclude")
+  regexMatch=$(find . "$regexTypeFlag" -type d -regex "$include" -not -regex "$exclude")
 else
-  regexMatch=$(find . -type d -regex "$include")
+  regexMatch=$(find . "$regexTypeFlag" -type d -regex "$include")
 fi
 
 if [ -z "$regexMatch" ]; then

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -6,7 +6,7 @@ dirs=""
 # Get Options from CLI
 
 # Options:
-#  -r (region): Specifies aws region to pull environments from. Defaults to us-east-2.
+#  -r (region): AWS region to pull environments from. Defaults to us-east-2.
 #  -i (include): Regex pattern that matches environment folders to pull from.
 #  -e (exclude): Regex pattern that matches environment folders to ignore.
 # If both -i and -e are specified, it'll match all dirs that match -i but not -e.

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -36,8 +36,6 @@ while getopts ':r:i:e:' OPTION; do
 
 done
 
-find -regextype help
-
 # Apply defaults
 [ -z "$region" ] && region="us-east-2"        # default to us-east-2
 [ -z "$include" ] && include="\./[a-zA-Z\-]*" # default to all folders in cwd
@@ -57,9 +55,11 @@ fi
 
 regexMatch=""
 if ! [ -z "$exclude" ]; then
-  regexMatch=$(find . "$regexTypeFlag" -type d -regex "$include" -not -regex "$exclude")
+  echo "$include"
+  regexMatch=$(find . -regextype posix-extended -type d -regex "$include" -not -regex "$exclude")
 else
-  regexMatch=$(find . "$regexTypeFlag" -type d -regex "$include")
+  echo "find -E . -type d -regex "$include""
+  regexMatch=$(find . -regextype posix-extended -type d -regex "$include")
 fi
 
 if [ -z "$regexMatch" ]; then

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -84,10 +84,10 @@ for dir in $regexMatch; do
 done
 
 # max number of parallel tasks at a time
-numParallelTasks=1 # Future improvement: could set this to # of logical cores in localdevice
+numParallelTasks=8 # Future improvement: could set this to # of logical cores in localdevice
 
 if [ "$NODE_ENV" = "test" ]; then
-  numParallelTasks=8 # GitHub actions has trouble handling parallel executions
+  numParallelTasks=1 # GitHub actions has trouble handling parallel executions
 fi
 
 # Get the path to this shell file relative to cwd

--- a/environments/pull-environments.sh
+++ b/environments/pull-environments.sh
@@ -39,6 +39,8 @@ done
 
 find -regextype help
 
+uname
+
 [ -z "$region" ] && region="us-east-2"        # default to us-east-2
 [ -z "$include" ] && include="\./[a-zA-Z\-]*" # default to all folders in cwd
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds three flags to `pull-environments.sh`:
- `-r`: aws region to pull from. Defaults to `us-east-2`.
- `-i`: regex pattern that matches environment folders to pull from. Defaults to all folder in current dir to match prev behavior.
- `-e`: regex pattern that matches environment folders to ignore.

It's worth noting that  won't use these flags directly, and we will instead use `yarn` scripts that abstract those flag usages. 

#### Why regex?

We used regex over glob because it's really difficult to specify multiple folder with globs (e.g. match `phone-and-sms-mfa` and `phone-number`). 

Admittedly, it is not intuitive to use regex over glob. But IMO this is the simplest solution to filter multiple environments, which is our purpose. Eventually, we can rewrite this script in Node.js so that it's more readable and extendable. Right now, we're restricted Linux/MacOS and would rather keep this flexible than add complexity.

**Example Usage**:
```bash
# Pull only the auth environments with phone or sms
./pull-environments.sh -r us-east-2 -i "\./auth/auth-with-((phone-and-sms-mfa)|(phone-number)|(totp-and-sms-mfa))"
```

#### Description of how you validated changes
Locally, plus POC workflows.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
