### PR TITLE
chore(ci): add timeout to cache downloads

### DIFF
--- a/.github/workflows/build-and-runtime-test.yml
+++ b/.github/workflows/build-and-runtime-test.yml
@@ -49,10 +49,12 @@ jobs:
         run: echo "::set-output name=version::$(amplify --version)"
       - name: Create or restore environments cache
         id: environments-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: canary/environments/**/aws-exports.js
           key: ${{ runner.os }}-canary-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('canary/environments/**/amplify/**') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       - name: Pull down AWS environments
         if: steps.environments-cache.outputs.cache-hit != 'true'
         run: yarn pull
@@ -66,11 +68,13 @@ jobs:
       # This steps attempts to restore cypress runner. It will not create any new
       # cache entries however, because cypress runner isn't available yet.
       - name: Restore cypress runner from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-cypress-cache
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-canary-cypress-${{ hashFiles('canary/e2e/yarn.lock') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       - name: Install e2e packages
         uses: ./.github/actions/install-with-retries
         with:
@@ -83,10 +87,12 @@ jobs:
       # step, so we go ahead and update the cache entry.
       - name: Cache cypress runner
         if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-canary-cypress-${{ hashFiles('canary/e2e/yarn.lock') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       - name: Start ${{ matrix.example }} example
         run: yarn start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000
         working-directory: ./canary/apps/${{ matrix.path }}

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -54,10 +54,12 @@ jobs:
         run: echo "::set-output name=version::$(amplify --version)"
       - name: Create or restore environments cache
         id: environments-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: canary/environments/**/aws-exports.js
           key: ${{ runner.os }}-canary-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('canary/environments/**/amplify/**') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       - name: Pull down AWS environments
         if: steps.environments-cache.outputs.cache-hit != 'true'
         run: yarn pull

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -63,11 +63,13 @@ jobs:
           cache: 'yarn'
 
       - name: Restore cypress runner Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-cypress-cache
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Install packages
         run: yarn install
@@ -130,10 +132,12 @@ jobs:
         run: echo "::set-output name=version::$(amplify --version)"
       - name: Create or restore environments cache
         id: environments-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: canary/environments/**/aws-exports.js
           key: ${{ runner.os }}-canary-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('canary/environments/**/amplify/**') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       - name: Pull down AWS environments
         if: steps.environments-cache.outputs.cache-hit != 'true'
         run: yarn pull

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -65,11 +65,13 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
       - name: Restore cypress runner from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-cypress-cache
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       - name: Install packages
         uses: ./.github/actions/install-with-retries
         with:
@@ -80,17 +82,17 @@ jobs:
       - name: Cache cypress runner
         # create new cypress cache entry only if cypress cache missed and we installed a new one.
         if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
       - name: Cache packages/ui/dist
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./packages/ui/dist
           key: ${{ runner.os }}-ui-${{ inputs.commit }}
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./node_modules
@@ -127,20 +129,24 @@ jobs:
           cache: 'yarn'
 
       - name: Restore node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-cache
         with:
           path: |
             ./node_modules
             **/node_modules
           key: ${{ runner.os }}-nodemodules-${{ inputs.commit }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
       - name: Restore ui/dist cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-ui-cache
         with:
           path: ./packages/ui/dist
           key: ${{ runner.os }}-ui-${{ inputs.commit }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true'
@@ -163,7 +169,7 @@ jobs:
         run: yarn react size
 
       - name: Cache ${{ matrix.package }}/dist
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./packages/${{ matrix.package }}/dist
           key: ${{ runner.os }}-${{ matrix.package }}-${{ inputs.commit }}
@@ -212,10 +218,12 @@ jobs:
           persist-credentials: false
 
       - name: Next.js Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Setup Node.js LTS
         uses: actions/setup-node@v3
@@ -224,23 +232,27 @@ jobs:
           cache: 'yarn'
 
       - name: Restore cypress runner Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-cypress-cache
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Restore node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-cache
         with:
           path: |
             ./node_modules
             **/node_modules
           key: ${{ runner.os }}-nodemodules-${{ inputs.commit }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
       - name: Restore ui/dist cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-ui-cache
         with:
           path: ./packages/ui/dist
@@ -248,10 +260,12 @@ jobs:
 
       - name: Restore ${{ matrix.package }}/dist cache
         id: restore-package-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./packages/${{ matrix.package }}/dist
           key: ${{ runner.os }}-${{ matrix.package }}-${{ inputs.commit }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Install packages
         if: steps.restore-cache.outputs.cache-hit != 'true' || steps.restore-cypress-cache.outputs.cache-hit != 'true'
@@ -278,10 +292,12 @@ jobs:
 
       - name: Create or restore environments cache
         id: environments-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: environments/**/aws-exports.js
           key: ${{ runner.os }}-environments-${{ steps.cli-version.outputs.version }}-${{ hashFiles('environments/**/amplify/**') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       # Pulling phone environments from original account,
       - name: Pull down Auth Phone AWS environments, on cache miss
@@ -352,11 +368,13 @@ jobs:
           cache: 'yarn'
 
       - name: Restore cypress runner Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-cypress-cache
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
       - name: Install packages
         run: yarn install

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-federated/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-federated/index.vue
@@ -15,3 +15,9 @@ Amplify.configure(aws_exports);
     </template>
   </authenticator>
 </template>
+
+<style>
+:not([data-amplify-authenticator-signin]) > .federated-sign-in-container {
+  display: none;
+}
+</style>

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-federated/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-federated/index.vue
@@ -15,9 +15,3 @@ Amplify.configure(aws_exports);
     </template>
   </authenticator>
 </template>
-
-<style>
-:not([data-amplify-authenticator-signin]) > .federated-sign-in-container {
-  display: none;
-}
-</style>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Bump `actions/cache` to v3, and adds timeout to each cache download steps (new feature in v3).

#### Details

`actions/cache` currently has a known issue (https://github.com/actions/cache/issues/810) with getting stuck in restoring cache phase. This can lead CI (especially our canaries) to be stuck for at most 6 hours. `actions/cache` team is working on getting this resolved, but meanwhile, they recommend that we add timeouts to our cache restoration steps.

#### Justification for timeout numbers
- environment cache (~<1mb): they take at most 1 seconds. Rounded up to 1 min.
- cypress cache (~149mb): they take at most 10 seconds. Rounded up to 1 min.
- `dist/` (~<1mb): they take at most 1 seconds. Rounded up to 1 min.
- `node_modules/` (~728mb): they take at most a minute. Rounded up to 3 mins. We could do 2, but I'm not too concerned about shaving as much time as possible because this is an infrequent transient error.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
