### PR TITLE
chore(rna): return unverifiedContactMethods as fields from useAuthenticator

### DIFF
--- a/packages/react-core/src/Authenticator/hooks/useAuthenticator/__tests__/__snapshots__/useAuthenticator.spec.tsx.snap
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticator/__tests__/__snapshots__/useAuthenticator.spec.tsx.snap
@@ -98,7 +98,9 @@ Object {
   "toResetPassword": [Function],
   "toSignIn": [Function],
   "toSignUp": [Function],
-  "unverifiedContactMethods": Array [],
+  "unverifiedContactMethods": Object {
+    "email": "test#example.com",
+  },
   "updateBlur": [Function],
   "updateForm": [Function],
   "user": Object {},

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticator/__tests__/useAuthenticator.spec.tsx
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticator/__tests__/useAuthenticator.spec.tsx
@@ -16,7 +16,7 @@ const mockServiceFacade: AuthenticatorServiceFacade = {
   isPending: false,
   route: 'idle',
   socialProviders: [],
-  unverifiedContactMethods: [] as UseAuthenticator['unverifiedContactMethods'],
+  unverifiedContactMethods: { email: 'test#example.com' },
   user: {} as UseAuthenticator['user'],
   validationErrors:
     undefined as unknown as UseAuthenticator['validationErrors'],

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticator/__tests__/utils.spec.tsx
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticator/__tests__/utils.spec.tsx
@@ -11,7 +11,7 @@ import {
   areSelectorDepsEqual,
   defaultComparator,
   getComparator,
-  getLegacyFields,
+  getMachineFields,
   getTotpSecretCodeCallback,
 } from '../utils';
 
@@ -100,17 +100,49 @@ describe('getTotpSecretCodeCallback', () => {
   });
 });
 
-describe('getLegacyFields', () => {
+describe('getMachineFields', () => {
   const state = {} as unknown as AuthMachineState;
   it('calls getSortedFormFields when route is a valid component route', () => {
-    getLegacyFields('signIn', state);
+    getMachineFields('signIn', state, {});
 
     expect(getSortedFormFieldsSpy).toHaveBeenCalledWith('signIn', state);
   });
 
   it('returns an empty array for a non-component route', () => {
-    const output = getLegacyFields('idle', state);
+    const output = getMachineFields('idle', state, {});
 
     expect(output).toHaveLength(0);
+  });
+
+  it('returns expected values for verifyUser route', () => {
+    const output = getMachineFields('verifyUser', state, {
+      email: 'test@example.com',
+    });
+
+    expect(output).toHaveLength(1);
+    expect(output).toStrictEqual([
+      {
+        label: 'test@example.com',
+        name: 'email',
+        value: 'test@example.com',
+        type: 'radio',
+      },
+    ]);
+  });
+
+  it('returns expected values for verifyUser route when contact method is empty', () => {
+    const output = getMachineFields('verifyUser', state, {});
+
+    expect(output).toHaveLength(0);
+    expect(output).toStrictEqual([]);
+  });
+
+  it('returns expected values for verifyUser route when contact method value is invalid', () => {
+    const output = getMachineFields('verifyUser', state, {
+      phone_number: null as unknown as string,
+    });
+
+    expect(output).toHaveLength(1);
+    expect(output).toStrictEqual([{}]);
   });
 });

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticator/useAuthenticator.tsx
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticator/useAuthenticator.tsx
@@ -9,7 +9,7 @@ import { UseAuthenticatorSelector, UseAuthenticator } from './types';
 import {
   defaultComparator,
   getComparator,
-  getLegacyFields,
+  getMachineFields,
   getTotpSecretCodeCallback,
 } from './utils';
 
@@ -37,7 +37,7 @@ export default function useAuthenticator(
 
   const facade = useSelector(service, xstateSelector, comparator);
 
-  const { route, user, ...rest } = facade;
+  const { route, unverifiedContactMethods, user, ...rest } = facade;
 
   // do not memoize output. `service.getSnapshot` reference remains stable preventing
   // `fields` from updating with current form state on value changes
@@ -45,14 +45,20 @@ export default function useAuthenticator(
 
   // legacy `formFields` values required until form state is removed from state machine
   const fields = useMemo(
-    () => getLegacyFields(route, serviceSnapshot as AuthMachineState),
-    [route, serviceSnapshot]
+    () =>
+      getMachineFields(
+        route,
+        serviceSnapshot as AuthMachineState,
+        unverifiedContactMethods
+      ),
+    [route, serviceSnapshot, unverifiedContactMethods]
   );
 
   return {
     ...rest,
     getTotpSecretCode: getTotpSecretCodeCallback(user),
     route,
+    unverifiedContactMethods,
     user,
     /** @deprecated For internal use only */
     fields,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Convert `unverifiedContactMethods` to shape of `AuthenticatorLegacyField` for passing as prop to `VerifyUser` subcomponent


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested, integ and unit tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
