### PR TITLE
chore(ui-react-native): add pressed state style to Button

### DIFF
--- a/packages/react-native/src/Authenticator/common/DefaultFooter/__tests__/__snapshots__/DefaultFooter.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/common/DefaultFooter/__tests__/__snapshots__/DefaultFooter.spec.tsx.snap
@@ -15,6 +15,12 @@ exports[`DefaultFooter renders as expected with children 1`] = `
     onResponderTerminate={[Function]}
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        null,
+        null,
+      ]
+    }
     testID="testButton"
   />
 </View>

--- a/packages/react-native/src/Authenticator/common/FederatedProviderButton/__tests__/__snapshots__/FederatedProviderButton.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/common/FederatedProviderButton/__tests__/__snapshots__/FederatedProviderButton.spec.tsx.snap
@@ -16,16 +16,19 @@ exports[`FederatedProviderButton renders default button as expected 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Array [
-      Object {
-        "alignItems": "center",
-        "borderRadius": 4,
-        "borderWidth": 0.5,
-        "flexDirection": "row",
-        "justifyContent": "center",
-        "paddingVertical": 8,
-        "width": "100%",
-      },
-      undefined,
+      null,
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderRadius": 4,
+          "borderWidth": 0.5,
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "paddingVertical": 8,
+          "width": "100%",
+        },
+        undefined,
+      ],
     ]
   }
 >

