### PR TITLE
chore(ui-react): mark useAuthenticator.toFederatedSignIn as deprecated

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/to-federated-sign-in.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/to-federated-sign-in.mdx
@@ -1,0 +1,8 @@
+import { ResponsiveTableCell } from '@/components/ResponsiveTable';
+import { TableRow, TableCell } from '@aws-amplify/ui-react';
+
+<TableRow>
+  <ResponsiveTableCell label="Name">`toFederatedSignIn`</ResponsiveTableCell>
+  <ResponsiveTableCell label="Description">Transitions to `provider`'s federated sign in page. Supported `provider` values can be found [here](https://github.com/aws-amplify/amplify-ui/blob/96830f6a34a417aa9bc6329c839679bd10da84f0/packages/ui/src/helpers/auth.ts#L104-L109).</ResponsiveTableCell>
+  <ResponsiveTableCell label="Type">`(provider: string) => void`</ResponsiveTableCell>
+</TableRow>

--- a/docs/src/pages/[platform]/connected-components/authenticator/headless/headless-usage.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/headless/headless-usage.web.mdx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { Fragment } from '@/components/Fragment';
 import { ResponsiveTable, ResponsiveTableCell } from '@/components/ResponsiveTable';
 import { Tabs, TabItem, Table, TableHead, TableRow, TableCell, TableBody, View } from '@aws-amplify/ui-react';
@@ -121,11 +122,9 @@ These helper functions trigger transition to another `route`. Note that any inva
           <ResponsiveTableCell label="Description">Transitions to `resetPassword`. Allowed from `signIn`.</ResponsiveTableCell>
           <ResponsiveTableCell label="Type">`() => void`</ResponsiveTableCell>
         </TableRow>
-        <TableRow>
-          <ResponsiveTableCell label="Name">`toFederatedSignIn`</ResponsiveTableCell>
-          <ResponsiveTableCell label="Description">Transitions to `provider`'s federated sign in page. Supported `provider` values can be found [here](https://github.com/aws-amplify/amplify-ui/blob/96830f6a34a417aa9bc6329c839679bd10da84f0/packages/ui/src/helpers/auth.ts#L104-L109).</ResponsiveTableCell>
-          <ResponsiveTableCell label="Type">`(provider: string) => void`</ResponsiveTableCell>
-        </TableRow>
+        <Fragment>
+          {({ platform }) => platform === 'angular' || platform === 'vue' ? import(`./advanced/to-federated-sign-in.mdx`) : Promise.resolve(() => null)}
+        </Fragment>
         <TableRow>
           <ResponsiveTableCell label="Name">`skipVerification`</ResponsiveTableCell>
           <ResponsiveTableCell label="Description">Skips verification process. Allowed from `verifyUser` and `confirmVerifyUser`</ResponsiveTableCell>

--- a/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
+++ b/packages/react/src/components/Authenticator/hooks/useAuthenticator/index.tsx
@@ -42,7 +42,12 @@ export type InternalAuthenticatorContext = {
  */
 export type Selector = (context: AuthenticatorContext) => Array<any>;
 
-export interface UseAuthenticator extends AuthenticatorServiceFacade {
+export interface UseAuthenticator
+  extends Omit<AuthenticatorServiceFacade, 'toFederatedSignIn'> {
+  /**
+   * @deprecated `toFederatedSignIn` will be removed in a future major version release of `@aws-amplify/ui-react`
+   */
+  toFederatedSignIn: AuthenticatorServiceFacade['toFederatedSignIn'];
   /** @deprecated For internal use only */
   _send: InternalAuthenticatorContext['_send'];
   /** @deprecated For internal use only */


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
mark `useAuthenticator.toFederatedSignIn` as deprecated

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
