### PR TITLE
fix(button): Fix loading state for Button

### DIFF
--- a/.changeset/many-masks-play.md
+++ b/.changeset/many-masks-play.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Fixes an issue where the Button loading spinner is not rendered unless the `loadingText` prop is supplied.

--- a/packages/react/src/primitives/Button/Button.tsx
+++ b/packages/react/src/primitives/Button/Button.tsx
@@ -55,10 +55,10 @@ const ButtonPrimitive: Primitive<ButtonProps, 'button'> = (
       type={type}
       {...rest}
     >
-      {isLoading && loadingText ? (
+      {isLoading ? (
         <Flex as="span" className={ComponentClassNames.ButtonLoaderWrapper}>
           <Loader size={size} />
-          {loadingText}
+          {loadingText ? loadingText : null}
         </Flex>
       ) : (
         children

--- a/packages/react/src/primitives/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/primitives/Button/__tests__/Button.test.tsx
@@ -184,6 +184,13 @@ describe('Button test suite', () => {
     expect(loader).toHaveAttribute('data-size', 'small');
   });
 
+  it('should render Loader correctly without loadingText and isLoading is set to true', async () => {
+    render(<Button isLoading />);
+
+    const loader = await screen.findByRole('img');
+    expect(loader).toHaveClass(ComponentClassNames.Loader);
+  });
+
   it('should fire onClick function if the button is clicked on', async () => {
     const onClick = jest.fn();
     render(<Button onClick={onClick} />);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change fixes an issue where the Button loading spinner is not rendered unless the `loadingText` prop is supplied, which is contrary to what our docs state:

https://github.com/aws-amplify/amplify-ui/blob/11c7d9c602af211cd0b378742e8975f936d61fc5/packages/react/src/primitives/types/button.ts#L28-L33

Also added unit test to catch any potential future regressions.

| Before  | After |
| ------------- | ------------- |
|<img width="1215" alt="Screen Shot 2022-11-13 at 10 47 57 AM" src="https://user-images.githubusercontent.com/68251134/201539319-98524963-84ec-460c-a7b3-9da098bd94e6.png">  | <img width="1217" alt="Screen Shot 2022-11-13 at 10 47 09 AM" src="https://user-images.githubusercontent.com/68251134/201539333-d05d7a21-198a-4d23-804c-948a981f9802.png">  |

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fixes: #2914 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
