### PR TITLE
feat(file-uploader): Prop for Auto Proceed

### DIFF
--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -9,6 +9,7 @@ const useFileUploaderSpy = jest.spyOn(UseHooks, 'useFileUploader');
 const fakeFile = new File(['hello'], 'hello.png', { type: 'image/png' });
 
 const mockReturnUseFileUploader = {
+  autoUploadRef: { current: '' } as any,
   onDragStart: () => null,
   onDragEnter: () => null,
   onDragLeave: () => null,
@@ -499,5 +500,32 @@ describe('File Uploader', () => {
     expect(
       await screen.findByText(`Preview: ${fileStatuses[0].name}`)
     ).toBeVisible();
+  });
+  it('starts upload after file is selected if autoProceed is true', async () => {
+    const fileStatuses = [fileStatus];
+    useFileUploaderSpy.mockReturnValueOnce({
+      ...mockReturnUseFileUploader,
+      fileStatuses,
+      autoUploadRef: { current: true },
+    });
+
+    const { container } = render(
+      <FileUploader {...commonProps} autoProceed={true} />
+    );
+
+    const input = container.getElementsByTagName('input')[0];
+    fireEvent.change(input, {
+      target: { files: [fakeFile] },
+    });
+
+    expect(uploadFileSpy).toBeCalledWith({
+      completeCallback: expect.any(Function),
+      errorCallback: expect.any(Function),
+      file: fakeFile,
+      fileName: fakeFile.name,
+      level: 'public',
+      resumable: true,
+      progressCallback: expect.any(Function),
+    });
   });
 });

--- a/packages/react/src/components/Storage/FileUploader/hooks/useFileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/hooks/useFileUploader/types.ts
@@ -9,6 +9,7 @@ export interface DragActionHandlers {
 }
 
 export interface UseFileUploader extends DragActionHandlers {
+  autoUploadRef: React.MutableRefObject<boolean>;
   showPreviewer?: boolean;
   setShowPreviewer?: React.Dispatch<React.SetStateAction<boolean>>;
   fileStatuses: FileStatuses;

--- a/packages/react/src/components/Storage/FileUploader/hooks/useFileUploader/useFileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/hooks/useFileUploader/useFileUploader.tsx
@@ -1,5 +1,5 @@
 import { checkMaxSize, returnAcceptedFiles } from '@aws-amplify/ui';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Files, FileStatuses } from '../../types';
 import { UseFileUploader } from './types';
 
@@ -16,6 +16,7 @@ export default function useFileUploader({
 }): UseFileUploader {
   const [fileStatuses, setFileStatuses] = useState<FileStatuses>([]);
   const [showPreviewer, setShowPreviewer] = useState(false);
+  const autoUploadRef = useRef(false);
 
   const [inDropZone, setInDropZone] = useState(false);
 
@@ -89,11 +90,15 @@ export default function useFileUploader({
     if (isLoading) return false;
     const { files } = event.dataTransfer;
     const addedFilesLength = addTargetFiles([...files]);
-    if (addedFilesLength > 0) setShowPreviewer(true);
+    if (addedFilesLength > 0) {
+      setShowPreviewer(true);
+      autoUploadRef.current = true;
+    }
     setInDropZone(false);
   };
 
   return {
+    autoUploadRef,
     inDropZone,
     onDragEnter,
     onDragLeave,

--- a/packages/react/src/components/Storage/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/types.ts
@@ -23,6 +23,7 @@ export interface UploadDropZoneProps extends DragActionHandlers {
 
 export interface FileUploaderProps {
   acceptedFileTypes: string[];
+  autoProceed?: boolean;
   fileNames?: string[];
   multiple?: boolean;
   components?: Components;


### PR DESCRIPTION
#### Description of changes
Added new prop `autoProceed` that will automatically start the download after a file is selected, instead of waiting for the customer to click the upload button.

#### Issue #, if available
[Asana](https://app.asana.com/0/1203303459000520/1203373828802431)

#### Description of how you validated changes
Test
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
