### PR TITLE
chore(ci): migrate canary auth environment

### DIFF
--- a/canary/environments/auth-with-email/.gitignore
+++ b/canary/environments/auth-with-email/.gitignore
@@ -6,7 +6,6 @@ amplify/.config/local-*
 amplify/logs
 amplify/mock-data
 amplify/backend/amplify-meta.json
-amplify/backend/awscloudformation
 amplify/backend/.temp
 build/
 dist/
@@ -19,4 +18,5 @@ amplify-build-config.json
 amplify-gradle-config.json
 amplifytools.xcconfig
 .secret-*
+**.sample
 #amplify-do-not-edit-end

--- a/canary/environments/auth-with-email/amplify/backend/auth/authwithemail/authwithemail-cloudformation-template.yml
+++ b/canary/environments/auth-with-email/amplify/backend/auth/authwithemail/authwithemail-cloudformation-template.yml
@@ -1,5 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
-
+AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
   env:
     Type: String
@@ -7,261 +6,208 @@ Parameters:
     Type: String
   unauthRoleArn:
     Type: String
-
-  
-
-    
   identityPoolName:
     Type: String
-  
-            
-  
   allowUnauthenticatedIdentities:
     Type: String
-            
   resourceNameTruncated:
     Type: String
-  
-            
   userPoolName:
     Type: String
-  
-            
-        
   autoVerifiedAttributes:
     Type: CommaDelimitedList
-      
   mfaConfiguration:
     Type: String
-  
-            
-        
   mfaTypes:
     Type: CommaDelimitedList
-      
   smsAuthenticationMessage:
     Type: String
-  
-            
   smsVerificationMessage:
     Type: String
-  
-            
   emailVerificationSubject:
     Type: String
-  
-            
   emailVerificationMessage:
     Type: String
-  
-            
-  
   defaultPasswordPolicy:
     Type: String
-            
-    
   passwordPolicyMinLength:
     Type: Number
-          
-        
   passwordPolicyCharacters:
     Type: CommaDelimitedList
-      
-        
   requiredAttributes:
     Type: CommaDelimitedList
-      
-  
   userpoolClientGenerateSecret:
     Type: String
-            
-    
   userpoolClientRefreshTokenValidity:
     Type: Number
-          
-        
   userpoolClientWriteAttributes:
     Type: CommaDelimitedList
-      
-        
   userpoolClientReadAttributes:
     Type: CommaDelimitedList
-      
   userpoolClientLambdaRole:
     Type: String
-  
-            
-  
   userpoolClientSetAttributes:
     Type: String
-            
   sharedId:
     Type: String
-  
-            
   resourceName:
     Type: String
-  
-            
   authSelections:
     Type: String
-  
-            
-            
-            
   serviceName:
     Type: String
-  
-            
-        
   usernameAttributes:
     Type: CommaDelimitedList
-      
   useDefault:
     Type: String
-  
-            
-  
   userPoolGroups:
     Type: String
-            
-        
   userPoolGroupList:
     Type: CommaDelimitedList
-      
-  
   adminQueries:
     Type: String
-            
-            
-  
   thirdPartyAuth:
     Type: String
-            
-        
   authProviders:
     Type: CommaDelimitedList
-      
-  
   usernameCaseSensitive:
     Type: String
-            
-        
   dependsOn:
     Type: CommaDelimitedList
-      
 Conditions:
-  ShouldNotCreateEnvResources: !Equals [ !Ref env, NONE ]
-  
-  ShouldOutputAppClientSecrets: !Equals [!Ref userpoolClientGenerateSecret, true ]
-  
-
+  ShouldNotCreateEnvResources:
+    Fn::Equals:
+      - Ref: env
+      - NONE
+  ShouldOutputAppClientSecrets:
+    Fn::Equals:
+      - Ref: userpoolClientGenerateSecret
+      - true
 Resources:
-  
-  
-  # BEGIN SNS ROLE RESOURCE
   SNSRole:
-  # Created to allow the UserPool SMS Config to publish via the Simple Notification Service during MFA Process
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !If [ShouldNotCreateEnvResources, 'authwi7d680c18_sns-role', !Join ['',[ 'sns', '7d680c18', !Select [3, !Split ['-', !Ref 'AWS::StackName']], '-', !Ref env]]]
+      RoleName:
+        Fn::If:
+          - ShouldNotCreateEnvResources
+          - authwi7d680c18_sns-role
+          - Fn::Join:
+              - ''
+              - - sns
+                - 7d680c18
+                - Fn::Select:
+                    - 3
+                    - Fn::Split:
+                        - '-'
+                        - Ref: AWS::StackName
+                - '-'
+                - Ref: env
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
-          - Sid: ""
-            Effect: "Allow"
+          - Sid: ''
+            Effect: Allow
             Principal:
