### PR TITLE
chore(e2e): Integration tests for useDataStore hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ aws-exports.ts
 # We have mock exports in the following locations
 !examples/angular/src/pages/ui/components/*/*/aws-exports.js
 !examples/next/pages/ui/components/*/*/aws-exports.js
+!examples/next/pages/ui/hooks/*/aws-exports.js
 !examples/vue/src/pages/ui/components/*/*/aws-exports.js
 !examples/react-native/src/features/*/*/aws-exports.js
 

--- a/examples/next/pages/ui/hooks/useDataStore/AuthActions.tsx
+++ b/examples/next/pages/ui/hooks/useDataStore/AuthActions.tsx
@@ -1,0 +1,7 @@
+import { Button } from '@aws-amplify/ui-react';
+import { useAuthSignOutAction } from '@aws-amplify/ui-react/internal';
+
+export const AuthSignOutButton = ({ children }) => {
+  const authSignOutAction = useAuthSignOutAction({ global: true });
+  return <Button onClick={authSignOutAction}>{children}</Button>;
+};

--- a/examples/next/pages/ui/hooks/useDataStore/aws-exports.js
+++ b/examples/next/pages/ui/hooks/useDataStore/aws-exports.js
@@ -1,0 +1,2 @@
+import awsExports from '@environments/datastore/action-hooks/src/aws-exports';
+export default awsExports;

--- a/examples/next/pages/ui/hooks/useDataStore/filter/CollectionAndRecord.tsx
+++ b/examples/next/pages/ui/hooks/useDataStore/filter/CollectionAndRecord.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { User, UserPreference } from '../models';
+import {
+  createDataStorePredicate,
+  getOverrideProps,
+  useDataStoreBinding,
+} from '@aws-amplify/ui-react/internal';
+import { Button, Collection, Flex } from '@aws-amplify/ui-react';
+import { colorFilterPredicate, userFilterPredicate } from '../utils';
+
+const CollectionAndRecord = (props) => {
+  const {
+    backgroundColor,
+    buttonColor: buttonColorProp,
+    items,
+    overrideItems,
+    overrides,
+    ...rest
+  } = props;
+
+  const userFilter = createDataStorePredicate(userFilterPredicate);
+  const usersDataStore = useDataStoreBinding({
+    criteria: userFilter,
+    model: User,
+    type: 'collection',
+  }).items;
+  const users = items !== undefined ? items : usersDataStore;
+
+  const colorFilter = createDataStorePredicate(colorFilterPredicate);
+  const colorDataStore = useDataStoreBinding({
+    type: 'collection',
+    model: UserPreference,
+    criteria: colorFilter,
+  }).items[0];
+  const buttonColor =
+    buttonColorProp !== undefined ? buttonColorProp : colorDataStore;
+
+  return (
+    <Flex>
+      <Collection
+        type="list"
+        isPaginated={true}
+        backgroundColor={backgroundColor}
+        items={users || []}
+        {...rest}
+        {...getOverrideProps(overrides, 'CollectionWithBinding')}
+      >
+        {(item: User, index) => (
+          <Button
+            data-testid="filtered-item"
+            backgroundColor={buttonColor?.favoriteColor}
+            {...(overrideItems && overrideItems({ item, index }))}
+          >
+            {item.firstName || 'Test'}
+          </Button>
+        )}
+      </Collection>
+    </Flex>
+  );
+};
+
+export default CollectionAndRecord;

