### PR TITLE
fix(rna): update radio button to submit name instead of value

### DIFF
--- a/packages/react-native/src/Authenticator/Defaults/VerifyUser/VerifyUser.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/VerifyUser/VerifyUser.tsx
@@ -82,7 +82,9 @@ const FormFields: DefaultVerifyUserComponent['FormFields'] = ({
         <Radio
           {...props}
           key={value}
-          value={value}
+          // value has to be name, because Auth is only interested in the
+          // string "email" or "phone_number", not the actual value
+          value={name}
           label={censorContactInformation(name, value)}
         />
       ))}

--- a/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/VerifyUser.spec.tsx
+++ b/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/VerifyUser.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 
 import { authenticatorTextUtil } from '@aws-amplify/ui';
 import { VerifyUser } from '..';
@@ -26,19 +26,25 @@ const radioField = {
   value: 'testValue',
 } as RadioFieldOptions;
 
+const handleSubmit = jest.fn();
+
 const props = {
   fields: [radioEmailField, radioPhoneField, radioField],
   FormFields: VerifyUser.FormFields,
   Footer: VerifyUser.Footer,
   handleBlur: jest.fn(),
   handleChange: jest.fn(),
-  handleSubmit: jest.fn(),
+  handleSubmit,
   Header: VerifyUser.Header,
   isPending: false,
   skipVerification: jest.fn(),
 };
 
 describe('VerifyUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders as expected', () => {
     const { toJSON, getByRole, getByText } = render(<VerifyUser {...props} />);
     expect(toJSON()).toMatchSnapshot();
@@ -62,6 +68,21 @@ describe('VerifyUser', () => {
 
     expect(getByRole('alert')).toBeDefined();
     expect(getByText(error)).toBeDefined();
+  });
+
+  it('calls onSubmit with expected values', () => {
+    const { getByRole } = render(<VerifyUser {...props} />);
+
+    const emailRadio = getByRole('radio', { name: 'h***o@world.com' });
+    fireEvent.press(emailRadio);
+
+    const submitButton = getByRole('button', {
+      name: 'Verify',
+    });
+    fireEvent.press(submitButton);
+
+    expect(handleSubmit).toBeCalledTimes(1);
+    expect(handleSubmit).toBeCalledWith({ unverifiedAttr: 'email' });
   });
 
   it('renders as expected when isPending is true', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

In `VerifyUser`, radio buttons were submitting its actual phone/email value like so:

```json
{
  "unverifiedAttr": "example@example.com"
}
```
but underlying state machine expects just the string `"email"` or `"phone_number"` and not its actual value. 

This PR updates `VerifyUser` to use `name` instead of `value` for its form handling.

#### Description of how you validated changes

New unit tests!

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
