### PR TITLE
feat(fileuploader): cancel file name edit, a11y improvements

### DIFF
--- a/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
@@ -37,9 +37,6 @@ export function FileUploader({
 
   const fileStatusesRef = useRef<FileStatuses>([]);
 
-  // Tracker state
-  const [isEditingName, setisEditingName] = React.useState<boolean[]>([]);
-
   const {
     addTargetFiles,
     fileStatuses,
@@ -267,16 +264,16 @@ export function FileUploader({
 
   const onSaveEdit = useCallback(
     (index: number) => {
-      return (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-        const fileName = fileStatuses[index].name;
+      return (value: string) => {
         // no empty file names
-        if (fileName.trim().length === 0) return;
-        const [extension] = fileName.split('.').reverse();
+        if (value.trim().length === 0) return;
+        const [extension] = value.split('.').reverse();
         const validExtension = acceptedFileTypes.includes('.' + extension);
         const newFileStatuses = [...fileStatuses];
         const status = fileStatuses[index];
         newFileStatuses[index] = {
           ...status,
+          name: value,
           fileState: !validExtension ? 'error' : null,
           fileErrors: validExtension
             ? null
@@ -284,32 +281,29 @@ export function FileUploader({
         };
 
         setFileStatuses(newFileStatuses);
-        const names = [...isEditingName];
-        names[index] = false;
-        setisEditingName(names);
       };
     },
-    [acceptedFileTypes, fileStatuses, isEditingName, setFileStatuses]
+    [acceptedFileTypes, fileStatuses, setFileStatuses]
   );
 
   const onCancelEdit = useCallback(
     (index: number) => {
-      return (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-        const fileName = fileStatuses[index].name;
-        if (fileName.trim().length === 0) return;
-        const names = [...isEditingName];
-        names[index] = false;
-        setisEditingName(names);
+      return () => {
+        const newFileStatuses = [...fileStatuses];
+        const status = fileStatuses[index];
+        newFileStatuses[index] = {
+          ...status,
+          fileState: null,
+        };
+        setFileStatuses(newFileStatuses);
       };
     },
-    [fileStatuses, isEditingName]
+    [fileStatuses, setFileStatuses]
   );
 
   const onStartEdit = useCallback(
     (index: number) => {
       return (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-        const names = [...isEditingName];
-        names[index] = true;
         const newFileStatuses = [...fileStatuses];
         const status = fileStatuses[index];
         newFileStatuses[index] = {
@@ -317,10 +311,9 @@ export function FileUploader({
           fileState: 'editing',
         };
         setFileStatuses(newFileStatuses);
-        setisEditingName(names);
       };
     },
-    [isEditingName, fileStatuses, setFileStatuses]
+    [fileStatuses, setFileStatuses]
   );
 
   // UploadButton
@@ -345,7 +338,6 @@ export function FileUploader({
         fileStatuses={fileStatuses}
         hiddenInput={hiddenInput}
         inDropZone={inDropZone}
-        isEditingName={isEditingName}
         isLoading={isLoading}
         isSuccess={isSuccess()}
         maxFilesError={maxFilesError}
@@ -376,7 +368,6 @@ export function FileUploader({
             name={status.name}
             fileState={status?.fileState}
             errorMessage={status?.fileErrors}
-            isEditing={isEditingName[index]}
             onSaveEdit={onSaveEdit(index)}
             onCancelEdit={onCancelEdit(index)}
             onStartEdit={onStartEdit(index)}

--- a/packages/react/src/components/Storage/FileUploader/Previewer/__tests__/Previewer.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Previewer/__tests__/Previewer.test.tsx
@@ -73,7 +73,17 @@ describe('Previewer', () => {
     expect(await screen.findByText('1 files selected')).toBeVisible();
   });
   it('shows a disabled button when any file is in an edit state', async () => {
-    render(<Previewer {...commonProps} isEditingName={[true]} />);
+    render(
+      <Previewer
+        {...commonProps}
+        fileStatuses={[
+          {
+            ...fileStatus,
+            fileState: 'editing',
+          },
+        ]}
+      />
+    );
 
     expect(await screen.findByText(/Upload 1 files/)).toBeDisabled();
   });

--- a/packages/react/src/components/Storage/FileUploader/Previewer/__tests__/__snapshots__/Previewer.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/Previewer/__tests__/__snapshots__/Previewer.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Previewer renders as expected 1`] = `
         class="amplify-fileuploader__dropzone"
       >
         <span
+          aria-hidden="true"
           class="amplify-icon amplify-fileuploader__dropzone__icon"
           style="width: 1em; height: 1em;"
         >
@@ -48,6 +49,7 @@ exports[`Previewer renders as expected 1`] = `
           <input
             accept=".png"
             multiple=""
+            tabindex="-1"
             type="file"
           />
         </span>

--- a/packages/react/src/components/Storage/FileUploader/Previewer/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Previewer/index.tsx
@@ -17,7 +17,6 @@ export function Previewer({
   children,
   fileStatuses,
   inDropZone,
-  isEditingName,
   isLoading,
   isSuccess,
   maxFilesError,
@@ -101,10 +100,9 @@ export function Previewer({
             <>
               <Button
                 disabled={
-                  fileStatuses.some(
-                    (status) => status?.fileState === 'error'
+                  fileStatuses.some((status) =>
+                    ['error', 'editing'].includes(status?.fileState)
                   ) ||
-                  isEditingName.some((edit) => edit) ||
                   remainingFilesLength === 0 ||
                   maxFilesError
                 }

--- a/packages/react/src/components/Storage/FileUploader/Tracker/__tests__/Tracker.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/__tests__/Tracker.test.tsx
@@ -20,7 +20,6 @@ describe('Tracker', () => {
         onResume={() => {}}
         percentage={0}
         errorMessage={''}
-        isEditing={false}
         onSaveEdit={() => null}
         onStartEdit={() => null}
         onCancelEdit={() => null}
@@ -45,7 +44,6 @@ describe('Tracker', () => {
         onResume={() => {}}
         percentage={0}
         errorMessage={''}
-        isEditing={false}
         onSaveEdit={() => null}
         onStartEdit={() => null}
         onCancelEdit={() => null}
@@ -72,7 +70,6 @@ describe('Tracker', () => {
         onResume={() => {}}
         percentage={0}
         errorMessage={''}
-        isEditing={false}
         onSaveEdit={() => null}
         onStartEdit={() => null}
         onCancelEdit={() => null}

--- a/packages/react/src/components/Storage/FileUploader/Tracker/__tests__/__snapshots__/Tracker.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/__tests__/__snapshots__/Tracker.test.tsx.snap
@@ -36,6 +36,13 @@ exports[`Tracker exists 1`] = `
       type="button"
     >
       <span
+        class="amplify-visually-hidden"
+      >
+        Edit file name 
+        hello.png
+      </span>
+      <span
+        aria-hidden="true"
         class="amplify-icon"
         style="width: 1em; height: 1em;"
       >
@@ -60,6 +67,13 @@ exports[`Tracker exists 1`] = `
       type="button"
     >
       <span
+        class="amplify-visually-hidden"
+      >
+        Remove file name 
+        hello.png
+      </span>
+      <span
+        aria-hidden="true"
         class="amplify-icon"
         style="width: 1em; height: 1em;"
       >

--- a/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
@@ -10,6 +10,7 @@ import {
   TextField,
   Loader,
   ComponentClassNames,
+  VisuallyHidden,
 } from '../../../../primitives';
 import {
   IconClose,
@@ -23,18 +24,19 @@ export function Tracker({
   fileState,
   hasImage,
   url,
-  onChange,
   onPause,
   onResume,
   onCancel,
   errorMessage,
   name,
   percentage,
-  isEditing,
   onSaveEdit,
   onStartEdit,
+  onCancelEdit,
   resumable,
 }: TrackerProps): JSX.Element {
+  const [tempName, setTempName] = React.useState(name);
+
   if (!file) return null;
 
   const { size } = file;
@@ -63,9 +65,26 @@ export function Tracker({
     switch (fileState) {
       case 'editing':
         return (
-          <Button size="small" variation="primary" onClick={onSaveEdit}>
-            Save
-          </Button>
+          <>
+            <Button
+              size="small"
+              variation="primary"
+              onClick={() => {
+                onSaveEdit(tempName);
+              }}
+            >
+              Save
+            </Button>
+            <Button
+              size="small"
+              onClick={() => {
+                setTempName(name);
+                onCancelEdit();
+              }}
+            >
+              Cancel
+            </Button>
+          </>
         );
       case 'loading':
         if (!resumable) return null;
@@ -87,11 +106,13 @@ export function Tracker({
           <>
             {showEditButton ? (
               <Button onClick={onStartEdit} size="small" variation="link">
-                <IconEdit fontSize="medium" />
+                <VisuallyHidden>Edit file name {file.name}</VisuallyHidden>
+                <IconEdit ariaHidden fontSize="medium" />
               </Button>
             ) : null}
             <Button size="small" onClick={onCancel}>
-              <IconClose />
+              <VisuallyHidden>Remove file name {file.name}</VisuallyHidden>
+              <IconClose ariaHidden fontSize="medium" />
             </Button>
           </>
         );
@@ -105,7 +126,7 @@ export function Tracker({
       <View className={ComponentClassNames.FileUploaderFileImage}>{icon}</View>
 
       {/* Main View */}
-      {isEditing ? (
+      {fileState === 'editing' ? (
         <TextField
           maxLength={1024}
           width="100%"
@@ -113,8 +134,10 @@ export function Tracker({
           size="small"
           variation="quiet"
           labelHidden
-          onChange={onChange}
-          value={name}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setTempName(e.target.value);
+          }}
+          value={tempName}
         />
       ) : (
         <DisplayView />

--- a/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
@@ -107,12 +107,12 @@ export function Tracker({
             {showEditButton ? (
               <Button onClick={onStartEdit} size="small" variation="link">
                 <VisuallyHidden>Edit file name {file.name}</VisuallyHidden>
-                <IconEdit ariaHidden fontSize="medium" />
+                <IconEdit aria-hidden fontSize="medium" />
               </Button>
             ) : null}
             <Button size="small" onClick={onCancel}>
               <VisuallyHidden>Remove file name {file.name}</VisuallyHidden>
-              <IconClose ariaHidden fontSize="medium" />
+              <IconClose aria-hidden fontSize="medium" />
             </Button>
           </>
         );

--- a/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
@@ -36,6 +36,14 @@ export function Tracker({
   resumable,
 }: TrackerProps): JSX.Element {
   const [tempName, setTempName] = React.useState(name);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  // Focus the input after pressing the edit button
+  React.useEffect(() => {
+    if (fileState === 'editing' && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [fileState]);
 
   if (!file) return null;
 
@@ -127,18 +135,28 @@ export function Tracker({
 
       {/* Main View */}
       {fileState === 'editing' ? (
-        <TextField
-          maxLength={1024}
-          width="100%"
-          label="file name"
-          size="small"
-          variation="quiet"
-          labelHidden
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setTempName(e.target.value);
+        // Wrapping this text field in a form with onSubmit will allow keyboard
+        // users to press enter to save changes.
+        <View
+          as="form"
+          flex="1"
+          onSubmit={() => {
+            onSaveEdit(tempName);
           }}
-          value={tempName}
-        />
+        >
+          <TextField
+            maxLength={1024}
+            ref={inputRef}
+            label="file name"
+            size="small"
+            variation="quiet"
+            labelHidden
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setTempName(e.target.value);
+            }}
+            value={tempName}
+          />
+        </View>
       ) : (
         <DisplayView />
       )}

--- a/packages/react/src/components/Storage/FileUploader/UploadButton/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadButton/index.tsx
@@ -26,6 +26,7 @@ export function UploadButton({
       <VisuallyHidden>
         <input
           type="file"
+          tabIndex={-1}
           ref={hiddenInput}
           onChange={onFileChange}
           multiple={multiple}

--- a/packages/react/src/components/Storage/FileUploader/UploadDropZone/__tests__/__snapshots__/UploadDropZone.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/UploadDropZone/__tests__/__snapshots__/UploadDropZone.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`UploaderDrop exists 1`] = `
     class="amplify-fileuploader__dropzone"
   >
     <span
+      aria-hidden="true"
       class="amplify-icon amplify-fileuploader__dropzone__icon"
       style="width: 1em; height: 1em;"
     >

--- a/packages/react/src/components/Storage/FileUploader/UploadDropZone/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadDropZone/index.tsx
@@ -27,7 +27,10 @@ export function UploadDropZone({
       onDrop={onDrop}
       onDragOver={onDragOver}
     >
-      <IconUpload className={ComponentClassNames.FileUploaderDropZoneIcon} />
+      <IconUpload
+        ariaHidden
+        className={ComponentClassNames.FileUploaderDropZoneIcon}
+      />
       {children}
     </View>
   );

--- a/packages/react/src/components/Storage/FileUploader/UploadDropZone/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadDropZone/index.tsx
@@ -28,7 +28,7 @@ export function UploadDropZone({
       onDragOver={onDragOver}
     >
       <IconUpload
-        ariaHidden
+        aria-hidden
         className={ComponentClassNames.FileUploaderDropZoneIcon}
       />
       {children}

--- a/packages/react/src/components/Storage/FileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`File Uploader exists 1`] = `
     class="amplify-fileuploader__dropzone"
   >
     <span
+      aria-hidden="true"
       class="amplify-icon amplify-fileuploader__dropzone__icon"
       style="width: 1em; height: 1em;"
     >
@@ -42,6 +43,7 @@ exports[`File Uploader exists 1`] = `
       <input
         accept=".png"
         multiple=""
+        tabindex="-1"
         type="file"
       />
     </span>

--- a/packages/react/src/components/Storage/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/types.ts
@@ -83,7 +83,7 @@ export interface TrackerProps {
 export interface FileStatus extends Partial<FileStateProps> {
   percentage?: number;
   uploadTask?: UploadTask;
-  fileErrors?: string;
+  fileErrors?: string | null;
   name?: string;
   file?: File;
 }

--- a/packages/react/src/components/Storage/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/types.ts
@@ -50,7 +50,6 @@ export interface PreviewerProps extends DragActionHandlers {
   fileStatuses: FileStatuses;
   hiddenInput: React.MutableRefObject<HTMLInputElement>;
   inDropZone?: boolean;
-  isEditingName: boolean[];
   isLoading: boolean;
   isSuccess: boolean;
   maxFilesError: boolean;
@@ -76,11 +75,8 @@ export interface TrackerProps {
   name: string;
   percentage: number;
   errorMessage: string;
-  isEditing: boolean;
-  onSaveEdit: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-  onCancelEdit?: (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => void;
+  onSaveEdit: (value: string) => void;
+  onCancelEdit?: () => void;
   onStartEdit: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Editing a file name is now cancel-able. Edits to the filename are in a local state rather than global
* Removed `isEditing` in place of the existing 'editing' fileStatus
* Added some visually hidden text for icon buttons and `ariaHidden` for icons
* Made sure input is not tab-able
* Auto-focus file name text input after hitting edit button and save after pressing enter

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes


https://user-images.githubusercontent.com/321279/201443669-9f9fd503-1138-40c7-9e27-7296d4d10959.mp4


https://user-images.githubusercontent.com/321279/201730985-25d6bd20-5991-4be1-b22b-a1b96a80f23a.mp4



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
