### PR TITLE
fix(docs): Heading demo showing initial text/level

### DIFF
--- a/docs/src/pages/[platform]/components/heading/demo.tsx
+++ b/docs/src/pages/[platform]/components/heading/demo.tsx
@@ -19,7 +19,10 @@ const propsToCode = (
 </Heading>`;
 };
 
-const defaultHeadingProps = {};
+const defaultHeadingProps = {
+  value: 'Heading text',
+  level: 6,
+};
 
 export const HeadingDemo = () => {
   const { level, setLevel, isTruncated, setIsTruncated, value, setValue } =


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

[Heading demo](https://ui.docs.amplify.aws/react/components/heading#demo) is not currently showing initial text or heading level.

**Before**

<img width="300" src="https://user-images.githubusercontent.com/376920/199531143-d9db8827-ce11-4a33-bf5f-5ec72f214eef.png" />

**After**

<img width="300" src="https://user-images.githubusercontent.com/376920/199531192-c6574823-bc95-48f9-ac1a-c60ec83b048d.png" />

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
