### PR TITLE
feat(in-app-messaging): add NextJS example apps

### DIFF
--- a/examples/next/pages/ui/components/in-app-messaging/basic-usage-hoc/aws-exports.js
+++ b/examples/next/pages/ui/components/in-app-messaging/basic-usage-hoc/aws-exports.js
@@ -1,0 +1,8 @@
+// This is a temporary amplify exports file.
+// You must supply the config from your own in-app env.
+// The Demo app will still function without values below,
+// but will throw warnings on some displayMessage calls
+
+const awsmobile = {};
+
+export default awsmobile;

--- a/examples/next/pages/ui/components/in-app-messaging/basic-usage-hoc/index.page.tsx
+++ b/examples/next/pages/ui/components/in-app-messaging/basic-usage-hoc/index.page.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+import { Amplify, Notifications } from 'aws-amplify';
+import { Text, withInAppMessaging } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+import config from './aws-exports';
+
+const { InAppMessaging } = Notifications;
+
+Amplify.configure(config);
+
+function App() {
+  useEffect(() => {
+    // sync remote in-app messages
+    InAppMessaging.syncMessages();
+  }, []);
+
+  return <Text>In-App Messaging Example</Text>;
+}
+
+export default withInAppMessaging(App);

--- a/examples/next/pages/ui/components/in-app-messaging/basic-usage-provider/aws-exports.js
+++ b/examples/next/pages/ui/components/in-app-messaging/basic-usage-provider/aws-exports.js
@@ -1,0 +1,8 @@
+// This is a temporary amplify exports file.
+// You must supply the config from your own in-app env.
+// The Demo app will still function without values below,
+// but will throw warnings on some displayMessage calls
+
+const awsmobile = {};
+
+export default awsmobile;

--- a/examples/next/pages/ui/components/in-app-messaging/basic-usage-provider/index.page.tsx
+++ b/examples/next/pages/ui/components/in-app-messaging/basic-usage-provider/index.page.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react';
+import { Amplify, Notifications } from 'aws-amplify';
+import {
+  Text,
+  InAppMessagingProvider,
+  InAppMessageDisplay,
+} from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+import config from './aws-exports';
+
+const { InAppMessaging } = Notifications;
+
+Amplify.configure(config);
+
+function App() {
+  useEffect(() => {
+    // sync remote in-app messages
+    InAppMessaging.syncMessages();
+  }, []);
+
+  return (
+    <InAppMessagingProvider>
+      <InAppMessageDisplay />
+      <Text>In-App Messaging Example</Text>
+    </InAppMessagingProvider>
+  );
+}
+
+export default App;

--- a/examples/next/pages/ui/components/in-app-messaging/override-component/aws-exports.js
+++ b/examples/next/pages/ui/components/in-app-messaging/override-component/aws-exports.js
@@ -1,0 +1,8 @@
+// This is a temporary amplify exports file.
+// You must supply the config from your own in-app env.
+// The Demo app will still function without values below,
+// but will throw warnings on some displayMessage calls
+
+const awsmobile = {};
+
+export default awsmobile;