--- a/examples/next/pages/ui/hooks/useDataStore/filter/index.page.tsx
+++ b/examples/next/pages/ui/hooks/useDataStore/filter/index.page.tsx
@@ -1,0 +1,56 @@
+import { Amplify, DataStore, Hub } from 'aws-amplify';
+import { Authenticator } from '@aws-amplify/ui-react';
+import * as React from 'react';
+import '@aws-amplify/ui-react/styles.css';
+
+import { AuthSignOutButton } from '../AuthActions';
+import awsExports from '../aws-exports';
+import CollectionAndRecord from './CollectionAndRecord';
+import { initializeTestData } from '../utils';
+
+Amplify.configure({
+  ...awsExports,
+  aws_appsync_graphqlEndpoint: 'https://fake-appsync-endpoint/graphql',
+});
+
+export default function App() {
+  const [isInitialized, setInitialized] = React.useState(false);
+  const initializeStarted = React.useRef(false);
+
+  React.useEffect(() => {
+    (window as any).LOG_LEVEL = 'DEBUG';
+    Hub.listen('ui', (data) => {
+      console.log(data);
+    });
+    Hub.listen('datastore', (data) => {
+      console.log(data);
+    });
+    const initializeTestUserData = async () => {
+      if (initializeStarted.current) {
+        return;
+      }
+      await DataStore.clear();
+      await initializeTestData();
+      setInitialized(true);
+    };
+
+    initializeTestUserData();
+    initializeStarted.current = true;
+  }, []);
+
+  if (!isInitialized) {
+    return null;
+  }
+
+  return (
+    <Authenticator>
+      {({ user }) => (
+        <main>
+          <h1>Hello {user.username}</h1>
+          <AuthSignOutButton>Sign out</AuthSignOutButton>
+          <CollectionAndRecord id="collectionWithFilter" />
+        </main>
+      )}
+    </Authenticator>
+  );
+}

--- a/examples/next/pages/ui/hooks/useDataStore/models/index.d.ts
+++ b/examples/next/pages/ui/hooks/useDataStore/models/index.d.ts
@@ -1,0 +1,52 @@
+
+import { ModelInit, MutableModel } from '@aws-amplify/datastore';
+
+type UserPreferenceMetaData = {
+  readOnlyFields: 'createdAt' | 'updatedAt';
+};
+
+type UserMetaData = {
+  readOnlyFields: 'createdAt' | 'updatedAt';
+};
+
+export declare class UserPreference {
+  readonly id: string;
+
+  readonly favoriteColor?: string;
+
+  readonly createdAt?: string;
+
+  readonly updatedAt?: string;
+  constructor(init: ModelInit<UserPreference, UserPreferenceMetaData>);
+  static copyOf(
+    source: UserPreference,
+    mutator: (
+      draft: MutableModel<UserPreference, UserPreferenceMetaData>,
+    ) => MutableModel<UserPreference, UserPreferenceMetaData> | void,
+  ): UserPreference;
+}
+
+export declare class User {
+  readonly id: string;
+
+  readonly firstName?: string;
+
+  readonly lastName?: string;
+
+  readonly age?: number;
+
+  readonly isLoggedIn?: boolean;
+
+  readonly loggedInColor?: string;
+
+  readonly loggedOutColor?: string;
+
+  readonly createdAt?: string;
+
+  readonly updatedAt?: string;
+  constructor(init: ModelInit<User, UserMetaData>);
+  static copyOf(
+    source: User,
+    mutator: (draft: MutableModel<User, UserMetaData>) => MutableModel<User, UserMetaData> | void,
+  ): User;
+}

--- a/examples/next/pages/ui/hooks/useDataStore/models/index.js
+++ b/examples/next/pages/ui/hooks/useDataStore/models/index.js
@@ -1,0 +1,7 @@
+// @ts-check
+import { initSchema } from '@aws-amplify/datastore';
+import { schema } from './schema';
+
+const { UserPreference, User } = initSchema(schema);
+
+export { UserPreference, User };

--- a/examples/next/pages/ui/hooks/useDataStore/models/schema.d.ts
+++ b/examples/next/pages/ui/hooks/useDataStore/models/schema.d.ts
@@ -1,0 +1,4 @@
+import { Schema } from '@aws-amplify/datastore';
+
+export declare const schema: Schema;
+  

