### PR TITLE
chore(rna): remove web only keys from SetupTOTPProps

### DIFF
--- a/packages/react-core/src/Authenticator/hooks/types.ts
+++ b/packages/react-core/src/Authenticator/hooks/types.ts
@@ -117,9 +117,6 @@ export type ResetPasswordBaseProps<FieldType = {}> = {
 export type SetupTOTPBaseProps<FieldType = {}> = {
   getTotpSecretCode: GetTotpSecretCode;
   toSignIn: AuthenticatorMachineContext['toSignIn'];
-  // `totpIssuer` and `totpUsername` are used for RWA only
-  totpIssuer?: string;
-  totpUsername?: string;
 } & CommonRouteProps &
   ComponentSlots<FieldType>;
 

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticator/__mock__/useAuthenticator.ts
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticator/__mock__/useAuthenticator.ts
@@ -27,12 +27,10 @@ const toSignUp = jest.fn();
 const unverifiedContactMethods = {};
 const updateBlur = jest.fn();
 const updateForm = jest.fn();
-const username = 'Charles';
 const validationErrors = {};
 
 const user = {
   challengeName,
-  username,
 } as AuthenticatorMachineContext['user'];
 
 export const mockMachineContext: AuthenticatorMachineContext = {

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/__tests__/__snapshots__/useAuthenticatorRoute.spec.ts.snap
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/__tests__/__snapshots__/useAuthenticatorRoute.spec.ts.snap
@@ -120,8 +120,6 @@ Object {
     "handleSubmit": [MockFunction],
     "isPending": false,
     "toSignIn": [MockFunction],
-    "totpIssuer": "AWSCognito",
-    "totpUsername": "Charles",
   },
 }
 `;

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/__tests__/utils.spec.ts
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/__tests__/utils.spec.ts
@@ -53,8 +53,7 @@ const {
   validationErrors,
 } = mockUseAuthenticatorOutput;
 
-const totpIssuer = 'AWSCognito';
-const { challengeName, username } = user;
+const { challengeName } = user;
 
 const machineContext = mockMachineContext;
 
@@ -94,7 +93,7 @@ describe('getRouteMachineSelector', () => {
       ],
     ],
     ['signUp', [...commonSelectorProps, toSignIn, validationErrors]],
-    ['setupTOTP', [...commonSelectorProps, toSignIn, user]],
+    ['setupTOTP', [...commonSelectorProps, toSignIn]],
     ['verifyUser', [...commonSelectorProps, skipVerification]],
   ])('returns the expected route selector for %s', (route, expected) => {
     const selector = getRouteMachineSelector(route as AuthenticatorRoute);
@@ -131,11 +130,7 @@ describe('props resolver functions', () => {
       resolveResetPasswordRoute,
       { error, isPending, toSignIn },
     ],
-    [
-      'SetupTOTP',
-      resolveSetupTOTPRoute,
-      { getTotpSecretCode, toSignIn, totpUsername: username, totpIssuer },
-    ],
+    ['SetupTOTP', resolveSetupTOTPRoute, { getTotpSecretCode, toSignIn }],
     [
       'SignIn',
       resolveSignInRoute,

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/constants.ts
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/constants.ts
@@ -18,8 +18,6 @@ import {
   VerifyUserMachineKey,
 } from './types';
 
-export const DEFAULT_TOTP_ISSUER = 'AWSCognito';
-
 export const EVENT_HANDLER_KEY_MAP: Record<
   FormEventHandlerMachineKey,
   FormEventHandlerPropKey
@@ -80,7 +78,6 @@ const SIGN_UP_MACHINE_KEYS: SignUpMachineKey[] = [
 const SETUP_TOTP_MACHINE_KEYS: SetupTOTPMachineKey[] = [
   ...COMMON_ROUTE_MACHINE_KEYS,
   'toSignIn',
-  'user',
 ];
 const VERIFY_USER_MACHINE_KEYS: VerifyUserMachineKey[] = [
   ...COMMON_ROUTE_MACHINE_KEYS,

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/types.ts
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/types.ts
@@ -85,8 +85,8 @@ export type ResetPasswordMachineKey =
   | CommonRouteMachineKey;
 
 export type SetupTOTPMachineKey =
-  // SetupTOTP requires `user` to extract values needed for `totpIssuer` and 'totpUsername`
-  ExtractMachineKey<SetupTOTPBaseProps> | CommonRouteMachineKey | 'user';
+  | ExtractMachineKey<SetupTOTPBaseProps>
+  | CommonRouteMachineKey;
 
 export type SignInMachineKey =
   | ExtractMachineKey<SignInBaseProps>

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/utils.ts
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/utils.ts
@@ -15,11 +15,7 @@ import {
   UseAuthenticatorSelector,
 } from '../useAuthenticator';
 import { isComponentRouteKey } from '../utils';
-import {
-  DEFAULT_TOTP_ISSUER,
-  MACHINE_PROP_KEYS,
-  EVENT_HANDLER_KEY_MAP,
-} from './constants';
+import { MACHINE_PROP_KEYS, EVENT_HANDLER_KEY_MAP } from './constants';
 import {
   ConvertedMachineProps,
   FormEventHandlerMachineKey,
@@ -152,24 +148,12 @@ export function resolveSetupTOTPRoute<FieldType = {}>(
   Component: Defaults<FieldType>['SetupTOTP'],
   { getTotpSecretCode, ...props }: UseAuthenticator
 ): UseAuthenticatorRoute<'SetupTOTP', FieldType> {
-  const { user, ...machineProps } = getConvertedMachineProps(
-    'setupTOTP',
-    props
-  );
-
-  // prior to reaching the `setupTOTP` route, `user` will be
-  // authenticated ensuring `username` is provided
-  const totpUsername = user.username!;
-  const totpIssuer = DEFAULT_TOTP_ISSUER;
-
   return {
     Component,
     props: {
       ...Component,
-      ...machineProps,
+      ...getConvertedMachineProps('setupTOTP', props),
       getTotpSecretCode,
-      totpUsername,
-      totpIssuer,
     },
   };
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Remove extraneous `totpIssuer` and `totpUsername` keys from `SetupTOTPProps` as RNA does not generate a QR code

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
