### PR TITLE
chore(ci): fix `publish-latest` + `build-and-runtime-test`

### DIFF
--- a/.github/workflows/build-and-runtime-test.yml
+++ b/.github/workflows/build-and-runtime-test.yml
@@ -28,11 +28,6 @@ jobs:
           - vue/vite3
           - vue/vuecli
     steps:
-      - name: Setup Node.js LTS
-        uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-          cache: 'yarn'
       - name: Checkout Amplify UI
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -23,11 +23,6 @@ jobs:
     outputs:
       has-changesets: ${{ steps.has-changesets.outputs.has-changesets }}
     steps:
-      - name: Setup Node.js LTS
-        uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-          cache: 'yarn'
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
@@ -50,11 +45,6 @@ jobs:
     environment: ci
     if: ${{ needs.setup.outputs.has-changesets != 'true' }}
     steps:
-      - name: Setup Node.js LTS
-        uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-          cache: 'yarn'
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Add Amplify CLI


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Removes erroneous `setup-node` in `publish-latest` scripts.

#### Details

There was a CI regression in #2789 , where `setup-node` was mistakenly introduced before `checkout`. These `setup-node` there aren't really necessary in these step because:
-  We don't use its [caching](https://github.com/actions/setup-node#caching-global-packages-data) capability
- Actions run on `Node.js` 16 by default now too ([blog](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/)), 

So we are just removing them back.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