--- a/examples/next/pages/ui/components/in-app-messaging/override-component/index.page.tsx
+++ b/examples/next/pages/ui/components/in-app-messaging/override-component/index.page.tsx
@@ -22,11 +22,11 @@ const CustomBannerMessage = (props) => {
   return (
     <Flex
       alignItems="center"
-      borderRadius=".5rem"
+      borderRadius="xs"
       position="absolute"
-      padding="2rem"
-      backgroundColor={theme.tokens.colors.teal[20]}
-      right="2rem"
+      padding="xl"
+      backgroundColor="teal.20"
+      right="xl"
     >
       <Text fontWeight="bold">{props.header.content}</Text>
       <Button onClick={props.onClose}>Close!</Button>

--- a/examples/next/pages/ui/components/in-app-messaging/override-component/index.page.tsx
+++ b/examples/next/pages/ui/components/in-app-messaging/override-component/index.page.tsx
@@ -5,7 +5,6 @@ import {
   Flex,
   Text,
   useInAppMessaging,
-  useTheme,
   withInAppMessaging,
 } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';

--- a/examples/next/pages/ui/components/in-app-messaging/override-component/index.page.tsx
+++ b/examples/next/pages/ui/components/in-app-messaging/override-component/index.page.tsx
@@ -16,8 +16,6 @@ const { InAppMessaging } = Notifications;
 Amplify.configure(config);
 
 const CustomBannerMessage = (props) => {
-  const theme = useTheme();
-
   return (
     <Flex
       alignItems="center"

--- a/examples/next/pages/ui/components/in-app-messaging/override-component/index.page.tsx
+++ b/examples/next/pages/ui/components/in-app-messaging/override-component/index.page.tsx
@@ -1,0 +1,67 @@
+import React, { useCallback, useEffect } from 'react';
+import { Amplify, Notifications } from 'aws-amplify';
+import {
+  Button,
+  Flex,
+  Text,
+  useInAppMessaging,
+  useTheme,
+  withInAppMessaging,
+} from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+import config from './aws-exports';
+
+const { InAppMessaging } = Notifications;
+
+Amplify.configure(config);
+
+const CustomBannerMessage = (props) => {
+  const theme = useTheme();
+
+  return (
+    <Flex
+      alignItems="center"
+      borderRadius=".5rem"
+      position="absolute"
+      padding="2rem"
+      backgroundColor={theme.tokens.colors.teal[20]}
+      right="2rem"
+    >
+      <Text fontWeight="bold">{props.header.content}</Text>
+      <Button onClick={props.onClose}>Close!</Button>
+    </Flex>
+  );
+};
+
+function App() {
+  const { displayMessage } = useInAppMessaging();
+
+  useEffect(() => {
+    // sync remote in-app messages
+    InAppMessaging.syncMessages();
+  }, []);
+
+  const displayCustomBannerMessage = useCallback(
+    () =>
+      displayMessage({
+        content: [{ header: { content: 'Hello World!' } }],
+        id: 'Custom message',
+        layout: 'TOP_BANNER',
+      }),
+    [displayMessage]
+  );
+
+  // display custom message component on initial render
+  useEffect(displayCustomBannerMessage, [displayCustomBannerMessage]);
+
+  return (
+    <Button margin="medium" onClick={displayCustomBannerMessage}>
+      Display Custom Banner Message
+    </Button>
+  );
+}
+
+export default withInAppMessaging(App, {
+  components: { BannerMessage: CustomBannerMessage },
+});

--- a/examples/next/pages/ui/components/in-app-messaging/override-styling/index.page.tsx
+++ b/examples/next/pages/ui/components/in-app-messaging/override-styling/index.page.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Amplify } from 'aws-amplify';
+import { Amplify, Notifications } from 'aws-amplify';
 import {
   Button,
   InAppMessageDisplay,
@@ -10,9 +10,11 @@ import '@aws-amplify/ui-react/styles.css';
 
 import config from './aws-exports';
 
+const { InAppMessaging } = Notifications;
+
 Amplify.configure(config);
 
-const CustomModalMessage = (props) => (
+const StyledModalMessage = (props) => (
   <InAppMessageDisplay.ModalMessage
     {...props}
     style={{ container: { backgroundColor: 'antiquewhite' } }}
@@ -22,26 +24,31 @@ const CustomModalMessage = (props) => (
 function App() {
   const { displayMessage } = useInAppMessaging();
 
-  const displayCustomModalMessage = useCallback(
+  useEffect(() => {
+    // sync remote in-app messages
+    InAppMessaging.syncMessages();
+  }, []);
+
+  const displayStyledModalMessage = useCallback(
     () =>
       displayMessage({
         content: [{ header: { content: 'Hello World!' } }],
-        id: 'custom message',
+        id: 'styled message',
         layout: 'MODAL',
       }),
     [displayMessage]
   );
 
   // display message component on initial render
-  useEffect(displayCustomModalMessage, [displayCustomModalMessage]);
+  useEffect(displayStyledModalMessage, [displayStyledModalMessage]);
 
   return (
-    <Button margin="medium" onClick={displayCustomModalMessage}>
+    <Button margin="medium" onClick={displayStyledModalMessage}>
       Display Custom Modal Message
     </Button>
   );
 }
 
 export default withInAppMessaging(App, {
-  components: { ModalMessage: CustomModalMessage },
+  components: { ModalMessage: StyledModalMessage },
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add In-App Messaging NextJS example apps:
- basic usage with `InAppMessagingProvider`
- basic usage with `withInAppMessaging`
- component override
- update style override

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested sample apps
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
