### PR TITLE
feat(ui-react-native): Add TextField component

### DIFF
--- a/examples/react-native/storybook/stories/TextField.stories.tsx
+++ b/examples/react-native/storybook/stories/TextField.stories.tsx
@@ -23,7 +23,11 @@ storiesOf('TextField', module)
     <TextField containerStyle={styles.container} label="Test" />
   ))
   .add('password', () => (
-    <TextField containerStyle={styles.container} label="Password" password />
+    <TextField
+      containerStyle={styles.container}
+      label="Password"
+      secureTextEntry
+    />
   ))
   .add('phone', () => (
     <TextField

--- a/examples/react-native/storybook/stories/TextField.stories.tsx
+++ b/examples/react-native/storybook/stories/TextField.stories.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+
+import { TextField } from '@aws-amplify/ui-react-native/dist/primitives';
+
+const styles = StyleSheet.create({
+  container: {
+    width: '50%',
+  },
+  errorMessage: {
+    color: 'red',
+  },
+});
+
+storiesOf('TextField', module)
+  .add('default', () => <TextField containerStyle={styles.container} />)
+
+  .add('placeholder', () => (
+    <TextField containerStyle={styles.container} placeholder="Test" />
+  ))
+  .add('with label', () => (
+    <TextField containerStyle={styles.container} label="Test" />
+  ))
+  .add('password', () => (
+    <TextField containerStyle={styles.container} label="Password" password />
+  ))
+  .add('phone', () => (
+    <TextField
+      containerStyle={styles.container}
+      label="Phone"
+      type="phone-pad"
+    />
+  ))
+  .add('with error', () => (
+    <TextField
+      containerStyle={styles.container}
+      label="Test"
+      error={true}
+      errorMessage="Error Message"
+      errorMessageStyle={styles.errorMessage}
+    />
+  ))
+  .add('disabled', () => (
+    <TextField containerStyle={styles.container} disabled />
+  ));

--- a/examples/react-native/storybook/stories/TextField.stories.tsx
+++ b/examples/react-native/storybook/stories/TextField.stories.tsx
@@ -33,7 +33,7 @@ storiesOf('TextField', module)
     <TextField
       containerStyle={styles.container}
       label="Phone"
-      type="phone-pad"
+      keyboardType="phone-pad"
     />
   ))
   .add('with error', () => (

--- a/examples/react-native/storybook/storyLoader.js
+++ b/examples/react-native/storybook/storyLoader.js
@@ -5,6 +5,7 @@ function loadStories() {
   require('./stories/Icon.stories');
   require('./stories/Label.stories');
   require('./stories/Radio.stories');
+  require('./stories/TextField.stories');
 }
 
 const stories = [
@@ -14,6 +15,7 @@ const stories = [
   './stories/Icon.stories',
   './stories/Label.stories',
   './stories/Radio.stories',
+  './stories/TextField.stories',
 ];
 
 module.exports = {

--- a/packages/react-native/src/primitives/TextField/TextField.tsx
+++ b/packages/react-native/src/primitives/TextField/TextField.tsx
@@ -43,7 +43,9 @@ export default function TextField({
         editable={!disabled}
         style={[styles.input, inputStyle]}
       />
-      {error ? <Label style={errorMessageStyle}>{errorMessage}</Label> : null}
+      {error && errorMessage ? (
+        <Label style={errorMessageStyle}>{errorMessage}</Label>
+      ) : null}
     </View>
   );
 }

--- a/packages/react-native/src/primitives/TextField/TextField.tsx
+++ b/packages/react-native/src/primitives/TextField/TextField.tsx
@@ -6,18 +6,18 @@ import { styles } from './styles';
 import { TextFieldProps } from './types';
 
 export default function TextField({
-  accessible = true,
   accessibilityLabel,
   accessibilityRole,
   accessibilityState,
+  accessible = true,
   containerStyle,
   disabled,
   error,
   errorMessage,
   errorMessageStyle,
+  inputStyle,
   label,
   labelStyle,
-  inputStyle,
   ...rest
 }: TextFieldProps): JSX.Element {
   const inputContainerStyle: ViewStyle = useMemo(

--- a/packages/react-native/src/primitives/TextField/TextField.tsx
+++ b/packages/react-native/src/primitives/TextField/TextField.tsx
@@ -1,0 +1,39 @@
+import React, { useMemo, useState } from 'react';
+import { TextInput, View, ViewStyle } from 'react-native';
+import { Label } from '../Label';
+
+import { styles } from './styles';
+import { TextFieldProps } from './types';
+import { getFlexDirectionFromLabelPosition } from '../Label/utils';
+
+export default function TextField({
+  disabled,
+  label,
+  labelPosition = 'end',
+  labelStyle,
+  style,
+  ...rest
+}: TextFieldProps): JSX.Element {
+  const [value, setValue] = useState('');
+
+  const containerStyle: ViewStyle = useMemo(
+    () => ({
+      ...styles.container,
+      flexDirection: getFlexDirectionFromLabelPosition(labelPosition),
+      ...(disabled && styles.disabled),
+    }),
+    [disabled, labelPosition]
+  );
+
+  return (
+    <View style={[containerStyle, style]}>
+      <TextInput
+        editable={!disabled}
+        value={value}
+        onChangeText={(text) => setValue(text)}
+        {...rest}
+      />
+      {label ? <Label style={labelStyle}>{label}</Label> : null}
+    </View>
+  );
+}

--- a/packages/react-native/src/primitives/TextField/TextField.tsx
+++ b/packages/react-native/src/primitives/TextField/TextField.tsx
@@ -14,9 +14,7 @@ export default function TextField({
   errorMessageStyle,
   label,
   labelStyle,
-  password,
-  textStyle,
-  type = 'default',
+  inputStyle,
   ...rest
 }: TextFieldProps): JSX.Element {
   const inputContainerStyle: ViewStyle = useMemo(
@@ -31,13 +29,10 @@ export default function TextField({
     <View style={[inputContainerStyle, containerStyle]}>
       {label ? <Label style={labelStyle}>{label}</Label> : null}
       <TextInput
-        accessible
-        accessibilityLabel={accessibilityLabel ?? label}
-        style={[styles.text, textStyle]}
-        editable={!disabled}
-        secureTextEntry={password}
-        keyboardType={type}
         {...rest}
+        accessibilityLabel={accessibilityLabel ?? label}
+        editable={!disabled}
+        style={[styles.input, inputStyle]}
       />
       {error ? <Label style={errorMessageStyle}>{errorMessage}</Label> : null}
     </View>

--- a/packages/react-native/src/primitives/TextField/TextField.tsx
+++ b/packages/react-native/src/primitives/TextField/TextField.tsx
@@ -1,39 +1,45 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { TextInput, View, ViewStyle } from 'react-native';
 import { Label } from '../Label';
 
 import { styles } from './styles';
 import { TextFieldProps } from './types';
-import { getFlexDirectionFromLabelPosition } from '../Label/utils';
 
 export default function TextField({
+  accessibilityLabel,
+  containerStyle,
   disabled,
+  error,
+  errorMessage,
+  errorMessageStyle,
   label,
-  labelPosition = 'end',
   labelStyle,
-  style,
+  password,
+  textStyle,
+  type = 'default',
   ...rest
 }: TextFieldProps): JSX.Element {
-  const [value, setValue] = useState('');
-
-  const containerStyle: ViewStyle = useMemo(
+  const inputContainerStyle: ViewStyle = useMemo(
     () => ({
       ...styles.container,
-      flexDirection: getFlexDirectionFromLabelPosition(labelPosition),
       ...(disabled && styles.disabled),
     }),
-    [disabled, labelPosition]
+    [disabled]
   );
 
   return (
-    <View style={[containerStyle, style]}>
+    <View style={[inputContainerStyle, containerStyle]}>
+      {label ? <Label style={labelStyle}>{label}</Label> : null}
       <TextInput
+        accessible
+        accessibilityLabel={accessibilityLabel ?? label}
+        style={[styles.text, textStyle]}
         editable={!disabled}
-        value={value}
-        onChangeText={(text) => setValue(text)}
+        secureTextEntry={password}
+        keyboardType={type}
         {...rest}
       />
-      {label ? <Label style={labelStyle}>{label}</Label> : null}
+      {error ? <Label style={errorMessageStyle}>{errorMessage}</Label> : null}
     </View>
   );
 }

--- a/packages/react-native/src/primitives/TextField/TextField.tsx
+++ b/packages/react-native/src/primitives/TextField/TextField.tsx
@@ -6,7 +6,10 @@ import { styles } from './styles';
 import { TextFieldProps } from './types';
 
 export default function TextField({
+  accessible = true,
   accessibilityLabel,
+  accessibilityRole,
+  accessibilityState,
   containerStyle,
   disabled,
   error,
@@ -26,11 +29,17 @@ export default function TextField({
   );
 
   return (
-    <View style={[inputContainerStyle, containerStyle]}>
+    <View
+      accessible={accessible}
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityRole={accessibilityRole}
+      accessibilityState={{ disabled, ...accessibilityState }}
+      style={[inputContainerStyle, containerStyle]}
+    >
       {label ? <Label style={labelStyle}>{label}</Label> : null}
       <TextInput
         {...rest}
-        accessibilityLabel={accessibilityLabel ?? label}
+        accessible={accessible}
         editable={!disabled}
         style={[styles.input, inputStyle]}
       />

--- a/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
+++ b/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
@@ -22,6 +22,7 @@ describe('TextField', () => {
     const textInput = getByPlaceholderText(placeHolderText);
     expect(textInput.props.editable).toBeTruthy();
     expect(textInput.props.secureTextEntry).toBeFalsy();
+    expect(textInput.parent?.props.accessible).toBeTruthy();
     const label = getByText(labelText);
     expect(label).not.toBeNull();
   });
@@ -33,6 +34,10 @@ describe('TextField', () => {
     expect(toJSON()).toMatchSnapshot();
     const textInput = getByPlaceholderText(placeHolderText);
     expect(textInput.props.editable).toBeFalsy();
+    expect(textInput.parent?.props.accessibilityState).toHaveProperty(
+      'disabled',
+      true
+    );
   });
 
   it('renders as expected with error message', async () => {

--- a/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
+++ b/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
@@ -23,7 +23,7 @@ describe('TextField', () => {
     expect(await findAllByRole('text')).toHaveLength(1);
     const textInput = getByTestId(testID);
     expect(textInput.props.editable).toBe(true);
-    expect(textInput.props.secureTextEntry).toBeFalsy();
+    expect(textInput.props.secureTextEntry).toBe(undefined);
     expect(textInput.props.accessible).toBe(true);
     const label = getByText(labelText);
     expect(label).not.toBeNull();
@@ -35,7 +35,7 @@ describe('TextField', () => {
     );
     expect(toJSON()).toMatchSnapshot();
     const textInput = getByPlaceholderText(placeHolderText);
-    expect(textInput.props.editable).toBeFalsy();
+    expect(textInput.props.editable).toBe(false);
     expect(textInput.parent?.props.accessibilityState).toHaveProperty(
       'disabled',
       true
@@ -59,7 +59,16 @@ describe('TextField', () => {
       <TextField {...defaultProps} errorMessage={message} />
     );
     expect(toJSON()).toMatchSnapshot();
-    expect(queryByText(message)).toBeFalsy();
+    expect(queryByText(message)).toBeNull();
+  });
+
+  it(`doesn't render the errorMessage if errorMessage prop is undefined`, () => {
+    const message = 'Error message';
+    const { toJSON, queryByText } = render(
+      <TextField {...defaultProps} error />
+    );
+    expect(toJSON()).toMatchSnapshot();
+    expect(queryByText(message)).toBeNull();
   });
 
   it('renders as expected as password field', async () => {

--- a/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
+++ b/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
@@ -23,7 +23,7 @@ describe('TextField', () => {
     expect(await findAllByRole('text')).toHaveLength(1);
     const textInput = getByTestId(testID);
     expect(textInput.props.editable).toBe(true);
-    expect(textInput.props.secureTextEntry).toBe(undefined);
+    expect(textInput.props.secureTextEntry).toBeUndefined();
     expect(textInput.props.accessible).toBe(true);
     const label = getByText(labelText);
     expect(label).not.toBeNull();

--- a/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
+++ b/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
@@ -4,7 +4,7 @@ import TextField from '../TextField';
 
 const placeHolderText = 'Placeholder';
 const labelText = 'Label';
-const testID = 'textField';
+const testID = 'textInput';
 const defaultProps = {
   testID: testID,
   label: labelText,
@@ -15,16 +15,16 @@ const onChangeText = jest.fn();
 
 describe('TextField', () => {
   it('renders as expected', async () => {
-    const { toJSON, findAllByRole, getByPlaceholderText, getByText } = render(
+    const { toJSON, findAllByRole, getByTestId, getByText } = render(
       <TextField {...defaultProps} />
     );
     expect(toJSON()).toMatchSnapshot();
 
     expect(await findAllByRole('text')).toHaveLength(1);
-    const textInput = getByPlaceholderText(placeHolderText);
-    expect(textInput.props.editable).toBeTruthy();
+    const textInput = getByTestId(testID);
+    expect(textInput.props.editable).toBe(true);
     expect(textInput.props.secureTextEntry).toBeFalsy();
-    expect(textInput.parent?.props.accessible).toBeTruthy();
+    expect(textInput.props.accessible).toBe(true);
     const label = getByText(labelText);
     expect(label).not.toBeNull();
   });
@@ -36,7 +36,8 @@ describe('TextField', () => {
     expect(toJSON()).toMatchSnapshot();
     const textInput = getByPlaceholderText(placeHolderText);
     expect(textInput.props.editable).toBeFalsy();
-    expect(textInput.parent?.props.accessibilityState).toHaveProperty(
+    expect(textInput.parent).not.toBeNull();
+    expect(textInput.parent.props.accessibilityState).toHaveProperty(
       'disabled',
       true
     );
@@ -70,7 +71,7 @@ describe('TextField', () => {
 
     expect(await findAllByRole('text')).toHaveLength(1);
     const textInput = getByTestId(testID);
-    expect(textInput.props.secureTextEntry).toBeTruthy();
+    expect(textInput.props.secureTextEntry).toBe(true);
   });
 
   it('does nothing when disabled', () => {

--- a/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
+++ b/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
@@ -4,7 +4,9 @@ import TextField from '../TextField';
 
 const placeHolderText = 'Placeholder';
 const labelText = 'Label';
+const testID = 'textField';
 const defaultProps = {
+  testID: testID,
   label: labelText,
   placeholder: placeHolderText,
 };
@@ -61,21 +63,21 @@ describe('TextField', () => {
   });
 
   it('renders as expected as password field', async () => {
-    const { toJSON, findAllByRole, getByPlaceholderText } = render(
+    const { toJSON, findAllByRole, getByTestId } = render(
       <TextField {...defaultProps} secureTextEntry />
     );
     expect(toJSON()).toMatchSnapshot();
 
     expect(await findAllByRole('text')).toHaveLength(1);
-    const textInput = getByPlaceholderText(placeHolderText);
+    const textInput = getByTestId(testID);
     expect(textInput.props.secureTextEntry).toBeTruthy();
   });
 
   it('does nothing when disabled', () => {
-    const { getByPlaceholderText } = render(
+    const { getByTestId } = render(
       <TextField {...defaultProps} disabled onChangeText={onChangeText} />
     );
-    const textInput = getByPlaceholderText(placeHolderText);
+    const textInput = getByTestId(testID);
     fireEvent.press(textInput);
     expect(onChangeText).not.toHaveBeenCalled();
   });

--- a/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
+++ b/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
@@ -36,8 +36,7 @@ describe('TextField', () => {
     expect(toJSON()).toMatchSnapshot();
     const textInput = getByPlaceholderText(placeHolderText);
     expect(textInput.props.editable).toBeFalsy();
-    expect(textInput.parent).not.toBeNull();
-    expect(textInput.parent.props.accessibilityState).toHaveProperty(
+    expect(textInput.parent?.props.accessibilityState).toHaveProperty(
       'disabled',
       true
     );

--- a/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
+++ b/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
@@ -57,7 +57,7 @@ describe('TextField', () => {
 
   it('renders as expected as password field', async () => {
     const { toJSON, findAllByRole, getByPlaceholderText } = render(
-      <TextField {...defaultProps} password />
+      <TextField {...defaultProps} secureTextEntry />
     );
     expect(toJSON()).toMatchSnapshot();
 

--- a/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
+++ b/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import TextField from '../TextField';
+
+const placeHolderText = 'Placeholder';
+const labelText = 'Label';
+const defaultProps = {
+  label: labelText,
+  placeholder: placeHolderText,
+};
+
+const onChangeText = jest.fn();
+
+describe('TextField', () => {
+  it('renders as expected', async () => {
+    const { toJSON, findAllByRole, getByPlaceholderText, getByText } = render(
+      <TextField {...defaultProps} />
+    );
+    expect(toJSON()).toMatchSnapshot();
+
+    expect(await findAllByRole('text')).toHaveLength(1);
+    const textInput = getByPlaceholderText(placeHolderText);
+    expect(textInput.props.editable).toBeTruthy();
+    expect(textInput.props.secureTextEntry).toBeFalsy();
+    const label = getByText(labelText);
+    expect(label).not.toBeNull();
+  });
+
+  it('renders as expected when disabled', () => {
+    const { toJSON, getByPlaceholderText } = render(
+      <TextField {...defaultProps} disabled />
+    );
+    expect(toJSON()).toMatchSnapshot();
+    const textInput = getByPlaceholderText(placeHolderText);
+    expect(textInput.props.editable).toBeFalsy();
+  });
+
+  it('renders as expected with error message', async () => {
+    const message = 'Error message';
+    const { toJSON, findAllByRole, getByText } = render(
+      <TextField {...defaultProps} error errorMessage={message} />
+    );
+    expect(toJSON()).toMatchSnapshot();
+
+    expect(await findAllByRole('text')).toHaveLength(2);
+    expect(getByText(message)).not.toBeNull();
+  });
+
+  it(`doesn't render the errorMessage if error prop is false`, () => {
+    const message = 'Error message';
+    const { toJSON, queryByText } = render(
+      <TextField {...defaultProps} errorMessage={message} />
+    );
+    expect(toJSON()).toMatchSnapshot();
+    expect(queryByText(message)).toBeFalsy();
+  });
+
+  it('renders as expected as password field', async () => {
+    const { toJSON, findAllByRole, getByPlaceholderText } = render(
+      <TextField {...defaultProps} password />
+    );
+    expect(toJSON()).toMatchSnapshot();
+
+    expect(await findAllByRole('text')).toHaveLength(1);
+    const textInput = getByPlaceholderText(placeHolderText);
+    expect(textInput.props.secureTextEntry).toBeTruthy();
+  });
+
+  it('does nothing when disabled', () => {
+    const { getByPlaceholderText } = render(
+      <TextField {...defaultProps} disabled onChangeText={onChangeText} />
+    );
+    const textInput = getByPlaceholderText(placeHolderText);
+    fireEvent.press(textInput);
+    expect(onChangeText).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
@@ -2,6 +2,13 @@
 
 exports[`TextField doesn't render the errorMessage if error prop is false 1`] = `
 <View
+  accessibilityLabel="Label"
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
+  accessible={true}
   style={
     Array [
       Object {
@@ -27,7 +34,7 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
     Label
   </Text>
   <TextInput
-    accessibilityLabel="Label"
+    accessible={true}
     editable={true}
     placeholder="Placeholder"
     style={
@@ -49,6 +56,13 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
 
 exports[`TextField renders as expected 1`] = `
 <View
+  accessibilityLabel="Label"
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
+  accessible={true}
   style={
     Array [
       Object {
@@ -74,7 +88,7 @@ exports[`TextField renders as expected 1`] = `
     Label
   </Text>
   <TextInput
-    accessibilityLabel="Label"
+    accessible={true}
     editable={true}
     placeholder="Placeholder"
     style={
@@ -96,6 +110,13 @@ exports[`TextField renders as expected 1`] = `
 
 exports[`TextField renders as expected as password field 1`] = `
 <View
+  accessibilityLabel="Label"
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
+  accessible={true}
   style={
     Array [
       Object {
@@ -121,7 +142,7 @@ exports[`TextField renders as expected as password field 1`] = `
     Label
   </Text>
   <TextInput
-    accessibilityLabel="Label"
+    accessible={true}
     editable={true}
     placeholder="Placeholder"
     secureTextEntry={true}
@@ -144,6 +165,13 @@ exports[`TextField renders as expected as password field 1`] = `
 
 exports[`TextField renders as expected when disabled 1`] = `
 <View
+  accessibilityLabel="Label"
+  accessibilityState={
+    Object {
+      "disabled": true,
+    }
+  }
+  accessible={true}
   style={
     Array [
       Object {
@@ -170,7 +198,7 @@ exports[`TextField renders as expected when disabled 1`] = `
     Label
   </Text>
   <TextInput
-    accessibilityLabel="Label"
+    accessible={true}
     editable={false}
     placeholder="Placeholder"
     style={
@@ -192,6 +220,13 @@ exports[`TextField renders as expected when disabled 1`] = `
 
 exports[`TextField renders as expected with error message 1`] = `
 <View
+  accessibilityLabel="Label"
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
+  accessible={true}
   style={
     Array [
       Object {
@@ -217,7 +252,7 @@ exports[`TextField renders as expected with error message 1`] = `
     Label
   </Text>
   <TextInput
-    accessibilityLabel="Label"
+    accessible={true}
     editable={true}
     placeholder="Placeholder"
     style={

--- a/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
@@ -50,6 +50,7 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
         undefined,
       ]
     }
+    testID="textField"
   />
 </View>
 `;
@@ -104,6 +105,7 @@ exports[`TextField renders as expected 1`] = `
         undefined,
       ]
     }
+    testID="textField"
   />
 </View>
 `;
@@ -159,6 +161,7 @@ exports[`TextField renders as expected as password field 1`] = `
         undefined,
       ]
     }
+    testID="textField"
   />
 </View>
 `;
@@ -214,6 +217,7 @@ exports[`TextField renders as expected when disabled 1`] = `
         undefined,
       ]
     }
+    testID="textField"
   />
 </View>
 `;
@@ -268,6 +272,7 @@ exports[`TextField renders as expected with error message 1`] = `
         undefined,
       ]
     }
+    testID="textField"
   />
   <Text
     accessibilityRole="text"

--- a/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TextField doesn't render the errorMessage is error prop is false 1`] = `
+exports[`TextField doesn't render the errorMessage if error prop is false 1`] = `
 <View
   style={
     Array [
@@ -28,20 +28,11 @@ exports[`TextField doesn't render the errorMessage is error prop is false 1`] = 
   </Text>
   <TextInput
     accessibilityLabel="Label"
-    accessible={true}
     editable={true}
-    keyboardType="default"
     placeholder="Placeholder"
     style={
       Array [
-        Object {
-          "borderColor": "black",
-          "borderRadius": 4,
-          "borderWidth": 1,
-          "fontSize": 16,
-          "padding": 8,
-          "width": "100%",
-        },
+        undefined,
         undefined,
       ]
     }
@@ -77,20 +68,11 @@ exports[`TextField renders as expected 1`] = `
   </Text>
   <TextInput
     accessibilityLabel="Label"
-    accessible={true}
     editable={true}
-    keyboardType="default"
     placeholder="Placeholder"
     style={
       Array [
-        Object {
-          "borderColor": "black",
-          "borderRadius": 4,
-          "borderWidth": 1,
-          "fontSize": 16,
-          "padding": 8,
-          "width": "100%",
-        },
+        undefined,
         undefined,
       ]
     }
@@ -126,21 +108,12 @@ exports[`TextField renders as expected as password field 1`] = `
   </Text>
   <TextInput
     accessibilityLabel="Label"
-    accessible={true}
     editable={true}
-    keyboardType="default"
     placeholder="Placeholder"
     secureTextEntry={true}
     style={
       Array [
-        Object {
-          "borderColor": "black",
-          "borderRadius": 4,
-          "borderWidth": 1,
-          "fontSize": 16,
-          "padding": 8,
-          "width": "100%",
-        },
+        undefined,
         undefined,
       ]
     }
@@ -177,20 +150,11 @@ exports[`TextField renders as expected when disabled 1`] = `
   </Text>
   <TextInput
     accessibilityLabel="Label"
-    accessible={true}
     editable={false}
-    keyboardType="default"
     placeholder="Placeholder"
     style={
       Array [
-        Object {
-          "borderColor": "black",
-          "borderRadius": 4,
-          "borderWidth": 1,
-          "fontSize": 16,
-          "padding": 8,
-          "width": "100%",
-        },
+        undefined,
         undefined,
       ]
     }
@@ -226,20 +190,11 @@ exports[`TextField renders as expected with error message 1`] = `
   </Text>
   <TextInput
     accessibilityLabel="Label"
-    accessible={true}
     editable={true}
-    keyboardType="default"
     placeholder="Placeholder"
     style={
       Array [
-        Object {
-          "borderColor": "black",
-          "borderRadius": 4,
-          "borderWidth": 1,
-          "fontSize": 16,
-          "padding": 8,
-          "width": "100%",
-        },
+        undefined,
         undefined,
       ]
     }

--- a/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
@@ -1,0 +1,263 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextField doesn't render the errorMessage is error prop is false 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "flex-start",
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessibilityRole="text"
+    style={
+      Array [
+        Object {
+          "fontSize": 16,
+          "marginHorizontal": 4,
+          "marginVertical": 2,
+        },
+        undefined,
+      ]
+    }
+  >
+    Label
+  </Text>
+  <TextInput
+    accessibilityLabel="Label"
+    accessible={true}
+    editable={true}
+    keyboardType="default"
+    placeholder="Placeholder"
+    style={
+      Array [
+        Object {
+          "borderColor": "black",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "fontSize": 16,
+          "padding": 8,
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`TextField renders as expected 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "flex-start",
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessibilityRole="text"
+    style={
+      Array [
+        Object {
+          "fontSize": 16,
+          "marginHorizontal": 4,
+          "marginVertical": 2,
+        },
+        undefined,
+      ]
+    }
+  >
+    Label
+  </Text>
+  <TextInput
+    accessibilityLabel="Label"
+    accessible={true}
+    editable={true}
+    keyboardType="default"
+    placeholder="Placeholder"
+    style={
+      Array [
+        Object {
+          "borderColor": "black",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "fontSize": 16,
+          "padding": 8,
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`TextField renders as expected as password field 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "flex-start",
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessibilityRole="text"
+    style={
+      Array [
+        Object {
+          "fontSize": 16,
+          "marginHorizontal": 4,
+          "marginVertical": 2,
+        },
+        undefined,
+      ]
+    }
+  >
+    Label
+  </Text>
+  <TextInput
+    accessibilityLabel="Label"
+    accessible={true}
+    editable={true}
+    keyboardType="default"
+    placeholder="Placeholder"
+    secureTextEntry={true}
+    style={
+      Array [
+        Object {
+          "borderColor": "black",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "fontSize": 16,
+          "padding": 8,
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`TextField renders as expected when disabled 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "flex-start",
+        "opacity": 0.6,
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessibilityRole="text"
+    style={
+      Array [
+        Object {
+          "fontSize": 16,
+          "marginHorizontal": 4,
+          "marginVertical": 2,
+        },
+        undefined,
+      ]
+    }
+  >
+    Label
+  </Text>
+  <TextInput
+    accessibilityLabel="Label"
+    accessible={true}
+    editable={false}
+    keyboardType="default"
+    placeholder="Placeholder"
+    style={
+      Array [
+        Object {
+          "borderColor": "black",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "fontSize": 16,
+          "padding": 8,
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`TextField renders as expected with error message 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "flex-start",
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessibilityRole="text"
+    style={
+      Array [
+        Object {
+          "fontSize": 16,
+          "marginHorizontal": 4,
+          "marginVertical": 2,
+        },
+        undefined,
+      ]
+    }
+  >
+    Label
+  </Text>
+  <TextInput
+    accessibilityLabel="Label"
+    accessible={true}
+    editable={true}
+    keyboardType="default"
+    placeholder="Placeholder"
+    style={
+      Array [
+        Object {
+          "borderColor": "black",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "fontSize": 16,
+          "padding": 8,
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  />
+  <Text
+    accessibilityRole="text"
+    style={
+      Array [
+        Object {
+          "fontSize": 16,
+          "marginHorizontal": 4,
+          "marginVertical": 2,
+        },
+        undefined,
+      ]
+    }
+  >
+    Error message
+  </Text>
+</View>
+`;

--- a/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
@@ -50,7 +50,7 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
         undefined,
       ]
     }
-    testID="textField"
+    testID="textInput"
   />
 </View>
 `;
@@ -105,7 +105,7 @@ exports[`TextField renders as expected 1`] = `
         undefined,
       ]
     }
-    testID="textField"
+    testID="textInput"
   />
 </View>
 `;
@@ -161,7 +161,7 @@ exports[`TextField renders as expected as password field 1`] = `
         undefined,
       ]
     }
-    testID="textField"
+    testID="textInput"
   />
 </View>
 `;
@@ -217,7 +217,7 @@ exports[`TextField renders as expected when disabled 1`] = `
         undefined,
       ]
     }
-    testID="textField"
+    testID="textInput"
   />
 </View>
 `;
@@ -272,7 +272,7 @@ exports[`TextField renders as expected with error message 1`] = `
         undefined,
       ]
     }
-    testID="textField"
+    testID="textInput"
   />
   <Text
     accessibilityRole="text"

--- a/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
@@ -32,7 +32,14 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
     placeholder="Placeholder"
     style={
       Array [
-        undefined,
+        Object {
+          "borderColor": "black",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "fontSize": 16,
+          "padding": 8,
+          "width": "100%",
+        },
         undefined,
       ]
     }
@@ -72,7 +79,14 @@ exports[`TextField renders as expected 1`] = `
     placeholder="Placeholder"
     style={
       Array [
-        undefined,
+        Object {
+          "borderColor": "black",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "fontSize": 16,
+          "padding": 8,
+          "width": "100%",
+        },
         undefined,
       ]
     }
@@ -113,7 +127,14 @@ exports[`TextField renders as expected as password field 1`] = `
     secureTextEntry={true}
     style={
       Array [
-        undefined,
+        Object {
+          "borderColor": "black",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "fontSize": 16,
+          "padding": 8,
+          "width": "100%",
+        },
         undefined,
       ]
     }
@@ -154,7 +175,14 @@ exports[`TextField renders as expected when disabled 1`] = `
     placeholder="Placeholder"
     style={
       Array [
-        undefined,
+        Object {
+          "borderColor": "black",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "fontSize": 16,
+          "padding": 8,
+          "width": "100%",
+        },
         undefined,
       ]
     }
@@ -194,7 +222,14 @@ exports[`TextField renders as expected with error message 1`] = `
     placeholder="Placeholder"
     style={
       Array [
-        undefined,
+        Object {
+          "borderColor": "black",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "fontSize": 16,
+          "padding": 8,
+          "width": "100%",
+        },
         undefined,
       ]
     }

--- a/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
@@ -55,6 +55,61 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
 </View>
 `;
 
+exports[`TextField doesn't render the errorMessage if errorMessage prop is undefined 1`] = `
+<View
+  accessibilityLabel="Label"
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
+  accessible={true}
+  style={
+    Array [
+      Object {
+        "alignItems": "flex-start",
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessibilityRole="text"
+    style={
+      Array [
+        Object {
+          "fontSize": 16,
+          "marginHorizontal": 4,
+          "marginVertical": 2,
+        },
+        undefined,
+      ]
+    }
+  >
+    Label
+  </Text>
+  <TextInput
+    accessible={true}
+    editable={true}
+    placeholder="Placeholder"
+    style={
+      Array [
+        Object {
+          "borderColor": "black",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "fontSize": 16,
+          "padding": 8,
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+    testID="textInput"
+  />
+</View>
+`;
+
 exports[`TextField renders as expected 1`] = `
 <View
   accessibilityLabel="Label"

--- a/packages/react-native/src/primitives/TextField/index.ts
+++ b/packages/react-native/src/primitives/TextField/index.ts
@@ -1,0 +1,2 @@
+export { default as TextField } from './TextField';
+export { TextFieldProps, TextFieldStyles } from './types';

--- a/packages/react-native/src/primitives/TextField/styles.ts
+++ b/packages/react-native/src/primitives/TextField/styles.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+
+import { TextFieldStyles } from './types';
+
+export const styles: TextFieldStyles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 16,
+  },
+  disabled: {
+    opacity: 0.6,
+  },
+});

--- a/packages/react-native/src/primitives/TextField/styles.ts
+++ b/packages/react-native/src/primitives/TextField/styles.ts
@@ -4,10 +4,15 @@ import { TextFieldStyles } from './types';
 
 export const styles: TextFieldStyles = StyleSheet.create({
   container: {
-    alignItems: 'center',
+    alignItems: 'flex-start',
   },
   text: {
     fontSize: 16,
+    borderColor: 'black',
+    borderWidth: 1,
+    borderRadius: 4,
+    padding: 8,
+    width: '100%',
   },
   disabled: {
     opacity: 0.6,

--- a/packages/react-native/src/primitives/TextField/styles.ts
+++ b/packages/react-native/src/primitives/TextField/styles.ts
@@ -6,7 +6,7 @@ export const styles: TextFieldStyles = StyleSheet.create({
   container: {
     alignItems: 'flex-start',
   },
-  text: {
+  input: {
     fontSize: 16,
     borderColor: 'black',
     borderWidth: 1,

--- a/packages/react-native/src/primitives/TextField/types.ts
+++ b/packages/react-native/src/primitives/TextField/types.ts
@@ -1,0 +1,58 @@
+import { StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native';
+import { LabelPosition, LabelProps } from '../Label/types';
+
+export interface TextFieldProps extends TextInputProps {
+  /**
+   * @description
+   * styling for TextField container
+   */
+  containerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * @description
+   * A Boolean attribute indicating that the user cannot interact with the control
+   */
+  disabled?: boolean;
+
+  /**
+   * @description
+   * Styling for TextField component
+   */
+  textStyle?: StyleProp<TextStyle>;
+
+  /**
+   * @description
+   * Label text for field
+   */
+  label?: string;
+
+  /**
+   * @description
+   * Position for TextField label
+   */
+  labelPosition?: LabelPosition;
+
+  /**
+   * @description
+   * Styling for TextField label
+   */
+  labelStyle?: LabelProps['style'];
+
+  /**
+   * @description
+   * Indicates whether the TextField component has an error
+   */
+  error?: boolean;
+
+  /**
+   * @description
+   *  When defined and `error` is true, show error message
+   */
+  errorMessage?: string;
+}
+
+export interface TextFieldStyles {
+  container: ViewStyle;
+  text: TextStyle;
+  disabled: ViewStyle;
+}

--- a/packages/react-native/src/primitives/TextField/types.ts
+++ b/packages/react-native/src/primitives/TextField/types.ts
@@ -1,5 +1,11 @@
-import { StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native';
-import { LabelPosition, LabelProps } from '../Label/types';
+import {
+  KeyboardTypeOptions,
+  StyleProp,
+  TextInputProps,
+  TextStyle,
+  ViewStyle,
+} from 'react-native';
+import { LabelProps } from '../Label/types';
 
 export interface TextFieldProps extends TextInputProps {
   /**
@@ -16,30 +22,6 @@ export interface TextFieldProps extends TextInputProps {
 
   /**
    * @description
-   * Styling for TextField component
-   */
-  textStyle?: StyleProp<TextStyle>;
-
-  /**
-   * @description
-   * Label text for field
-   */
-  label?: string;
-
-  /**
-   * @description
-   * Position for TextField label
-   */
-  labelPosition?: LabelPosition;
-
-  /**
-   * @description
-   * Styling for TextField label
-   */
-  labelStyle?: LabelProps['style'];
-
-  /**
-   * @description
    * Indicates whether the TextField component has an error
    */
   error?: boolean;
@@ -49,6 +31,42 @@ export interface TextFieldProps extends TextInputProps {
    *  When defined and `error` is true, show error message
    */
   errorMessage?: string;
+
+  /**
+   * @description
+   *  Styling for error message
+   */
+  errorMessageStyle?: StyleProp<TextStyle>;
+
+  /**
+   * @description
+   * Label text for field
+   */
+  label?: string;
+
+  /**
+   * @description
+   * Styling for TextField label
+   */
+  labelStyle?: LabelProps['style'];
+
+  /**
+   * @description
+   * Indicates whether to mask the text
+   */
+  password?: boolean;
+
+  /**
+   * @description
+   * Styling for TextField component
+   */
+  textStyle?: StyleProp<TextStyle>;
+
+  /**
+   * @description
+   * Determines which keyboard to open: default or phone number.
+   */
+  type?: Extract<KeyboardTypeOptions, 'default' | 'phone-pad'>;
 }
 
 export interface TextFieldStyles {

--- a/packages/react-native/src/primitives/TextField/types.ts
+++ b/packages/react-native/src/primitives/TextField/types.ts
@@ -1,16 +1,10 @@
-import {
-  KeyboardTypeOptions,
-  StyleProp,
-  TextInputProps,
-  TextStyle,
-  ViewStyle,
-} from 'react-native';
+import { StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native';
 import { LabelProps } from '../Label/types';
 
-export interface TextFieldProps extends TextInputProps {
+export interface TextFieldProps extends Omit<TextInputProps, 'editable'> {
   /**
    * @description
-   * styling for TextField container
+   * Styling for TextField container
    */
   containerStyle?: StyleProp<ViewStyle>;
 
@@ -46,31 +40,19 @@ export interface TextFieldProps extends TextInputProps {
 
   /**
    * @description
-   * Styling for TextField label
+   * Styling for the label
    */
   labelStyle?: LabelProps['style'];
 
   /**
    * @description
-   * Indicates whether to mask the text
+   * Styling for the input
    */
-  password?: boolean;
-
-  /**
-   * @description
-   * Styling for TextField component
-   */
-  textStyle?: StyleProp<TextStyle>;
-
-  /**
-   * @description
-   * Determines which keyboard to open: default or phone number.
-   */
-  type?: Extract<KeyboardTypeOptions, 'default' | 'phone-pad'>;
+  inputStyle?: StyleProp<TextStyle>;
 }
 
 export interface TextFieldStyles {
   container: ViewStyle;
-  text: TextStyle;
+  input: TextStyle;
   disabled: ViewStyle;
 }

--- a/packages/react-native/src/primitives/index.ts
+++ b/packages/react-native/src/primitives/index.ts
@@ -6,3 +6,4 @@ export * from './Icon';
 export * from './IconButton';
 export * from './Label';
 export * from './Radio';
+export * from './TextField';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change adds TextField component:
* base component
* unit test
* storybook

Notes:
* styling, size and variant will be added as follow-up with theming.
* iOS simulator is not bringing up the keyboard, should just be a simulator issue.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran Storybook. Tested accessibility with Xcode Accessibility Inspector.

![Kapture 2022-10-04 at 10 44 30](https://user-images.githubusercontent.com/68251134/193900663-6929f330-e223-4be4-98c6-0542347e054b.gif)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
