### PR TITLE
fix(ui-react): Add fieldset and labelledby to RadioGroupField

### DIFF
--- a/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
+++ b/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
@@ -7,6 +7,7 @@ import { Flex } from '../Flex';
 import { Label } from '../Label';
 import { RadioGroupContext, RadioGroupContextType } from './context';
 import { RadioGroupFieldProps, Primitive } from '../types';
+import { getTestId } from '../utils/testUtils';
 import { useStableId } from '../utils/useStableId';
 
 // Note: RadioGroupField doesn't extend the JSX.IntrinsicElements<'input'> types (instead extending 'typeof Flex')
@@ -29,6 +30,7 @@ const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
     onChange,
     name,
     size,
+    testId,
     value,
     ...rest
   },
@@ -38,6 +40,8 @@ const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
   const labelId = useStableId();
   const descriptionId = useStableId();
   const ariaDescribedBy = descriptiveText ? descriptionId : undefined;
+  const legendId = `legend-${labelId}`;
+  const radioGroupTestId = getTestId(testId, ComponentClassNames.RadioGroup);
 
   const radioGroupContextValue: RadioGroupContextType = React.useMemo(
     () => ({
@@ -68,6 +72,8 @@ const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
 
   return (
     <Flex
+      aria-labelledby={legendId}
+      as="fieldset"
       className={classNames(
         ComponentClassNames.Field,
         ComponentClassNames.RadioGroupField,
@@ -75,9 +81,11 @@ const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
       )}
       data-size={size}
       ref={ref}
+      role="radiogroup"
+      testId={testId}
       {...rest}
     >
-      <Label id={labelId} visuallyHidden={labelHidden}>
+      <Label id={legendId} visuallyHidden={labelHidden}>
         {label}
       </Label>
       <FieldDescription
@@ -87,10 +95,9 @@ const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
       />
       <Flex
         aria-describedby={ariaDescribedBy}
-        aria-labelledby={labelId}
         className={ComponentClassNames.RadioGroup}
         id={fieldId}
-        role="radiogroup"
+        testId={radioGroupTestId}
       >
         <RadioGroupContext.Provider value={radioGroupContextValue}>
           {children}

--- a/packages/react/src/primitives/RadioGroupField/__tests__/RadioGroupField.test.tsx
+++ b/packages/react/src/primitives/RadioGroupField/__tests__/RadioGroupField.test.tsx
@@ -10,6 +10,7 @@ import {
   testFlexProps,
   expectFlexContainerStyleProps,
 } from '../../Flex/__tests__/Flex.test';
+import { getTestId } from '../../utils/testUtils';
 
 describe('RadioFieldGroup test suite', () => {
   const basicProps = { label: 'testLabel', name: 'testName', testId: 'testId' };
@@ -66,7 +67,7 @@ describe('RadioFieldGroup test suite', () => {
     render(<RadioGroupField {...basicProps} ref={ref}></RadioGroupField>);
 
     await screen.findByTestId(basicProps.testId);
-    expect(ref.current.nodeName).toBe('DIV');
+    expect(ref.current?.nodeName).toBe('FIELDSET');
   });
 
   it('should render all flex style props', async () => {
@@ -141,7 +142,7 @@ describe('RadioFieldGroup test suite', () => {
     it('should render default classname', async () => {
       render(getRadioFieldGroup({ ...basicProps }));
       const radioGroup = await screen.findByRole('radiogroup');
-      expect(radioGroup).toHaveClass(ComponentClassNames.RadioGroup);
+      expect(radioGroup).toHaveClass(ComponentClassNames.RadioGroupField);
     });
 
     it('should work in uncontrolled way', () => {
@@ -223,6 +224,19 @@ describe('RadioFieldGroup test suite', () => {
       expect(radios[1]).toHaveAttribute('aria-invalid', 'true');
       expect(radios[2]).toHaveAttribute('aria-invalid', 'true');
     });
+
+    it('should render the RadioGroup as a fieldset that uses aria-labelledby instead of legend', async () => {
+      render(getRadioFieldGroup({ ...basicProps }));
+      const radioGroup = await screen.findByRole('radiogroup');
+
+      expect(radioGroup).toHaveAttribute('aria-labelledby');
+
+      const labelledBy = radioGroup.getAttribute('aria-labelledby');
+      const label = await screen.findByText(basicProps.label);
+      const labelId = label.getAttribute('id');
+
+      expect(labelledBy).toBe(labelId);
+    });
   });
 
   describe('Descriptive message', () => {
@@ -236,9 +250,13 @@ describe('RadioFieldGroup test suite', () => {
     });
 
     it('should map to descriptive text correctly', async () => {
+      const radioGroupTestId = getTestId(
+        basicProps.testId,
+        ComponentClassNames.RadioGroup
+      );
       const descriptiveText = 'Description';
       render(getRadioFieldGroup({ ...basicProps, descriptiveText }));
-      const radioGroup = await screen.findByRole('radiogroup');
+      const radioGroup = await screen.findByTestId(radioGroupTestId);
       expect(radioGroup).toHaveAccessibleDescription(descriptiveText);
     });
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Addresses the accessibility issues identified in [this PR](https://github.com/aws-amplify/amplify-ui/issues/1805). 

Due to the following [constraints in styling](https://github.com/aws-amplify/amplify-ui/issues/1805#:~:text=...%20this%20correctly%20updated,of%20its%20parent) `fieldset` and `legend` elements using `flex`, this PR takes the following approach:
- Add the `aria-labelledby` property to the outer `Flex`, and set it to the `id` of the `Label`, which is functioning as a `legend`
- Move the `role="radiogroup"` to the outer `Flex`, to reproduce the same accessibility experience of using `fieldset` and `legend` for a `radiogroup`

Current:
https://user-images.githubusercontent.com/48109584/206017482-c6c223c2-e574-4655-bd2c-a6504dc19c7b.mov

Updated:
https://user-images.githubusercontent.com/48109584/206018053-e971c443-3664-4d93-9dcd-cbfef2138767.mov

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fixes: https://github.com/aws-amplify/amplify-ui/issues/1805

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the docs locally and tested with VoiceOver on Mac

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
