### PR TITLE
chore(ui-react-native): Fix accessibility audit issues

### DIFF
--- a/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/__snapshots__/ConfirmResetPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/__snapshots__/ConfirmResetPassword.spec.tsx.snap
@@ -31,13 +31,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Code"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -48,8 +41,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Code"
         accessibilityRole="text"
         style={
           Array [
@@ -75,6 +70,7 @@ Array [
         Code
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -83,12 +79,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -103,6 +103,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -111,13 +112,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="New Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -131,8 +125,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="New Password"
         accessibilityRole="text"
         style={
           Array [
@@ -158,6 +154,7 @@ Array [
         New Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -166,12 +163,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -187,12 +188,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -248,13 +251,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Confirm Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -268,8 +264,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Confirm Password"
         accessibilityRole="text"
         style={
           Array [
@@ -295,6 +293,7 @@ Array [
         Confirm Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -303,12 +302,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -324,12 +327,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -519,7 +524,9 @@ Array [
         },
         null,
         null,
-        Object {},
+        Object {
+          "margin": 16,
+        },
       ]
     }
   >
@@ -573,13 +580,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Code"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -590,8 +590,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Code"
         accessibilityRole="text"
         style={
           Array [
@@ -617,6 +619,7 @@ Array [
         Code
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -625,12 +628,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -645,6 +652,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -653,13 +661,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="New Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -673,8 +674,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="New Password"
         accessibilityRole="text"
         style={
           Array [
@@ -700,6 +703,7 @@ Array [
         New Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -708,12 +712,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -729,12 +737,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -790,13 +800,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Confirm Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -810,8 +813,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Confirm Password"
         accessibilityRole="text"
         style={
           Array [
@@ -837,6 +842,7 @@ Array [
         Confirm Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -845,12 +851,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -866,12 +876,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -1008,7 +1020,9 @@ Array [
         },
         null,
         null,
-        Object {},
+        Object {
+          "margin": 16,
+        },
       ]
     }
   >

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/__snapshots__/ConfirmSignIn.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/__snapshots__/ConfirmSignIn.spec.tsx.snap
@@ -31,13 +31,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Code"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -48,8 +41,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Code"
         accessibilityRole="text"
         style={
           Array [
@@ -75,6 +70,7 @@ Array [
         Code
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -83,12 +79,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -103,6 +103,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -309,13 +310,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Code"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -326,8 +320,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Code"
         accessibilityRole="text"
         style={
           Array [
@@ -353,6 +349,7 @@ Array [
         Code
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -361,12 +358,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -381,6 +382,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/__tests__/__snapshots__/ConfirmSignUp.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignUp/__tests__/__snapshots__/ConfirmSignUp.spec.tsx.snap
@@ -132,7 +132,9 @@ Array [
         },
         null,
         null,
-        Object {},
+        Object {
+          "margin": 16,
+        },
       ]
     }
   >
@@ -287,7 +289,9 @@ Array [
         },
         null,
         null,
-        Object {},
+        Object {
+          "margin": 16,
+        },
       ]
     }
   >
@@ -495,7 +499,9 @@ Array [
         },
         null,
         null,
-        Object {},
+        Object {
+          "margin": 16,
+        },
       ]
     }
   >

--- a/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/__snapshots__/ResetPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/__snapshots__/ResetPassword.spec.tsx.snap
@@ -31,13 +31,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Username"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -48,8 +41,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Username"
         accessibilityRole="text"
         style={
           Array [
@@ -75,6 +70,7 @@ Array [
         Username
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -83,12 +79,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -103,6 +103,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -309,13 +310,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Username"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -326,8 +320,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Username"
         accessibilityRole="text"
         style={
           Array [
@@ -353,6 +349,7 @@ Array [
         Username
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -361,12 +358,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -381,6 +382,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]

--- a/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/__snapshots__/SetupTOTP.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/__snapshots__/SetupTOTP.spec.tsx.snap
@@ -31,13 +31,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Code"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -48,8 +41,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Code"
         accessibilityRole="text"
         style={
           Array [
@@ -75,6 +70,7 @@ Array [
         Code
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -83,12 +79,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -103,6 +103,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -309,13 +310,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Code"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -326,8 +320,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Code"
         accessibilityRole="text"
         style={
           Array [
@@ -353,6 +349,7 @@ Array [
         Code
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -361,12 +358,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -381,6 +382,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]

--- a/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/__snapshots__/SignIn.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/__snapshots__/SignIn.spec.tsx.snap
@@ -31,13 +31,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Username"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -48,8 +41,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Username"
         accessibilityRole="text"
         style={
           Array [
@@ -75,6 +70,7 @@ Array [
         Username
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -83,12 +79,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -103,6 +103,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -111,13 +112,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -131,8 +125,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Password"
         accessibilityRole="text"
         style={
           Array [
@@ -158,6 +154,7 @@ Array [
         Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -166,12 +163,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -187,12 +188,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -443,13 +446,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Username"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -460,8 +456,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Username"
         accessibilityRole="text"
         style={
           Array [
@@ -487,6 +485,7 @@ Array [
         Username
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -495,12 +494,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -515,6 +518,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -523,13 +527,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -543,8 +540,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Password"
         accessibilityRole="text"
         style={
           Array [
@@ -570,6 +569,7 @@ Array [
         Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -578,12 +578,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -599,12 +603,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -805,13 +811,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Username"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -822,8 +821,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Username"
         accessibilityRole="text"
         style={
           Array [
@@ -849,6 +850,7 @@ Array [
         Username
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -857,12 +859,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -877,6 +883,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -885,13 +892,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -905,8 +905,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Password"
         accessibilityRole="text"
         style={
           Array [
@@ -932,6 +934,7 @@ Array [
         Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -940,12 +943,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -961,12 +968,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {

--- a/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/__snapshots__/SignUp.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/__snapshots__/SignUp.spec.tsx.snap
@@ -31,13 +31,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Username"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -48,8 +41,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Username"
         accessibilityRole="text"
         style={
           Array [
@@ -75,6 +70,7 @@ Array [
         Username
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -83,12 +79,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -103,6 +103,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -111,13 +112,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -131,8 +125,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Password"
         accessibilityRole="text"
         style={
           Array [
@@ -158,6 +154,7 @@ Array [
         Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -166,12 +163,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -187,12 +188,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -248,13 +251,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Confirm Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -268,8 +264,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Confirm Password"
         accessibilityRole="text"
         style={
           Array [
@@ -295,6 +293,7 @@ Array [
         Confirm Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -303,12 +302,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -324,12 +327,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -385,13 +390,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Phone"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -405,8 +403,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Phone"
         accessibilityRole="text"
         style={
           Array [
@@ -435,6 +435,7 @@ Array [
         Phone
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -443,12 +444,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -464,6 +469,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Array [
                 Object {},
@@ -620,13 +626,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Username"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -637,8 +636,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Username"
         accessibilityRole="text"
         style={
           Array [
@@ -664,6 +665,7 @@ Array [
         Username
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -672,12 +674,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -692,6 +698,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -700,13 +707,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -720,8 +720,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Password"
         accessibilityRole="text"
         style={
           Array [
@@ -747,6 +749,7 @@ Array [
         Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -755,12 +758,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -776,12 +783,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -837,13 +846,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Confirm Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -857,8 +859,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Confirm Password"
         accessibilityRole="text"
         style={
           Array [
@@ -884,6 +888,7 @@ Array [
         Confirm Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -892,12 +897,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -913,12 +922,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -974,13 +985,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Phone"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -994,8 +998,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Phone"
         accessibilityRole="text"
         style={
           Array [
@@ -1024,6 +1030,7 @@ Array [
         Phone
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -1032,12 +1039,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -1053,6 +1064,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Array [
                 Object {},
@@ -1149,13 +1161,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Username"
-      accessibilityState={
-        Object {
-          "disabled": true,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -1166,8 +1171,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Username"
         accessibilityRole="text"
         style={
           Array [
@@ -1193,6 +1200,7 @@ Array [
         Username
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -1202,12 +1210,16 @@ Array [
             "flexDirection": "row",
             "opacity": 0.6,
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": true,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={false}
@@ -1222,6 +1234,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -1230,13 +1243,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Password"
-      accessibilityState={
-        Object {
-          "disabled": true,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -1250,8 +1256,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Password"
         accessibilityRole="text"
         style={
           Array [
@@ -1277,6 +1285,7 @@ Array [
         Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -1286,12 +1295,16 @@ Array [
             "flexDirection": "row",
             "opacity": 0.6,
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": true,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={false}
@@ -1307,12 +1320,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -1370,13 +1385,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Confirm Password"
-      accessibilityState={
-        Object {
-          "disabled": true,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -1390,8 +1398,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Confirm Password"
         accessibilityRole="text"
         style={
           Array [
@@ -1417,6 +1427,7 @@ Array [
         Confirm Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -1426,12 +1437,16 @@ Array [
             "flexDirection": "row",
             "opacity": 0.6,
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": true,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={false}
@@ -1447,12 +1462,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -1510,13 +1527,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Phone"
-      accessibilityState={
-        Object {
-          "disabled": true,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -1530,8 +1540,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Phone"
         accessibilityRole="text"
         style={
           Array [
@@ -1560,6 +1572,7 @@ Array [
         Phone
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -1569,12 +1582,16 @@ Array [
             "flexDirection": "row",
             "opacity": 0.6,
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": true,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={false}
@@ -1590,6 +1607,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Array [
                 Object {},
@@ -1746,13 +1764,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Username"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -1763,8 +1774,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Username"
         accessibilityRole="text"
         style={
           Array [
@@ -1790,6 +1803,7 @@ Array [
         Username
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -1798,12 +1812,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -1818,6 +1836,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -1826,13 +1845,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -1846,8 +1858,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Password"
         accessibilityRole="text"
         style={
           Array [
@@ -1873,6 +1887,7 @@ Array [
         Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -1881,12 +1896,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -1902,12 +1921,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -1963,13 +1984,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Confirm Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -1983,8 +1997,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Confirm Password"
         accessibilityRole="text"
         style={
           Array [
@@ -2010,6 +2026,7 @@ Array [
         Confirm Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -2018,12 +2035,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -2039,12 +2060,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -2100,13 +2123,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Phone"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -2120,8 +2136,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Phone"
         accessibilityRole="text"
         style={
           Array [
@@ -2150,6 +2168,7 @@ Array [
         Phone
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -2158,12 +2177,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -2179,6 +2202,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Array [
                 Object {},
@@ -2388,13 +2412,6 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Username"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -2405,8 +2422,10 @@ Array [
           },
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Username"
         accessibilityRole="text"
         style={
           Array [
@@ -2432,6 +2451,7 @@ Array [
         Username
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -2440,12 +2460,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -2460,6 +2484,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
@@ -2468,13 +2493,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -2488,8 +2506,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Password"
         accessibilityRole="text"
         style={
           Array [
@@ -2515,6 +2535,7 @@ Array [
         Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -2523,12 +2544,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -2544,12 +2569,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -2605,13 +2632,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Confirm Password"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -2625,8 +2645,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Confirm Password"
         accessibilityRole="text"
         style={
           Array [
@@ -2652,6 +2674,7 @@ Array [
         Confirm Password
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -2660,12 +2683,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -2681,12 +2708,14 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Object {},
             ]
           }
         />
         <View
+          accessibilityLabel="Show password"
           accessibilityRole="button"
           accessibilityState={
             Object {
@@ -2742,13 +2771,6 @@ Array [
       </View>
     </View>
     <View
-      accessibilityLabel="Phone"
-      accessibilityState={
-        Object {
-          "disabled": false,
-        }
-      }
-      accessible={true}
       style={
         Array [
           Object {
@@ -2762,8 +2784,10 @@ Array [
           ],
         ]
       }
+      testID="amplify__text-field-container"
     >
       <Text
+        accessibilityLabel="Phone"
         accessibilityRole="text"
         style={
           Array [
@@ -2792,6 +2816,7 @@ Array [
         Phone
       </Text>
       <View
+        accessible={true}
         style={
           Object {
             "alignItems": "center",
@@ -2800,12 +2825,16 @@ Array [
             "borderWidth": 1,
             "flexDirection": "row",
             "paddingHorizontal": 8,
-            "paddingVertical": 12,
           }
         }
         testID="amplify__text-field__input-container"
       >
         <TextInput
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
           accessible={true}
           autoCapitalize="none"
           editable={true}
@@ -2821,6 +2850,7 @@ Array [
                 "color": "hsl(210, 50%, 10%)",
                 "flexGrow": 1,
                 "fontSize": 16,
+                "paddingVertical": 12,
               },
               Array [
                 Object {},

--- a/packages/react-native/src/Authenticator/common/DefaultContent/styles.ts
+++ b/packages/react-native/src/Authenticator/common/DefaultContent/styles.ts
@@ -15,7 +15,9 @@ export const getDefaultStyle = ({
       margin: space.medium,
     },
     buttonPrimaryLabel: {}, // themed value only
-    buttonSecondary: {}, // themed value only
+    buttonSecondary: {
+      margin: space.medium,
+    },
     buttonSecondaryLabel: {}, // themed value only
     errorMessage: {
       marginVertical: space.small,

--- a/packages/react-native/src/Authenticator/common/DefaultContent/types.ts
+++ b/packages/react-native/src/Authenticator/common/DefaultContent/types.ts
@@ -62,7 +62,7 @@ export type DefaultContentProps<
   'error' | 'Footer' | 'isPending'
 > & {
   buttons: DefaultButtons;
-  body?: React.ReactNode | string;
+  body?: React.ReactNode;
   fields: FieldsType[];
   headerText: string;
   Footer: AuthenticatorFooterComponent<{ style?: StyleProp<TextStyle> }>;

--- a/packages/react-native/src/primitives/PasswordField/PasswordField.tsx
+++ b/packages/react-native/src/primitives/PasswordField/PasswordField.tsx
@@ -7,6 +7,9 @@ import { TextField } from '../TextField';
 
 import { PasswordFieldProps } from './types';
 import { getThemedStyles } from './styles';
+import { authenticatorTextUtil } from '@aws-amplify/ui';
+
+const { getHidePasswordText, getShowPasswordText } = authenticatorTextUtil;
 
 export default function PasswordField({
   disabled,
@@ -26,6 +29,11 @@ export default function PasswordField({
     setObscureText(!obscureText);
   }, [obscureText]);
 
+  const toggleVisibilityAccessibilityLabel =
+    iconAccessibilityLabel ?? obscureText
+      ? getShowPasswordText()
+      : getHidePasswordText();
+
   return (
     <TextField
       {...rest}
@@ -35,7 +43,7 @@ export default function PasswordField({
       endAccessory={
         showPasswordButton ? (
           <IconButton
-            accessibilityLabel={iconAccessibilityLabel}
+            accessibilityLabel={toggleVisibilityAccessibilityLabel}
             disabled={disabled}
             iconStyle={[themedStyle.icon, iconStyle]}
             size={16}

--- a/packages/react-native/src/primitives/PasswordField/__tests__/PasswordField.spec.tsx
+++ b/packages/react-native/src/primitives/PasswordField/__tests__/PasswordField.spec.tsx
@@ -5,6 +5,7 @@ import { icons } from '../../../assets';
 import { useTheme } from '../../../theme';
 import PasswordField from '../PasswordField';
 import { getThemedStyles } from '../styles';
+import { TEXTFIELD_CONTAINER_TEST_ID } from '../../TextField/TextField';
 
 const labelText = 'Label';
 const testID = 'passwordInput';
@@ -80,10 +81,9 @@ describe('PasswordField', () => {
     const customStyle = { backgroundColor: 'red' };
     const customIconStyle = { backgroundColor: 'blue' };
 
-    const { toJSON, getByRole } = render(
+    const { toJSON, getByRole, getByTestId } = render(
       <PasswordField
         {...defaultProps}
-        accessibilityRole="none"
         iconStyle={customIconStyle}
         style={customStyle}
       />
@@ -92,7 +92,7 @@ describe('PasswordField', () => {
     const { result } = renderHook(() => useTheme());
     const themedStyle = getThemedStyles(result.current);
 
-    const container = getByRole('none');
+    const container = getByTestId(TEXTFIELD_CONTAINER_TEST_ID);
     const icon = getByRole('image');
 
     expect(container.props.style).toContainEqual([

--- a/packages/react-native/src/primitives/PasswordField/__tests__/__snapshots__/PasswordField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/PasswordField/__tests__/__snapshots__/PasswordField.spec.tsx.snap
@@ -2,14 +2,6 @@
 
 exports[`PasswordField applies theme and style props 1`] = `
 <View
-  accessibilityLabel="Label"
-  accessibilityRole="none"
-  accessibilityState={
-    Object {
-      "disabled": undefined,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -23,8 +15,10 @@ exports[`PasswordField applies theme and style props 1`] = `
       ],
     ]
   }
+  testID="amplify__text-field-container"
 >
   <Text
+    accessibilityLabel="Label"
     accessibilityRole="text"
     style={
       Array [
@@ -50,6 +44,7 @@ exports[`PasswordField applies theme and style props 1`] = `
     Label
   </Text>
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -58,12 +53,16 @@ exports[`PasswordField applies theme and style props 1`] = `
         "borderWidth": 1,
         "flexDirection": "row",
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={true}
@@ -76,6 +75,7 @@ exports[`PasswordField applies theme and style props 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           undefined,
         ]
@@ -83,6 +83,7 @@ exports[`PasswordField applies theme and style props 1`] = `
       testID="passwordInput"
     />
     <View
+      accessibilityLabel="Show password"
       accessibilityRole="button"
       accessible={true}
       collapsable={false}
@@ -138,13 +139,6 @@ exports[`PasswordField applies theme and style props 1`] = `
 
 exports[`PasswordField renders as expected 1`] = `
 <View
-  accessibilityLabel="Label"
-  accessibilityState={
-    Object {
-      "disabled": undefined,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -156,8 +150,10 @@ exports[`PasswordField renders as expected 1`] = `
       ],
     ]
   }
+  testID="amplify__text-field-container"
 >
   <Text
+    accessibilityLabel="Label"
     accessibilityRole="text"
     style={
       Array [
@@ -183,6 +179,7 @@ exports[`PasswordField renders as expected 1`] = `
     Label
   </Text>
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -191,12 +188,16 @@ exports[`PasswordField renders as expected 1`] = `
         "borderWidth": 1,
         "flexDirection": "row",
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={true}
@@ -209,6 +210,7 @@ exports[`PasswordField renders as expected 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           undefined,
         ]
@@ -216,6 +218,7 @@ exports[`PasswordField renders as expected 1`] = `
       testID="passwordInput"
     />
     <View
+      accessibilityLabel="Show password"
       accessibilityRole="button"
       accessible={true}
       collapsable={false}
@@ -269,13 +272,6 @@ exports[`PasswordField renders as expected 1`] = `
 
 exports[`PasswordField renders as expected when disabled 1`] = `
 <View
-  accessibilityLabel="Label"
-  accessibilityState={
-    Object {
-      "disabled": true,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -287,8 +283,10 @@ exports[`PasswordField renders as expected when disabled 1`] = `
       ],
     ]
   }
+  testID="amplify__text-field-container"
 >
   <Text
+    accessibilityLabel="Label"
     accessibilityRole="text"
     style={
       Array [
@@ -314,6 +312,7 @@ exports[`PasswordField renders as expected when disabled 1`] = `
     Label
   </Text>
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -323,12 +322,16 @@ exports[`PasswordField renders as expected when disabled 1`] = `
         "flexDirection": "row",
         "opacity": 0.6,
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": true,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={false}
@@ -341,6 +344,7 @@ exports[`PasswordField renders as expected when disabled 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           undefined,
         ]
@@ -348,6 +352,7 @@ exports[`PasswordField renders as expected when disabled 1`] = `
       testID="passwordInput"
     />
     <View
+      accessibilityLabel="Show password"
       accessibilityRole="button"
       accessibilityState={
         Object {
@@ -408,13 +413,6 @@ exports[`PasswordField renders as expected when disabled 1`] = `
 
 exports[`PasswordField should be able to hide show password icon 1`] = `
 <View
-  accessibilityLabel="Label"
-  accessibilityState={
-    Object {
-      "disabled": undefined,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -426,8 +424,10 @@ exports[`PasswordField should be able to hide show password icon 1`] = `
       ],
     ]
   }
+  testID="amplify__text-field-container"
 >
   <Text
+    accessibilityLabel="Label"
     accessibilityRole="text"
     style={
       Array [
@@ -453,6 +453,7 @@ exports[`PasswordField should be able to hide show password icon 1`] = `
     Label
   </Text>
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -461,12 +462,16 @@ exports[`PasswordField should be able to hide show password icon 1`] = `
         "borderWidth": 1,
         "flexDirection": "row",
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={true}
@@ -479,6 +484,7 @@ exports[`PasswordField should be able to hide show password icon 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           undefined,
         ]
@@ -491,13 +497,6 @@ exports[`PasswordField should be able to hide show password icon 1`] = `
 
 exports[`PasswordField should be able to obscure text programmatically 1`] = `
 <View
-  accessibilityLabel="Label"
-  accessibilityState={
-    Object {
-      "disabled": undefined,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -509,8 +508,10 @@ exports[`PasswordField should be able to obscure text programmatically 1`] = `
       ],
     ]
   }
+  testID="amplify__text-field-container"
 >
   <Text
+    accessibilityLabel="Label"
     accessibilityRole="text"
     style={
       Array [
@@ -536,6 +537,7 @@ exports[`PasswordField should be able to obscure text programmatically 1`] = `
     Label
   </Text>
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -544,12 +546,16 @@ exports[`PasswordField should be able to obscure text programmatically 1`] = `
         "borderWidth": 1,
         "flexDirection": "row",
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={true}
@@ -562,6 +568,7 @@ exports[`PasswordField should be able to obscure text programmatically 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           undefined,
         ]
@@ -569,6 +576,7 @@ exports[`PasswordField should be able to obscure text programmatically 1`] = `
       testID="passwordInput"
     />
     <View
+      accessibilityLabel="Hide password"
       accessibilityRole="button"
       accessible={true}
       collapsable={false}

--- a/packages/react-native/src/primitives/PhoneNumberField/__tests__/__snapshots__/PhoneNumberField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/PhoneNumberField/__tests__/__snapshots__/PhoneNumberField.spec.tsx.snap
@@ -2,12 +2,6 @@
 
 exports[`PhoneNumberField applies theming 1`] = `
 <View
-  accessibilityState={
-    Object {
-      "disabled": undefined,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -19,8 +13,10 @@ exports[`PhoneNumberField applies theming 1`] = `
       ],
     ]
   }
+  testID="amplify__text-field-container"
 >
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -29,12 +25,16 @@ exports[`PhoneNumberField applies theming 1`] = `
         "borderWidth": 1,
         "flexDirection": "row",
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={true}
@@ -47,6 +47,7 @@ exports[`PhoneNumberField applies theming 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           Array [
             Object {},
@@ -62,12 +63,6 @@ exports[`PhoneNumberField applies theming 1`] = `
 
 exports[`PhoneNumberField renders as expected 1`] = `
 <View
-  accessibilityState={
-    Object {
-      "disabled": undefined,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -79,8 +74,10 @@ exports[`PhoneNumberField renders as expected 1`] = `
       ],
     ]
   }
+  testID="amplify__text-field-container"
 >
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -89,12 +86,16 @@ exports[`PhoneNumberField renders as expected 1`] = `
         "borderWidth": 1,
         "flexDirection": "row",
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={true}
@@ -107,6 +108,7 @@ exports[`PhoneNumberField renders as expected 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           Array [
             Object {},
@@ -122,12 +124,6 @@ exports[`PhoneNumberField renders as expected 1`] = `
 
 exports[`PhoneNumberField renders as expected when disabled 1`] = `
 <View
-  accessibilityState={
-    Object {
-      "disabled": true,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -139,8 +135,10 @@ exports[`PhoneNumberField renders as expected when disabled 1`] = `
       ],
     ]
   }
+  testID="amplify__text-field-container"
 >
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -150,12 +148,16 @@ exports[`PhoneNumberField renders as expected when disabled 1`] = `
         "flexDirection": "row",
         "opacity": 0.6,
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": true,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={false}
@@ -168,6 +170,7 @@ exports[`PhoneNumberField renders as expected when disabled 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           Array [
             Object {},

--- a/packages/react-native/src/primitives/TextField/TextField.tsx
+++ b/packages/react-native/src/primitives/TextField/TextField.tsx
@@ -6,6 +6,7 @@ import { useTheme } from '../../theme';
 import { getThemedStyles } from './styles';
 import { TextFieldProps } from './types';
 
+export const TEXTFIELD_CONTAINER_TEST_ID = 'amplify__text-field-container';
 export const INPUT_CONTAINER_TEST_ID = 'amplify__text-field__input-container';
 
 export default function TextField({
@@ -38,19 +39,28 @@ export default function TextField({
 
   return (
     <View
-      accessible={accessible}
-      accessibilityLabel={accessibilityLabel ?? label}
-      accessibilityRole={accessibilityRole}
-      accessibilityState={{ disabled, ...accessibilityState }}
+      testID={TEXTFIELD_CONTAINER_TEST_ID}
       style={[themedStyle.container, style]}
     >
       {label ? (
-        <Label style={[themedStyle.label, labelStyle]}>{label}</Label>
+        <Label
+          accessibilityLabel={label}
+          style={[themedStyle.label, labelStyle]}
+        >
+          {label}
+        </Label>
       ) : null}
-      <View style={fieldContainerStyle} testID={INPUT_CONTAINER_TEST_ID}>
+      <View
+        accessible
+        style={fieldContainerStyle}
+        testID={INPUT_CONTAINER_TEST_ID}
+      >
         <TextInput
           {...rest}
           accessible={accessible}
+          accessibilityLabel={label ? undefined : accessibilityLabel}
+          accessibilityRole={accessibilityRole}
+          accessibilityState={{ disabled, ...accessibilityState }}
           autoCapitalize={autoCapitalize}
           editable={!disabled}
           placeholderTextColor={theme.tokens.colors.font.tertiary}

--- a/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
+++ b/packages/react-native/src/primitives/TextField/__tests__/TextField.spec.tsx
@@ -3,7 +3,10 @@ import { fireEvent, render, renderHook } from '@testing-library/react-native';
 
 import { useTheme } from '../../../theme';
 import { getThemedStyles } from '../styles';
-import TextField, { INPUT_CONTAINER_TEST_ID } from '../TextField';
+import TextField, {
+  INPUT_CONTAINER_TEST_ID,
+  TEXTFIELD_CONTAINER_TEST_ID,
+} from '../TextField';
 
 const placeHolderText = 'Placeholder';
 const labelText = 'Label';
@@ -34,16 +37,13 @@ describe('TextField', () => {
   });
 
   it('renders as expected when disabled', () => {
-    const { toJSON, getByLabelText, getByTestId } = render(
+    const { toJSON, getByTestId } = render(
       <TextField {...defaultProps} disabled />
     );
     expect(toJSON()).toMatchSnapshot();
-    const textInputContainer = getByLabelText(labelText);
-    expect(textInputContainer.props.accessibilityState).toHaveProperty(
-      'disabled',
-      true
-    );
     const textInput = getByTestId(testID);
+    expect(textInput.props.accessibilityState).toHaveProperty('disabled', true);
+
     expect(textInput.props.editable).toBe(false);
   });
 
@@ -117,10 +117,9 @@ describe('TextField', () => {
     const customLabelStyle = { color: 'blue' };
     const customStyle = { backgroundColor: 'purple' };
 
-    const { getByTestId, getByText, getByRole } = render(
+    const { getByTestId, getByText } = render(
       <TextField
         {...defaultProps}
-        accessibilityRole="none"
         error
         errorMessage={errorMessageText}
         errorMessageStyle={customErrorMessageStyle}
@@ -133,7 +132,7 @@ describe('TextField', () => {
     const { result } = renderHook(() => useTheme());
     const themedStyle = getThemedStyles(result.current);
 
-    const container = getByRole('none');
+    const container = getByTestId(TEXTFIELD_CONTAINER_TEST_ID);
     const inputContainer = getByTestId(INPUT_CONTAINER_TEST_ID);
     const input = getByTestId(testID);
     const errorMessage = getByText(errorMessageText);

--- a/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
@@ -2,13 +2,6 @@
 
 exports[`TextField doesn't render the errorMessage if error prop is false 1`] = `
 <View
-  accessibilityLabel="Label"
-  accessibilityState={
-    Object {
-      "disabled": undefined,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -17,8 +10,10 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
       undefined,
     ]
   }
+  testID="amplify__text-field-container"
 >
   <Text
+    accessibilityLabel="Label"
     accessibilityRole="text"
     style={
       Array [
@@ -44,6 +39,7 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
     Label
   </Text>
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -52,12 +48,16 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
         "borderWidth": 1,
         "flexDirection": "row",
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={true}
@@ -70,6 +70,7 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           undefined,
         ]
@@ -82,13 +83,6 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
 
 exports[`TextField doesn't render the errorMessage if errorMessage prop is undefined 1`] = `
 <View
-  accessibilityLabel="Label"
-  accessibilityState={
-    Object {
-      "disabled": undefined,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -97,8 +91,10 @@ exports[`TextField doesn't render the errorMessage if errorMessage prop is undef
       undefined,
     ]
   }
+  testID="amplify__text-field-container"
 >
   <Text
+    accessibilityLabel="Label"
     accessibilityRole="text"
     style={
       Array [
@@ -124,6 +120,7 @@ exports[`TextField doesn't render the errorMessage if errorMessage prop is undef
     Label
   </Text>
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -132,12 +129,16 @@ exports[`TextField doesn't render the errorMessage if errorMessage prop is undef
         "borderWidth": 1,
         "flexDirection": "row",
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={true}
@@ -150,6 +151,7 @@ exports[`TextField doesn't render the errorMessage if errorMessage prop is undef
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           undefined,
         ]
@@ -162,13 +164,6 @@ exports[`TextField doesn't render the errorMessage if errorMessage prop is undef
 
 exports[`TextField renders as expected 1`] = `
 <View
-  accessibilityLabel="Label"
-  accessibilityState={
-    Object {
-      "disabled": undefined,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -177,8 +172,10 @@ exports[`TextField renders as expected 1`] = `
       undefined,
     ]
   }
+  testID="amplify__text-field-container"
 >
   <Text
+    accessibilityLabel="Label"
     accessibilityRole="text"
     style={
       Array [
@@ -204,6 +201,7 @@ exports[`TextField renders as expected 1`] = `
     Label
   </Text>
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -212,12 +210,16 @@ exports[`TextField renders as expected 1`] = `
         "borderWidth": 1,
         "flexDirection": "row",
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={true}
@@ -230,6 +232,7 @@ exports[`TextField renders as expected 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           undefined,
         ]
@@ -242,13 +245,6 @@ exports[`TextField renders as expected 1`] = `
 
 exports[`TextField renders as expected as password field 1`] = `
 <View
-  accessibilityLabel="Label"
-  accessibilityState={
-    Object {
-      "disabled": undefined,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -257,8 +253,10 @@ exports[`TextField renders as expected as password field 1`] = `
       undefined,
     ]
   }
+  testID="amplify__text-field-container"
 >
   <Text
+    accessibilityLabel="Label"
     accessibilityRole="text"
     style={
       Array [
@@ -284,6 +282,7 @@ exports[`TextField renders as expected as password field 1`] = `
     Label
   </Text>
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -292,12 +291,16 @@ exports[`TextField renders as expected as password field 1`] = `
         "borderWidth": 1,
         "flexDirection": "row",
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={true}
@@ -311,6 +314,7 @@ exports[`TextField renders as expected as password field 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           undefined,
         ]
@@ -323,13 +327,6 @@ exports[`TextField renders as expected as password field 1`] = `
 
 exports[`TextField renders as expected when disabled 1`] = `
 <View
-  accessibilityLabel="Label"
-  accessibilityState={
-    Object {
-      "disabled": true,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -338,8 +335,10 @@ exports[`TextField renders as expected when disabled 1`] = `
       undefined,
     ]
   }
+  testID="amplify__text-field-container"
 >
   <Text
+    accessibilityLabel="Label"
     accessibilityRole="text"
     style={
       Array [
@@ -365,6 +364,7 @@ exports[`TextField renders as expected when disabled 1`] = `
     Label
   </Text>
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -374,12 +374,16 @@ exports[`TextField renders as expected when disabled 1`] = `
         "flexDirection": "row",
         "opacity": 0.6,
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": true,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={false}
@@ -392,6 +396,7 @@ exports[`TextField renders as expected when disabled 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           undefined,
         ]
@@ -404,13 +409,6 @@ exports[`TextField renders as expected when disabled 1`] = `
 
 exports[`TextField renders as expected with error message 1`] = `
 <View
-  accessibilityLabel="Label"
-  accessibilityState={
-    Object {
-      "disabled": undefined,
-    }
-  }
-  accessible={true}
   style={
     Array [
       Object {
@@ -419,8 +417,10 @@ exports[`TextField renders as expected with error message 1`] = `
       undefined,
     ]
   }
+  testID="amplify__text-field-container"
 >
   <Text
+    accessibilityLabel="Label"
     accessibilityRole="text"
     style={
       Array [
@@ -446,6 +446,7 @@ exports[`TextField renders as expected with error message 1`] = `
     Label
   </Text>
   <View
+    accessible={true}
     style={
       Object {
         "alignItems": "center",
@@ -454,12 +455,16 @@ exports[`TextField renders as expected with error message 1`] = `
         "borderWidth": 1,
         "flexDirection": "row",
         "paddingHorizontal": 8,
-        "paddingVertical": 12,
       }
     }
     testID="amplify__text-field__input-container"
   >
     <TextInput
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       autoCapitalize="none"
       editable={true}
@@ -472,6 +477,7 @@ exports[`TextField renders as expected with error message 1`] = `
             "color": "hsl(210, 50%, 10%)",
             "flexGrow": 1,
             "fontSize": 16,
+            "paddingVertical": 12,
           },
           undefined,
         ]

--- a/packages/react-native/src/primitives/TextField/styles.ts
+++ b/packages/react-native/src/primitives/TextField/styles.ts
@@ -26,13 +26,13 @@ export const getThemedStyles = (theme: StrictTheme): TextFieldStyles => {
       borderWidth: borderWidths.small,
       flexDirection: 'row',
       paddingHorizontal: space.xs,
-      paddingVertical: space.small,
       ...components?.textField?.fieldContainer,
     },
     field: {
       color: colors.font.primary,
       fontSize: fontSizes.medium,
       flexGrow: 1,
+      paddingVertical: space.small,
       // this is needed because of extra padding inside the input - in Android only
       ...(Platform.OS === 'android' && { padding: 0 }),
       ...components?.textField?.field,

--- a/packages/ui/src/helpers/authenticator/textUtil.ts
+++ b/packages/ui/src/helpers/authenticator/textUtil.ts
@@ -94,12 +94,14 @@ export const authenticatorTextUtil = {
   getConfirmText: () => translate(DefaultTexts.CONFIRM),
   getConfirmingText: () => translate(DefaultTexts.CONFIRMING),
   getCopyText: () => translate(DefaultTexts.UPPERCASE_COPY),
+  getHidePasswordText: () => translate(DefaultTexts.HIDE_PASSWORD),
+  getLoadingText: () => translate(DefaultTexts.LOADING),
   getResendCodeText: () => translate(DefaultTexts.RESEND_CODE),
   getSendCodeText: () => translate(DefaultTexts.SEND_CODE),
   getSendingText: () => translate(DefaultTexts.SENDING),
+  getShowPasswordText: () => translate(DefaultTexts.SHOW_PASSWORD),
   getSubmitText: () => translate(DefaultTexts.SUBMIT),
   getSubmittingText: () => translate(DefaultTexts.SUBMITTING),
-  getLoadingText: () => translate(DefaultTexts.LOADING),
 
   /** SignInSignUpTabs */
   getSignInTabText: () => translate(DefaultTexts.SIGN_IN_TAB),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change addresses accessibility issues found by XCode Accessibility inspector:
* Hit area was too small for all text fields
* For text fields with accessory the icon button was not announced by voiceover

Things I was looking out for with voiceover:
* labels being announced multiple times
* fields/buttons not being announced at all

Only issue remaining is about Dynamic text not being supported. 

<img width="1448" alt="Screen Shot 2022-11-21 at 2 49 39 PM" src="https://user-images.githubusercontent.com/68251134/203174404-5c2917d4-7972-43de-8fbf-706ebb453908.png">

Also fixed a small issue with secondary button styling:
<img src="https://user-images.githubusercontent.com/68251134/203174849-3f4c2d69-a937-4431-86a0-74d41ac68374.png" width="50%" height="50%" />


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