--- a/packages/react-native/src/primitives/Button/Button.tsx
+++ b/packages/react-native/src/primitives/Button/Button.tsx
@@ -1,16 +1,32 @@
-import React from 'react';
-import { Pressable, Text } from 'react-native';
+import React, { useCallback } from 'react';
+import {
+  Pressable,
+  PressableStateCallbackType,
+  StyleProp,
+  Text,
+  ViewStyle,
+} from 'react-native';
 
 import { styles } from './styles';
 import { ButtonProps } from './types';
 
 export default function Button({
   children,
+  style,
   textStyle,
-  ...pressableProps
+  ...props
 }: ButtonProps): JSX.Element {
+  const pressableStyle = useCallback(
+    ({ pressed }: PressableStateCallbackType): StyleProp<ViewStyle> => {
+      const pressedStateStyle =
+        (typeof style === 'function' ? style({ pressed }) : style) ?? null;
+      return [pressed ? styles.pressed : null, pressedStateStyle];
+    },
+    [style]
+  );
+
   return (
-    <Pressable {...pressableProps}>
+    <Pressable {...props} style={pressableStyle}>
       {typeof children === 'string' ? (
         <Text style={[styles.text, textStyle]}>{children}</Text>
       ) : (

--- a/packages/react-native/src/primitives/Button/__tests__/__snapshots__/Button.spec.tsx.snap
+++ b/packages/react-native/src/primitives/Button/__tests__/__snapshots__/Button.spec.tsx.snap
@@ -14,6 +14,12 @@ exports[`Button renders as expected with a component passed as children 1`] = `
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      null,
+      null,
+    ]
+  }
 >
   <Text>
     A preesable button
@@ -35,6 +41,12 @@ exports[`Button renders as expected with a string passed as children 1`] = `
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      null,
+      null,
+    ]
+  }
 >
   <Text
     style={

--- a/packages/react-native/src/primitives/Button/styles.ts
+++ b/packages/react-native/src/primitives/Button/styles.ts
@@ -2,5 +2,6 @@ import { StyleSheet } from 'react-native';
 import { ButtonStyles } from './types';
 
 export const styles: ButtonStyles = StyleSheet.create({
+  pressed: { opacity: 0.6 },
   text: { alignSelf: 'center' },
 });

--- a/packages/react-native/src/primitives/Button/types.ts
+++ b/packages/react-native/src/primitives/Button/types.ts
@@ -1,9 +1,10 @@
-import { PressableProps, StyleProp, TextStyle } from 'react-native';
+import { PressableProps, StyleProp, TextStyle, ViewStyle } from 'react-native';
 
 export interface ButtonProps extends PressableProps {
   textStyle?: StyleProp<TextStyle>;
 }
 
 export interface ButtonStyles {
+  pressed: ViewStyle;
   text: TextStyle;
 }

--- a/packages/react-native/src/primitives/Tabs/Tab.tsx
+++ b/packages/react-native/src/primitives/Tabs/Tab.tsx
@@ -13,15 +13,18 @@ export default function Tab({
   textStyle,
   ...rest
 }: TabProps): JSX.Element {
-  const selectedStyles = selected ? styles.selected : undefined;
+  const selectedStyles = selected ? styles.selected : null;
 
   const containerStyle = useCallback(
     ({ pressed }: PressableStateCallbackType): StyleProp<ViewStyle> => {
+      const readonlyStyle = selected ? styles.readonly : null;
       const pressedStateStyle =
-        typeof style === 'function' ? style({ pressed }) : style;
-      return [styles.tab, pressedStateStyle, selectedStyles];
+        (typeof style === 'function' ? style({ pressed }) : style) ?? null;
+
+      // include `pressedStateStyle` last to override other styles
+      return [styles.tab, readonlyStyle, selectedStyles, pressedStateStyle];
     },
-    [selectedStyles, style]
+    [selected, selectedStyles, style]
   );
 
   return (

--- a/packages/react-native/src/primitives/Tabs/__tests__/Tab.spec.tsx
+++ b/packages/react-native/src/primitives/Tabs/__tests__/Tab.spec.tsx
@@ -28,26 +28,34 @@ describe('Tab', () => {
   });
 
   it('renders as expected when Tab is selected', () => {
-    const { queryAllByRole, toJSON } = render(<Tab selected>Selected Tab</Tab>);
+    const { getByRole, toJSON } = render(<Tab selected>Selected Tab</Tab>);
 
     expect(toJSON()).toMatchSnapshot();
 
-    const tab = queryAllByRole('tab');
-    expect((tab[0].props.style as ViewStyle[]).includes(styles.selected)).toBe(
-      true
-    );
+    const tab = getByRole('tab');
+    // select second index as `Button` applies its own style first
+    expect((tab.props.style as ViewStyle[])[1]).toStrictEqual([
+      styles.tab,
+      styles.readonly,
+      styles.selected,
+      null,
+    ]);
   });
 
   it('can apply custom styling', () => {
-    const { queryAllByRole, toJSON } = render(
+    const { getByRole, toJSON } = render(
       <Tab style={customStyles.tabStyle}>Styled Tab</Tab>
     );
 
     expect(toJSON()).toMatchSnapshot();
 
-    const tab = queryAllByRole('tab');
-    expect(
-      (tab[0].props.style as ViewStyle[]).includes(customStyles.tabStyle)
-    ).toBe(true);
+    const tab = getByRole('tab');
+    // select second index as `Button` applies its own style first
+    expect((tab.props.style as ViewStyle[])[1]).toStrictEqual([
+      styles.tab,
+      null,
+      null,
+      customStyles.tabStyle,
+    ]);
   });
 });

--- a/packages/react-native/src/primitives/Tabs/__tests__/Tabs.spec.tsx
+++ b/packages/react-native/src/primitives/Tabs/__tests__/Tabs.spec.tsx
@@ -2,8 +2,6 @@ import React, { useState } from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 
 import { Tab, Tabs } from '..';
-import { styles } from '../styles';
-import { ViewStyle } from 'react-native';
 
 const onChangeMock = jest.fn();
 
@@ -44,20 +42,6 @@ describe('Tabs', () => {
     expect(onChangeMock).toBeCalledWith(1);
     fireEvent.press(tabs[0]);
     expect(onChangeMock).toBeCalledWith(0);
-  });
-
-  it('renders correctly based on selectedIndex', () => {
-    const { queryAllByRole } = render(
-      <ControlledTabs onChangeCallback={onChangeMock} selectedIndex={1} />
-    );
-
-    const tabs = queryAllByRole('tab');
-    expect((tabs[0].props.style as ViewStyle[]).includes(styles.selected)).toBe(
-      false
-    );
-    expect((tabs[1].props.style as ViewStyle[]).includes(styles.selected)).toBe(
-      true
-    );
   });
 
   it('does not allow disabled Tabs to be selected', () => {

--- a/packages/react-native/src/primitives/Tabs/__tests__/__snapshots__/Tab.spec.tsx.snap
+++ b/packages/react-native/src/primitives/Tabs/__tests__/__snapshots__/Tab.spec.tsx.snap
@@ -17,19 +17,23 @@ exports[`Tab can apply custom styling 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Array [
-      Object {
-        "backgroundColor": "#fafafa",
-        "borderTopColor": "#dcdee0",
-        "borderTopWidth": 2,
-        "flexBasis": 0,
-        "flexGrow": 1,
-        "padding": 12,
-      },
-      Object {
-        "backgroundColor": "lavender",
-        "borderTopColor": "rebeccapurple",
-      },
-      undefined,
+      null,
+      Array [
+        Object {
+          "backgroundColor": "#fafafa",
+          "borderTopColor": "#dcdee0",
+          "borderTopWidth": 2,
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "padding": 12,
+        },
+        null,
+        null,
+        Object {
+          "backgroundColor": "lavender",
+          "borderTopColor": "rebeccapurple",
+        },
+      ],
     ]
   }
 >
@@ -46,7 +50,7 @@ exports[`Tab can apply custom styling 1`] = `
             "fontWeight": "800",
           },
           undefined,
-          undefined,
+          null,
         ],
       ]
     }
@@ -73,20 +77,26 @@ exports[`Tab renders as expected when Tab is selected 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Array [
-      Object {
-        "backgroundColor": "#fafafa",
-        "borderTopColor": "#dcdee0",
-        "borderTopWidth": 2,
-        "flexBasis": 0,
-        "flexGrow": 1,
-        "padding": 12,
-      },
-      undefined,
-      Object {
-        "backgroundColor": "#fff",
-        "borderTopColor": "#047d95",
-        "color": "#047d95",
-      },
+      null,
+      Array [
+        Object {
+          "backgroundColor": "#fafafa",
+          "borderTopColor": "#dcdee0",
+          "borderTopWidth": 2,
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "padding": 12,
+        },
+        Object {
+          "opacity": 1,
+        },
+        Object {
+          "backgroundColor": "#fff",
+          "borderTopColor": "#047d95",
+          "color": "#047d95",
+        },
+        null,
+      ],
     ]
   }
 >
@@ -134,16 +144,20 @@ exports[`Tab renders as expected with a component passed as children 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Array [
-      Object {
-        "backgroundColor": "#fafafa",
-        "borderTopColor": "#dcdee0",
-        "borderTopWidth": 2,
-        "flexBasis": 0,
-        "flexGrow": 1,
-        "padding": 12,
-      },
-      undefined,
-      undefined,
+      null,
+      Array [
+        Object {
+          "backgroundColor": "#fafafa",
+          "borderTopColor": "#dcdee0",
+          "borderTopWidth": 2,
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "padding": 12,
+        },
+        null,
+        null,
+        null,
+      ],
     ]
   }
 >
@@ -170,16 +184,20 @@ exports[`Tab renders default Tab as expected 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Array [
-      Object {
-        "backgroundColor": "#fafafa",
-        "borderTopColor": "#dcdee0",
-        "borderTopWidth": 2,
-        "flexBasis": 0,
-        "flexGrow": 1,
-        "padding": 12,
-      },
-      undefined,
-      undefined,
+      null,
+      Array [
+        Object {
+          "backgroundColor": "#fafafa",
+          "borderTopColor": "#dcdee0",
+          "borderTopWidth": 2,
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "padding": 12,
+        },
+        null,
+        null,
+        null,
+      ],
     ]
   }
 >
@@ -196,7 +214,7 @@ exports[`Tab renders default Tab as expected 1`] = `
             "fontWeight": "800",
           },
           undefined,
-          undefined,
+          null,
         ],
       ]
     }

--- a/packages/react-native/src/primitives/Tabs/styles.ts
+++ b/packages/react-native/src/primitives/Tabs/styles.ts
@@ -5,6 +5,9 @@ import { TabsStyles } from './types';
 const SELECTED_COLOR = '#047d95';
 
 export const styles: TabsStyles = StyleSheet.create({
+  readonly: {
+    opacity: 1,
+  },
   tabList: {
     flexDirection: 'row',
     width: '100%',

--- a/packages/react-native/src/primitives/Tabs/types.ts
+++ b/packages/react-native/src/primitives/Tabs/types.ts
@@ -34,8 +34,9 @@ export interface TabProps extends ButtonProps {
 }
 
 export interface TabsStyles {
+  readonly: ViewStyle;
+  selected: ViewStyle;
   tabList: ViewStyle;
   tab: ViewStyle;
   tabText: TextStyle;
-  selected: ViewStyle;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add a default pressed state style to `Button`
- update unit tests
- add `readonly` prop to `Tab` to prevent opacity change on press of selected `Tab`
- 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested, updated unit tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
