### PR TITLE
fix(primitives): fix default text color for alert primitive

### DIFF
--- a/.changeset/many-cats-allow.md
+++ b/.changeset/many-cats-allow.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-react": patch
+---
+
+fix(primitives): fix default text color for alert primitive

--- a/packages/ui/src/theme/css/component/alert.scss
+++ b/packages/ui/src/theme/css/component/alert.scss
@@ -1,6 +1,7 @@
 .amplify-alert {
   align-items: var(--amplify-components-alert-align-items);
   background-color: var(--amplify-components-alert-background-color);
+  color: var(--amplify-components-alert-color);
   justify-content: var(--amplify-components-alert-justify-content);
   padding-block: var(--amplify-components-alert-padding-block);
   padding-inline: var(--amplify-components-alert-padding-inline);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adding `color` to the alert default styles to prevent color contrast issues because the color is being inherited. The design token already existed, we just weren't using it. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

fixes #2610


#### Description of how you validated changes

| Before | After |
| - | - |
| <img width="1584" alt="CleanShot 2022-12-01 at 15 11 31@2x" src="https://user-images.githubusercontent.com/321279/205179504-0e44cb0c-b155-43b0-abd7-8d8d3bf06c06.png"> |  <img width="1580" alt="CleanShot 2022-12-01 at 15 11 08@2x" src="https://user-images.githubusercontent.com/321279/205179523-b8b34dd0-a984-445a-b844-ae2a9a25eb73.png"> |


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
