### PR TITLE
fix(e2e): mock sign up call in autosignin test

### DIFF
--- a/packages/e2e/features/ui/components/authenticator/hub-events.feature
+++ b/packages/e2e/features/ui/components/authenticator/hub-events.feature
@@ -27,6 +27,7 @@ Feature: Hub Events
   @angular @react @vue
   Scenario: autoSignIn signs in the user after sign up
     When I click the "Create Account" tab 
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "sign-up-with-email"
     And I type a new "email"
     And I type my password
     And I confirm my password


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

SignUp wasn't getting mocked in `hub-events.feature` tests, and was throwing SES limit errors.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
