### PR TITLE
fix(primitives): fix radio button sizing issue

### DIFF
--- a/.changeset/small-planes-train.md
+++ b/.changeset/small-planes-train.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-react": patch
+---
+
+fix(primitives): fix radio button sizing issue #2756

--- a/packages/ui/src/theme/css/component/radio.scss
+++ b/packages/ui/src/theme/css/component/radio.scss
@@ -10,6 +10,7 @@
 }
 
 .amplify-radio__button {
+  flex-shrink: 0;
   align-items: var(--amplify-components-radio-button-align-items);
   justify-content: var(--amplify-components-radio-button-justify-content);
   padding: var(--amplify-components-radio-button-padding);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Added `flex-shrink` to the radio button so if the label is too large it doesn't get squeezed. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

fixes #2756

#### Description of how you validated changes

| Before | After |
|-|-|
| <img width="618" alt="CleanShot 2022-11-22 at 15 20 19@2x" src="https://user-images.githubusercontent.com/321279/203440690-28969a3a-00a0-4e0a-b2a8-067101438a03.png"> |  <img width="613" alt="CleanShot 2022-11-22 at 15 04 31@2x" src="https://user-images.githubusercontent.com/321279/203440716-9573e48f-0943-4660-9642-51e9db3499a5.png"> |


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
