### PR TITLE
fix(docs): url param to set tab

### DIFF
--- a/docs/src/components/Layout/PageTabLayout.tsx
+++ b/docs/src/components/Layout/PageTabLayout.tsx
@@ -3,20 +3,28 @@ import { useRouter } from 'next/router';
 
 import { Tabs, TabItem, View } from '@aws-amplify/ui-react';
 
-export const PageTabLayout = ({ tabComponents }) => {
+export const PageTabLayout = ({
+  tabComponents,
+}: {
+  tabComponents: [{ title: string; children: React.Component }];
+}) => {
   const {
     query: { tab = '', platform },
     pathname,
     push,
   } = useRouter();
+  const tabComponentsMap = tabComponents.map(({ title }) =>
+    title.toLocaleLowerCase()
+  );
 
-  const defaultIndex = tab === 'props' ? 1 : 0;
+  const getIndex = (tab: string) =>
+    tab === '' ? 0 : tabComponentsMap.indexOf(tab);
+  const defaultIndex = getIndex(tab as string);
   const [tabIndex, setTabIndex] = React.useState(defaultIndex);
-
   const changeURL = (index) => {
     push(
       {
-        pathname: index == 0 ? pathname.replace('/[tab]', '') : pathname,
+        pathname,
         query: {
           platform,
           ...(index != 0 && { tab: tabComponents[index].title.toLowerCase() }),
@@ -27,6 +35,10 @@ export const PageTabLayout = ({ tabComponents }) => {
     );
     setTabIndex(index);
   };
+
+  React.useEffect(() => {
+    setTabIndex(getIndex(tab as string));
+  }, [tab, getIndex]);
 
   return (
     <Tabs


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**Issue**: When using a link with `?tab=props` on a component's page, the tab doesn't change to the Props tab. e.g. https://ui.docs.amplify.aws/react/components/flex?tab=props


https://user-images.githubusercontent.com/11983489/201013047-b19384fc-bfd9-40de-a958-366781fb788c.mov

**Reason**: the `tab` param is an empty string first and then updated, but since the value's already set, the component won't re-render.

**Fix**: update whenever `tab` changes.

**Other code change**: before this PR, `PageTabLayout` component only works for `props` tab in the current scenario. This PR makes `PageTabLayout` generic.
 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Local and Amplify Hosting https://fix-pagetablayout.drxs1ztvfjtps.amplifyapp.com/

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
