### PR TITLE
chore(ci): run react-native tests on next-release

### DIFF
--- a/.github/workflows/test-next-release-prs.yml
+++ b/.github/workflows/test-next-release-prs.yml
@@ -1,11 +1,11 @@
-# Description: This workflow runs unit + e2e tests on PRs targeting `main` and
-#              other protected branches listed below.
+# Description: This workflow runs unit + e2e tests on PRs targeting
+#   - `next-release/main`
 #
 # Triggered by:
-#   (1) Internal PRs: contirubutor pushes a commit to PRs targeting protected branches.
-#   (2) Fork PRs: maintainer adds "run-test" label to PRs targeting protected branches.
+#   (1) Internal PRs: maintainer pushes a commit to PRs targeting those branches.
+#   (2) Fork PRs: maintainer adds "run-test" label to PRs targeting those branches.
 
-name: Test / PRs
+name: Test / next-release / PRs
 
 concurrency:
   group: e2e-${{ github.event.pull_request.id }}
@@ -13,7 +13,7 @@ concurrency:
 
 on:
   pull_request_target:
-    branches: [main, ui-svelte/main, ui-geo/main, ui-react@v2, studio-release]
+    branches: [next-release/main]
     types: [opened, synchronize, labeled]
 
 permissions:
@@ -40,20 +40,14 @@ jobs:
             const label = 'run-tests';
             github.issues.removeLabel({ owner, repo, issue_number, name: label });
   test:
-    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@main
+    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@next-release/main
     needs: setup
     with:
       commit: ${{ github.event.pull_request.head.sha }}
       repository: ${{ github.event.pull_request.head.repo.full_name }}
     secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }} # TODO: Remove this
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }} # TODO: Remove this
-      AWS_ACCESS_KEY_ID_AUTH: ${{ secrets.AWS_ACCESS_KEY_ID_AUTH }}
-      AWS_SECRET_ACCESS_KEY_AUTH: ${{ secrets.AWS_SECRET_ACCESS_KEY_AUTH }}
-      AWS_ACCESS_KEY_ID_DATASTORE: ${{ secrets.AWS_ACCESS_KEY_ID_DATASTORE }}
-      AWS_SECRET_ACCESS_KEY_DATASTORE: ${{ secrets.AWS_SECRET_ACCESS_KEY_DATASTORE }}
-      AWS_ACCESS_KEY_ID_GEO: ${{ secrets.AWS_ACCESS_KEY_ID_GEO }}
-      AWS_SECRET_ACCESS_KEY_GEO: ${{ secrets.AWS_SECRET_ACCESS_KEY_GEO }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       DOMAIN: ${{ secrets.DOMAIN }}
       PHONE_NUMBER: ${{ secrets.PHONE_NUMBER }}
       USERNAME: ${{ secrets.USERNAME }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

With `next-release/main` containing RN changes now, we need to run react-native unit tests on that branch. 

For that reason, this PR creates a `test-next-release.yml` that runs `reusable-e2e@next-release/main` instead of `reusable-e2e@main`. This is similar to how we have `test-rna.yml`, `test-in-app-messaging.yml`, etc.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
