### PR TITLE
fix(docs): hash link start with number

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/configuration/index.page.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/configuration/index.page.mdx
@@ -74,7 +74,7 @@ By default, unauthenticated users are redirected to the Sign In flow. You can ex
 
 <Alert role="none" heading="Zero Configuration">
 
-The Authenticator [automatically infers](#zero-configuration) `signUpAttributes` from `amplify pull`,
+The Authenticator [automatically infers](/connected-components/authenticator#step-1-configure-backend) `signUpAttributes` from `amplify pull`,
 but can be explicitly defined as seen below.
 
 </Alert>

--- a/docs/src/pages/[platform]/connected-components/authenticator/configuration/loginMechanisms.flutter.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/configuration/loginMechanisms.flutter.mdx
@@ -5,7 +5,7 @@ import { Tabs, TabItem } from '@aws-amplify/ui-react';
 
 <Alert role="none" heading="Zero Configuration">
 
-The Authenticator [automatically infers](#1-configure-backend) `loginMechanisms` from `amplify pull`.
+The Authenticator [automatically infers](/connected-components/authenticator#step-1-configure-backend) `loginMechanisms` from `amplify pull`.
 Below are examples of username, email, and phone number based login.
 
 </Alert>

--- a/docs/src/pages/[platform]/connected-components/authenticator/configuration/loginMechanisms.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/configuration/loginMechanisms.react-native.mdx
@@ -5,7 +5,7 @@ import { Tabs, TabItem } from '@aws-amplify/ui-react';
 
 <Alert role="none" heading="Zero Configuration">
 
-The Authenticator [automatically infers](#1-configure-backend) `loginMechanisms` from `amplify pull`,
+The Authenticator [automatically infers](/connected-components/authenticator#step-1-configure-backend) `loginMechanisms` from `amplify pull`,
 but can be explicitly defined as seen below.
 
 </Alert>

--- a/docs/src/pages/[platform]/connected-components/authenticator/configuration/loginMechanisms.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/configuration/loginMechanisms.web.mdx
@@ -5,7 +5,7 @@ import { Tabs, TabItem } from '@aws-amplify/ui-react';
 
 <Alert role="none" heading="Zero Configuration">
 
-The Authenticator [automatically infers](#1-configure-backend) `loginMechanisms` from `amplify pull`,
+The Authenticator [automatically infers](/connected-components/authenticator#step-1-configure-backend) `loginMechanisms` from `amplify pull`,
 but can be explicitly defined as seen below.
 
 </Alert>

--- a/docs/src/pages/[platform]/connected-components/authenticator/configuration/socialProviders.flutter.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/configuration/socialProviders.flutter.mdx
@@ -7,7 +7,7 @@ import { Fragment } from '@/components/Fragment';
 
 <Alert role="none" heading="Zero Configuration">
 
-The Authenticator [automatically infers](#zero-configuration) `socialProviders` from `amplify pull`.
+The Authenticator [automatically infers](/connected-components/authenticator#step-1-configure-backend) `socialProviders` from `amplify pull`.
 
 </Alert>
 

--- a/docs/src/pages/[platform]/connected-components/authenticator/configuration/socialProviders.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/configuration/socialProviders.web.mdx
@@ -7,7 +7,7 @@ import {SocialProviderDemo} from "@/components/SocialProviderDemo";
 
 <Alert role="none" heading="Zero Configuration">
 
-The Authenticator [automatically infers](#zero-configuration) `socialProviders` from `amplify pull`,
+The Authenticator [automatically infers](/connected-components/authenticator#step-1-configure-backend) `socialProviders` from `amplify pull`,
 but can be explicitly defined as seen below.
 
 </Alert>

--- a/docs/src/pages/[platform]/connected-components/authenticator/index.page.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/index.page.mdx
@@ -29,19 +29,19 @@ export async function getStaticProps() {
 
 ## Quick start
 
-### 1. Configure backend
+### Step 1. Configure backend
 
 <Fragment useCommonWebContent>
   {({ platform }) => import(`./quick-start-pull.${platform}.mdx`)}
 </Fragment>
 
-### 2. Install dependencies
+### Step 2. Install dependencies
 
 <Fragment useCommonWebContent>
   {({ platform }) => import(`./quick-start-install.${platform}.mdx`)}
 </Fragment>
 
-### 3. Add the Authenticator
+### Step 3. Add the Authenticator
 
 <Fragment useCommonWebContent>
   {({ platform }) => import(`./quick-start-add.${platform}.mdx`)}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Links start with number, like "connected-components/authenticator#1-configure-backend" would have the following issue.

<img width="865" alt="image" src="https://user-images.githubusercontent.com/11983489/203406962-f1fa0a00-6029-416c-8a1f-cd04e5eeefe9.png">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
