### PR TITLE
fix(Autocomplete): remove handler to open menu on focus

### DIFF
--- a/.changeset/good-donuts-obey.md
+++ b/.changeset/good-donuts-obey.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(Autocomplete): remove handler to open menu on focus to fix #3030

--- a/packages/react/src/primitives/Autocomplete/Autocomplete.tsx
+++ b/packages/react/src/primitives/Autocomplete/Autocomplete.tsx
@@ -29,7 +29,6 @@ export const AutocompletePrimitive: Primitive<AutocompleteProps, 'input'> = (
     onChange,
     onClear,
     onClick,
-    onFocus,
     onSelect,
     onSubmit,
     renderOption,
@@ -46,7 +45,6 @@ export const AutocompletePrimitive: Primitive<AutocompleteProps, 'input'> = (
     handleOnBlur,
     handleOnClear,
     handleOnClick,
-    handleOnFocus,
     handleOnChange,
     handleOnKeyDown,
     isControlled,
@@ -67,7 +65,6 @@ export const AutocompletePrimitive: Primitive<AutocompleteProps, 'input'> = (
     onChange,
     onClear,
     onClick,
-    onFocus,
     onSelect,
     onSubmit,
   });
@@ -145,7 +142,6 @@ export const AutocompletePrimitive: Primitive<AutocompleteProps, 'input'> = (
         onChange={handleOnChange}
         onClear={handleOnClear}
         onClick={handleOnClick}
-        onFocus={handleOnFocus}
         onKeyDown={handleOnKeyDown}
         ref={ref}
         value={composedValue}

--- a/packages/react/src/primitives/Autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/react/src/primitives/Autocomplete/__tests__/Autocomplete.test.tsx
@@ -65,6 +65,13 @@ describe('Autocomplete: ', () => {
     userEvent.keyboard('{Esc}');
     expect(textInput).toHaveValue('');
 
+    // Focus will not open menu
+    userEvent.click(document.body);
+    expect(textInput).not.toHaveFocus();
+    textInput.focus();
+    expect(textInput).toHaveFocus();
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+
     // Click will open menu
     expect(textInput).toHaveFocus();
     userEvent.click(textInput);
@@ -188,7 +195,7 @@ describe('Autocomplete: ', () => {
     render(<Autocomplete label={label} options={options} isLoading />);
 
     const textInput = await screen.findByRole('combobox');
-    textInput.focus();
+    userEvent.click(textInput);
     const listbox = screen.queryByRole('listbox');
     expect(listbox).not.toBeInTheDocument();
     const loading = screen.getByText(ComponentText.Autocomplete.loadingText);
@@ -199,7 +206,7 @@ describe('Autocomplete: ', () => {
     render(<Autocomplete label={label} options={options} />);
 
     const textInput = await screen.findByRole('combobox');
-    textInput.focus();
+    userEvent.click(textInput);
 
     const appleOption = screen.getByText('apple')
       .parentElement as HTMLLIElement;
@@ -230,7 +237,7 @@ describe('Autocomplete: ', () => {
     );
 
     userEvent.keyboard('{ArrowDown}');
-    expect(textInput).toHaveFocus();
+    // expect(textInput).toHaveFocus();
     expect(appleOption).not.toHaveClass(
       classNameModifier(ComponentClassNames.AutocompleteMenuOption, 'active')
     );
@@ -281,7 +288,7 @@ describe('Autocomplete: ', () => {
     );
 
     const textInput = await screen.findByRole('combobox');
-    textInput.focus();
+    userEvent.click(textInput);
     expect(renderOption).toHaveBeenCalled();
   });
 
@@ -297,7 +304,7 @@ describe('Autocomplete: ', () => {
     );
 
     const textInput = await screen.findByRole('combobox');
-    textInput.focus();
+    userEvent.click(textInput);
 
     const loading = screen.getByText(LoadingIndicator);
     expect(loading).toBeInTheDocument();
@@ -309,7 +316,7 @@ describe('Autocomplete: ', () => {
     render(<Autocomplete label={label} options={[]} menuSlots={{ Empty }} />);
 
     const textInput = await screen.findByRole('combobox');
-    textInput.focus();
+    userEvent.click(textInput);
 
     const empty = screen.getByText(Empty);
     expect(empty).toBeInTheDocument();
@@ -328,7 +335,7 @@ describe('Autocomplete: ', () => {
     );
 
     const textInput = await screen.findByRole('combobox');
-    textInput.focus();
+    userEvent.click(textInput);
 
     const header = screen.getByText(Header);
     expect(header).toBeInTheDocument();
@@ -347,7 +354,7 @@ describe('Autocomplete: ', () => {
     expect(textInput).toHaveAttribute('aria-haspopup', 'listbox');
     expect(textInput).toHaveAttribute('aria-expanded', 'false');
 
-    textInput.focus();
+    userEvent.click(textInput);
     const menu = screen.getByRole('listbox').parentElement;
     expect(textInput).toHaveAttribute('aria-expanded', 'true');
     expect(textInput).toHaveAttribute('aria-controls', menu?.id);

--- a/packages/react/src/primitives/Autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/react/src/primitives/Autocomplete/__tests__/Autocomplete.test.tsx
@@ -237,7 +237,7 @@ describe('Autocomplete: ', () => {
     );
 
     userEvent.keyboard('{ArrowDown}');
-    // expect(textInput).toHaveFocus();
+    expect(textInput).toHaveFocus();
     expect(appleOption).not.toHaveClass(
       classNameModifier(ComponentClassNames.AutocompleteMenuOption, 'active')
     );

--- a/packages/react/src/primitives/Autocomplete/useAutocomplete.tsx
+++ b/packages/react/src/primitives/Autocomplete/useAutocomplete.tsx
@@ -21,7 +21,6 @@ export const useAutocomplete = ({
   onChange,
   onClear,
   onClick,
-  onFocus,
   onSelect,
   onSubmit,
 }: UseAutocompleteProps) => {
@@ -101,17 +100,6 @@ export const useAutocomplete = ({
         }
       },
       [onClick]
-    );
-
-  const handleOnFocus: React.FocusEventHandler<HTMLInputElement> =
-    React.useCallback(
-      (event) => {
-        setIsMenuOpen(true);
-        if (isFunction(onFocus)) {
-          onFocus(event);
-        }
-      },
-      [onFocus]
     );
 
   const handleOnKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (
@@ -239,7 +227,6 @@ export const useAutocomplete = ({
     handleOnBlur,
     handleOnClear,
     handleOnClick,
-    handleOnFocus,
     handleOnChange,
     handleOnKeyDown,
     isControlled,

--- a/packages/react/src/primitives/types/autocomplete.ts
+++ b/packages/react/src/primitives/types/autocomplete.ts
@@ -143,6 +143,4 @@ export interface UseAutocompleteProps extends Partial<AutocompleteProps> {
   onChange: React.ChangeEventHandler<HTMLInputElement>;
 
   onClick: React.MouseEventHandler<HTMLInputElement>;
-
-  onFocus: React.FocusEventHandler<HTMLInputElement>;
 }


### PR DESCRIPTION
#### Description of changes

In a special case(#3030), opening dropdown menu on focus is annoying.

#### Issue #, if available

Fix #3030 

#### Description of how you validated changes

Add new unit tests 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
