### PR TITLE
chore: increase size limit for cra-ts canary

### DIFF
--- a/canary/apps/react/cra-ts/package.json
+++ b/canary/apps/react/cra-ts/package.json
@@ -54,7 +54,7 @@
   "size-limit": [
     {
       "path": "build/static/js/main.*.js",
-      "limit": "280 kB"
+      "limit": "281 kB"
     }
   ]
 }

--- a/canary/apps/react/cra/package.json
+++ b/canary/apps/react/cra/package.json
@@ -49,7 +49,7 @@
   "size-limit": [
     {
       "path": "build/static/js/main.*.js",
-      "limit": "280 kB"
+      "limit": "281 kB"
     }
   ]
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
The latest release of `aws-amplify`, v4.3.36, introduced a small package size increase, causing our Create React App Typescript canary size-limit check to fail. This pull request increases the package size limit for the cra-ts canary in order to unblock the Amplify UI release.

Related to https://github.com/aws-amplify/amplify-ui/pull/2615

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
In the `canary/apps/react/cra` canary, run `yarn && yarn build` and verify that the final `size-limit` check passes.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
