### PR TITLE
fix(theme): update types for ThemeProvider to accept output of createTheme

### DIFF
--- a/.changeset/popular-pigs-glow.md
+++ b/.changeset/popular-pigs-glow.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+fix(theme): update types for `ThemeProvider` to accept output of `createTheme`

--- a/packages/react/src/components/ThemeProvider/__tests__/ThemeProvider.test.tsx
+++ b/packages/react/src/components/ThemeProvider/__tests__/ThemeProvider.test.tsx
@@ -31,7 +31,7 @@ describe('ThemeProvider', () => {
         tokens: {
           colors: {
             font: {
-              primary: { value: 'blue' },
+              primary: { value: 'hotpink' },
             },
           },
         },

--- a/packages/react/src/components/ThemeProvider/__tests__/ThemeProvider.test.tsx
+++ b/packages/react/src/components/ThemeProvider/__tests__/ThemeProvider.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen } from '@testing-library/react';
-import { Theme } from '@aws-amplify/ui';
+import { renderHook } from '@testing-library/react-hooks';
+import { Theme, createTheme } from '@aws-amplify/ui';
 import * as React from 'react';
 
 import { ThemeProvider } from '../index';
 import { Heading } from '../../../primitives';
+import { useTheme } from '../../../hooks';
 
 const App = () => {
   return <Heading>Howdy</Heading>;
@@ -19,6 +21,31 @@ describe('ThemeProvider', () => {
 
     const heading = await screen.getByText('Howdy');
     expect(heading.nodeName).toBe('H6');
+  });
+
+  it('should accept the output of createTheme to allow for extending themes', async () => {
+    const studioTheme = createTheme();
+    const extendedTheme = createTheme(
+      {
+        name: 'extended-theme',
+        tokens: {
+          colors: {
+            font: {
+              primary: { value: 'blue' },
+            },
+          },
+        },
+      },
+      studioTheme
+    );
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => (
+        <ThemeProvider theme={extendedTheme}>{children}</ThemeProvider>
+      ),
+    });
+
+    expect(result.current.tokens.colors.font.primary.value).toBe('hotpink');
   });
 
   it('wraps the App in [data-amplify-theme="default-theme"]', () => {

--- a/packages/react/src/components/ThemeProvider/index.tsx
+++ b/packages/react/src/components/ThemeProvider/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DirectionProvider } from '@radix-ui/react-direction';
 
-import { createTheme, Theme } from '@aws-amplify/ui';
+import { createTheme, Theme, WebTheme } from '@aws-amplify/ui';
 
 import { AmplifyContext } from './AmplifyContext';
 
@@ -28,7 +28,7 @@ interface ThemeProviderProps {
   /**
    * Custom theme
    */
-  theme?: Theme;
+  theme?: Theme | WebTheme;
 }
 
 export function AmplifyProvider({

--- a/packages/ui/src/theme/createTheme.ts
+++ b/packages/ui/src/theme/createTheme.ts
@@ -31,7 +31,7 @@ const setupToken: SetupToken<WebDesignToken> = ({ token, path }) => {
  * const myOtherTheme = createTheme({}, myTheme);
  */
 export function createTheme(
-  theme?: Theme,
+  theme?: Theme | WebTheme,
   DefaultTheme: DefaultTheme | WebTheme = defaultTheme
 ): WebTheme {
   // merge theme and DefaultTheme to get a complete theme


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

One use-case of theming is to extend from a theme, for example the Studio generated theme. To do this, customers pass in the studio theme as the 2nd argument to the `createTheme` method. The issue is `createTheme` returns a `WebTheme` type and not a `Theme` type which is what the `ThemeProvider` expects. Loosening up the type of the `ThemeProvider` theme prop to allow either `Theme` or `WebTheme`

```javascript
const theme = createTheme({

}, studioTheme);

<ThemeProvider theme={theme}>
</ThemeProvider>
```

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
