### PR TITLE
docs(next-release): improve wordings in migration guide

### DIFF
--- a/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
@@ -33,14 +33,13 @@ If your application is on Angular 11 or older, please migrate to Angular 12+ as 
 
 #### 2. `@aws-amplify/ui-angular@3.x` migrates Angular compiler to IVY
 
-`@aws-amplify/ui-angular@3.x` drops support for legacy View engine, and migrated to IVY compiler. Please migrate to Angular 12+, and make sure you did not disable ivy in your `tsconfig.json`:
+`@aws-amplify/ui-angular@3.x` drops support for legacy View engine, and migrated to IVY compiler. Please migrate to Angular 12+, and make sure you did not disable ivy in your `tsconfig.json`. In particular, please remove `"enableIvy": false` in your `tsconfig.json`:
 
-```json
+```diff
 {
   ...,
   "angularCompilerOption": {
-    // REMOVE this line if you have it in your tsconfig.json
-    "enableIvy": false
+-    "enableIvy": false
   }
 }
 ```

--- a/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
@@ -23,9 +23,29 @@ yarn add aws-amplify@5.x @aws-amplify/ui-angular@3.x
 
 ### Update and usage
 
-The following breaking changes were introduced in `@aws-amplify/ui-angular` major version `3.0`:
+`@aws-amplify/ui-angular@3.x` introduces the following breaking changes:
 
-#### 1. Automatic signin on signup logic moved to `aws-amplify`. 
+#### 1. `@aws-amplify/ui-angular@3.x` bumps minimum Angular version to 12
+
+If your application is on Angular 11 or older, please migrate to Angular 12+ as per [official guide](https://update.angular.io).
+
+*Note*: Going forward, `@aws-amplify/ui-angular` will have the same version support as Angular's official LTS [support window](https://angular.io/guide/releases#actively-supported-versions). 
+
+#### 2. `@aws-amplify/ui-angular@3.x` migrates Angular compiler to IVY
+
+`@aws-amplify/ui-angular@3.x` drops support for legacy View engine, and migrated to IVY compiler. Please migrate to Angular 12+, and make sure you did not disable ivy in your `tsconfig.json`:
+
+```json
+{
+  ...,
+  "angularCompilerOption": {
+    // REMOVE this line if you have it in your tsconfig.json
+    "enableIvy": false
+  }
+}
+```
+
+#### 3. `@aws-amplify/ui-angular@3.x` removes moves Automatic signin on signup logic to `aws-amplify`. 
 
 If you are overriding `Auth.signUp`, update the override function call to include the `autoSignIn` option set to `enabled`. If this change is not made, users will not be automatically signed in on signup.
 
@@ -47,7 +67,7 @@ If you are overriding `Auth.signUp`, update the override function call to includ
 
 ```
 
-#### 2. Legacy i18n translation keys removed
+#### 4. `@aws-amplify/ui-angular@3.x` removes legacy i18n translation keys
 
 We replaced following legacy Authenticator texts:
 
@@ -57,26 +77,6 @@ We replaced following legacy Authenticator texts:
 - `Forgot your password? ` with the trailing space is replaced by `Forgot your password`.
 
 If you were using `I18n` to translate those keys, please update your translations accordingly to match the new strings.
