### PR TITLE
ci(account-settings): start publishing to `@account-settings` tag

### DIFF
--- a/.github/workflows/publish-account-settings.yml
+++ b/.github/workflows/publish-account-settings.yml
@@ -35,11 +35,10 @@ jobs:
       DOCSEARCH_DOCS_API_KEY: ${{ secrets.DOCSEARCH_DOCS_API_KEY }}
       DOCSEARCH_DOCS_INDEX_NAME: ${{ secrets.DOCSEARCH_DOCS_INDEX_NAME }}
 
-  # Disabled until there's a component to publish
-  # publish:
-  #   needs: test
-  #   uses: ./.github/workflows/reusable-tagged-publish.yml
-  #   with:
-  #     dist-tag: account-settings
-  #   secrets:
-  #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  publish:
+    needs: test
+    uses: ./.github/workflows/reusable-tagged-publish.yml
+    with:
+      dist-tag: account-settings
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Now that most of account settings component, we're now ready to start running tagged release to `@account-settings`. This will run on every merge to `account-settings/main` (just like how we release `@next`), and will be available for preview purposes. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
