### PR TITLE
chore(ui-react): add deprecation message to Expander onChange prop

### DIFF
--- a/docs/src/pages/[platform]/components/expander/examples/ControlledSingleExample.tsx
+++ b/docs/src/pages/[platform]/components/expander/examples/ControlledSingleExample.tsx
@@ -5,7 +5,7 @@ import { Expander, ExpanderItem } from '@aws-amplify/ui-react';
 export const ControlledSingleExpander = () => {
   const [value, setValue] = React.useState<string | string[]>();
   return (
-    <Expander type="single" value={value} onChange={setValue}>
+    <Expander type="single" value={value} onValueChange={setValue}>
       <ExpanderItem
         title="What do you call a deer with no eyes?"
         value="joke-1"

--- a/docs/src/pages/[platform]/components/expander/props-table.mdx
+++ b/docs/src/pages/[platform]/components/expander/props-table.mdx
@@ -79,25 +79,14 @@ boolean
     </TableRow>
 
     <TableRow>
-      <ResponsiveTableCell label="Name">onChange</ResponsiveTableCell>
-      <ResponsiveTableCell label="Type">
-```jsx
-(value?: string | string[]) => void
-```
-</ResponsiveTableCell>
-      <ResponsiveTableCell label="Description">Event handler called when the expanded state of an item changes</ResponsiveTableCell>
-    </TableRow>
-
-    <TableRow>
       <ResponsiveTableCell label="Name">onValueChange</ResponsiveTableCell>
       <ResponsiveTableCell label="Type">
-```jsx
-(value: string) => void
-```
-</ResponsiveTableCell>
-      <ResponsiveTableCell label="Description">-</ResponsiveTableCell>
+        ```jsx
+          (value?: string | string[]) => void
+        ```
+      </ResponsiveTableCell>
+      <ResponsiveTableCell label="Description">Event handler called when the expanded state of an item changes</ResponsiveTableCell>
     </TableRow>
-
     <TableRow>
       <ResponsiveTableCell label="Name">style</ResponsiveTableCell>
       <ResponsiveTableCell label="Type">

--- a/docs/src/pages/[platform]/components/expander/react.mdx
+++ b/docs/src/pages/[platform]/components/expander/react.mdx
@@ -114,7 +114,7 @@ To expand specific items by default, pass a `string` or `string[]` of value(s) t
 
 ### Controlled component
 
-To use the Expander as controlled component, specify the `value` of the item(s) to expand and use in conjunction with `onChange`.
+To use the Expander as controlled component, specify the `value` of the item(s) to expand and use in conjunction with `onValueChange`.
 
 <Example>
   <View>

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -69,7 +69,7 @@ module.exports = {
         'src/components/**/*',
         'src/helpers/**/*',
         'src/hooks/**/*',
-        'src/primitives/+(shared|utils)/**/*',
+        'src/primitives/+(shared|utils|E*)/**/*',
         'src/studio',
         // 'src/primitives/**/*',
       ],

--- a/packages/react/src/primitives/Expander/Expander.tsx
+++ b/packages/react/src/primitives/Expander/Expander.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { Root } from '@radix-ui/react-accordion';
 import classNames from 'classnames';
 
+import { useDeprecationWarning } from '../../hooks/useDeprecationWarning';
+
 import { ComponentClassNames } from '../shared/constants';
 import { ExpanderProps } from '../types/expander';
 import { Primitive } from '../types/view';
@@ -14,7 +16,6 @@ const ExpanderPrimitive: Primitive<ExpanderProps, typeof Root> = (
     defaultValue,
     isCollapsible,
     onChange,
-    // It is not in use but remove it from rest to avoid type errors
     onValueChange,
     testId,
     type = 'single',
@@ -26,13 +27,21 @@ const ExpanderPrimitive: Primitive<ExpanderProps, typeof Root> = (
   // Throw away baseStyleProps and flexContainerStyleProps since they won't work on Root element
   const { rest } = splitPrimitiveProps(_rest);
 
+  const handleValueChange = onValueChange ?? onChange;
+
+  useDeprecationWarning({
+    shouldWarn: !!onChange,
+    message:
+      'Expander `onChange` prop will be deprecated in the next major release of @aws-amplify/ui-react. Please replace usage with `onValueChange`.',
+  });
+
   const expander =
     type === 'multiple' ? (
       <Root
         className={classNames(ComponentClassNames.Expander, className)}
         data-testid={testId}
         defaultValue={defaultValue as string[]}
-        onValueChange={onChange}
+        onValueChange={handleValueChange as (value?: string[]) => void}
         ref={ref}
         type={type}
         value={value as string[]}
@@ -46,7 +55,7 @@ const ExpanderPrimitive: Primitive<ExpanderProps, typeof Root> = (
         collapsible={isCollapsible}
         data-testid={testId}
         defaultValue={defaultValue as string}
-        onValueChange={onChange}
+        onValueChange={handleValueChange as (value?: string) => void}
         ref={ref}
         type={type}
         value={value as string}

--- a/packages/react/src/primitives/Expander/__tests__/Expander.test.tsx
+++ b/packages/react/src/primitives/Expander/__tests__/Expander.test.tsx
@@ -30,7 +30,7 @@ describe('Expander: ', () => {
     ({ value: initialValue, ...rest }, ref) => {
       const [value, setValue] = React.useState(initialValue);
       return (
-        <Expander value={value} onChange={setValue} ref={ref} {...rest}>
+        <Expander value={value} onValueChange={setValue} ref={ref} {...rest}>
           <ExpanderItem title="Section 1 title" value="item-1">
             content 1
           </ExpanderItem>

--- a/packages/react/src/primitives/types/expander.ts
+++ b/packages/react/src/primitives/types/expander.ts
@@ -28,10 +28,15 @@ export interface ExpanderProps extends ViewProps {
   type?: ExpanderType;
 
   /**
+   * @deprecated replace usage with `onValueChange`
+   */
+  onChange?: (value?: string | string[]) => void;
+
+  /**
    * @description
    * Event handler called when the expanded state of an item changes
    */
-  onChange?: (value?: string | string[]) => void;
+  onValueChange?: (value?: string | string[]) => void;
 }
 
 export interface ExpanderItemProps extends ViewProps {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add deprecation message to `Expander` component `onChange` prop
- add JSDoc deprecation warning
- add `useDeprecationWarning` for `onChange`
- update unit test
- update docs

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested in the docs

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
