### PR TITLE
fix(ui-react): Update useDataStore hook predicate generation logic

### DIFF
--- a/.changeset/gorgeous-pumas-glow.md
+++ b/.changeset/gorgeous-pumas-glow.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Updates the useDataStore hook to generate the predicates according to the new syntax.

--- a/.changeset/loud-apes-fail.md
+++ b/.changeset/loud-apes-fail.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+This change updates the useDataStore hook to generate predicates in accordance with the new syntax.

--- a/.changeset/loud-apes-fail.md
+++ b/.changeset/loud-apes-fail.md
@@ -1,5 +1,0 @@
----
-'@aws-amplify/ui-react': patch
----
-
-This change updates the useDataStore hook to generate predicates in accordance with the new syntax.

--- a/packages/react/src/hooks/__tests__/useDataStore.test.ts
+++ b/packages/react/src/hooks/__tests__/useDataStore.test.ts
@@ -1,10 +1,12 @@
 import { DataStore, SortDirection } from '@aws-amplify/datastore';
 import { renderHook } from '@testing-library/react-hooks';
+import { createDataStorePredicate } from '../../primitives/shared/datastore';
 import {
   useDataStoreBinding,
   useDataStoreCollection,
   useDataStoreItem,
 } from '../useDataStore';
+import { Todo } from '../actions/testShared';
 
 jest.mock('@aws-amplify/datastore');
 