--- a/examples/next/pages/ui/hooks/useDataStore/models/schema.js
+++ b/examples/next/pages/ui/hooks/useDataStore/models/schema.js
@@ -1,0 +1,164 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+export const schema = {
+  codegenVersion: '3.2.0',
+  models: {
+    UserPreference: {
+      name: 'UserPreference',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        favoriteColor: {
+          name: 'favoriteColor',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'UserPreferences',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'auth',
+          properties: {
+            rules: [
+              {
+                allow: 'public',
+                operations: ['create', 'update', 'delete', 'read'],
+              },
+            ],
+          },
+        },
+      ],
+    },
+    User: {
+      name: 'User',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        firstName: {
+          name: 'firstName',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        lastName: {
+          name: 'lastName',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        age: {
+          name: 'age',
+          isArray: false,
+          type: 'Int',
+          isRequired: false,
+          attributes: [],
+        },
+        isLoggedIn: {
+          name: 'isLoggedIn',
+          isArray: false,
+          type: 'Boolean',
+          isRequired: false,
+          attributes: [],
+        },
+        loggedInColor: {
+          name: 'loggedInColor',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        loggedOutColor: {
+          name: 'loggedOutColor',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'Users',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'auth',
+          properties: {
+            rules: [
+              {
+                allow: 'public',
+                operations: ['create', 'update', 'delete', 'read'],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  version: 'f6252c821249b6b1abda9fb24481c5a4',
+};

--- a/examples/next/pages/ui/hooks/useDataStore/sort/Collection.tsx
+++ b/examples/next/pages/ui/hooks/useDataStore/sort/Collection.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { User } from '../models';
+import {
+  createDataStorePredicate,
+  getOverrideProps,
+  useDataStoreBinding,
+} from '@aws-amplify/ui-react/internal';
+import { SortDirection } from '@aws-amplify/datastore';
+import { Collection, Flex, Text } from '@aws-amplify/ui-react';
+import { userFilterPredicate } from '../utils';
+
+const CollectionWithSort = (props) => {
+  const { backgroundColor, items, overrideItems, overrides, ...rest } = props;
+
+  const userFilter = createDataStorePredicate(userFilterPredicate);
+  const userPagination = {
+    sort: (s) => s.lastName(SortDirection.ASCENDING),
+  };
+  const usersDataStore = useDataStoreBinding({
+    type: 'collection',
+    model: User,
+    criteria: userFilter,
+    pagination: userPagination,
+  }).items;
+  const users = items !== undefined ? items : usersDataStore;
+
+  return (
+    <Flex>
+      <Collection
+        type="list"
+        isPaginated={true}
+        backgroundColor={backgroundColor}
+        items={users || []}
+        {...rest}
+        {...getOverrideProps(overrides, 'CollectionWithSort')}
+      >
+        {(item: User, index) => (
+          <Text key={index} data-testid="sorted-item">
+            {item.lastName || 'Test'}
+          </Text>
+        )}
+      </Collection>
+    </Flex>
+  );
+};
+
+export default CollectionWithSort;

--- a/examples/next/pages/ui/hooks/useDataStore/sort/index.page.tsx
+++ b/examples/next/pages/ui/hooks/useDataStore/sort/index.page.tsx
@@ -1,0 +1,57 @@
+import { Amplify, DataStore, Hub } from 'aws-amplify';
+import { Authenticator } from '@aws-amplify/ui-react';
+import * as React from 'react';
+import '@aws-amplify/ui-react/styles.css';
+
+import { AuthSignOutButton } from '../AuthActions';
+import awsExports from '../aws-exports';
+import { User } from '../models';
+import Collection from './Collection';
+import { initializeTestData } from '../utils';
+
+Amplify.configure({
+  ...awsExports,
+  aws_appsync_graphqlEndpoint: 'https://fake-appsync-endpoint/graphql',
+});
+
+export default function App() {
+  const [isInitialized, setInitialized] = React.useState(false);
+  const initializeStarted = React.useRef(false);
+
+  React.useEffect(() => {
+    (window as any).LOG_LEVEL = 'DEBUG';
+    Hub.listen('ui', (data) => {
+      console.log(data);
+    });
+    Hub.listen('datastore', (data) => {
+      console.log(data);
+    });
+    const initializeTestUserData = async () => {
+      if (initializeStarted.current) {
+        return;
+      }
+      await DataStore.clear();
+      await initializeTestData();
+      setInitialized(true);
+    };
+
+    initializeTestUserData();
+    initializeStarted.current = true;
+  }, []);
+
+  if (!isInitialized) {
+    return null;
+  }
+
+  return (
+    <Authenticator>
+      {({ user }) => (
+        <main>
+          <h1>Hello {user.username}</h1>
+          <AuthSignOutButton>Sign out</AuthSignOutButton>
+          <Collection id="collectionWithSort" />
+        </main>
+      )}
+    </Authenticator>
+  );
+}

--- a/examples/next/pages/ui/hooks/useDataStore/utils.ts
+++ b/examples/next/pages/ui/hooks/useDataStore/utils.ts
@@ -1,0 +1,31 @@
+import { DataStore } from 'aws-amplify';
+import { User, UserPreference } from './models';
+
+export const initializeTestData = async (): Promise<void> => {
+  await DataStore.save(
+    new User({ firstName: 'Super', lastName: 'User3', age: 30 })
+  );
+  await DataStore.save(
+    new User({ firstName: 'Admin', lastName: 'User2', age: 70 })
+  );
+  await DataStore.save(
+    new User({ firstName: 'Generic', lastName: 'User1', age: 50 })
+  );
+  await DataStore.save(
+    new User({ firstName: 'Toddler', lastName: 'User0', age: 5 })
+  );
+  await DataStore.save(new UserPreference({ favoriteColor: 'rgb(0, 0, 255)' }));
+};
+
+export const userFilterPredicate = {
+  and: [
+    { field: 'age', operand: '10', operator: 'gt' },
+    { field: 'lastName', operand: 'U', operator: 'beginsWith' },
+  ],
+};
+
+export const colorFilterPredicate = {
+  field: 'favoriteColor',
+  operand: 'rgb(0, 0, 255)',
+  operator: 'eq',
+};

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -24,5 +24,5 @@ export default defineConfig({
       return config;
     },
   },
-  videoUploadOnPasses: false,
+  video: false,
 });

--- a/packages/e2e/cypress/integration/ui/hooks/query-datastore/query-datastore.steps.ts
+++ b/packages/e2e/cypress/integration/ui/hooks/query-datastore/query-datastore.steps.ts
@@ -1,0 +1,24 @@
+import { Then } from '@badeball/cypress-cucumber-preprocessor';
+
+Then('the page contains filtered buttons', () => {
+  cy.findAllByTestId('filtered-item')
+    .should('have.length', 3)
+    .should('have.css', 'background-color', 'rgb(0, 0, 255)')
+    .first()
+    .should('have.text', 'Super')
+    .next()
+    .should('have.text', 'Admin')
+    .next()
+    .should('have.text', 'Generic');
+});
+
+Then('the page contains sorted buttons', () => {
+  cy.findAllByTestId('sorted-item')
+    .should('have.length', 3)
+    .first()
+    .should('have.text', 'User1')
+    .next()
+    .should('have.text', 'User2')
+    .next()
+    .should('have.text', 'User3');
+});

--- a/packages/e2e/features/ui/hooks/query-datastore.feature
+++ b/packages/e2e/features/ui/hooks/query-datastore.feature
@@ -1,0 +1,16 @@
+Feature: useDataStore hook
+
+  The useDataStore hook works correctly
+
+  @react
+  Scenario: DataStore filters work correctly
+    Given I'm running the example "ui/hooks/useDataStore/filter"
+    Then the page contains filtered buttons
+    And I don't see 'Toddler'
+    And I don't see 'Test'
+
+  @react
+  Scenario: DataStore sort works correctly
+    Given I'm running the example "ui/hooks/useDataStore/sort"
+    Then the page contains sorted buttons
+    And I don't see 'User0'   


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change adds integration tests that exercise the `useDataStore` hook and `createDataStorePredicate` util. Based on Studio builder tests.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
