### PR TITLE
fix(collection): adding ref to collections

### DIFF
--- a/packages/react/src/primitives/Collection/Collection.tsx
+++ b/packages/react/src/primitives/Collection/Collection.tsx
@@ -13,30 +13,34 @@ import {
   CollectionProps,
   GridCollectionProps,
   ListCollectionProps,
+  Primitive,
 } from '../types';
 import { getItemsAtPage, itemHasText, getPageCount } from './utils';
 
 const DEFAULT_PAGE_SIZE = 10;
 const TYPEAHEAD_DELAY_MS = 300;
 
-const ListCollection = <Item,>({
-  children,
-  direction = 'column',
-  items,
-  ...rest
-}: ListCollectionProps<Item>) => (
-  <Flex direction={direction} {...rest}>
+const ListCollection: Primitive<ListCollectionProps<any>, 'div'> = (
+  { children, direction = 'column', items, ...rest },
+  ref
+) => (
+  <Flex ref={ref} direction={direction} {...rest}>
     {Array.isArray(items) ? items.map(children) : null}
   </Flex>
 );
 
-const GridCollection = <Item,>({
-  children,
-  items,
-  ...rest
-}: GridCollectionProps<Item>) => (
-  <Grid {...rest}>{Array.isArray(items) ? items.map(children) : null}</Grid>
+const ListCollectionWithRef = React.forwardRef(ListCollection);
+
+const GridCollection: Primitive<GridCollectionProps<any>, 'div'> = (
+  { children, items, ...rest },
+  ref
+) => (
+  <Grid ref={ref} {...rest}>
+    {Array.isArray(items) ? items.map(children) : null}
+  </Grid>
 );
+
+const GridCollectionWithRef = React.forwardRef(GridCollection);
 
 const renderCollectionOrNoResultsFound = <Item,>(
   collection: JSX.Element,
@@ -56,23 +60,23 @@ const renderCollectionOrNoResultsFound = <Item,>(
   );
 };
 
-/**
- * [📖 Docs](https://ui.docs.amplify.aws/react/components/collection)
- */
-export const Collection = <Item,>({
-  className,
-  isSearchable,
-  isPaginated,
-  items,
-  itemsPerPage = DEFAULT_PAGE_SIZE,
-  searchFilter = itemHasText,
-  searchLabel = ComponentText.Collection.searchButtonLabel,
-  searchNoResultsFound,
-  searchPlaceholder,
-  type = 'list',
-  testId,
-  ...rest
-}: CollectionProps<Item>): JSX.Element => {
+const CollectionPrimitive: Primitive<CollectionProps<any>, 'div'> = (
+  {
+    className,
+    isSearchable,
+    isPaginated,
+    items,
+    itemsPerPage = DEFAULT_PAGE_SIZE,
+    searchFilter = itemHasText,
+    searchLabel = ComponentText.Collection.searchButtonLabel,
+    searchNoResultsFound,
+    searchPlaceholder,
+    type = 'list',
+    testId,
+    ...rest
+  },
+  ref
+) => {
   const [searchText, setSearchText] = React.useState<string>();
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -100,13 +104,15 @@ export const Collection = <Item,>({
 
   const collection =
     type === 'list' ? (
-      <ListCollection
+      <ListCollectionWithRef
+        ref={ref}
         className={ComponentClassNames.CollectionItems}
         items={items}
         {...rest}
       />
     ) : type === 'grid' ? (
-      <GridCollection
+      <GridCollectionWithRef
+        ref={ref}
         className={ComponentClassNames.CollectionItems}
         items={items}
         {...rest}
@@ -144,4 +150,8 @@ export const Collection = <Item,>({
   );
 };
 
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/collection)
+ */
+export const Collection = React.forwardRef(CollectionPrimitive);
 Collection.displayName = 'Collection';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Collection component does not forward refs. Some animation libraries like https://auto-animate.formkit.com/ use refs to animate when children of an element change. Collections need refs to have that happen. 

*NOTE: PLEASE HELP WITH THE TS. IT MAKES NO SENSE TO ME.*

TODO
- [ ] Fix Collection unit test, I broke the type somehow


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes


https://user-images.githubusercontent.com/321279/198384891-e7ea9eb8-1199-4da4-ab12-666b394aa0eb.mp4



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