@@ -76,7 +78,12 @@ describe('useDataStoreCollection', () => {
   it('should return items on success', async () => {
     const fakeItems = Array.from({ length: 100 }).map((_) => fakeItem);
 
-    const fakePredicate = (p) => p.fieldName('eq', 'fake-value');
+    const namePredicateObject = {
+      field: 'name',
+      operator: 'eq',
+      operand: 'fake-value',
+    };
+    const predicate: any = createDataStorePredicate<Todo>(namePredicateObject);
 
     const fakePagination = {
       limit: 100,
@@ -97,7 +104,7 @@ describe('useDataStoreCollection', () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useDataStoreCollection({
         model: fakeModel,
-        criteria: fakePredicate,
+        criteria: predicate,
         pagination: fakePagination,
       })
     );
@@ -285,7 +292,12 @@ describe('useDataStoreBinding', () => {
   it('handles calls with type collection in the happy path', async () => {
     const fakeItems = Array.from({ length: 100 }).map((_) => fakeItem);
 
-    const fakePredicate = (p) => p.fieldName('eq', 'fake-value');
+    const namePredicateObject = {
+      field: 'name',
+      operator: 'eq',
+      operand: 'fake-value',
+    };
+    const predicate: any = createDataStorePredicate<Todo>(namePredicateObject);
 
     const fakePagination = {
       limit: 100,
@@ -305,8 +317,8 @@ describe('useDataStoreBinding', () => {
 
     const { result, waitForNextUpdate } = renderHook(() =>
       useDataStoreBinding({
-        model: fakeModel,
-        criteria: fakePredicate,
+        model: Todo,
+        criteria: predicate,
         pagination: fakePagination,
         type: 'collection',
       })

--- a/packages/react/src/primitives/shared/__tests__/datastore.test.ts
+++ b/packages/react/src/primitives/shared/__tests__/datastore.test.ts
@@ -99,12 +99,6 @@ describe('createDataStorePredicate', () => {
     expect(agePredicate).toHaveBeenCalledWith(agePredicateObject.operand);
   });
 
-  /*
-  DataStore.query(Post, p => p.or(p => [
-  p.and(p => [ p.name.eq('john')]),
-  p.age.lt(34)
-]));
-*/
   test('should generate a nested predicate', () => {
     const predicateObject: DataStorePredicateObject = {
       and: [

--- a/packages/react/src/primitives/shared/__tests__/datastore.test.ts
+++ b/packages/react/src/primitives/shared/__tests__/datastore.test.ts
@@ -26,15 +26,13 @@ describe('createDataStorePredicate', () => {
     const namePredicate = jest.fn();
 
     const condition: any = {
-      name: namePredicate,
+      [namePredicateObject.field]: {
+        [namePredicateObject.operator]: namePredicate,
+      },
     };
 
     predicate(condition);
-
-    expect(namePredicate).toHaveBeenCalledWith(
-      namePredicateObject.operator,
-      namePredicateObject.operand
-    );
+    expect(namePredicate).toHaveBeenCalledWith(namePredicateObject.operand);
   });
 
   test('should generate a group predicate: or', () => {
@@ -44,34 +42,30 @@ describe('createDataStorePredicate', () => {
 
     const predicate = createDataStorePredicate<Post>(predicateObject);
 
+    console.log({ predicate: predicate.toString() });
+
     const namePredicate = jest.fn();
     const agePredicate = jest.fn();
 
     const condition: any = {
-      or: (p) =>
+      or: (p) => [
         p({
-          name: (operator, operand) => {
-            namePredicate(operator, operand);
-            return {
-              age: (operator, operand) => {
-                agePredicate(operator, operand);
-                return p;
-              },
-            };
+          [namePredicateObject.field]: {
+            [namePredicateObject.operator]: namePredicate,
           },
         }),
+        p({
+          [agePredicateObject.field]: {
+            [agePredicateObject.operator]: agePredicate,
+          },
+        }),
+      ],
     };
 
     predicate(condition);
 
-    expect(namePredicate).toHaveBeenCalledWith(
-      namePredicateObject.operator,
-      namePredicateObject.operand
-    );
-    expect(agePredicate).toHaveBeenCalledWith(
-      agePredicateObject.operator,
-      agePredicateObject.operand
-    );
+    expect(namePredicate).toHaveBeenCalledWith(namePredicateObject.operand);
+    expect(agePredicate).toHaveBeenCalledWith(agePredicateObject.operand);
   });
 
   test('should generate a group predicate: and', () => {
@@ -85,32 +79,32 @@ describe('createDataStorePredicate', () => {
     const agePredicate = jest.fn();
 
     const condition: any = {
-      and: (p) => {
+      and: (p) => [
         p({
-          name: (operator, operand) => {
-            namePredicate(operator, operand);
-            return {
-              age: (operator, operand) => {
-                agePredicate(operator, operand);
-              },
-            };
+          [namePredicateObject.field]: {
+            [namePredicateObject.operator]: namePredicate,
           },
-        });
-      },
+        }),
+        p({
+          [agePredicateObject.field]: {
+            [agePredicateObject.operator]: agePredicate,
+          },
+        }),
+      ],
     };
 
     predicate(condition);
 
-    expect(namePredicate).toHaveBeenCalledWith(
-      namePredicateObject.operator,
-      namePredicateObject.operand
-    );
-    expect(agePredicate).toHaveBeenCalledWith(
-      agePredicateObject.operator,
-      agePredicateObject.operand
-    );
+    expect(namePredicate).toHaveBeenCalledWith(namePredicateObject.operand);
+    expect(agePredicate).toHaveBeenCalledWith(agePredicateObject.operand);
   });
 
+  /*
+  DataStore.query(Post, p => p.or(p => [
+  p.and(p => [ p.name.eq('john')]),
+  p.age.lt(34)
+]));
+*/
   test('should generate a nested predicate', () => {
     const predicateObject: DataStorePredicateObject = {
       and: [
@@ -127,33 +121,24 @@ describe('createDataStorePredicate', () => {
     const agePredicate = jest.fn();
 
     const condition: any = {
-      and: (p) => {
-        p({
-          name: (operator, operand) => {
-            namePredicate(operator, operand);
-            return {
-              or: (p) =>
-                p({
-                  age: (operator, operand) => {
-                    agePredicate(operator, operand);
-                    return p;
-                  },
-                }),
-            };
+      and: (andGroup) => {
+        andGroup({
+          [namePredicateObject.field]: {
+            [namePredicateObject.operator]: namePredicate,
+          },
+          or: (orGroup) => {
+            orGroup({
+              [agePredicateObject.field]: {
+                [agePredicateObject.operator]: agePredicate,
+              },
+            });
           },
         });
       },
     };
-
     predicate(condition);
 
-    expect(namePredicate).toHaveBeenCalledWith(
-      namePredicateObject.operator,
-      namePredicateObject.operand
-    );
-    expect(agePredicate).toHaveBeenCalledWith(
-      agePredicateObject.operator,
-      agePredicateObject.operand
-    );
+    expect(namePredicate).toHaveBeenCalledWith(namePredicateObject.operand);
+    expect(agePredicate).toHaveBeenCalledWith(agePredicateObject.operand);
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change updates the  `useDataStore` hook to generate predicates in accordance with the new syntax: https://docs.amplify.aws/lib/datastore/data-access/q/platform/js/#predicates.

To make this future-proof, e2e tests that don't rely on mocks need to be added as follow-up.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