-              Service: "cognito-idp.amazonaws.com"
+              Service: cognito-idp.amazonaws.com
             Action:
-              - "sts:AssumeRole"
+              - sts:AssumeRole
             Condition:
               StringEquals:
                 sts:ExternalId: authwi7d680c18_role_external_id
       Policies:
-        -
-          PolicyName: authwi7d680c18-sns-policy
+        - PolicyName: authwi7d680c18-sns-policy
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
-              -
-                Effect: "Allow"
+              - Effect: Allow
                 Action:
-                  - "sns:Publish"
-                Resource: "*"
-  # BEGIN USER POOL RESOURCES
+                  - sns:Publish
+                Resource: '*'
   UserPool:
-  # Created upon user selection
-  # Depends on SNS Role for Arn if MFA is enabled
     Type: AWS::Cognito::UserPool
     UpdateReplacePolicy: Retain
     Properties:
-      UserPoolName: !If [ShouldNotCreateEnvResources, !Ref userPoolName, !Join ['',[!Ref userPoolName, '-', !Ref env]]]
-      
-      
+      UserPoolName:
+        Fn::If:
+          - ShouldNotCreateEnvResources
+          - Ref: userPoolName
+          - Fn::Join:
+              - ''
+              - - Ref: userPoolName
+                - '-'
+                - Ref: env
       UsernameConfiguration:
         CaseSensitive: false
-      
       Schema:
-        
-        -
-          Name: email
+        - Name: email
           Required: true
           Mutable: true
-        
-      
-      
-      
-      AutoVerifiedAttributes: !Ref autoVerifiedAttributes
-      
-      
-      EmailVerificationMessage: !Ref emailVerificationMessage
-      EmailVerificationSubject: !Ref emailVerificationSubject
-      
+      AutoVerifiedAttributes:
+        Ref: autoVerifiedAttributes
+      EmailVerificationMessage:
+        Ref: emailVerificationMessage
+      EmailVerificationSubject:
+        Ref: emailVerificationSubject
       Policies:
         PasswordPolicy:
-          MinimumLength: !Ref passwordPolicyMinLength
+          MinimumLength:
+            Ref: passwordPolicyMinLength
           RequireLowercase: true
           RequireNumbers: true
           RequireSymbols: true
           RequireUppercase: true
-      
-      UsernameAttributes: !Ref usernameAttributes
-      
-      MfaConfiguration: !Ref mfaConfiguration
-      SmsVerificationMessage: !Ref smsVerificationMessage
-      SmsAuthenticationMessage: !Ref smsAuthenticationMessage
+      UsernameAttributes:
+        Ref: usernameAttributes
+      MfaConfiguration:
+        Ref: mfaConfiguration
+      SmsVerificationMessage:
+        Ref: smsVerificationMessage
+      SmsAuthenticationMessage:
+        Ref: smsAuthenticationMessage
       SmsConfiguration:
-        SnsCallerArn: !GetAtt SNSRole.Arn
+        SnsCallerArn:
+          Fn::GetAtt:
+            - SNSRole
+            - Arn
         ExternalId: authwi7d680c18_role_external_id
-    
-  
   UserPoolClientWeb:
-  # Created provide application access to user pool
-  # Depends on UserPool for ID reference
-    Type: "AWS::Cognito::UserPoolClient"
+    Type: AWS::Cognito::UserPoolClient
     Properties:
       ClientName: authwi7d680c18_app_clientWeb
-      
-      RefreshTokenValidity: !Ref userpoolClientRefreshTokenValidity
-      UserPoolId: !Ref UserPool
+      RefreshTokenValidity:
+        Ref: userpoolClientRefreshTokenValidity
+      UserPoolId:
+        Ref: UserPool
     DependsOn: UserPool
   UserPoolClient:
-  # Created provide application access to user pool
-  # Depends on UserPool for ID reference
-    Type: "AWS::Cognito::UserPoolClient"
+    Type: AWS::Cognito::UserPoolClient
     Properties:
       ClientName: authwi7d680c18_app_client
-      
-      GenerateSecret: !Ref userpoolClientGenerateSecret
-      RefreshTokenValidity: !Ref userpoolClientRefreshTokenValidity
-      UserPoolId: !Ref UserPool
+      GenerateSecret:
+        Ref: userpoolClientGenerateSecret
+      RefreshTokenValidity:
+        Ref: userpoolClientRefreshTokenValidity
+      UserPoolId:
+        Ref: UserPool
     DependsOn: UserPool
