### PR TITLE
fix federatedSignIn bug

### DIFF
--- a/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignInButtons/FederatedSignInButton.tsx
+++ b/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignInButtons/FederatedSignInButton.tsx
@@ -102,7 +102,7 @@ export const FederatedSignInButton = (
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
     event.preventDefault();
 
-    toFederatedSignIn({ data: { provider } });
+    toFederatedSignIn({ provider });
   };
 
   let iconComponent;


### PR DESCRIPTION
#### Description of changes
`federatedSignIn` broke in one of the last two releases. The issue ended up being that `federatedSignIn()` was being called with a doubly nested `:data` object (ex: `{"type":"FEDERATED_SIGN_IN","data":{"data":{"provider":"Google"}}}`). This fixes the bug so that `federatedSignIn` works again.

#### Description of how you validated changes
Manually changed code in `node_modules` to reflect the bugfix and confirmed federated sign in worked again.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.