### PR TITLE
style: disable scroll chaining on Autocomplete menu to improve UX

### DIFF
--- a/.changeset/fuzzy-icons-jog.md
+++ b/.changeset/fuzzy-icons-jog.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+style: disable scroll chaining on Autocomplete menu to improve UX

--- a/packages/ui/src/theme/css/component/autocomplete.scss
+++ b/packages/ui/src/theme/css/component/autocomplete.scss
@@ -46,6 +46,7 @@
 
   &__options {
     position: relative;
+    overscroll-behavior: contain;
     display: var(--amplify-components-autocomplete-menu-options-display);
     flex-direction: var(
       --amplify-components-autocomplete-menu-options-flex-direction


### PR DESCRIPTION
#### Description of changes

Disable scroll chaining on Autocomplete to improve UX.

#### Issue #, if available

When Autocomplete menu scroll boundary is reached, the underlying page will then start to scroll. This could be annoying for users.

![Kapture 2022-12-01 at 12 03 21](https://user-images.githubusercontent.com/40295569/205149226-951fb663-c18b-4ff6-bbc0-42068a91a077.gif)

After disabling it, the outer page will not start to scroll when the bottom is reached even though I keep scrolling

![Kapture 2022-12-01 at 12 09 19](https://user-images.githubusercontent.com/40295569/205149973-9066276e-ebf0-4eb3-8440-cfc4cb82e0c8.gif)


#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
