### PR TITLE
ci(next-release): Add publish step to next-release/main

### DIFF
--- a/.github/workflows/publish-next-release.yml
+++ b/.github/workflows/publish-next-release.yml
@@ -2,7 +2,7 @@
 #
 # Triggered by: merge to `next-release/main` branch
 
-name: Test / next-release
+name: Publish / next-release
 
 on:
   push:
@@ -26,3 +26,11 @@ jobs:
       DOCSEARCH_DOCS_APP_ID: ${{ secrets.DOCSEARCH_DOCS_APP_ID }}
       DOCSEARCH_DOCS_API_KEY: ${{ secrets.DOCSEARCH_DOCS_API_KEY }}
       DOCSEARCH_DOCS_INDEX_NAME: ${{ secrets.DOCSEARCH_DOCS_INDEX_NAME }}
+
+  publish:
+    needs: test
+    uses: ./.github/workflows/reusable-tagged-publish.yml
+    with:
+      dist-tag: next-release
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This adds a tagged publish step to `@next-release` on every merge to `next-release/main`. This is analogous to how we publish to `@next` on every merge to `main`.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Copy and pasted the step directly from publish-next workflow

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
