### PR TITLE
feat: add resumable as a prop

### DIFF
--- a/packages/react/src/components/Storage/FileUploader/Previewer/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Previewer/index.tsx
@@ -77,7 +77,10 @@ export function Previewer({
         <View>
           {isLoading && (
             <>
-              <Text>Uploading: {percentage}%</Text>
+              <Text>
+                {translate('Uploading')}
+                {percentage > 0 ? `: ${percentage}%` : ''}
+              </Text>
               <Loader
                 className={ComponentClassNames.FileUploaderLoader}
                 variation="linear"

--- a/packages/react/src/components/Storage/FileUploader/Tracker/FileState.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/FileState.tsx
@@ -12,12 +12,15 @@ export const FileState = ({
   percentage,
 }: FileStateProps): JSX.Element => {
   switch (fileState) {
-    case 'loading':
+    case 'loading': {
+      let text = translate('Uploading');
+      if (percentage > 0) text = text + `: ${percentage}%`;
       return (
         <Text className={ComponentClassNames.FileUploaderFileStatus}>
-          {translate('Loading')}: {percentage}%
+          {text}
         </Text>
       );
+    }
     case 'paused':
       return (
         <Text className={ComponentClassNames.FileUploaderFileStatus}>
@@ -43,7 +46,10 @@ export const FileState = ({
         <Text
           className={classNames(
             ComponentClassNames.FileUploaderFileStatus,
-            classNameModifier(ComponentClassNames.FileUploaderFileStatus, 'error')
+            classNameModifier(
+              ComponentClassNames.FileUploaderFileStatus,
+              'error'
+            )
           )}
         >
           <IconError fontSize="xl" /> {errorMessage}

--- a/packages/react/src/components/Storage/FileUploader/Tracker/__tests__/FileState.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/__tests__/FileState.test.tsx
@@ -17,7 +17,7 @@ describe('FileState', () => {
       <FileState fileState={'loading'} percentage={10} errorMessage={''} />
     );
 
-    expect(await findByText('Loading: 10%')).toBeVisible();
+    expect(await findByText('Uploading: 10%')).toBeVisible();
   });
   it('displays paused message if fileState is paused', async () => {
     const { findByText } = render(

--- a/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
@@ -98,7 +98,7 @@ export function Tracker({
     }
   };
 
-  const isDeterminate = !resumable || (resumable && percentage === 0);
+  const isDeterminate = !resumable || (resumable && percentage > 0);
 
   return (
     <View className={ComponentClassNames.FileUploaderFile}>

--- a/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
@@ -33,6 +33,7 @@ export function Tracker({
   isEditing,
   onSaveEdit,
   onStartEdit,
+  resumable,
 }: TrackerProps): JSX.Element {
   if (!file) return null;
 
@@ -67,6 +68,7 @@ export function Tracker({
           </Button>
         );
       case 'loading':
+        if (!resumable) return null;
         return (
           <Button onClick={onPause} size="small" variation="link">
             {translate('pause')}
@@ -96,6 +98,8 @@ export function Tracker({
     }
   };
 
+  const isDeterminate = !resumable || (resumable && percentage === 0);
+
   return (
     <View className={ComponentClassNames.FileUploaderFile}>
       <View className={ComponentClassNames.FileUploaderFileImage}>{icon}</View>
@@ -124,7 +128,7 @@ export function Tracker({
           className={ComponentClassNames.FileUploaderLoader}
           variation="linear"
           percentage={percentage}
-          isDeterminate
+          isDeterminate={isDeterminate}
           isPercentageTextHidden
         />
       ) : null}

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -93,6 +93,7 @@ describe('File Uploader', () => {
       file: fakeFile,
       fileName: fakeFile.name,
       level: 'public',
+      resumable: false,
       progressCallback: expect.any(Function),
     });
   });
@@ -155,6 +156,7 @@ describe('File Uploader', () => {
       file: fakeFile,
       fileName: fileName2,
       level: 'public',
+      resumable: false,
       progressCallback: expect.any(Function),
     });
   });

--- a/packages/react/src/components/Storage/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/types.ts
@@ -34,6 +34,7 @@ export interface FileUploaderProps {
   onSuccess?: (event: { key: string }) => void;
   path?: string;
   variation?: 'drop' | 'button';
+  resumable?: boolean;
 }
 
 export interface IconProps {
@@ -62,6 +63,7 @@ export interface TrackerProps {
   fileState: FileState;
   hasImage: boolean;
   url: string;
+  resumable?: boolean;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onCancel: () => void;
   onPause: () => void;

--- a/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
+++ b/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
@@ -36,7 +36,8 @@ export function uploadFile({
       resumable,
       progressCallback,
       errorCallback,
-      // hack to remove the bucket name at the beginning
+      // TODO: Remove this override once we depend on aws-amplify@5
+      // this behavior is fixed in version 5
       completeCallback: (event) => {
         completeCallback({ key: event.key.split('/').slice(1).join('/') });
       },

--- a/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
+++ b/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
@@ -19,21 +19,37 @@ export function uploadFile({
   progressCallback,
   errorCallback,
   completeCallback,
+  resumable = false,
+  ...rest
 }: {
   file: File;
   fileName: string;
   level: StorageAccessLevel;
+  resumable?: boolean;
   progressCallback: (progress: { loaded: number; total: number }) => void;
   errorCallback: (err: string) => void;
   completeCallback: (event) => void;
-}): UploadTask {
-  return Storage.put(fileName, file, {
-    level,
-    resumable: true,
-    progressCallback,
-    errorCallback,
-    completeCallback,
-  });
+}) {
+  if (resumable === true) {
+    return Storage.put(fileName, file, {
+      level,
+      resumable,
+      progressCallback,
+      errorCallback,
+      // hack to remove the bucket name at the beginning
+      completeCallback: (event) => {
+        completeCallback({ key: event.key.split('/').slice(1).join('/') });
+      },
+      ...rest,
+    });
+  } else {
+    return Storage.put(fileName, file, {
+      level,
+      resumable: false,
+      progressCallback,
+      ...rest,
+    }).then(completeCallback, errorCallback);
+  }
 }
 /**
  * Format bytes as human-readable text.

--- a/packages/ui/src/theme/css/component/fileUploader.scss
+++ b/packages/ui/src/theme/css/component/fileUploader.scss
@@ -125,12 +125,14 @@
   
   // Previewer
   &__previewer {
-    max-height: var(--amplify-components-fileuploader-previewer-max-height);
+    display: block;
+    
     max-width: var(--amplify-components-fileuploader-previewer-max-width);
     background-color: var(--amplify-components-fileuploader-previewer-background-color);
     border-width: var(--amplify-components-fileuploader-previewer-border-width);
     border-style: var(--amplify-components-fileuploader-previewer-border-style);
     border-color: var(--amplify-components-fileuploader-previewer-border-color);
+    border-radius: var(--amplify-components-fileuploader-previewer-border-radius);
     
     padding-inline: var(--amplify-components-fileuploader-previewer-padding-inline);
     padding-block: var(--amplify-components-fileuploader-previewer-padding-block);
@@ -144,6 +146,7 @@
     &__body {
       display: flex;
       flex-direction: column;
+      max-height: var(--amplify-components-fileuploader-previewer-max-height);
 
       overflow: auto;
       gap: var(--amplify-components-fileuploader-previewer-body-gap);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Added the ability for uploads to be resumable or not. In doing so had to write a hack to fix the Storage lib's code. 

Need some help on my Typescript. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes


https://user-images.githubusercontent.com/321279/200904115-714aaf32-631a-4cf8-ad37-e909a9a960d2.mp4



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
