### PR TITLE
chore(docs): Update Link docs for React Router v5 and v6

### DIFF
--- a/docs/src/pages/[platform]/components/link/react.mdx
+++ b/docs/src/pages/[platform]/components/link/react.mdx
@@ -47,19 +47,45 @@ To create a Link which opens in a new tab, use the `isExternal` prop. Under the 
 
 ### Routing Libraries
 
-You can use a Link with any React routing library that supports custom components. Below is an example using Link with React Router v5, in which the Link is passed to the `component` prop as a custom navigation component:
+You can use a Link with any React routing library that supports custom components. Below are examples for both React Router v5 and v6:
+
+#### React Router v5
+
+Pass the Amplify UI Link to React Router Link's `component` prop:
 
 <Example>
   <ExampleCode>
     ```jsx
-    import { Link, Flex, Heading } from '@aws-amplify/ui-react';
+    import { Heading, Link as AmplifyUiLink } from "@aws-amplify/ui-react";
 
     import {
-      BrowserRouter as Router,
+      BrowserRouter,
       Link as ReactRouterLink,
-      Routes,
       Route,
-    } from 'react-router-dom';
+      Switch,
+    } from "react-router-dom";
+
+    function App() {
+      return (
+        <BrowserRouter>
+          <ReactRouterLink to="/" component={AmplifyUiLink}>
+            Home
+          </ReactRouterLink>
+          <ReactRouterLink to="/about" component={AmplifyUiLink}>
+            About
+          </ReactRouterLink>
+
+          <Switch>
+            <Route exact path="/">
+              <Home />
+            </Route>
+            <Route path="/about">
+              <About />
+            </Route>
+          </Switch>
+        </BrowserRouter>
+      );
+    }
 
     function Home() {
       return <Heading level={2}>Home</Heading>;
@@ -69,26 +95,42 @@ You can use a Link with any React routing library that supports custom component
       return <Heading level={2}>About</Heading>;
     }
 
-    function Users() {
-      return <Heading level={2}>Users</Heading>;
-    }
+    export default App;
+    ```
+  </ExampleCode>
+</Example>
+
+#### React Router v6
+
+Since the React Router Link [no longer supports the `component` prop in v6](https://reactrouter.com/en/main/upgrading/v5#remove-link-component-prop), we recommend just passing an `href` to the Amplify UI Link :
+
+<Example>
+  <ExampleCode>
+    ```jsx
+    import { Heading, Link } from "@aws-amplify/ui-react";
+
+    import { BrowserRouter, Route, Routes } from "react-router-dom";
 
     function App() {
       return (
-        <Router>
-          <Flex>
-            <ReactRouterLink to="/" component={Link}>Home</ReactRouterLink>
-            <ReactRouterLink to="/about" component={Link}>About</ReactRouterLink>
-            <ReactRouterLink to="/users" component={Link}>Users</ReactRouterLink>
-          </Flex>
+        <BrowserRouter>
+          <Link href="/">Home</Link>
+          <Link href="/about">About</Link>
 
           <Routes>
-            <Route path="/about" element={<About />} />
-            <Route path="/users" element={<Users />} />
             <Route path="/" element={<Home />} />
+            <Route path="/about" element={<About />} />
           </Routes>
-        </Router>
+        </BrowserRouter>
       );
+    }
+
+    function Home() {
+      return <Heading level={2}>Home</Heading>;
+    }
+
+    function About() {
+      return <Heading level={2}>About</Heading>;
     }
 
     export default App;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Since React Router now has a newer version 6.x, this PR updates the Link documentation to include examples for both v5 and v6. 

Although [this StackBlitz example](https://stackblitz.com/edit/react-ts-fsk25s?file=index.tsx) works, it still causes a console warning about the [soon-to-be deprecated `to` prop](https://github.com/aws-amplify/amplify-ui/blob/c455bcea2d49e1dee433466c8938825df5d1177b/packages/react/src/primitives/types/link.ts#L19). I found that simply using our Link component with an `href` prop worked in my example app for React Router v6, but I would want someone else to verify that before merging this PR. 

![ReactRouter1](https://user-images.githubusercontent.com/48109584/204927806-e2259f12-cfc9-4d49-83b0-433df035f687.png)
![ReactRouter2](https://user-images.githubusercontent.com/48109584/204927808-99c8463f-dc77-4863-b462-ab2be84858b2.png)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/2889

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the sample apps using both React Router v5 and v6.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
