### PR TITLE
fix(account-settings): early return if `isPending` is true

### DIFF
--- a/packages/react/src/components/AccountSettings/DeleteUser/DeleteUser.tsx
+++ b/packages/react/src/components/AccountSettings/DeleteUser/DeleteUser.tsx
@@ -71,7 +71,12 @@ function DeleteUser({
     runDeleteUser();
   }, [runDeleteUser]);
 
-  // Return null if user isn't authenticated in the first place
+  // Return null if Auth.getCurrentAuthenticatedUser is still in progress
+  if (isLoading) {
+    return null;
+  }
+
+  // Return null if user isn't authenticated
   if (!user) {
     logger.warn('<DeleteUser /> requires user to be authenticated.');
     return null;
@@ -79,11 +84,6 @@ function DeleteUser({
 
   // Return null if delete user was successful
   if (state === 'DONE') {
-    return null;
-  }
-
-  // Return null if Auth.getCurrentAuthenticatedUser is still in progress
-  if (isLoading) {
     return null;
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Changes the order of early returns, so that it checks `isLoading` before it checks `!user`. This ensures that component does not prematurely log that user isn't present to console.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
