### PR TITLE
chore(ci): bump `actions/checkout` to V3

### DIFF
--- a/.github/workflows/build-and-runtime-test.yml
+++ b/.github/workflows/build-and-runtime-test.yml
@@ -28,15 +28,15 @@ jobs:
           - vue/vite3
           - vue/vuecli
     steps:
-      - name: Checkout Amplify UI
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
       - name: Setup Node.js LTS
         uses: actions/setup-node@v3
         with:
           node-version: lts/*
           cache: 'yarn'
+      - name: Checkout Amplify UI
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Install canary package
         uses: ./.github/actions/install-with-retries
         with:

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -23,6 +23,11 @@ jobs:
     outputs:
       has-changesets: ${{ steps.has-changesets.outputs.has-changesets }}
     steps:
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          cache: 'yarn'
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
@@ -45,6 +50,11 @@ jobs:
     environment: ci
     if: ${{ needs.setup.outputs.has-changesets != 'true' }}
     steps:
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          cache: 'yarn'
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Add Amplify CLI

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout Amplify UI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Checkout Amplify UI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.commit }}
           repository: ${{ inputs.repository }}
@@ -208,7 +208,7 @@ jobs:
 
     steps:
       - name: Checkout Amplify UI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # For `pull_request_target`, we want ref to point to `pull_request.head.ref` because `github.ref`
           # always points to the target branch.
@@ -355,7 +355,7 @@ jobs:
       NODE_ENV: test
     steps:
       - name: Checkout Amplify UI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.commit }}
           repository: ${{ inputs.repository }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Bumps `actions/checkout` to v3, which will get rid of all `Node.js 12` deprecated warnings:

<img width="1358" alt="Screen Shot 2022-10-22 at 5 54 12 PM" src="https://user-images.githubusercontent.com/43682783/197368029-0ba15a94-d5b9-4a1b-a5a7-fe529ea1d3b3.png">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

This is a clean version bump. Looking at https://github.com/actions/checkout/releases/tag/v3.0.0, their only breaking change is using Node.js 16 by default. We were running on it anyway, so no changes from our end need to be made.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