-  # BEGIN USER POOL LAMBDA RESOURCES
   UserPoolClientRole:
-  # Created to execute Lambda which gets userpool app client config values
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
-      RoleName: !If [ShouldNotCreateEnvResources, !Ref userpoolClientLambdaRole, !Join ['',['upClientLambdaRole', '7d680c18', !Select [3, !Split ['-', !Ref 'AWS::StackName']], '-', !Ref env]]]
+      RoleName:
+        Fn::If:
+          - ShouldNotCreateEnvResources
+          - Ref: userpoolClientLambdaRole
+          - Fn::Join:
+              - ''
+              - - upClientLambdaRole
+                - 7d680c18
+                - Fn::Select:
+                    - 3
+                    - Fn::Split:
+                        - '-'
+                        - Ref: AWS::StackName
+                - '-'
+                - Ref: env
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -270,170 +216,179 @@ Resources:
               Service:
                 - lambda.amazonaws.com
             Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
     DependsOn: UserPoolClient
   UserPoolClientLambda:
-  # Lambda which gets userpool app client config values
-  # Depends on UserPool for id
-  # Depends on UserPoolClientRole for role ARN
-    Type: 'AWS::Lambda::Function'
+    Type: AWS::Lambda::Function
     Properties:
       Code:
-        ZipFile: !Join
-          - |+
-          - - 'const response = require(''cfn-response'');'
-            - 'const aws = require(''aws-sdk'');'
-            - 'const identity = new aws.CognitoIdentityServiceProvider();'
-            - 'exports.handler = (event, context, callback) => {'
-            - ' if (event.RequestType == ''Delete'') { '
-            - '   response.send(event, context, response.SUCCESS, {})'
-            - ' }'
-            - ' if (event.RequestType == ''Update'' || event.RequestType == ''Create'') {'
-            - '   const params = {'
-            - '     ClientId: event.ResourceProperties.clientId,'
-            - '     UserPoolId: event.ResourceProperties.userpoolId'
-            - '   };'
-            - '   identity.describeUserPoolClient(params).promise()'
-            - '     .then((res) => {'
-            - '       response.send(event, context, response.SUCCESS, {''appSecret'': res.UserPoolClient.ClientSecret});'
-            - '     })'
-            - '     .catch((err) => {'
-            - '       response.send(event, context, response.FAILED, {err});'
-            - '     });'
-            - ' }'
-            - '};'
+        ZipFile:
+          Fn::Join:
+            - ''
+            - - const response = require('cfn-response');
+              - const aws = require('aws-sdk');
+              - const identity = new aws.CognitoIdentityServiceProvider();
+              - exports.handler = (event, context, callback) => {
+              - ' if (event.RequestType == ''Delete'') { '
+              - '   response.send(event, context, response.SUCCESS, {})'
+              - ' }'
+              - ' if (event.RequestType == ''Update'' || event.RequestType == ''Create'') {'
+              - '   const params = {'
+              - '     ClientId: event.ResourceProperties.clientId,'
+              - '     UserPoolId: event.ResourceProperties.userpoolId'
+              - '   };'
+              - '   identity.describeUserPoolClient(params).promise()'
+              - '     .then((res) => {'
+              - '       response.send(event, context, response.SUCCESS, {''appSecret'': res.UserPoolClient.ClientSecret});'
+              - '     })'
+              - '     .catch((err) => {'
+              - '       response.send(event, context, response.FAILED, {err});'
+              - '     });'
+              - ' }'
+              - '};'
       Handler: index.handler
       Runtime: nodejs12.x
       Timeout: '300'
-      Role: !GetAtt
-        - UserPoolClientRole
-        - Arn
+      Role:
+        Fn::GetAtt:
+          - UserPoolClientRole
+          - Arn
     DependsOn: UserPoolClientRole
   UserPoolClientLambdaPolicy:
-  # Sets userpool policy for the role that executes the Userpool Client Lambda
-  # Depends on UserPool for Arn
-  # Marked as depending on UserPoolClientRole for easier to understand CFN sequencing
-    Type: 'AWS::IAM::Policy'
+    Type: AWS::IAM::Policy
     Properties:
       PolicyName: authwi7d680c18_userpoolclient_lambda_iam_policy
       Roles:
-        - !Ref UserPoolClientRole
+        - Ref: UserPoolClientRole
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
-              - 'cognito-idp:DescribeUserPoolClient'
-            Resource: !GetAtt UserPool.Arn
+              - cognito-idp:DescribeUserPoolClient
+            Resource:
+              Fn::GetAtt:
+                - UserPool
+                - Arn
     DependsOn: UserPoolClientLambda
   UserPoolClientLogPolicy:
-  # Sets log policy for the role that executes the Userpool Client Lambda
-  # Depends on UserPool for Arn
-  # Marked as depending on UserPoolClientLambdaPolicy for easier to understand CFN sequencing
-    Type: 'AWS::IAM::Policy'
+    Type: AWS::IAM::Policy
     Properties:
       PolicyName: authwi7d680c18_userpoolclient_lambda_log_policy
       Roles:
-        - !Ref UserPoolClientRole
+        - Ref: UserPoolClientRole
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
-              - 'logs:CreateLogGroup'
-              - 'logs:CreateLogStream'
-              - 'logs:PutLogEvents'
-            Resource: !Sub
-              - arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*
-              - { region: !Ref "AWS::Region",  account: !Ref "AWS::AccountId", lambda: !Ref UserPoolClientLambda}
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource:
+              Fn::Sub:
+                - >-
+                  arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*
+                - region:
+                    Ref: AWS::Region
+                  account:
+                    Ref: AWS::AccountId
+                  lambda:
+                    Ref: UserPoolClientLambda
     DependsOn: UserPoolClientLambdaPolicy
   UserPoolClientInputs:
-  # Values passed to Userpool client Lambda
-  # Depends on UserPool for Id
-  # Depends on UserPoolClient for Id
-  # Marked as depending on UserPoolClientLambdaPolicy for easier to understand CFN sequencing
-    Type: 'Custom::LambdaCallout'
+    Type: Custom::LambdaCallout
     Properties:
-      ServiceToken: !GetAtt UserPoolClientLambda.Arn
-      clientId: !Ref UserPoolClient
-      userpoolId: !Ref UserPool
+      ServiceToken:
+        Fn::GetAtt:
+          - UserPoolClientLambda
+          - Arn
+      clientId:
+        Ref: UserPoolClient
+      userpoolId:
+        Ref: UserPool
     DependsOn: UserPoolClientLogPolicy
-  
-
-  
-  
-
-  
-    
-  # BEGIN IDENTITY POOL RESOURCES
-  
-
   IdentityPool:
-  # Always created
     Type: AWS::Cognito::IdentityPool
     Properties:
-      IdentityPoolName: !If [ShouldNotCreateEnvResources, 'testAuthIdentityPool', !Join ['',['testAuthIdentityPool', '__', !Ref env]]]
-      
+      IdentityPoolName:
+        Fn::If:
+          - ShouldNotCreateEnvResources
+          - testAuthIdentityPool
+          - Fn::Join:
+              - ''
+              - - testAuthIdentityPool
+                - __
+                - Ref: env
       CognitoIdentityProviders:
-        - ClientId:  !Ref UserPoolClient
-          ProviderName: !Sub
-            - cognito-idp.${region}.amazonaws.com/${client}
-            - { region: !Ref "AWS::Region",  client: !Ref UserPool}
-        - ClientId:  !Ref UserPoolClientWeb
-          ProviderName: !Sub
-            - cognito-idp.${region}.amazonaws.com/${client}
-            - { region: !Ref "AWS::Region",  client: !Ref UserPool}
-            
-      AllowUnauthenticatedIdentities: !Ref allowUnauthenticatedIdentities
-      
-    
+        - ClientId:
+            Ref: UserPoolClient
+          ProviderName:
+            Fn::Sub:
+              - cognito-idp.${region}.amazonaws.com/${client}
+              - region:
+                  Ref: AWS::Region
+                client:
+                  Ref: UserPool
+        - ClientId:
+            Ref: UserPoolClientWeb
+          ProviderName:
+            Fn::Sub:
+              - cognito-idp.${region}.amazonaws.com/${client}
+              - region:
+                  Ref: AWS::Region
+                client:
+                  Ref: UserPool
+      AllowUnauthenticatedIdentities:
+        Ref: allowUnauthenticatedIdentities
     DependsOn: UserPoolClientInputs
-    
-
   IdentityPoolRoleMap:
-  # Created to map Auth and Unauth roles to the identity pool
-  # Depends on Identity Pool for ID ref
     Type: AWS::Cognito::IdentityPoolRoleAttachment
     Properties:
-      IdentityPoolId: !Ref IdentityPool
+      IdentityPoolId:
+        Ref: IdentityPool
       Roles:
-          unauthenticated: !Ref unauthRoleArn
-          authenticated: !Ref authRoleArn
+        unauthenticated:
+          Ref: unauthRoleArn
+        authenticated:
+          Ref: authRoleArn
     DependsOn: IdentityPool
-  
-
-Outputs :
-  
+Outputs:
   IdentityPoolId:
-    Value: !Ref 'IdentityPool'
-    Description:  Id for the identity pool
+    Value:
+      Ref: IdentityPool
+    Description: Id for the identity pool
   IdentityPoolName:
-    Value: !GetAtt IdentityPool.Name
-  
-  
-  
-  
+    Value:
+      Fn::GetAtt:
+        - IdentityPool
+        - Name
   UserPoolId:
-    Value: !Ref 'UserPool'
-    Description:  Id for the user pool
+    Value:
+      Ref: UserPool
+    Description: Id for the user pool
   UserPoolArn:
-    Value: !GetAtt UserPool.Arn
-    Description:  Arn for the user pool
+    Value:
+      Fn::GetAtt:
+        - UserPool
+        - Arn
+    Description: Arn for the user pool
   UserPoolName:
-    Value: !Ref userPoolName
+    Value:
+      Ref: userPoolName
   AppClientIDWeb:
-    Value: !Ref 'UserPoolClientWeb'
+    Value:
+      Ref: UserPoolClientWeb
     Description: The user pool app client id for web
   AppClientID:
-    Value: !Ref 'UserPoolClient'
+    Value:
+      Ref: UserPoolClient
     Description: The user pool app client id
   AppClientSecret:
-    Value: !GetAtt UserPoolClientInputs.appSecret
+    Value:
+      Fn::GetAtt:
+        - UserPoolClientInputs
+        - appSecret
     Condition: ShouldOutputAppClientSecrets
-  
-  
-  
-  
-  
-  
-  
+Description: >-
+  {"createdOn":"Mac","createdBy":"Amplify","createdWith":"10.0.0","stackType":"auth-Cognito","metadata":{}}

--- a/canary/environments/auth-with-email/amplify/backend/types/amplify-dependent-resources-ref.d.ts
+++ b/canary/environments/auth-with-email/amplify/backend/types/amplify-dependent-resources-ref.d.ts
@@ -1,13 +1,13 @@
 export type AmplifyDependentResourcesAttributes = {
-  auth: {
-    authwithemail: {
-      IdentityPoolId: 'string';
-      IdentityPoolName: 'string';
-      UserPoolId: 'string';
-      UserPoolArn: 'string';
-      UserPoolName: 'string';
-      AppClientIDWeb: 'string';
-      AppClientID: 'string';
-    };
-  };
-};
+    "auth": {
+        "authwithemail": {
+            "IdentityPoolId": "string",
+            "IdentityPoolName": "string",
+            "UserPoolId": "string",
+            "UserPoolArn": "string",
+            "UserPoolName": "string",
+            "AppClientIDWeb": "string",
+            "AppClientID": "string"
+        }
+    }
+}