-
-#### 3. Bumped minimum Angular version to 12
-
-If your application is on Angular 11 or older, please migrate to Angular 12+ as per [official guide](https://update.angular.io).
-
-*Note*: Going forward, `@aws-amplify/ui-angular` will have the same version support as Angular's official LTS [support window](https://angular.io/guide/releases#actively-supported-versions). 
-
-#### 4. Migrated Angular compiler to IVY
-
-We dropped support for legacy View engine, and migrated to IVY compiler. Please migrate to Angular 12+, and make sure you did not disable ivy in your `tsconfig.json`:
-
-```json
-{
-  ...,
-  "angularCompilerOption": {
-    // REMOVE this line if you have it in your tsconfig.json
-    "enableIvy": false
-  }
-}
-```
 
 ## 1.x to 2.x
 ## Installation

--- a/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
@@ -33,7 +33,7 @@ If your application is on Angular 11 or older, please migrate to Angular 12+ as 
 
 #### 2. `@aws-amplify/ui-angular@3.x` migrates Angular compiler to IVY
 
-`@aws-amplify/ui-angular@3.x` drops support for legacy View engine, and migrated to IVY compiler. Please migrate to Angular 12+, and make sure you did not disable ivy in your `tsconfig.json`. In particular, please remove `"enableIvy": false` in your `tsconfig.json`:
+`@aws-amplify/ui-angular@3.x` drops support for legacy View engine, and migrated to the [Ivy compiler](https://docs.angular.lat/guide/ivy). Please migrate to Angular 12+, and make sure you did not disable Ivy in your `tsconfig.json`. In particular, please remove `"enableIvy": false` in your `tsconfig.json`:
 
 ```diff
 {

--- a/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
@@ -44,7 +44,7 @@ If your application is on Angular 11 or older, please migrate to Angular 12+ as 
 }
 ```
 
-#### 3. `@aws-amplify/ui-angular@3.x` removes moves Automatic signin on signup logic to `aws-amplify`. 
+#### 3. `@aws-amplify/ui-angular@3.x` moves automatic signin on signup logic to `aws-amplify`. 
 
 If you are overriding `Auth.signUp`, update the override function call to include the `autoSignIn` option set to `enabled`. If this change is not made, users will not be automatically signed in on signup.
 

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -54,7 +54,7 @@ Also see: [Internationalization](react/getting-started/internationalization)
 
 #### 3. `@aws-amplify/ui-react@4.x` removes legacy component exports
 
-Remove any of the following deprecated components imported from `@aws-amplify/ui-react/legacy`:
+The following deprecated components imported from `@aws-amplify/ui-react/legacy` are removed:
 
 - AmplifyAuthenticator
 - AmplifySignIn

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -41,7 +41,7 @@ Replace any `TextField` components using the `isMultiline` prop with the `TextAr
   If you are NOT using `dir="rtl"` in your application, feel free to skip this item.
 </Alert>
 
-`@aws-amplify/ui-react` has a dependency on Radix components for Menu, SliderField, Tabs, and Expander. There were a number of changes in the [July 21, 2022 release](https://www.radix-ui.com/docs/primitives/overview/releases#july-21-2022) of `radix-ui/*` packages, and the breaking change for `@aws-amplify/ui-react` was removal of support for the `dir` HTML attribute, and the addition of the DirectionProvider. In order to make the transition seamless for most of Amplify users, we've added the `DirectionProvider` with a default `direction` of `ltr` to the `ThemeProvider`.
+`@aws-amplify/ui-react` has a dependency on Radix components for Menu, SliderField, Tabs, and Expander. There were a number of changes in the [July 21, 2022 release](https://www.radix-ui.com/docs/primitives/overview/releases#july-21-2022) of `radix-ui/*` packages, and the breaking change for `@aws-amplify/ui-react` was removal of support for the `dir` HTML attribute, and the addition of the `DirectionProvider`. In order to make the transition seamless for most of Amplify users, we've added the `DirectionProvider` with a default `direction` of `ltr` to the `ThemeProvider`.
 
 If your application is using right to left directionality, the example below shows the needed change for apps using the native HTML `dir="rtl"`:
 

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -80,7 +80,7 @@ Hopefully this change won't affect your code but will allow for more customizati
   The TextAreaField component does apply 1 style prop directly on the `textarea` element: `resize`. We felt this one makes sense to apply direclty on the the `textarea` element and not the wrapper element.
 </Alert>
 
-#### 5. `@aws-amplify/ui-react@4.x` moves Automatic signin on signup logic to `aws-amplify`. 
+#### 5. `@aws-amplify/ui-react@4.x` moves automatic signin on signup logic to `aws-amplify`. 
 
 If you are overriding `Auth.signUp`, update the override function call to include the `autoSignIn` option set to `enabled`. If this change is not made, users will not be automatically signed in on signup.
 

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -102,7 +102,7 @@ If you are overriding `Auth.signUp`, update the override function call to includ
 
 ```
 
-#### 6. `@aws-amplify/ui-react@v4` removes legacy i18n translation keys removed
+#### 6. `@aws-amplify/ui-react@4.x` removes legacy i18n translation keys removed
 
 We replaced following legacy Authenticator texts:
 

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -23,9 +23,9 @@ yarn add aws-amplify@5.x @aws-amplify/ui-react@4.x
 
 ### Update and usage
 
-The following breaking changes were introduced in `@aws-amplify/ui-react` major version `4.0`:
+`@aws-amplify/ui-react@4.x` introduces the following breaking changes:
 
-#### 1. We removed the `isMultiline` prop from `TextField`.
+#### 1. `@aws-amplify/ui-react@4.x` removes `isMultiline` prop from `TextField`.
 
 Replace any `TextField` components using the `isMultiline` prop with the `TextAreaField` component.
 
@@ -35,43 +35,44 @@ Replace any `TextField` components using the `isMultiline` prop with the `TextAr
 + <TextAreaField
 ```
 
-#### 2. Support for text directionality moved to ThemeProvider
+#### 2. `@aws-amplify/ui-react@4.x` moves text directionality support to ThemeProvider
 
 <Alert variation="info" heading="Note">
   If you are NOT using `dir="rtl"` in your application, feel free to skip this item.
 </Alert>
 
-We have a dependency on Radix components for Menu, SliderField, Tabs, and Expander. There were a number of changes in the [July 21, 2022 release](https://www.radix-ui.com/docs/primitives/overview/releases#july-21-2022) of `radix-ui/*` packages, but the breaking change for Amplify UI components was removal of support for the `dir` HTML attribute, and the addition of the DirectionProvider. In order to make the transition seamless for most of our users, we've added the
-`DirectionProvider` with a default `direction` of `ltr` to the `ThemeProvider`.
+`@aws-amplify/ui-react` has a dependency on Radix components for Menu, SliderField, Tabs, and Expander. There were a number of changes in the [July 21, 2022 release](https://www.radix-ui.com/docs/primitives/overview/releases#july-21-2022) of `radix-ui/*` packages, and the breaking change for `@aws-amplify/ui-react` was removal of support for the `dir` HTML attribute, and the addition of the DirectionProvider. In order to make the transition seamless for most of Amplify users, we've added the `DirectionProvider` with a default `direction` of `ltr` to the `ThemeProvider`.
 
-For customers with applications using right to left directionality, the example below shows the needed change for apps using the native HTML `dir="rtl"`:
+If your applications was using right to left directionality, the example below shows the needed change for apps using the native HTML `dir="rtl"`:
 
 ```diff
 - <View dir="rtl">
 + <ThemeProvider direction="rtl">
 ```
+
 Also see: [Internationalization](react/getting-started/internationalization)
 
-#### 3. Legacy component exports removed
+#### 3. `@aws-amplify/ui-react@4.x` removes legacy component exports
 
-Remove any of the following deprecated components imported from `@aws-amplify/ui-react/legacy` .
-* AmplifyAuthenticator
-* AmplifySignIn
-* AmplifySignOut
-* AmplifyChatbot
-* AmplifyPhotoPicker
-* AmplifyPicker
-* AmplifyS3Album
-* AmplifyS3Image
-* AmplifyS3ImagePicker
-* AmplifyS3Text
-* AmplifyS3TextPicker
-* withAuthenticator
+Remove any of the following deprecated components imported from `@aws-amplify/ui-react/legacy`:
+
+- AmplifyAuthenticator
+- AmplifySignIn
+- AmplifySignOut
+- AmplifyChatbot
+- AmplifyPhotoPicker
+- AmplifyPicker
+- AmplifyS3Album
+- AmplifyS3Image
+- AmplifyS3ImagePicker
+- AmplifyS3Text
+- AmplifyS3TextPicker
+- withAuthenticator
 
 
-#### 4. Added `inputStyles` prop to Field primitives
+#### 4. `@aws-amplify/ui-react@4.x` adds `inputStyles` prop to Field primitives
 
-Before 4.0, Field components like `TextField` would try to intelligently apply certain style props onto the wrapper element and some on the input element. We felt this was a little too opaque to users, but we still want to allow you to style the input element directly. We added an `inputStyles` prop to Field components so you can apply style props directly on the input (or `textarea` or `select`) as well as on the wrapper element. 
+Before 4.0, Field components like `TextField` would try to intelligently apply certain style props onto the wrapper element and some on the input element. We felt this was a little too opaque to users, but we still want to allow you to style the input element directly. `@aws-amplify/ui-react@4.x` adds an `inputStyles` prop to Field components so you can apply style props directly on the input (or `textarea` or `select`) as well as on the wrapper element. 
 
 Hopefully this change won't affect your code but will allow for more customization and control. 
 
@@ -79,7 +80,7 @@ Hopefully this change won't affect your code but will allow for more customizati
   The TextAreaField component does apply 1 style prop directly on the `textarea` element: `resize`. We felt this one makes sense to apply direclty on the the `textarea` element and not the wrapper element.
 </Alert>
 
-#### 5. Automatic signin on signup logic moved to `aws-amplify`. 
+#### 5. `@aws-amplify/ui-react@4.x` moves Automatic signin on signup logic to `aws-amplify`. 
 
 If you are overriding `Auth.signUp`, update the override function call to include the `autoSignIn` option set to `enabled`. If this change is not made, users will not be automatically signed in on signup.
 
@@ -101,7 +102,7 @@ If you are overriding `Auth.signUp`, update the override function call to includ
 
 ```
 
-#### 6. Legacy i18n translation keys removed
+#### 6. `@aws-amplify/ui-react@v4` removes legacy i18n translation keys removed
 
 We replaced following legacy Authenticator texts:
 
@@ -132,9 +133,9 @@ yarn add aws-amplify @aws-amplify/ui-react@3.x
 
 ### Update and usage
 
-The following breaking changes were introduced in `@aws-amplify/ui-react` major version `3.0`:
+`@aws-amplify/ui-react@3.x` introduces the following breaking changes:
 
-#### 1. We removed the built-in icons (Icon360, IconSave, etc).
+#### 1. `@aws-amplify/ui-react@3.x` removes the built-in icons (Icon360, IconSave, etc).
 
 Replace any icon components in use the react-icons package or other React icon libraries in its place.
 
@@ -145,7 +146,7 @@ Replace any icon components in use the react-icons package or other React icon l
 
 Note: We did not remove the [Icon](/react/components/icon) component, which allows customers to easily add SVG icons using the `pathData` prop.
 
-#### 2. We removed `ShareText` export.
+#### 2. `@aws-amplify/ui-react@3.x` `ShareText` export.
 
 This export has been removed and should no longer be used.
 

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -43,7 +43,7 @@ Replace any `TextField` components using the `isMultiline` prop with the `TextAr
 
 `@aws-amplify/ui-react` has a dependency on Radix components for Menu, SliderField, Tabs, and Expander. There were a number of changes in the [July 21, 2022 release](https://www.radix-ui.com/docs/primitives/overview/releases#july-21-2022) of `radix-ui/*` packages, and the breaking change for `@aws-amplify/ui-react` was removal of support for the `dir` HTML attribute, and the addition of the DirectionProvider. In order to make the transition seamless for most of Amplify users, we've added the `DirectionProvider` with a default `direction` of `ltr` to the `ThemeProvider`.
 
-If your applications was using right to left directionality, the example below shows the needed change for apps using the native HTML `dir="rtl"`:
+If your application is using right to left directionality, the example below shows the needed change for apps using the native HTML `dir="rtl"`:
 
 ```diff
 - <View dir="rtl">

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -146,7 +146,7 @@ Replace any icon components in use the react-icons package or other React icon l
 
 Note: We did not remove the [Icon](/react/components/icon) component, which allows customers to easily add SVG icons using the `pathData` prop.
 
-#### 2. `@aws-amplify/ui-react@3.x` `ShareText` export.
+#### 2. `@aws-amplify/ui-react@3.x` removes `ShareText`.
 
 This export has been removed and should no longer be used.
 

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -68,6 +68,9 @@ The following deprecated components imported from `@aws-amplify/ui-react/legacy`
 - AmplifyS3Text
 - AmplifyS3TextPicker
 - withAuthenticator
+Depending on the v1 version of this package and re-exporting these components caused issues. If you still want to use these legacy components you can depend on the v1 version of this package with an npm alias in your dependencies: 
+
+`"@aws-amplify/ui-react-v1": "npm:@aws-amplify/ui-react@1.2.9"`
 
 
 #### 4. `@aws-amplify/ui-react@4.x` adds `inputStyles` prop to Field primitives

--- a/docs/src/pages/[platform]/getting-started/migration/migration.vue.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.vue.mdx
@@ -3,8 +3,6 @@ import { Alert } from '@aws-amplify/ui-react';
 
 ## 2.x to 3.x
 ### Installation
-For Vue.js 2 users please continue to use our legacy library found [here](https://github.com/aws-amplify/amplify-ui/tree/legacy/legacy/amplify-ui-vue).
-
 Install the 3.x version of the `@aws-amplify/ui-vue` library and the 5.x version of the `aws-amplify` library.
 
 <Tabs>
@@ -25,9 +23,9 @@ yarn add aws-amplify@5.x @aws-amplify/ui-vue@3.x
 
 ### Update and usage
 
-The following breaking changes were introduced in `@aws-amplify/ui-vue` major version `3.0`:
+`@aws-amplify/ui-vue@3.x` introduces the following breaking changes:
 
-#### 1. Automatic signin on signup logic moved to `aws-amplify`. 
+#### 1. `@aws-amplify/ui-vue@3.x` moves automatic signin on signup logic to `aws-amplify`. 
 
 If you are overriding `Auth.signUp`, update the override function call to include the `autoSignIn` option set to `enabled`. If this change is not made, users will not be automatically signed in on signup.
 
@@ -49,9 +47,9 @@ If you are overriding `Auth.signUp`, update the override function call to includ
 
 ```
 
-#### 2. Legacy i18n translation keys removed
+#### 2. `@aws-amplify/ui-vue@3.x` removes legacy i18n translation keys
 
-We replaced following legacy Authenticator texts:
+`@aws-amplify/ui-vue@3.x` replaces following legacy Authenticator texts:
 
 - `Send Code` in reset password screen is replaced by `Send code`.
 - `Forgot your password? ` with the trailing space is replaced by `Forgot your password`.
@@ -60,11 +58,6 @@ If you were using `I18n` to translate those keys, please update your translation
 
 ## 1.x to 2.x
 ## Installation
-
-For Vue.js 2 users please continue to use our legacy library found [here](https://github.com/aws-amplify/amplify-ui/tree/legacy/legacy/amplify-ui-vue).
-
-For Vue.js 3 users please continue on with the following steps:
-
 Install the 2.x version of the `@aws-amplify/ui-vue` library.
 
 <Tabs>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This edits migration guide:
- align each subtitle to read "`@aws-amplify/ui-react@4.x` does something"
- Prefer `@aws-amplify/ui-react@4.x` over pronoun "we"
- remove passive voices
- no comment in JSON

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
