### PR TITLE
fix(docs): cache control for entire site

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -4,18 +4,16 @@
 applications:
   - appRoot: docs
     customHeaders:
-      - pattern: "**/*"
+      - pattern: '**/*'
         headers:
-          - key: "Strict-Transport-Security"
-            value: "max-age=31536000; includeSubDomains"
-          - key: "X-Frame-Options"
-            value: "SAMEORIGIN"
-          - key: "X-XSS-Protection"
-            value: "1; mode=block"
-          - key: "X-Content-Type-Options"
-            value: "nosniff"
+          - key: 'Strict-Transport-Security'
+            value: 'max-age=31536000; includeSubDomains'
+          - key: 'X-Frame-Options'
+            value: 'SAMEORIGIN'
+          - key: 'X-XSS-Protection'
+            value: '1; mode=block'
+          - key: 'X-Content-Type-Options'
+            value: 'nosniff'
           # CSP set in _document.page.tsx meta tag
-      - pattern: "flutter/**/*"
-        headers:
-          - key: "Cache-Control"
-            value: "public, max-age=300"
+          - key: 'Cache-Control'
+            value: 'public, max-age=300'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**issue**: We are seeing 5xx error spikes recently from `/_next/data/...`. The spikes started from 9/06, which is after we introduced `getStaticPaths` and `getCustomStaticPath` in https://github.com/aws-amplify/amplify-ui/pull/2478. which causes pre-render.

**fix**: It may help if we add a cache [ref](https://stackoverflow.com/questions/70317603/nextjs-ssr-getting-next-data-json-requst)



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

PoC app:
https://cache-control.d3c4lyvg8o1hf2.amplifyapp.com/

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