--- a/canary/environments/auth-with-email/amplify/cli.json
+++ b/canary/environments/auth-with-email/amplify/cli.json
@@ -7,7 +7,9 @@
       "useexperimentalpipelinedtransformer": false,
       "enableiterativegsiupdates": true,
       "secondarykeyasgsi": true,
-      "skipoverridemutationinputtypes": true
+      "skipoverridemutationinputtypes": true,
+      "securityEnhancementNotification": false,
+      "showfieldauthnotification": false
     },
     "frontend-ios": {
       "enablexcodeintegration": true

--- a/canary/environments/auth-with-email/package.json
+++ b/canary/environments/auth-with-email/package.json
@@ -3,6 +3,6 @@
   "name": "auth-with-email-environment",
   "version": "0.0.1",
   "scripts": {
-    "pull": "amplify pull --appId d39wm44u5j8yn5 --envName staging"
+    "pull": "amplify pull --appId d38yznh7fio4c0 --envName staging"
   }
 }

--- a/canary/environments/pull-environments.sh
+++ b/canary/environments/pull-environments.sh
@@ -25,7 +25,7 @@ AWSCLOUDFORMATIONCONFIG="{\
 \"profileName\":\"$AWS_PROFILE\",\
 \"accessKeyId\":\"$AWS_ACCESS_KEY_ID\",\
 \"secretAccessKey\":\"$AWS_SECRET_ACCESS_KEY\",\
-\"region\":\"us-east-1\"\
+\"region\":\"us-east-2\"\
 }"
 PROVIDERS="{\
 \"awscloudformation\":$AWSCLOUDFORMATIONCONFIG\


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Migrates auth canary auth environment to the new account.

We should really just remove this canary-specific environment and  consolidate all environments in `environments/` folder. I'll create an internal task for that.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

All workflows will be fully tested before fetaure branch is merged.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
