### PR TITLE
chore(next-release): use named imports instead of default imports

### DIFF
--- a/canary/apps/angular/angularcli/src/app/app.module.ts
+++ b/canary/apps/angular/angularcli/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { BrowserModule } from '@angular/platform-browser';
 
 import { AppComponent } from './app.component';
 import { AmplifyAuthenticatorModule } from '@aws-amplify/ui-angular';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import aws_exports from '../../../../../environments/auth-with-email/src/aws-exports.js';
 Amplify.configure(aws_exports);
 

--- a/canary/apps/react/cra-ts/src/App.tsx
+++ b/canary/apps/react/cra-ts/src/App.tsx
@@ -7,7 +7,7 @@ import {
   useAuthenticator,
 } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import aws_exports from '../../../../environments/auth-with-email/src/aws-exports.js';
 Amplify.configure(aws_exports);
 

--- a/canary/apps/react/cra/src/App.js
+++ b/canary/apps/react/cra/src/App.js
@@ -7,7 +7,7 @@ import {
   useAuthenticator,
 } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import aws_exports from '../../../../environments/auth-with-email/src/aws-exports.js';
 Amplify.configure(aws_exports);
 

--- a/canary/apps/react/next/pages/index.js
+++ b/canary/apps/react/next/pages/index.js
@@ -7,7 +7,7 @@ import {
   useAuthenticator,
 } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import aws_exports from '../../../../environments/auth-with-email/src/aws-exports.js';
 Amplify.configure(aws_exports);
 

--- a/canary/apps/react/vite/src/App.jsx
+++ b/canary/apps/react/vite/src/App.jsx
@@ -7,7 +7,7 @@ import {
   useAuthenticator,
 } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import aws_exports from '../../../../environments/auth-with-email/src/aws-exports.js';
 Amplify.configure(aws_exports);
 

--- a/canary/apps/react/vite3/src/App.tsx
+++ b/canary/apps/react/vite3/src/App.tsx
@@ -7,7 +7,7 @@ import {
   useAuthenticator,
 } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import aws_exports from '../../../../environments/auth-with-email/src/aws-exports';
 Amplify.configure(aws_exports);
 

--- a/canary/apps/vue/vite/src/App.vue
+++ b/canary/apps/vue/vite/src/App.vue
@@ -2,7 +2,7 @@
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import aws_exports from '../../../../environments/auth-with-email/src/aws-exports';
 
 Amplify.configure(aws_exports);

--- a/canary/apps/vue/vuecli/src/App.vue
+++ b/canary/apps/vue/vuecli/src/App.vue
@@ -2,7 +2,7 @@
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import aws_exports from '../../../../environments/auth-with-email/src/aws-exports';
 
 Amplify.configure(aws_exports);

--- a/docs/src/components/home/sections/AuthenticationSection.tsx
+++ b/docs/src/components/home/sections/AuthenticationSection.tsx
@@ -54,7 +54,7 @@ export default function App() {
   import { Authenticator } from "@aws-amplify/ui-vue";
   import "@aws-amplify/ui-vue/styles.css";
 
-  import Amplify from 'aws-amplify';
+  import { Amplify } from 'aws-amplify';
   import awsconfig from './aws-exports';
 
   Amplify.configure(awsconfig);

--- a/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsExports from './aws-exports';
 
 @Component({

--- a/examples/angular/src/pages/ui/components/authenticator/custom-slots/custom-slots.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/custom-slots/custom-slots.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { AuthenticatorService } from '@aws-amplify/ui-angular';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 
 import awsExports from './aws-exports';
 

--- a/examples/angular/src/pages/ui/components/authenticator/hub-events/hub-events.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/hub-events/hub-events.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import Amplify, { Auth } from 'aws-amplify';
+import { Amplify, Auth } from 'aws-amplify';
 import awsExports from './aws-exports';
 
 @Component({

--- a/examples/angular/src/pages/ui/components/authenticator/i18n/i18n.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/i18n/i18n.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { translations } from '@aws-amplify/ui-angular';
 import awsExports from './aws-exports';
-import Amplify, { I18n } from 'aws-amplify';
+import { Amplify, I18n } from 'aws-amplify';
 @Component({
   selector: 'i18n',
   templateUrl: 'i18n.component.html',

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-federated/sign-in-federated.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-federated/sign-in-federated.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsExports from './aws-exports';
 
 @Component({

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsExports from './aws-exports';
 
 @Component({

--- a/examples/vue/src/pages/ui/components/authenticator/hub-events/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/hub-events/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify, { Auth } from 'aws-amplify';
+import { Amplify, Auth } from 'aws-amplify';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from './aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-sms-mfa/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-sms-mfa/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify, { I18n } from 'aws-amplify';
+import { Amplify, I18n } from 'aws-amplify';
 import '@aws-amplify/ui-vue/styles.css';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import { translations } from '@aws-amplify/ui';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify, { Auth } from 'aws-amplify';
+import { Amplify, Auth } from 'aws-amplify';
 import { Authenticator } from '@aws-amplify/ui-vue';
 import '@aws-amplify/ui-vue/styles.css';
 import aws_exports from './aws-exports';

--- a/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-up-with-email/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Amplify, { Auth, I18n } from 'aws-amplify';
+import { Amplify, Auth, I18n } from 'aws-amplify';
 import {
   Authenticator,
   translations,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR updates our code to use named imports instead of default imports to import Amplify JS resources, because Amplify JS is [dropping support](https://github.com/aws-amplify/amplify-js/pull/10461) for default imports/exports.

#### Description of how you validated changes

Ran `yarn install` and `yarn build` on canaries locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
