### PR TITLE
chore(canary): Updated canaries to v4

### DIFF
--- a/canary/apps/angular/angularcli/package.json
+++ b/canary/apps/angular/angularcli/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser-dynamic": "~11.2.14",
     "@angular/router": "~11.2.14",
     "@aws-amplify/ui-angular": "latest",
-    "aws-amplify": "latest",
+    "aws-amplify": "^4",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.3"

--- a/canary/apps/react/cra-ts/package.json
+++ b/canary/apps/react/cra-ts/package.json
@@ -11,7 +11,7 @@
     "@types/node": "^16.11.22",
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
-    "aws-amplify": "latest",
+    "aws-amplify": "^4",
     "react": "latest",
     "react-dom": "latest",
     "react-scripts": "5.0.0",

--- a/canary/apps/react/cra/package.json
+++ b/canary/apps/react/cra/package.json
@@ -7,7 +7,7 @@
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
-    "aws-amplify": "latest",
+    "aws-amplify": "^4",
     "react": "latest",
     "react-dom": "latest",
     "react-scripts": "5.0.0",

--- a/canary/apps/react/next/package.json
+++ b/canary/apps/react/next/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-react": "latest",
-    "aws-amplify": "latest",
+    "aws-amplify": "^4",
     "next": "12.0.10",
     "react": "latest",
     "react-dom": "latest"

--- a/canary/apps/react/vite/package.json
+++ b/canary/apps/react/vite/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-react": "latest",
-    "aws-amplify": "^4.3.15",
+    "aws-amplify": "^4",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/canary/apps/react/vite3/package.json
+++ b/canary/apps/react/vite3/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-react": "latest",
-    "aws-amplify": "latest",
+    "aws-amplify": "^4",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/canary/apps/vue/vite/package.json
+++ b/canary/apps/vue/vite/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-vue": "latest",
-    "aws-amplify": "latest",
+    "aws-amplify": "^4",
     "vue": "^3.2.27"
   },
   "devDependencies": {

--- a/canary/apps/vue/vite3/package.json
+++ b/canary/apps/vue/vite3/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-vue": "latest",
-    "aws-amplify": "latest",
+    "aws-amplify": "^4",
     "vue": "^3.2.37"
   },
   "devDependencies": {

--- a/canary/apps/vue/vuecli/package.json
+++ b/canary/apps/vue/vuecli/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-vue": "latest",
-    "aws-amplify": "latest",
+    "aws-amplify": "^4",
     "core-js": "^3.6.5",
     "vue": "^3.0.0"
   },


### PR DESCRIPTION
#### Description of changes
Due to the latest JS update, we are setting our canaries to run on v4 for now.

#### Issue #, if available

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
