### PR TITLE
chore(ci): Migrate away from adminui environments

### DIFF
--- a/examples/angular/src/pages/ui/components/authenticator/custom-slots/aws-exports.js
+++ b/examples/angular/src/pages/ui/components/authenticator/custom-slots/aws-exports.js
@@ -1,2 +1,2 @@
-import awsExports from '@environments/auth/adminui-auth-with-totp-mfa/src/aws-exports';
+import awsExports from '@environments/auth/auth-with-totp-mfa/src/aws-exports';
 export default awsExports;

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-totp-mfa/aws-exports.js
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-totp-mfa/aws-exports.js
@@ -1,2 +1,2 @@
-import awsExports from '@environments/auth/adminui-auth-with-totp-mfa/src/aws-exports';
+import awsExports from '@environments/auth/auth-with-totp-mfa/src/aws-exports';
 export default awsExports;

--- a/examples/next/pages/ui/components/authenticator/custom-slots/aws-exports.js
+++ b/examples/next/pages/ui/components/authenticator/custom-slots/aws-exports.js
@@ -1,2 +1,2 @@
-import awsExports from '@environments/auth/adminui-auth-with-totp-mfa/src/aws-exports';
+import awsExports from '@environments/auth/auth-with-totp-mfa/src/aws-exports';
 export default awsExports;

--- a/examples/next/pages/ui/components/authenticator/sign-in-totp-mfa/aws-exports.js
+++ b/examples/next/pages/ui/components/authenticator/sign-in-totp-mfa/aws-exports.js
@@ -1,2 +1,2 @@
-import awsExports from '@environments/auth/adminui-auth-with-totp-mfa/src/aws-exports';
+import awsExports from '@environments/auth/auth-with-totp-mfa/src/aws-exports';
 export default awsExports;

--- a/examples/vue/src/pages/ui/components/authenticator/custom-slots/aws-exports.js
+++ b/examples/vue/src/pages/ui/components/authenticator/custom-slots/aws-exports.js
@@ -1,2 +1,2 @@
-import awsExports from '@environments/auth/adminui-auth-with-totp-mfa/src/aws-exports';
+import awsExports from '@environments/auth/auth-with-totp-mfa/src/aws-exports';
 export default awsExports;

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-totp-mfa/aws-exports.js
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-totp-mfa/aws-exports.js
@@ -1,2 +1,2 @@
-import awsExports from '@environments/auth/adminui-auth-with-totp-mfa/src/aws-exports';
+import awsExports from '@environments/auth/auth-with-totp-mfa/src/aws-exports';
 export default awsExports;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Previously, we created both `adminui-auth-with-totp-mfa` and `auth-with-totp-mfa` environments, because zero config was unstable back then and there were discrepancies between the two. 

Now these features are stable, and we can migrate away from adminui environments and just use the CLI one. 

I verified that this is the only remnant of `adminui-` environments.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Feature branch will have tests running against it before merge.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
