### PR TITLE
chore(file-uploader): Removed fileNames prop and added warning for users for required props

### DIFF
--- a/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { UploadTask, Storage } from '@aws-amplify/storage';
-import { getFileName, translate, uploadFile } from '@aws-amplify/ui';
+import { translate, uploadFile } from '@aws-amplify/ui';
 import { FileStatuses, FileUploaderProps } from './types';
 import { useFileUploader } from './hooks/useFileUploader';
 import { ComponentClassNames, Text } from '../../../primitives';
@@ -15,7 +15,6 @@ const isUploadTask = (value: unknown): value is UploadTask =>
 export function FileUploader({
   acceptedFileTypes,
   components = {},
-  fileNames,
   isPreviewerVisible,
   level,
   maxFiles,
@@ -33,6 +32,13 @@ export function FileUploader({
     Previewer = FileUploader.Previewer,
     Tracker = FileUploader.Tracker,
   } = components;
+
+  if (!acceptedFileTypes || !level) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'You must include the level and acceptedFileNames props to use the file uploader!'
+    );
+  }
 
   // File Previewer loading state
   const [isLoading, setLoading] = useState(false);
@@ -167,16 +173,9 @@ export function FileUploader({
     fileStatuses.forEach((status, i) => {
       if (status?.fileState === 'success') return;
 
-      // remove any filenames that are not accepted from user prop
-      const fileNamesFiltered = fileNames?.filter((file: string) => {
-        const [extension] = file.split('.').reverse();
-        return acceptedFileTypes.includes('.' + extension);
-      });
-      const uploadFileName = getFileName(fileNamesFiltered?.[i], status.name);
-
       const uploadTask = uploadFile({
         file: status.file,
-        fileName: uploadFileName,
+        fileName: status.name,
         level,
         resumable,
         progressCallback: progressCallback(i),
@@ -202,10 +201,8 @@ export function FileUploader({
     const uploadTasks = [...fileStatusesRef.current];
     setFileStatuses(uploadTasks);
   }, [
-    acceptedFileTypes,
     completeCallback,
     errorCallback,
-    fileNames,
     fileStatuses,
     level,
     progressCallback,

--- a/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
@@ -8,6 +8,7 @@ import { UploadButton } from './UploadButton';
 import { Previewer } from './Previewer';
 import { UploadDropZone } from './UploadDropZone';
 import { Tracker } from './Tracker';
+import { Logger } from 'aws-amplify';
 
 const isUploadTask = (value: unknown): value is UploadTask =>
   typeof (value as UploadTask)?.resume === 'function';
@@ -36,8 +37,7 @@ export function FileUploader({
   } = components;
 
   if (!acceptedFileTypes || !level) {
-    // eslint-disable-next-line no-console
-    console.warn(
+    new Logger(
       'You must include the level and acceptedFileNames props to use the file uploader!'
     );
   }

--- a/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
@@ -13,6 +13,8 @@ import { Logger } from 'aws-amplify';
 const isUploadTask = (value: unknown): value is UploadTask =>
   typeof (value as UploadTask)?.resume === 'function';
 
+const logger = new Logger('AmplifyUI:Auth');
+
 export function FileUploader({
   acceptedFileTypes,
   autoProceed = false,
@@ -37,9 +39,7 @@ export function FileUploader({
   } = components;
 
   if (!acceptedFileTypes || !level) {
-    new Logger(
-      'You must include the level and acceptedFileNames props to use the file uploader!'
-    );
+    logger.warn('FileUploader requires level and acceptedFileTypes props');
   }
 
   // File Previewer loading state

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -188,46 +188,6 @@ describe('File Uploader', () => {
 
     expect(uploadTaskSpy).toBeCalled();
   });
-  it('updates the name from the fileName prop', async () => {
-    uploadFileSpy.mockResolvedValue({} as never);
-    const oldFileName = 'test.png';
-    const updatedFileName = 'update.png';
-    const fileStatuses = [
-      {
-        ...fileStatus,
-        name: oldFileName,
-      },
-    ];
-
-    useFileUploaderSpy.mockReturnValue({
-      fileStatuses,
-      ...mockReturnUseFileUploader,
-    });
-    const { container } = render(
-      <FileUploader {...commonProps} fileNames={[updatedFileName]} />
-    );
-
-    const input = container.getElementsByTagName('input')[0];
-    fireEvent.change(input, {
-      target: { files: [fakeFile] },
-    });
-
-    const clickButton = await screen.findByRole('button', {
-      name: uploadOneFile,
-    });
-
-    fireEvent.click(clickButton);
-
-    expect(uploadFileSpy).toBeCalledWith({
-      completeCallback: expect.any(Function),
-      errorCallback: expect.any(Function),
-      file: fakeFile,
-      fileName: updatedFileName,
-      level: 'public',
-      progressCallback: expect.any(Function),
-      resumable: true,
-    });
-  });
   it('calls the errorCallback when there is an eror', async () => {
     const ERROR_MESSAGE = 'error!';
     uploadFileSpy.mockResolvedValue({} as never);

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -3,11 +3,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import * as UseHooks from '../hooks/useFileUploader';
 import { FileUploader } from '..';
 import * as UIModule from '@aws-amplify/ui';
-import * as Amplify from 'aws-amplify';
 import { act } from 'react-dom/test-utils';
 import { ComponentClassNames } from '../../../../primitives';
 const uploadFileSpy = jest.spyOn(UIModule, 'uploadFile');
-const LoggerSpy = jest.spyOn(Amplify, 'Logger');
 const useFileUploaderSpy = jest.spyOn(UseHooks, 'useFileUploader');
 const fakeFile = new File(['hello'], 'hello.png', { type: 'image/png' });
 
@@ -526,18 +524,5 @@ describe('File Uploader', () => {
       resumable: true,
       progressCallback: expect.any(Function),
     });
-  });
-  it('shows logger message if acceptedFileTypes and level are not set', async () => {
-    const acceptedFileTypes = null as any;
-    const level = null as any;
-
-    render(
-      <FileUploader acceptedFileTypes={acceptedFileTypes} level={level} />
-    );
-
-    const errorText =
-      'You must include the level and acceptedFileNames props to use the file uploader!';
-
-    expect(LoggerSpy).toBeCalledWith(errorText);
   });
 });

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -3,9 +3,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import * as UseHooks from '../hooks/useFileUploader';
 import { FileUploader } from '..';
 import * as UIModule from '@aws-amplify/ui';
+import * as Amplify from 'aws-amplify';
 import { act } from 'react-dom/test-utils';
 import { ComponentClassNames } from '../../../../primitives';
 const uploadFileSpy = jest.spyOn(UIModule, 'uploadFile');
+const LoggerSpy = jest.spyOn(Amplify, 'Logger');
 const useFileUploaderSpy = jest.spyOn(UseHooks, 'useFileUploader');
 const fakeFile = new File(['hello'], 'hello.png', { type: 'image/png' });
 
@@ -524,5 +526,18 @@ describe('File Uploader', () => {
       resumable: true,
       progressCallback: expect.any(Function),
     });
+  });
+  it('shows logger message if acceptedFileTypes and level are not set', async () => {
+    const acceptedFileTypes = null as any;
+    const level = null as any;
+
+    render(
+      <FileUploader acceptedFileTypes={acceptedFileTypes} level={level} />
+    );
+
+    const errorText =
+      'You must include the level and acceptedFileNames props to use the file uploader!';
+
+    expect(LoggerSpy).toBeCalledWith(errorText);
   });
 });

--- a/packages/react/src/components/Storage/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/types.ts
@@ -23,7 +23,6 @@ export interface UploadDropZoneProps extends DragActionHandlers {
 
 export interface FileUploaderProps {
   acceptedFileTypes: string[];
-  fileNames?: string[];
   multiple?: boolean;
   components?: Components;
   level: LevelInfo;

--- a/packages/ui/src/helpers/storage/fileUploader/utils/__tests__/uploader.test.tsx
+++ b/packages/ui/src/helpers/storage/fileUploader/utils/__tests__/uploader.test.tsx
@@ -1,5 +1,3 @@
-import { getFileName } from '..';
-
 describe('getFileName', () => {
   it('true', () => {
     expect(true).toEqual(true);

--- a/packages/ui/src/helpers/storage/fileUploader/utils/index.ts
+++ b/packages/ui/src/helpers/storage/fileUploader/utils/index.ts
@@ -1,5 +1,4 @@
 export {
-  getFileName,
   uploadFile,
   humanFileSize,
   checkMaxSize,

--- a/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
+++ b/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
@@ -1,16 +1,6 @@
 import { Storage } from 'aws-amplify';
-import { StorageAccessLevel, UploadTask } from '@aws-amplify/storage';
+import { StorageAccessLevel } from '@aws-amplify/storage';
 import { translate } from '../../../../i18n';
-
-export function getFileName(fileName: string, name: string): string {
-  if (!fileName) {
-    // If user did not send over fileName prop
-    // default to the file name, or the name they changed
-    return name;
-  } else {
-    return fileName;
-  }
-}
 
 export function uploadFile({
   file,


### PR DESCRIPTION
#### Description of changes
After some discuss with @dbanksdesign we are removing the `fileNames` prop, since it is not obvious to use. Also added warning if users add the file-uploader without the correct props.

#### Issue #, if available


#### Description of how you validated changes
Removed test not needed
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
