### PR TITLE
fix: issue where theme cannot override default font

### DIFF
--- a/.changeset/small-turkeys-glow.md
+++ b/.changeset/small-turkeys-glow.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix: issue where custom theme via ThemeProvider cannot override default font

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -4,13 +4,17 @@
 
 @import 'dist/theme';
 
-// Keeping these selector low (001) so it can be easily overridden
-html {
+// Allows both users with and without ThemeProvider to use or override default font
+// html => customers w/o ThemeProvider still get default font
+// [data-amplify-theme] => customers with ThemeProvider can override default font
+html,
+[data-amplify-theme] {
   font-family: var(--amplify-fonts-default-static);
 }
 
 @supports (font-variation-settings: normal) {
-  html {
+  html,
+  [data-amplify-theme] {
     font-family: var(--amplify-fonts-default-variable);
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This PR fixes an issue where custom fonts set via the `ThemeProvider` aren't being applied. 

_This doesn't work_
```tsx
const theme: Theme = {
    name: 'MyTheme',
    tokens: {
      fonts: {
        default: {
          variable: { value: "'Amazon Ember', sans-serif" },
          static: { value: "'Amazon Ember', sans-serif" },
        },
      },
    },
  };
```

_This does work_
```css
html {
  font-family: 'Raleway', sans-serif;
}
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-ui/issues/2762
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Using a test Vite app, I overrode the font using theme object and `ThemeProvider`:

```tsx
const theme: Theme = {
    name: 'MyTheme',
    tokens: {
      fonts: {
        default: {
          variable: { value: "'Amazon Ember', sans-serif" },
          static: { value: "'Amazon Ember', sans-serif" },
        },
      },
    },
  };
```

Before:
![image](https://user-images.githubusercontent.com/6165315/197004021-345fa52f-9520-4fba-85f7-b66796570d31.png)


Then used `npm link` to test new version and saw:

After:
<img width="526" alt="image" src="https://user-images.githubusercontent.com/6165315/196799129-e51bf90f-8b49-4dea-93a0-fb2d6f0451e1.png">

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
