### PR TITLE
feat(ui-react-native): Add default header component

### DIFF
--- a/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/ConfirmResetPassword.tsx
@@ -8,9 +8,8 @@ const ConfirmResetPassword: ConfirmResetPasswordComponent = () => {
   return <Text>ConfirmResetPassword</Text>;
 };
 
-ConfirmResetPassword.Header = function Header() {
-  return <DefaultHeader>Confirm Reset Password</DefaultHeader>;
-};
+ConfirmResetPassword.Header = DefaultHeader;
+
 ConfirmResetPassword.Footer = function Footer() {
   return null;
 };

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/ConfirmResetPassword.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/ConfirmResetPassword.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Text } from 'react-native';
 
 import { ConfirmResetPasswordComponent } from './types';
+import { DefaultHeader } from '../../common/DefaultHeader';
 
 const ConfirmResetPassword: ConfirmResetPasswordComponent = () => {
   return <Text>ConfirmResetPassword</Text>;
 };
 
 ConfirmResetPassword.Header = function Header() {
-  return null;
+  return <DefaultHeader>Confirm Reset Password</DefaultHeader>;
 };
 ConfirmResetPassword.Footer = function Footer() {
   return null;

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/ConfirmResetPassword.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/ConfirmResetPassword.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ConfirmResetPassword', () => {
   it('renders as expected', () => {
-    const { toJSON } = render(
+    const { toJSON, findByRole } = render(
       <>
         <ConfirmResetPassword {...props} />
         <ConfirmResetPassword.Header />
@@ -16,5 +16,7 @@ describe('ConfirmResetPassword', () => {
       </>
     );
     expect(toJSON()).toMatchSnapshot();
+
+    expect(findByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/ConfirmResetPassword.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/ConfirmResetPassword.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ConfirmResetPassword', () => {
   it('renders as expected', () => {
-    const { toJSON, findByRole } = render(
+    const { toJSON, getByRole } = render(
       <>
         <ConfirmResetPassword {...props} />
         <ConfirmResetPassword.Header />
@@ -17,6 +17,6 @@ describe('ConfirmResetPassword', () => {
     );
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/__snapshots__/ConfirmResetPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/__snapshots__/ConfirmResetPassword.spec.tsx.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfirmResetPassword renders as expected 1`] = `
-<Text>
-  ConfirmResetPassword
-</Text>
+Array [
+  <Text>
+    ConfirmResetPassword
+  </Text>,
+  <Text
+    accessibilityRole="header"
+    style={
+      Array [
+        Object {
+          "color": "black",
+        },
+        Object {
+          "fontSize": 34,
+          "fontWeight": "300",
+          "lineHeight": 51,
+        },
+        undefined,
+      ]
+    }
+  >
+    Confirm Reset Password
+  </Text>,
+]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/__snapshots__/ConfirmResetPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/__snapshots__/ConfirmResetPassword.spec.tsx.snap
@@ -20,8 +20,6 @@ Array [
         undefined,
       ]
     }
-  >
-    Confirm Reset Password
-  </Text>,
+  />,
 ]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/ConfirmSignIn.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Text } from 'react-native';
 
 import { ConfirmSignInComponent } from './types';
+import { DefaultHeader } from '../../common/DefaultHeader';
 
 const ConfirmSignIn: ConfirmSignInComponent = () => {
   return <Text>ConfirmSignIn</Text>;
 };
 
 ConfirmSignIn.Header = function Header() {
-  return null;
+  return <DefaultHeader>Confirm Sign In</DefaultHeader>;
 };
 ConfirmSignIn.Footer = function Footer() {
   return null;

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/ConfirmSignIn.tsx
@@ -8,9 +8,8 @@ const ConfirmSignIn: ConfirmSignInComponent = () => {
   return <Text>ConfirmSignIn</Text>;
 };
 
-ConfirmSignIn.Header = function Header() {
-  return <DefaultHeader>Confirm Sign In</DefaultHeader>;
-};
+ConfirmSignIn.Header = DefaultHeader;
+
 ConfirmSignIn.Footer = function Footer() {
   return null;
 };

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/ConfirmSignIn.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/ConfirmSignIn.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ConfirmSignIn', () => {
   it('renders as expected', () => {
-    const { toJSON, findByRole } = render(
+    const { toJSON, getByRole } = render(
       <>
         <ConfirmSignIn {...props} />
         <ConfirmSignIn.Header />
@@ -17,6 +17,6 @@ describe('ConfirmSignIn', () => {
     );
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/ConfirmSignIn.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/ConfirmSignIn.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ConfirmSignIn', () => {
   it('renders as expected', () => {
-    const { toJSON } = render(
+    const { toJSON, findByRole } = render(
       <>
         <ConfirmSignIn {...props} />
         <ConfirmSignIn.Header />
@@ -16,5 +16,7 @@ describe('ConfirmSignIn', () => {
       </>
     );
     expect(toJSON()).toMatchSnapshot();
+
+    expect(findByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/__snapshots__/ConfirmSignIn.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/__snapshots__/ConfirmSignIn.spec.tsx.snap
@@ -20,8 +20,6 @@ Array [
         undefined,
       ]
     }
-  >
-    Confirm Sign In
-  </Text>,
+  />,
 ]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/__snapshots__/ConfirmSignIn.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/__snapshots__/ConfirmSignIn.spec.tsx.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfirmSignIn renders as expected 1`] = `
-<Text>
-  ConfirmSignIn
-</Text>
+Array [
+  <Text>
+    ConfirmSignIn
+  </Text>,
+  <Text
+    accessibilityRole="header"
+    style={
+      Array [
+        Object {
+          "color": "black",
+        },
+        Object {
+          "fontSize": 34,
+          "fontWeight": "300",
+          "lineHeight": 51,
+        },
+        undefined,
+      ]
+    }
+  >
+    Confirm Sign In
+  </Text>,
+]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/ConfirmSignUp.tsx
@@ -8,9 +8,8 @@ const ConfirmSignUp: ConfirmSignUpComponent = () => {
   return <Text>ConfirmSignUp</Text>;
 };
 
-ConfirmSignUp.Header = function Header() {
-  return <DefaultHeader>Confirm Sign Up</DefaultHeader>;
-};
+ConfirmSignUp.Header = DefaultHeader;
+
 ConfirmSignUp.Footer = function Footer() {
   return null;
 };

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/ConfirmSignUp.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/ConfirmSignUp.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Text } from 'react-native';
 
 import { ConfirmSignUpComponent } from './types';
+import { DefaultHeader } from '../../common/DefaultHeader';
 
 const ConfirmSignUp: ConfirmSignUpComponent = () => {
   return <Text>ConfirmSignUp</Text>;
 };
 
 ConfirmSignUp.Header = function Header() {
-  return null;
+  return <DefaultHeader>Confirm Sign Up</DefaultHeader>;
 };
 ConfirmSignUp.Footer = function Footer() {
   return null;

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/__tests__/ConfirmSignUp.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/__tests__/ConfirmSignUp.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ConfirmSignUp', () => {
   it('renders as expected', () => {
-    const { toJSON } = render(
+    const { toJSON, findByRole } = render(
       <>
         <ConfirmSignUp {...props} />
         <ConfirmSignUp.Header />
@@ -16,5 +16,7 @@ describe('ConfirmSignUp', () => {
       </>
     );
     expect(toJSON()).toMatchSnapshot();
+
+    expect(findByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/__tests__/ConfirmSignUp.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/__tests__/ConfirmSignUp.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ConfirmSignUp', () => {
   it('renders as expected', () => {
-    const { toJSON, findByRole } = render(
+    const { toJSON, getByRole } = render(
       <>
         <ConfirmSignUp {...props} />
         <ConfirmSignUp.Header />
@@ -17,6 +17,6 @@ describe('ConfirmSignUp', () => {
     );
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/__tests__/__snapshots__/ConfirmSignUp.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/__tests__/__snapshots__/ConfirmSignUp.spec.tsx.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfirmSignUp renders as expected 1`] = `
-<Text>
-  ConfirmSignUp
-</Text>
+Array [
+  <Text>
+    ConfirmSignUp
+  </Text>,
+  <Text
+    accessibilityRole="header"
+    style={
+      Array [
+        Object {
+          "color": "black",
+        },
+        Object {
+          "fontSize": 34,
+          "fontWeight": "300",
+          "lineHeight": 51,
+        },
+        undefined,
+      ]
+    }
+  >
+    Confirm Sign Up
+  </Text>,
+]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/__tests__/__snapshots__/ConfirmSignUp.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/__tests__/__snapshots__/ConfirmSignUp.spec.tsx.snap
@@ -20,8 +20,6 @@ Array [
         undefined,
       ]
     }
-  >
-    Confirm Sign Up
-  </Text>,
+  />,
 ]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/ConfirmVerifyUser.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Text } from 'react-native';
 
 import { ConfirmVerifyUserComponent } from './types';
+import { DefaultHeader } from '../../common/DefaultHeader';
 
 const ConfirmVerifyUser: ConfirmVerifyUserComponent = () => {
   return <Text>ConfirmVerifyUser</Text>;
 };
 
 ConfirmVerifyUser.Header = function Header() {
-  return null;
+  return <DefaultHeader>Confirm Verify User</DefaultHeader>;
 };
 ConfirmVerifyUser.Footer = function Footer() {
   return null;

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/ConfirmVerifyUser.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/ConfirmVerifyUser.tsx
@@ -8,9 +8,8 @@ const ConfirmVerifyUser: ConfirmVerifyUserComponent = () => {
   return <Text>ConfirmVerifyUser</Text>;
 };
 
-ConfirmVerifyUser.Header = function Header() {
-  return <DefaultHeader>Confirm Verify User</DefaultHeader>;
-};
+ConfirmVerifyUser.Header = DefaultHeader;
+
 ConfirmVerifyUser.Footer = function Footer() {
   return null;
 };

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/__tests__/ConfirmVerifyUser.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/__tests__/ConfirmVerifyUser.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ConfirmVerifyUser', () => {
   it('renders as expected', () => {
-    const { toJSON } = render(
+    const { toJSON, findByRole } = render(
       <>
         <ConfirmVerifyUser {...props} />
         <ConfirmVerifyUser.Header />
@@ -16,5 +16,7 @@ describe('ConfirmVerifyUser', () => {
       </>
     );
     expect(toJSON()).toMatchSnapshot();
+
+    expect(findByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/__tests__/ConfirmVerifyUser.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/__tests__/ConfirmVerifyUser.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ConfirmVerifyUser', () => {
   it('renders as expected', () => {
-    const { toJSON, findByRole } = render(
+    const { toJSON, getByRole } = render(
       <>
         <ConfirmVerifyUser {...props} />
         <ConfirmVerifyUser.Header />
@@ -17,6 +17,6 @@ describe('ConfirmVerifyUser', () => {
     );
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/__tests__/__snapshots__/ConfirmVerifyUser.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/__tests__/__snapshots__/ConfirmVerifyUser.spec.tsx.snap
@@ -20,8 +20,6 @@ Array [
         undefined,
       ]
     }
-  >
-    Confirm Verify User
-  </Text>,
+  />,
 ]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/__tests__/__snapshots__/ConfirmVerifyUser.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmVerifyUser/__tests__/__snapshots__/ConfirmVerifyUser.spec.tsx.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfirmVerifyUser renders as expected 1`] = `
-<Text>
-  ConfirmVerifyUser
-</Text>
+Array [
+  <Text>
+    ConfirmVerifyUser
+  </Text>,
+  <Text
+    accessibilityRole="header"
+    style={
+      Array [
+        Object {
+          "color": "black",
+        },
+        Object {
+          "fontSize": 34,
+          "fontWeight": "300",
+          "lineHeight": 51,
+        },
+        undefined,
+      ]
+    }
+  >
+    Confirm Verify User
+  </Text>,
+]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/ForceNewPassword.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Text } from 'react-native';
 
 import { ForceNewPasswordComponent } from './types';
+import { DefaultHeader } from '../../common/DefaultHeader';
 
 const ForceNewPassword: ForceNewPasswordComponent = () => {
   return <Text>ForceNewPassword</Text>;
 };
 
 ForceNewPassword.Header = function Header() {
-  return null;
+  return <DefaultHeader>Force New Password</DefaultHeader>;
 };
 ForceNewPassword.Footer = function Footer() {
   return null;

--- a/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/ForceNewPassword.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/ForceNewPassword.tsx
@@ -8,9 +8,8 @@ const ForceNewPassword: ForceNewPasswordComponent = () => {
   return <Text>ForceNewPassword</Text>;
 };
 
-ForceNewPassword.Header = function Header() {
-  return <DefaultHeader>Force New Password</DefaultHeader>;
-};
+ForceNewPassword.Header = DefaultHeader;
+
 ForceNewPassword.Footer = function Footer() {
   return null;
 };

--- a/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/ForceNewPassword.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/ForceNewPassword.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ForceNewPassword', () => {
   it('renders as expected', () => {
-    const { toJSON } = render(
+    const { toJSON, findByRole } = render(
       <>
         <ForceNewPassword {...props} />
         <ForceNewPassword.Header />
@@ -16,5 +16,7 @@ describe('ForceNewPassword', () => {
       </>
     );
     expect(toJSON()).toMatchSnapshot();
+
+    expect(findByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/ForceNewPassword.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/ForceNewPassword.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ForceNewPassword', () => {
   it('renders as expected', () => {
-    const { toJSON, findByRole } = render(
+    const { toJSON, getByRole } = render(
       <>
         <ForceNewPassword {...props} />
         <ForceNewPassword.Header />
@@ -17,6 +17,6 @@ describe('ForceNewPassword', () => {
     );
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/__snapshots__/ForceNewPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/__snapshots__/ForceNewPassword.spec.tsx.snap
@@ -20,8 +20,6 @@ Array [
         undefined,
       ]
     }
-  >
-    Force New Password
-  </Text>,
+  />,
 ]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/__snapshots__/ForceNewPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/__snapshots__/ForceNewPassword.spec.tsx.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ForceNewPassword renders as expected 1`] = `
-<Text>
-  ForceNewPassword
-</Text>
+Array [
+  <Text>
+    ForceNewPassword
+  </Text>,
+  <Text
+    accessibilityRole="header"
+    style={
+      Array [
+        Object {
+          "color": "black",
+        },
+        Object {
+          "fontSize": 34,
+          "fontWeight": "300",
+          "lineHeight": 51,
+        },
+        undefined,
+      ]
+    }
+  >
+    Force New Password
+  </Text>,
+]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/ResetPassword/ResetPassword.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ResetPassword/ResetPassword.tsx
@@ -8,9 +8,8 @@ const ResetPassword: ResetPasswordComponent = () => {
   return <Text>ResetPassword</Text>;
 };
 
-ResetPassword.Header = function Header() {
-  return <DefaultHeader>Reset Password</DefaultHeader>;
-};
+ResetPassword.Header = DefaultHeader;
+
 ResetPassword.Footer = function Footer() {
   return null;
 };

--- a/packages/react-native/src/Authenticator/Defaults/ResetPassword/ResetPassword.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ResetPassword/ResetPassword.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Text } from 'react-native';
 
 import { ResetPasswordComponent } from './types';
+import { DefaultHeader } from '../../common/DefaultHeader';
 
 const ResetPassword: ResetPasswordComponent = () => {
   return <Text>ResetPassword</Text>;
 };
 
 ResetPassword.Header = function Header() {
-  return null;
+  return <DefaultHeader>Reset Password</DefaultHeader>;
 };
 ResetPassword.Footer = function Footer() {
   return null;

--- a/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/ResetPassword.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/ResetPassword.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ResetPassword', () => {
   it('renders as expected', () => {
-    const { toJSON } = render(
+    const { toJSON, findByRole } = render(
       <>
         <ResetPassword {...props} />
         <ResetPassword.Header />
@@ -16,5 +16,7 @@ describe('ResetPassword', () => {
       </>
     );
     expect(toJSON()).toMatchSnapshot();
+
+    expect(findByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/ResetPassword.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/ResetPassword.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('ResetPassword', () => {
   it('renders as expected', () => {
-    const { toJSON, findByRole } = render(
+    const { toJSON, getByRole } = render(
       <>
         <ResetPassword {...props} />
         <ResetPassword.Header />
@@ -17,6 +17,6 @@ describe('ResetPassword', () => {
     );
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/__snapshots__/ResetPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/__snapshots__/ResetPassword.spec.tsx.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ResetPassword renders as expected 1`] = `
-<Text>
-  ResetPassword
-</Text>
+Array [
+  <Text>
+    ResetPassword
+  </Text>,
+  <Text
+    accessibilityRole="header"
+    style={
+      Array [
+        Object {
+          "color": "black",
+        },
+        Object {
+          "fontSize": 34,
+          "fontWeight": "300",
+          "lineHeight": 51,
+        },
+        undefined,
+      ]
+    }
+  >
+    Reset Password
+  </Text>,
+]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/__snapshots__/ResetPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/__snapshots__/ResetPassword.spec.tsx.snap
@@ -20,8 +20,6 @@ Array [
         undefined,
       ]
     }
-  >
-    Reset Password
-  </Text>,
+  />,
 ]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SetupTOTP/SetupTOTP.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Text } from 'react-native';
 
 import { SetupTOTPComponent } from './types';
+import { DefaultHeader } from '../../common/DefaultHeader';
 
 const SetupTOTP: SetupTOTPComponent = () => {
   return <Text>SetupTOTP</Text>;
 };
 
 SetupTOTP.Header = function Header() {
-  return null;
+  return <DefaultHeader>Setup TOTP</DefaultHeader>;
 };
 SetupTOTP.Footer = function Footer() {
   return null;

--- a/packages/react-native/src/Authenticator/Defaults/SetupTOTP/SetupTOTP.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SetupTOTP/SetupTOTP.tsx
@@ -8,9 +8,8 @@ const SetupTOTP: SetupTOTPComponent = () => {
   return <Text>SetupTOTP</Text>;
 };
 
-SetupTOTP.Header = function Header() {
-  return <DefaultHeader>Setup TOTP</DefaultHeader>;
-};
+SetupTOTP.Header = DefaultHeader;
+
 SetupTOTP.Footer = function Footer() {
   return null;
 };

--- a/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/SetupTOTP.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/SetupTOTP.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('SetupTOTP', () => {
   it('renders as expected', () => {
-    const { toJSON } = render(
+    const { toJSON, findByRole } = render(
       <>
         <SetupTOTP {...props} />
         <SetupTOTP.Header />
@@ -16,5 +16,7 @@ describe('SetupTOTP', () => {
       </>
     );
     expect(toJSON()).toMatchSnapshot();
+
+    expect(findByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/SetupTOTP.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/SetupTOTP.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('SetupTOTP', () => {
   it('renders as expected', () => {
-    const { toJSON, findByRole } = render(
+    const { toJSON, getByRole } = render(
       <>
         <SetupTOTP {...props} />
         <SetupTOTP.Header />
@@ -17,6 +17,6 @@ describe('SetupTOTP', () => {
     );
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/__snapshots__/SetupTOTP.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/__snapshots__/SetupTOTP.spec.tsx.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SetupTOTP renders as expected 1`] = `
-<Text>
-  SetupTOTP
-</Text>
+Array [
+  <Text>
+    SetupTOTP
+  </Text>,
+  <Text
+    accessibilityRole="header"
+    style={
+      Array [
+        Object {
+          "color": "black",
+        },
+        Object {
+          "fontSize": 34,
+          "fontWeight": "300",
+          "lineHeight": 51,
+        },
+        undefined,
+      ]
+    }
+  >
+    Setup TOTP
+  </Text>,
+]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/__snapshots__/SetupTOTP.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/__snapshots__/SetupTOTP.spec.tsx.snap
@@ -20,8 +20,6 @@ Array [
         undefined,
       ]
     }
-  >
-    Setup TOTP
-  </Text>,
+  />,
 ]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/SignIn/SignIn.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SignIn/SignIn.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Text } from 'react-native';
 
 import { SignInComponent } from './types';
+import { DefaultHeader } from '../../common/DefaultHeader';
 
 const SignIn: SignInComponent = () => {
   return <Text>SignIn</Text>;
 };
 
 SignIn.Header = function Header() {
-  return null;
+  return <DefaultHeader>Sign In</DefaultHeader>;
 };
 SignIn.Footer = function Footer() {
   return null;

--- a/packages/react-native/src/Authenticator/Defaults/SignIn/SignIn.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SignIn/SignIn.tsx
@@ -8,9 +8,8 @@ const SignIn: SignInComponent = () => {
   return <Text>SignIn</Text>;
 };
 
-SignIn.Header = function Header() {
-  return <DefaultHeader>Sign In</DefaultHeader>;
-};
+SignIn.Header = DefaultHeader;
+
 SignIn.Footer = function Footer() {
   return null;
 };

--- a/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/SignIn.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/SignIn.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('SignIn', () => {
   it('renders as expected', () => {
-    const { toJSON, findByRole } = render(
+    const { toJSON, getByRole } = render(
       <>
         <SignIn {...props} />
         <SignIn.Header />
@@ -17,6 +17,6 @@ describe('SignIn', () => {
     );
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/SignIn.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/SignIn.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('SignIn', () => {
   it('renders as expected', () => {
-    const { toJSON } = render(
+    const { toJSON, findByRole } = render(
       <>
         <SignIn {...props} />
         <SignIn.Header />
@@ -16,5 +16,7 @@ describe('SignIn', () => {
       </>
     );
     expect(toJSON()).toMatchSnapshot();
+
+    expect(findByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/__snapshots__/SignIn.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/__snapshots__/SignIn.spec.tsx.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SignIn renders as expected 1`] = `
-<Text>
-  SignIn
-</Text>
+Array [
+  <Text>
+    SignIn
+  </Text>,
+  <Text
+    accessibilityRole="header"
+    style={
+      Array [
+        Object {
+          "color": "black",
+        },
+        Object {
+          "fontSize": 34,
+          "fontWeight": "300",
+          "lineHeight": 51,
+        },
+        undefined,
+      ]
+    }
+  >
+    Sign In
+  </Text>,
+]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/__snapshots__/SignIn.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/__snapshots__/SignIn.spec.tsx.snap
@@ -20,8 +20,6 @@ Array [
         undefined,
       ]
     }
-  >
-    Sign In
-  </Text>,
+  />,
 ]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/SignUp/SignUp.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SignUp/SignUp.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Text } from 'react-native';
 
 import { SignUpComponent } from './types';
+import { DefaultHeader } from '../../common/DefaultHeader';
 
 const SignUp: SignUpComponent = () => {
   return <Text>SignUp</Text>;
 };
 
 SignUp.Header = function Header() {
-  return null;
+  return <DefaultHeader>Sign Up</DefaultHeader>;
 };
 SignUp.Footer = function Footer() {
   return null;

--- a/packages/react-native/src/Authenticator/Defaults/SignUp/SignUp.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SignUp/SignUp.tsx
@@ -8,9 +8,8 @@ const SignUp: SignUpComponent = () => {
   return <Text>SignUp</Text>;
 };
 
-SignUp.Header = function Header() {
-  return <DefaultHeader>Sign Up</DefaultHeader>;
-};
+SignUp.Header = DefaultHeader;
+
 SignUp.Footer = function Footer() {
   return null;
 };

--- a/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/SignUp.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/SignUp.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('SignUp', () => {
   it('renders as expected', () => {
-    const { toJSON, findByRole } = render(
+    const { toJSON, getByRole } = render(
       <>
         <SignUp {...props} />
         <SignUp.Header />
@@ -17,6 +17,6 @@ describe('SignUp', () => {
     );
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/SignUp.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/SignUp.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('SignUp', () => {
   it('renders as expected', () => {
-    const { toJSON } = render(
+    const { toJSON, findByRole } = render(
       <>
         <SignUp {...props} />
         <SignUp.Header />
@@ -16,5 +16,7 @@ describe('SignUp', () => {
       </>
     );
     expect(toJSON()).toMatchSnapshot();
+
+    expect(findByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/__snapshots__/SignUp.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/__snapshots__/SignUp.spec.tsx.snap
@@ -20,8 +20,6 @@ Array [
         undefined,
       ]
     }
-  >
-    Sign Up
-  </Text>,
+  />,
 ]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/__snapshots__/SignUp.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/__snapshots__/SignUp.spec.tsx.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SignUp renders as expected 1`] = `
-<Text>
-  SignUp
-</Text>
+Array [
+  <Text>
+    SignUp
+  </Text>,
+  <Text
+    accessibilityRole="header"
+    style={
+      Array [
+        Object {
+          "color": "black",
+        },
+        Object {
+          "fontSize": 34,
+          "fontWeight": "300",
+          "lineHeight": 51,
+        },
+        undefined,
+      ]
+    }
+  >
+    Sign Up
+  </Text>,
+]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/VerifyUser/VerifyUser.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/VerifyUser/VerifyUser.tsx
@@ -8,9 +8,8 @@ const VerifyUser: VerifyUserComponent = () => {
   return <Text>VerifyUser</Text>;
 };
 
-VerifyUser.Header = function Header() {
-  return <DefaultHeader>Verify User</DefaultHeader>;
-};
+VerifyUser.Header = DefaultHeader;
+
 VerifyUser.Footer = function Footer() {
   return null;
 };

--- a/packages/react-native/src/Authenticator/Defaults/VerifyUser/VerifyUser.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/VerifyUser/VerifyUser.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Text } from 'react-native';
 
 import { VerifyUserComponent } from './types';
+import { DefaultHeader } from '../../common/DefaultHeader';
 
 const VerifyUser: VerifyUserComponent = () => {
   return <Text>VerifyUser</Text>;
 };
 
 VerifyUser.Header = function Header() {
-  return null;
+  return <DefaultHeader>Verify User</DefaultHeader>;
 };
 VerifyUser.Footer = function Footer() {
   return null;

--- a/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/VerifyUser.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/VerifyUser.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('VerifyUser', () => {
   it('renders as expected', () => {
-    const { toJSON, findByRole } = render(
+    const { toJSON, getByRole } = render(
       <>
         <VerifyUser {...props} />
         <VerifyUser.Header />
@@ -17,6 +17,6 @@ describe('VerifyUser', () => {
     );
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/VerifyUser.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/VerifyUser.spec.tsx
@@ -7,7 +7,7 @@ const props = {} as any;
 
 describe('VerifyUser', () => {
   it('renders as expected', () => {
-    const { toJSON } = render(
+    const { toJSON, findByRole } = render(
       <>
         <VerifyUser {...props} />
         <VerifyUser.Header />
@@ -16,5 +16,7 @@ describe('VerifyUser', () => {
       </>
     );
     expect(toJSON()).toMatchSnapshot();
+
+    expect(findByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/__snapshots__/VerifyUser.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/__snapshots__/VerifyUser.spec.tsx.snap
@@ -20,8 +20,6 @@ Array [
         undefined,
       ]
     }
-  >
-    Verify User
-  </Text>,
+  />,
 ]
 `;

--- a/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/__snapshots__/VerifyUser.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/__snapshots__/VerifyUser.spec.tsx.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`VerifyUser renders as expected 1`] = `
-<Text>
-  VerifyUser
-</Text>
+Array [
+  <Text>
+    VerifyUser
+  </Text>,
+  <Text
+    accessibilityRole="header"
+    style={
+      Array [
+        Object {
+          "color": "black",
+        },
+        Object {
+          "fontSize": 34,
+          "fontWeight": "300",
+          "lineHeight": 51,
+        },
+        undefined,
+      ]
+    }
+  >
+    Verify User
+  </Text>,
+]
 `;

--- a/packages/react-native/src/Authenticator/common/DefaultHeader/DefaultHeader.tsx
+++ b/packages/react-native/src/Authenticator/common/DefaultHeader/DefaultHeader.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import { Heading } from '../../../primitives/Heading';
+import { DefaultHeaderProps } from './types';
+
+export default function DefaultHeader({
+  children,
+}: DefaultHeaderProps): JSX.Element {
+  return <Heading level={3}>{children}</Heading>;
+}

--- a/packages/react-native/src/Authenticator/common/DefaultHeader/__tests__/DefaultHeader.spec.tsx
+++ b/packages/react-native/src/Authenticator/common/DefaultHeader/__tests__/DefaultHeader.spec.tsx
@@ -6,13 +6,20 @@ import { DefaultHeader } from '..';
 const heading = 'test';
 
 describe('DefaultHeader', () => {
-  it('renders as expected', () => {
+  it('renders as expected with children', () => {
     const { toJSON, findByLabelText, findByRole } = render(
       <DefaultHeader>{heading}</DefaultHeader>
     );
     expect(toJSON()).toMatchSnapshot();
 
     expect(findByLabelText(heading)).toBeDefined();
+    expect(findByRole('header')).toBeDefined();
+  });
+
+  it('renders as expected without children', () => {
+    const { toJSON, findByRole } = render(<DefaultHeader />);
+    expect(toJSON()).toMatchSnapshot();
+
     expect(findByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/common/DefaultHeader/__tests__/DefaultHeader.spec.tsx
+++ b/packages/react-native/src/Authenticator/common/DefaultHeader/__tests__/DefaultHeader.spec.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { DefaultHeader } from '..';
+
+const heading = 'test';
+
+describe('DefaultHeader', () => {
+  it('renders as expected', () => {
+    const { toJSON, findByLabelText, findByRole } = render(
+      <DefaultHeader>{heading}</DefaultHeader>
+    );
+    expect(toJSON()).toMatchSnapshot();
+
+    expect(findByLabelText(heading)).toBeDefined();
+    expect(findByRole('header')).toBeDefined();
+  });
+});

--- a/packages/react-native/src/Authenticator/common/DefaultHeader/__tests__/DefaultHeader.spec.tsx
+++ b/packages/react-native/src/Authenticator/common/DefaultHeader/__tests__/DefaultHeader.spec.tsx
@@ -7,19 +7,19 @@ const heading = 'test';
 
 describe('DefaultHeader', () => {
   it('renders as expected with children', () => {
-    const { toJSON, findByLabelText, findByRole } = render(
+    const { toJSON, getByRole, getByText } = render(
       <DefaultHeader>{heading}</DefaultHeader>
     );
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByLabelText(heading)).toBeDefined();
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
+    expect(getByText(heading)).toBeDefined();
   });
 
   it('renders as expected without children', () => {
-    const { toJSON, findByRole } = render(<DefaultHeader />);
+    const { toJSON, getByRole } = render(<DefaultHeader />);
     expect(toJSON()).toMatchSnapshot();
 
-    expect(findByRole('header')).toBeDefined();
+    expect(getByRole('header')).toBeDefined();
   });
 });

--- a/packages/react-native/src/Authenticator/common/DefaultHeader/__tests__/__snapshots__/DefaultHeader.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/common/DefaultHeader/__tests__/__snapshots__/DefaultHeader.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DefaultHeader renders as expected 1`] = `
+exports[`DefaultHeader renders as expected with children 1`] = `
 <Text
   accessibilityRole="header"
   style={
@@ -19,4 +19,23 @@ exports[`DefaultHeader renders as expected 1`] = `
 >
   test
 </Text>
+`;
+
+exports[`DefaultHeader renders as expected without children 1`] = `
+<Text
+  accessibilityRole="header"
+  style={
+    Array [
+      Object {
+        "color": "black",
+      },
+      Object {
+        "fontSize": 34,
+        "fontWeight": "300",
+        "lineHeight": 51,
+      },
+      undefined,
+    ]
+  }
+/>
 `;

--- a/packages/react-native/src/Authenticator/common/DefaultHeader/__tests__/__snapshots__/DefaultHeader.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/common/DefaultHeader/__tests__/__snapshots__/DefaultHeader.spec.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DefaultHeader renders as expected 1`] = `
+<Text
+  accessibilityRole="header"
+  style={
+    Array [
+      Object {
+        "color": "black",
+      },
+      Object {
+        "fontSize": 34,
+        "fontWeight": "300",
+        "lineHeight": 51,
+      },
+      undefined,
+    ]
+  }
+>
+  test
+</Text>
+`;

--- a/packages/react-native/src/Authenticator/common/DefaultHeader/index.ts
+++ b/packages/react-native/src/Authenticator/common/DefaultHeader/index.ts
@@ -1,0 +1,2 @@
+export { default as DefaultHeader } from './DefaultHeader';
+export { DefaultHeaderProps } from './types';

--- a/packages/react-native/src/Authenticator/common/DefaultHeader/types.ts
+++ b/packages/react-native/src/Authenticator/common/DefaultHeader/types.ts
@@ -1,0 +1,3 @@
+import { HeadingProps } from '../../../primitives/Heading';
+
+export interface DefaultHeaderProps extends HeadingProps {}

--- a/packages/react-native/src/Authenticator/common/index.ts
+++ b/packages/react-native/src/Authenticator/common/index.ts
@@ -1,1 +1,2 @@
+export * from './DefaultHeader';
 export * from './FederatedProviderButton';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change adds a default header for Authenticator sub components.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
