### PR TITLE
feat(file-uploader): Prop to turn off or on images in Tracker

### DIFF
--- a/examples/next/pages/ui/components/storage/file-uploader/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/file-uploader/index.page.tsx
@@ -13,7 +13,6 @@ export default function FileUploaderEmail() {
       <FileUploader
         variation="drop"
         onSuccess={onSuccess}
-        showImages={true}
         acceptedFileTypes={['.png', '.jpg', '.pdf']}
         level="public"
         multiple={true}

--- a/examples/next/pages/ui/components/storage/file-uploader/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/file-uploader/index.page.tsx
@@ -13,6 +13,7 @@ export default function FileUploaderEmail() {
       <FileUploader
         variation="drop"
         onSuccess={onSuccess}
+        showImages={true}
         acceptedFileTypes={['.png', '.jpg', '.pdf']}
         level="public"
         multiple={true}

--- a/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
@@ -23,6 +23,7 @@ export function FileUploader({
   multiple = true,
   onError,
   onSuccess,
+  showImages = true,
   variation = 'button',
   resumable = false,
   ...rest
@@ -357,23 +358,23 @@ export function FileUploader({
       >
         {fileStatuses?.map((status, index) => (
           <Tracker
-            percentage={status.percentage}
+            errorMessage={status?.fileErrors}
             file={status.file}
-            hasImage={status.file?.type.startsWith('image/')}
-            url={URL.createObjectURL(status.file)}
+            fileState={status?.fileState}
+            hasImage={status.file?.type.startsWith('image/') && showImages}
             key={index}
-            onChange={onNameChange(index)}
+            name={status.name}
             onCancel={onFileCancel(index)}
+            onCancelEdit={onCancelEdit(index)}
+            onChange={onNameChange(index)}
+            onDelete={onDelete}
             onPause={onPause(index)}
             onResume={onResume(index)}
-            onDelete={onDelete}
-            name={status.name}
-            fileState={status?.fileState}
-            errorMessage={status?.fileErrors}
             onSaveEdit={onSaveEdit(index)}
-            onCancelEdit={onCancelEdit(index)}
             onStartEdit={onStartEdit(index)}
+            percentage={status.percentage}
             resumable={resumable}
+            url={URL.createObjectURL(status.file)}
           />
         ))}
       </Previewer>

--- a/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
@@ -361,7 +361,8 @@ export function FileUploader({
             errorMessage={status?.fileErrors}
             file={status.file}
             fileState={status?.fileState}
-            hasImage={status.file?.type.startsWith('image/') && showImages}
+            hasImage={status.file?.type.startsWith('image/')}
+            showImage={showImages}
             key={index}
             name={status.name}
             onCancel={onFileCancel(index)}

--- a/packages/react/src/components/Storage/FileUploader/Tracker/__tests__/Tracker.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/__tests__/Tracker.test.tsx
@@ -23,6 +23,7 @@ describe('Tracker', () => {
         onSaveEdit={() => null}
         onStartEdit={() => null}
         onCancelEdit={() => null}
+        showImage={true}
       />
     );
 
@@ -47,6 +48,7 @@ describe('Tracker', () => {
         onSaveEdit={() => null}
         onStartEdit={() => null}
         onCancelEdit={() => null}
+        showImage={true}
       />
     );
 
@@ -73,6 +75,7 @@ describe('Tracker', () => {
         onSaveEdit={() => null}
         onStartEdit={() => null}
         onCancelEdit={() => null}
+        showImage={true}
       />
     );
 

--- a/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
@@ -136,9 +136,7 @@ export function Tracker({
         <View className={ComponentClassNames.FileUploaderFileImage}>
           {icon}
         </View>
-      ) : (
-        ''
-      )}
+      ) : null}
 
       {/* Main View */}
       {fileState === 'editing' ? (

--- a/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
@@ -20,20 +20,20 @@ import {
 import { FileState } from './FileState';
 
 export function Tracker({
+  errorMessage,
   file,
   fileState,
   hasImage,
-  url,
+  name,
+  onCancel,
+  onCancelEdit,
   onPause,
   onResume,
-  onCancel,
-  errorMessage,
-  name,
-  percentage,
   onSaveEdit,
   onStartEdit,
-  onCancelEdit,
+  percentage,
   resumable,
+  url,
 }: TrackerProps): JSX.Element {
   const [tempName, setTempName] = React.useState(name);
   const inputRef = React.useRef<HTMLInputElement>(null);

--- a/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/Tracker/index.tsx
@@ -33,6 +33,7 @@ export function Tracker({
   onStartEdit,
   percentage,
   resumable,
+  showImage,
   url,
 }: TrackerProps): JSX.Element {
   const [tempName, setTempName] = React.useState(name);
@@ -131,7 +132,13 @@ export function Tracker({
 
   return (
     <View className={ComponentClassNames.FileUploaderFile}>
-      <View className={ComponentClassNames.FileUploaderFileImage}>{icon}</View>
+      {showImage ? (
+        <View className={ComponentClassNames.FileUploaderFileImage}>
+          {icon}
+        </View>
+      ) : (
+        ''
+      )}
 
       {/* Main View */}
       {fileState === 'editing' ? (

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -4,6 +4,7 @@ import * as UseHooks from '../hooks/useFileUploader';
 import { FileUploader } from '..';
 import * as UIModule from '@aws-amplify/ui';
 import { act } from 'react-dom/test-utils';
+import { ComponentClassNames } from '../../../../primitives';
 const uploadFileSpy = jest.spyOn(UIModule, 'uploadFile');
 const useFileUploaderSpy = jest.spyOn(UseHooks, 'useFileUploader');
 const fakeFile = new File(['hello'], 'hello.png', { type: 'image/png' });
@@ -500,7 +501,7 @@ describe('File Uploader', () => {
       await screen.findByText(`Preview: ${fileStatuses[0].name}`)
     ).toBeVisible();
   });
-  it('shows an icon for the image previewer if showImages is false', async () => {
+  it('shows nothing in Tracker if showImages is false', async () => {
     const fileStatuses = [fileStatus];
     useFileUploaderSpy.mockReturnValue({
       ...mockReturnUseFileUploader,
@@ -515,10 +516,10 @@ describe('File Uploader', () => {
     );
 
     expect(
-      container.querySelector('.amplify-fileuploader__file__image > span')
-    ).toBeVisible();
+      container.querySelector(`.${ComponentClassNames.FileUploaderFileImage}`)
+    ).toBeNull();
   });
-  it('shows an image for the image previewer if showImages is true', async () => {
+  it('shows an image inside the tracker if showImages is true', async () => {
     const fileStatuses = [fileStatus];
     useFileUploaderSpy.mockReturnValue({
       ...mockReturnUseFileUploader,
@@ -533,7 +534,7 @@ describe('File Uploader', () => {
     );
 
     expect(
-      container.querySelector('.amplify-fileuploader__file__image > img')
+      container.querySelector(`.${ComponentClassNames.FileUploaderFileImage}`)
     ).toBeVisible();
   });
 });

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -500,4 +500,40 @@ describe('File Uploader', () => {
       await screen.findByText(`Preview: ${fileStatuses[0].name}`)
     ).toBeVisible();
   });
+  it('shows an icon for the image previewer if showImages is false', async () => {
+    const fileStatuses = [fileStatus];
+    useFileUploaderSpy.mockReturnValue({
+      ...mockReturnUseFileUploader,
+      fileStatuses,
+    });
+    const { container } = render(
+      <FileUploader
+        {...commonProps}
+        showImages={false}
+        isPreviewerVisible={true}
+      />
+    );
+
+    expect(
+      container.querySelector('.amplify-fileuploader__file__image > span')
+    ).toBeVisible();
+  });
+  it('shows an image for the image previewer if showImages is true', async () => {
+    const fileStatuses = [fileStatus];
+    useFileUploaderSpy.mockReturnValue({
+      ...mockReturnUseFileUploader,
+      fileStatuses,
+    });
+    const { container } = render(
+      <FileUploader
+        {...commonProps}
+        showImages={true}
+        isPreviewerVisible={true}
+      />
+    );
+
+    expect(
+      container.querySelector('.amplify-fileuploader__file__image > img')
+    ).toBeVisible();
+  });
 });

--- a/packages/react/src/components/Storage/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/types.ts
@@ -78,6 +78,7 @@ export interface TrackerProps {
   onStartEdit: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   percentage: number;
   resumable?: boolean;
+  showImage: boolean;
   url: string;
 }
 

--- a/packages/react/src/components/Storage/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/types.ts
@@ -35,6 +35,7 @@ export interface FileUploaderProps {
   onError?: (error: string) => void;
   onSuccess?: (event: { key: string }) => void;
   path?: string;
+  showImages?: boolean;
   variation?: 'drop' | 'button';
   resumable?: boolean;
 }
@@ -62,22 +63,22 @@ export interface PreviewerProps extends DragActionHandlers {
 }
 
 export interface TrackerProps {
+  errorMessage: string;
   file: File;
   fileState: FileState;
   hasImage: boolean;
-  url: string;
-  resumable?: boolean;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  name: string;
   onCancel: () => void;
+  onCancelEdit?: () => void;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onDelete?: () => void;
   onPause: () => void;
   onResume: () => void;
-  onDelete?: () => void;
-  name: string;
-  percentage: number;
-  errorMessage: string;
   onSaveEdit: (value: string) => void;
-  onCancelEdit?: () => void;
   onStartEdit: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  percentage: number;
+  resumable?: boolean;
+  url: string;
 }
 
 export interface FileStatus extends Partial<FileStateProps> {


### PR DESCRIPTION
#### Description of changes
This new prop allows customers to turn on or off images to display in the tracker component

#### Issue #, if available
[Asana](https://app.asana.com/0/1203303459000520/1203373828802426)
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Add test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
