### PR TITLE
fix(rna): Fix memoization issue in `useAuthenticatorRoute`

### DIFF
--- a/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/__tests__/utils.spec.ts
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/__tests__/utils.spec.ts
@@ -40,6 +40,7 @@ const {
   getTotpSecretCode,
   isPending,
   resendCode,
+  route,
   skipVerification,
   socialProviders,
   submitForm,
@@ -71,17 +72,20 @@ describe('getRouteMachineSelector', () => {
   it.each([
     [
       'confirmResetPassword',
-      [...commonSelectorProps, resendCode, validationErrors],
+      [...commonSelectorProps, resendCode, validationErrors, route],
     ],
-    ['confirmSignIn', [...commonSelectorProps, toSignIn, user]],
+    ['confirmSignIn', [...commonSelectorProps, toSignIn, user, route]],
     [
       'confirmSignUp',
-      [...commonSelectorProps, codeDeliveryDetails, resendCode],
+      [...commonSelectorProps, codeDeliveryDetails, resendCode, route],
     ],
-    ['confirmVerifyUser', [...commonSelectorProps, skipVerification]],
-    ['forceNewPassword', [...commonSelectorProps, toSignIn, validationErrors]],
-    ['idle', []],
-    ['resetPassword', [...commonSelectorProps, toSignIn]],
+    ['confirmVerifyUser', [...commonSelectorProps, skipVerification, route]],
+    [
+      'forceNewPassword',
+      [...commonSelectorProps, toSignIn, validationErrors, route],
+    ],
+    ['idle', [route]],
+    ['resetPassword', [...commonSelectorProps, toSignIn, route]],
     [
       'signIn',
       [
@@ -90,11 +94,12 @@ describe('getRouteMachineSelector', () => {
         toFederatedSignIn,
         toResetPassword,
         toSignUp,
+        route,
       ],
     ],
-    ['signUp', [...commonSelectorProps, toSignIn, validationErrors]],
-    ['setupTOTP', [...commonSelectorProps, toSignIn]],
-    ['verifyUser', [...commonSelectorProps, skipVerification]],
+    ['signUp', [...commonSelectorProps, toSignIn, validationErrors, route]],
+    ['setupTOTP', [...commonSelectorProps, toSignIn, route]],
+    ['verifyUser', [...commonSelectorProps, skipVerification, route]],
   ])('returns the expected route selector for %s', (route, expected) => {
     const selector = getRouteMachineSelector(route as AuthenticatorRoute);
     const output = selector(machineContext);

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/utils.ts
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/utils.ts
@@ -32,7 +32,7 @@ const createSelector =
   (context) => {
     const dependencies = selectorKeys.map((key) => context[key]);
     // route should always be part of deps, so hook knows when route changes.
-    return [...dependencies, 'route'];
+    return [...dependencies, context.route];
   };
 
 export const getRouteMachineSelector = (

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/utils.ts
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticatorRoute/utils.ts
@@ -24,23 +24,23 @@ import {
   UseAuthenticatorRouteDefault,
 } from './types';
 
-// selects nothing
-const defaultSelector = () => [];
-
 // only select `route` from machine context
 export const routeSelector: UseAuthenticatorSelector = ({ route }) => [route];
 
 const createSelector =
   (selectorKeys: AuthenticatorMachineContextKey[]): UseAuthenticatorSelector =>
-  (context) =>
-    selectorKeys.map((key) => context[key]);
+  (context) => {
+    const dependencies = selectorKeys.map((key) => context[key]);
+    // route should always be part of deps, so hook knows when route changes.
+    return [...dependencies, 'route'];
+  };
 
 export const getRouteMachineSelector = (
   route: AuthenticatorRoute
 ): UseAuthenticatorSelector =>
   isComponentRouteKey(route)
     ? createSelector(MACHINE_PROP_KEYS[route])
-    : defaultSelector;
+    : routeSelector;
 
 const isFormEventHandlerKey = (
   key: AuthenticatorMachineContextKey


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes memoization issue in `useAuthenticatorRoute`. The default selector was too restrictive, because it kept its memoization even when `route` changed. 

This PR changes the default selectors to always include "route".

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
