### PR TITLE
chore(ui-react-native): Refactor unit tests

### DIFF
--- a/packages/react-native/src/InAppMessaging/components/BannerMessage/__tests__/BannerMessage.spec.tsx
+++ b/packages/react-native/src/InAppMessaging/components/BannerMessage/__tests__/BannerMessage.spec.tsx
@@ -95,9 +95,7 @@ describe('BannerMessage', () => {
       const { getByTestId } = render(<BannerMessage {...props} />);
       const testElement = getByTestId(testID);
 
-      for (const [key, value] of Object.entries(expectedProps)) {
-        expect(testElement.props[key]).toEqual(value);
-      }
+      expect(testElement.children).toContain(expectedProps.children);
     }
   );
 
@@ -116,7 +114,7 @@ describe('BannerMessage', () => {
         testProps: { onAction, title: 'secondary button' },
       },
     ],
-  ])('correctly handles a %s prop', (key, testID, { testProps }) => {
+  ])('correctly handles a %s button prop', (key, testID, { testProps }) => {
     mockUseMessageImage.mockReturnValueOnce({
       hasRenderableImage: false,
       imageDimensions: { height: undefined, width: undefined },

--- a/packages/react-native/src/InAppMessaging/components/BannerMessage/__tests__/BannerMessage.spec.tsx
+++ b/packages/react-native/src/InAppMessaging/components/BannerMessage/__tests__/BannerMessage.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestRenderer from 'react-test-renderer';
+import { fireEvent, render } from '@testing-library/react-native';
 
 import { IN_APP_MESSAGING_TEST_ID } from '../../../constants';
 import { useMessageImage } from '../../../hooks/useMessageImage';
@@ -27,9 +27,9 @@ describe('BannerMessage', () => {
       isImageFetching: false,
     });
 
-    const renderer = TestRenderer.create(<BannerMessage {...baseProps} />);
+    const { toJSON } = render(<BannerMessage {...baseProps} />);
 
-    expect(renderer.toJSON()).toMatchSnapshot();
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('renders a message as expected with an image', () => {
@@ -42,16 +42,14 @@ describe('BannerMessage', () => {
     const src = 'asset.png';
     const props = { ...baseProps, image: { src } };
 
-    const renderer = TestRenderer.create(<BannerMessage {...props} />);
+    const { toJSON, getByTestId } = render(<BannerMessage {...props} />);
 
-    const image = renderer.root.findByProps({
-      testID: IN_APP_MESSAGING_TEST_ID.IMAGE,
-    });
+    const image = getByTestId(IN_APP_MESSAGING_TEST_ID.IMAGE);
 
     expect(image.props).toEqual(
       expect.objectContaining({ source: { uri: src } })
     );
-    expect(renderer.toJSON()).toMatchSnapshot();
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('returns null while an image is fetching', () => {
@@ -61,9 +59,9 @@ describe('BannerMessage', () => {
       isImageFetching: true,
     });
 
-    const renderer = TestRenderer.create(<BannerMessage {...baseProps} />);
+    const { toJSON } = render(<BannerMessage {...baseProps} />);
 
-    expect(renderer.toJSON()).toBeNull();
+    expect(toJSON()).toBeNull();
   });
 
   it.each([
@@ -83,22 +81,6 @@ describe('BannerMessage', () => {
         expectedProps: { children: 'body content' },
       },
     ],
-    [
-      'primaryButton',
-      IN_APP_MESSAGING_TEST_ID.PRIMARY_BUTTON,
-      {
-        testProps: { onAction, title: 'primary button' },
-        expectedProps: { children: 'primary button', onPress: onAction },
-      },
-    ],
-    [
-      'secondaryButton',
-      IN_APP_MESSAGING_TEST_ID.SECONDARY_BUTTON,
-      {
-        testProps: { onAction, title: 'secondary button' },
-        expectedProps: { children: 'secondary button', onPress: onAction },
-      },
-    ],
   ])(
     'correctly handles a %s prop',
     (key, testID, { testProps, expectedProps }) => {
@@ -110,12 +92,49 @@ describe('BannerMessage', () => {
 
       const props = { ...baseProps, [key]: testProps };
 
-      const renderer = TestRenderer.create(<BannerMessage {...props} />);
-      const testElement = renderer.root.findByProps({ testID });
+      const { getByTestId } = render(<BannerMessage {...props} />);
+      const testElement = getByTestId(testID);
 
-      expect(testElement.props).toEqual(expect.objectContaining(expectedProps));
+      for (const [key, value] of Object.entries(expectedProps)) {
+        expect(testElement.props[key]).toEqual(value);
+      }
     }
   );
+
+  it.each([
+    [
+      'primaryButton',
+      IN_APP_MESSAGING_TEST_ID.PRIMARY_BUTTON,
+      {
+        testProps: { onAction, title: 'primary button' },
+      },
+    ],
+    [
+      'secondaryButton',
+      IN_APP_MESSAGING_TEST_ID.SECONDARY_BUTTON,
+      {
+        testProps: { onAction, title: 'secondary button' },
+      },
+    ],
+  ])('correctly handles a %s prop', (key, testID, { testProps }) => {
+    mockUseMessageImage.mockReturnValueOnce({
+      hasRenderableImage: false,
+      imageDimensions: { height: undefined, width: undefined },
+      isImageFetching: false,
+    });
+
+    const props = { ...baseProps, [key]: testProps };
+    const { toJSON, getByRole, getByTestId, getByText, queryAllByRole } =
+      render(<BannerMessage {...props} />);
+
+    expect(toJSON()).toMatchSnapshot();
+    expect(queryAllByRole('button')).toHaveLength(2);
+    expect(getByTestId(testID)).toBeDefined();
+    expect(getByTestId(IN_APP_MESSAGING_TEST_ID.CLOSE_BUTTON)).toBeDefined();
+
+    expect(getByRole('image')).toBeDefined();
+    expect(getByText(testProps.title)).toBeDefined();
+  });
 
   it('calls onClose when the close button is pressed', () => {
     mockUseMessageImage.mockReturnValueOnce({
@@ -124,14 +143,10 @@ describe('BannerMessage', () => {
       isImageFetching: false,
     });
 
-    const renderer = TestRenderer.create(<BannerMessage {...baseProps} />);
-    const closeButton = renderer.root.findByProps({
-      testID: IN_APP_MESSAGING_TEST_ID.CLOSE_BUTTON,
-    });
+    const { getByTestId } = render(<BannerMessage {...baseProps} />);
+    const closeButton = getByTestId(IN_APP_MESSAGING_TEST_ID.CLOSE_BUTTON);
 
-    TestRenderer.act(() => {
-      (closeButton.props as { onPress: () => void }).onPress();
-    });
+    fireEvent.press(closeButton);
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/packages/react-native/src/InAppMessaging/components/BannerMessage/__tests__/__snapshots__/BannerMessage.spec.tsx.snap
+++ b/packages/react-native/src/InAppMessaging/components/BannerMessage/__tests__/__snapshots__/BannerMessage.spec.tsx.snap
@@ -1,5 +1,377 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BannerMessage correctly handles a primaryButton prop 1`] = `
+<MessageWrapper
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "flex": 1,
+      "justifyContent": "flex-start",
+    }
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#fff",
+          "elevation": 3,
+          "margin": 16,
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 2,
+            "width": 2,
+          },
+          "shadowOpacity": 0.1,
+          "shadowRadius": 2,
+        },
+        Object {},
+        Object {},
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "padding": 12,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "paddingHorizontal": 8,
+          }
+        }
+      />
+      <View
+        accessibilityRole="button"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 10,
+            "left": 10,
+            "right": 10,
+            "top": 10,
+          }
+        }
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {},
+            undefined,
+            Array [
+              Object {
+                "alignSelf": "flex-start",
+                "marginLeft": "auto",
+              },
+              undefined,
+            ],
+          ]
+        }
+        testID="in-app-messaging--close-button"
+      >
+        <Image
+          accessibilityRole="image"
+          source={
+            Object {
+              "testUri": "../../../src/assets/icons/close.png",
+            }
+          }
+          style={
+            Array [
+              Object {
+                "height": 20,
+                "resizeMode": "contain",
+                "tintColor": undefined,
+                "width": 20,
+              },
+              undefined,
+            ]
+          }
+        />
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "padding": 4,
+        }
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "hsl(210, 10%, 58%)",
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 12,
+            },
+            undefined,
+            Array [
+              Object {},
+              Object {
+                "backgroundColor": "#e8e8e8",
+                "borderRadius": 4,
+                "flex": 1,
+                "margin": 8,
+                "padding": 12,
+              },
+              Object {},
+              Object {},
+            ],
+          ]
+        }
+        testID="in-app-messaging--primary-button"
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "hsl(210, 50%, 10%)",
+                "fontSize": 16,
+                "fontWeight": "700",
+                "textAlign": "center",
+              },
+              Array [
+                Object {
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "textAlign": "center",
+                },
+                Object {},
+                Object {},
+              ],
+            ]
+          }
+        >
+          primary button
+        </Text>
+      </View>
+    </View>
+  </View>
+</MessageWrapper>
+`;
+
+exports[`BannerMessage correctly handles a secondaryButton prop 1`] = `
+<MessageWrapper
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "flex": 1,
+      "justifyContent": "flex-start",
+    }
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#fff",
+          "elevation": 3,
+          "margin": 16,
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 2,
+            "width": 2,
+          },
+          "shadowOpacity": 0.1,
+          "shadowRadius": 2,
+        },
+        Object {},
+        Object {},
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "padding": 12,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "paddingHorizontal": 8,
+          }
+        }
+      />
+      <View
+        accessibilityRole="button"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 10,
+            "left": 10,
+            "right": 10,
+            "top": 10,
+          }
+        }
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {},
+            undefined,
+            Array [
+              Object {
+                "alignSelf": "flex-start",
+                "marginLeft": "auto",
+              },
+              undefined,
+            ],
+          ]
+        }
+        testID="in-app-messaging--close-button"
+      >
+        <Image
+          accessibilityRole="image"
+          source={
+            Object {
+              "testUri": "../../../src/assets/icons/close.png",
+            }
+          }
+          style={
+            Array [
+              Object {
+                "height": 20,
+                "resizeMode": "contain",
+                "tintColor": undefined,
+                "width": 20,
+              },
+              undefined,
+            ]
+          }
+        />
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "padding": 4,
+        }
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "hsl(210, 10%, 58%)",
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 12,
+            },
+            undefined,
+            Array [
+              Object {},
+              Object {
+                "backgroundColor": "#e8e8e8",
+                "borderRadius": 4,
+                "flex": 1,
+                "margin": 8,
+                "padding": 12,
+              },
+              Object {},
+              Object {},
+            ],
+          ]
+        }
+        testID="in-app-messaging--secondary-button"
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "hsl(210, 50%, 10%)",
+                "fontSize": 16,
+                "fontWeight": "700",
+                "textAlign": "center",
+              },
+              Array [
+                Object {
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "textAlign": "center",
+                },
+                Object {},
+                Object {},
+              ],
+            ]
+          }
+        >
+          secondary button
+        </Text>
+      </View>
+    </View>
+  </View>
+</MessageWrapper>
+`;
+
 exports[`BannerMessage renders a message as expected with an image 1`] = `
 <MessageWrapper
   style={

--- a/packages/react-native/src/InAppMessaging/components/BannerMessage/__tests__/__snapshots__/BannerMessage.spec.tsx.snap
+++ b/packages/react-native/src/InAppMessaging/components/BannerMessage/__tests__/__snapshots__/BannerMessage.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BannerMessage correctly handles a primaryButton prop 1`] = `
+exports[`BannerMessage correctly handles a primaryButton button prop 1`] = `
 <MessageWrapper
   style={
     Object {
@@ -186,7 +186,7 @@ exports[`BannerMessage correctly handles a primaryButton prop 1`] = `
 </MessageWrapper>
 `;
 
-exports[`BannerMessage correctly handles a secondaryButton prop 1`] = `
+exports[`BannerMessage correctly handles a secondaryButton button prop 1`] = `
 <MessageWrapper
   style={
     Object {

--- a/packages/react-native/src/InAppMessaging/components/CarouselMessage/CarouselMessage.tsx
+++ b/packages/react-native/src/InAppMessaging/components/CarouselMessage/CarouselMessage.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { MessageContentProps } from '@aws-amplify/ui-react-core';
 
 import { Carousel } from '../../../primitives';
+import { IN_APP_MESSAGING_TEST_ID } from '../../constants';
 
 import { MessageWrapper } from '../MessageWrapper';
 import CarouselMessageItem from './CarouselMessageItem';
@@ -36,6 +37,7 @@ export default function CarouselMessage(
         renderItem={renderItem}
         indicatorActiveStyle={indicatorStyle.active}
         indicatorInactiveStyle={indicatorStyle.inactive}
+        testID={IN_APP_MESSAGING_TEST_ID.CAROUSEL}
       />
     </MessageWrapper>
   );

--- a/packages/react-native/src/InAppMessaging/components/CarouselMessage/__tests__/CarouselMessageItem.spec.tsx
+++ b/packages/react-native/src/InAppMessaging/components/CarouselMessage/__tests__/CarouselMessageItem.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, create, ReactTestRenderer } from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 
 import { useDeviceOrientation } from '../../../../hooks';
 import { useMessageImage } from '../../../hooks/useMessageImage';
@@ -14,8 +14,6 @@ jest.mock('../../MessageWrapper', () => ({ MessageWrapper: 'MessageWrapper' }));
 const baseProps = { layout: 'CAROUSEL' as const };
 
 describe('CarouselMessageItem', () => {
-  let carouselMessageItem: ReactTestRenderer;
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -34,11 +32,9 @@ describe('CarouselMessageItem', () => {
       isImageFetching: false,
     });
 
-    act(() => {
-      carouselMessageItem = create(<CarouselMessageItem {...baseProps} />);
-    });
+    const { toJSON } = render(<CarouselMessageItem {...baseProps} />);
 
-    expect(carouselMessageItem.toJSON()).toMatchSnapshot();
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('returns null if message is not ready for rendering', () => {
@@ -47,10 +43,8 @@ describe('CarouselMessageItem', () => {
       imageDimensions: { height: null, width: null },
       isImageFetching: true,
     });
-    act(() => {
-      carouselMessageItem = create(<CarouselMessageItem {...baseProps} />);
-    });
+    const { toJSON } = render(<CarouselMessageItem {...baseProps} />);
 
-    expect(carouselMessageItem.toJSON()).toBeNull();
+    expect(toJSON()).toBeNull();
   });
 });

--- a/packages/react-native/src/InAppMessaging/components/CarouselMessage/__tests__/__snapshots__/CarouselMessage.spec.tsx.snap
+++ b/packages/react-native/src/InAppMessaging/components/CarouselMessage/__tests__/__snapshots__/CarouselMessage.spec.tsx.snap
@@ -35,6 +35,7 @@ exports[`CarouselMessage allows style overrides 1`] = `
       ]
     }
     renderItem={[Function]}
+    testID="in-app-messaging--carousel"
   />
 </MessageWrapper>
 `;
@@ -70,6 +71,43 @@ exports[`CarouselMessage renders as expected 1`] = `
       ]
     }
     renderItem={[Function]}
+    testID="in-app-messaging--carousel"
+  />
+</MessageWrapper>
+`;
+
+exports[`CarouselMessage renders as expected with minimal props 1`] = `
+<MessageWrapper
+  disableSafeAreaView={true}
+>
+  <Carousel
+    data={Array []}
+    indicatorActiveStyle={
+      Array [
+        Object {
+          "backgroundColor": "#a1a1a1",
+          "borderRadius": 6,
+          "height": 12,
+          "margin": 4,
+          "width": 12,
+        },
+        undefined,
+      ]
+    }
+    indicatorInactiveStyle={
+      Array [
+        Object {
+          "backgroundColor": "#d8d8d8",
+          "borderRadius": 6,
+          "height": 12,
+          "margin": 4,
+          "width": 12,
+        },
+        undefined,
+      ]
+    }
+    renderItem={[Function]}
+    testID="in-app-messaging--carousel"
   />
 </MessageWrapper>
 `;

--- a/packages/react-native/src/InAppMessaging/components/FullScreenMessage/__tests__/FullScreenMessage.spec.tsx
+++ b/packages/react-native/src/InAppMessaging/components/FullScreenMessage/__tests__/FullScreenMessage.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 
 import { useDeviceOrientation } from '../../../../hooks';
 import { useMessageImage } from '../../../hooks';
@@ -34,9 +34,9 @@ describe('FullScreenMessage', () => {
       isImageFetching: false,
     });
 
-    const renderer = TestRenderer.create(<FullScreenMessage {...baseProps} />);
+    const { toJSON } = render(<FullScreenMessage {...baseProps} />);
 
-    expect(renderer.toJSON()).toMatchSnapshot();
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('returns null while an image is fetching', () => {
@@ -46,8 +46,8 @@ describe('FullScreenMessage', () => {
       isImageFetching: true,
     });
 
-    const renderer = TestRenderer.create(<FullScreenMessage {...baseProps} />);
+    const { toJSON } = render(<FullScreenMessage {...baseProps} />);
 
-    expect(renderer.toJSON()).toBeNull();
+    expect(toJSON()).toBeNull();
   });
 });

--- a/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/__tests__/InAppMessageDisplay.spec.tsx
+++ b/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/__tests__/InAppMessageDisplay.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, View } from 'react-native';
-import TestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 import { useMessage } from '@aws-amplify/ui-react-core';
 
 import InAppMessageDisplay from '../InAppMessageDisplay';
@@ -24,8 +24,8 @@ describe('InAppMessageDisplay', () => {
 
     mockUseMessage.mockReturnValueOnce({ Component, props });
 
-    const inAppMessageDisplay = TestRenderer.create(<InAppMessageDisplay />);
+    const { toJSON } = render(<InAppMessageDisplay />);
 
-    expect(inAppMessageDisplay.toJSON()).toMatchSnapshot();
+    expect(toJSON()).toMatchSnapshot();
   });
 });

--- a/packages/react-native/src/InAppMessaging/components/MessageWrapper/__tests__/MessageWrapper.spec.tsx
+++ b/packages/react-native/src/InAppMessaging/components/MessageWrapper/__tests__/MessageWrapper.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 import { Text } from 'react-native';
 
 import MessageWrapper from '../MessageWrapper';
@@ -8,12 +8,12 @@ const Children = () => <Text>Children</Text>;
 
 describe('MessageWrapper', () => {
   it('renders as expected', () => {
-    const renderer = TestRenderer.create(
+    const { toJSON } = render(
       <MessageWrapper>
         <Children />
       </MessageWrapper>
     );
 
-    expect(renderer.toJSON()).toMatchSnapshot();
+    expect(toJSON()).toMatchSnapshot();
   });
 });

--- a/packages/react-native/src/InAppMessaging/components/ModalMessage/__tests__/__snapshots__/ModalMessage.spec.tsx.snap
+++ b/packages/react-native/src/InAppMessaging/components/ModalMessage/__tests__/__snapshots__/ModalMessage.spec.tsx.snap
@@ -1,5 +1,377 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ModalMessage correctly handles a primaryButton prop 1`] = `
+<MessageWrapper
+  style={
+    Object {
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#fff",
+          "elevation": 3,
+          "margin": 16,
+          "minHeight": "40%",
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 2,
+            "width": 2,
+          },
+          "shadowOpacity": 0.1,
+          "shadowRadius": 2,
+        },
+        Object {},
+        Object {},
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "padding": 12,
+        }
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 10,
+            "left": 10,
+            "right": 10,
+            "top": 10,
+          }
+        }
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {},
+            undefined,
+            Array [
+              Object {
+                "alignSelf": "flex-start",
+                "marginLeft": "auto",
+              },
+              undefined,
+            ],
+          ]
+        }
+        testID="in-app-messaging--close-button"
+      >
+        <Image
+          accessibilityRole="image"
+          source={
+            Object {
+              "testUri": "../../../src/assets/icons/close.png",
+            }
+          }
+          style={
+            Array [
+              Object {
+                "height": 20,
+                "resizeMode": "contain",
+                "tintColor": undefined,
+                "width": 20,
+              },
+              undefined,
+            ]
+          }
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "marginTop": 12,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "marginTop": "auto",
+          "paddingBottom": 4,
+          "paddingHorizontal": 4,
+        }
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "hsl(210, 10%, 58%)",
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 12,
+            },
+            undefined,
+            Array [
+              Object {},
+              Object {
+                "backgroundColor": "#e8e8e8",
+                "borderRadius": 4,
+                "flex": 1,
+                "margin": 8,
+                "padding": 12,
+              },
+              Object {},
+              Object {},
+            ],
+          ]
+        }
+        testID="in-app-messaging--primary-button"
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "hsl(210, 50%, 10%)",
+                "fontSize": 16,
+                "fontWeight": "700",
+                "textAlign": "center",
+              },
+              Array [
+                Object {
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "textAlign": "center",
+                },
+                Object {},
+                Object {},
+              ],
+            ]
+          }
+        >
+          primary button
+        </Text>
+      </View>
+    </View>
+  </View>
+</MessageWrapper>
+`;
+
+exports[`ModalMessage correctly handles a secondaryButton prop 1`] = `
+<MessageWrapper
+  style={
+    Object {
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#fff",
+          "elevation": 3,
+          "margin": 16,
+          "minHeight": "40%",
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 2,
+            "width": 2,
+          },
+          "shadowOpacity": 0.1,
+          "shadowRadius": 2,
+        },
+        Object {},
+        Object {},
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "padding": 12,
+        }
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 10,
+            "left": 10,
+            "right": 10,
+            "top": 10,
+          }
+        }
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {},
+            undefined,
+            Array [
+              Object {
+                "alignSelf": "flex-start",
+                "marginLeft": "auto",
+              },
+              undefined,
+            ],
+          ]
+        }
+        testID="in-app-messaging--close-button"
+      >
+        <Image
+          accessibilityRole="image"
+          source={
+            Object {
+              "testUri": "../../../src/assets/icons/close.png",
+            }
+          }
+          style={
+            Array [
+              Object {
+                "height": 20,
+                "resizeMode": "contain",
+                "tintColor": undefined,
+                "width": 20,
+              },
+              undefined,
+            ]
+          }
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "marginTop": 12,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "marginTop": "auto",
+          "paddingBottom": 4,
+          "paddingHorizontal": 4,
+        }
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "hsl(210, 10%, 58%)",
+              "borderRadius": 4,
+              "borderWidth": 1,
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 12,
+            },
+            undefined,
+            Array [
+              Object {},
+              Object {
+                "backgroundColor": "#e8e8e8",
+                "borderRadius": 4,
+                "flex": 1,
+                "margin": 8,
+                "padding": 12,
+              },
+              Object {},
+              Object {},
+            ],
+          ]
+        }
+        testID="in-app-messaging--secondary-button"
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "hsl(210, 50%, 10%)",
+                "fontSize": 16,
+                "fontWeight": "700",
+                "textAlign": "center",
+              },
+              Array [
+                Object {
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "textAlign": "center",
+                },
+                Object {},
+                Object {},
+              ],
+            ]
+          }
+        >
+          secondary button
+        </Text>
+      </View>
+    </View>
+  </View>
+</MessageWrapper>
+`;
+
 exports[`ModalMessage renders a message as expected with an image 1`] = `
 <MessageWrapper
   style={

--- a/packages/react-native/src/InAppMessaging/components/withInAppMessaging/__tests__/withInAppMessaging.spec.tsx
+++ b/packages/react-native/src/InAppMessaging/components/withInAppMessaging/__tests__/withInAppMessaging.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 
 import withInAppMessaging from '../withInAppMessaging';
 
@@ -8,8 +8,8 @@ const TestComponent = ({ title }: { title: string }) => <>{title}</>;
 describe('withInAppMessaging', () => {
   it('renders as expected', () => {
     const WrappedComponent = withInAppMessaging(TestComponent);
-    const output = TestRenderer.create(<WrappedComponent title="example" />);
+    const { toJSON } = render(<WrappedComponent title="example" />);
 
-    expect(output.toJSON()).toMatchSnapshot();
+    expect(toJSON()).toMatchSnapshot();
   });
 });

--- a/packages/react-native/src/InAppMessaging/constants.ts
+++ b/packages/react-native/src/InAppMessaging/constants.ts
@@ -54,4 +54,5 @@ export const IN_APP_MESSAGING_TEST_ID = {
   IMAGE: 'in-app-messaging--image',
   PRIMARY_BUTTON: 'in-app-messaging--primary-button',
   SECONDARY_BUTTON: 'in-app-messaging--secondary-button',
+  CAROUSEL: 'in-app-messaging--carousel',
 };

--- a/packages/react-native/src/primitives/Carousel/__tests__/CarouselPageIndicator.spec.tsx
+++ b/packages/react-native/src/primitives/Carousel/__tests__/CarouselPageIndicator.spec.tsx
@@ -1,71 +1,73 @@
 import React from 'react';
-import { View } from 'react-native';
-import { act, create, ReactTestRenderer } from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 
 import CarouselPageIndicator from '../CarouselPageIndicator';
+import { ReactTestRendererJSON } from 'react-test-renderer';
+import {
+  DEFAULT_CAROUSEL_INDICATOR_ACTIVE_STYLE,
+  DEFAULT_CAROUSEL_INDICATOR_INACTIVE_STYLE,
+} from '../constants';
 
 describe('CarouselPageIndicator', () => {
-  let carouselPageIndicator: ReactTestRenderer;
-
   it('renders with multiple items', () => {
-    act(() => {
-      carouselPageIndicator = create(
-        <CarouselPageIndicator currentIndex={0} numberOfItems={3} />
-      );
-    });
-    const instance = carouselPageIndicator.root;
+    const { toJSON } = render(
+      <CarouselPageIndicator currentIndex={0} numberOfItems={3} />
+    );
 
-    expect(carouselPageIndicator.toJSON()).toMatchSnapshot();
-    expect(instance.findAllByType(View)).toHaveLength(3);
+    expect(toJSON()).toMatchSnapshot();
+
+    const { children } = toJSON() as ReactTestRendererJSON;
+    expect(children).toHaveLength(3);
   });
 
   it('renders with just one item', () => {
-    act(() => {
-      carouselPageIndicator = create(
-        <CarouselPageIndicator currentIndex={0} numberOfItems={1} />
-      );
-    });
-    const instance = carouselPageIndicator.root;
+    const { toJSON } = render(
+      <CarouselPageIndicator currentIndex={0} numberOfItems={1} />
+    );
 
-    expect(carouselPageIndicator.toJSON()).toMatchSnapshot();
-    expect(instance.findAllByType(View)).toHaveLength(1);
+    expect(toJSON()).toMatchSnapshot();
+    const { children } = toJSON() as ReactTestRendererJSON;
+    expect(children).toHaveLength(1);
   });
 
   it('handles null numberOfItems value', () => {
     // Ideally, this should not happen but, if it does, we should be able to handle gracefully
-    act(() => {
-      carouselPageIndicator = create(
-        <CarouselPageIndicator currentIndex={0} numberOfItems={null as any} />
-      );
-    });
+    const { toJSON } = render(
+      <CarouselPageIndicator currentIndex={0} numberOfItems={null as any} />
+    );
 
-    expect(carouselPageIndicator.toJSON()).toMatchSnapshot();
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('renders indicator styles based on current index', () => {
-    act(() => {
-      carouselPageIndicator = create(
-        <CarouselPageIndicator currentIndex={1} numberOfItems={3} />
-      );
-    });
-    const instance = carouselPageIndicator.root;
-    const indicators = instance.findAllByType(View);
-    const activeIndicator = indicators[1];
+    const { toJSON } = render(
+      <CarouselPageIndicator currentIndex={1} numberOfItems={3} />
+    );
 
-    expect(carouselPageIndicator.toJSON()).toMatchSnapshot();
-    expect(indicators[0].props).toStrictEqual(indicators[2].props);
-    expect(indicators[0].props).not.toStrictEqual(activeIndicator.props);
-    expect(indicators[2].props).not.toStrictEqual(activeIndicator.props);
+    const { children } = toJSON() as ReactTestRendererJSON;
+
+    expect(toJSON()).toMatchSnapshot();
+
+    expect((children?.[0] as ReactTestRendererJSON).props.style).toStrictEqual([
+      DEFAULT_CAROUSEL_INDICATOR_INACTIVE_STYLE,
+      undefined,
+    ]);
+    expect((children?.[1] as ReactTestRendererJSON).props.style).toStrictEqual([
+      DEFAULT_CAROUSEL_INDICATOR_ACTIVE_STYLE,
+      undefined,
+    ]);
+    expect((children?.[2] as ReactTestRendererJSON).props.style).toStrictEqual([
+      DEFAULT_CAROUSEL_INDICATOR_INACTIVE_STYLE,
+      undefined,
+    ]);
   });
 
   it('handles null index value', () => {
     // Ideally, this should not happen but, if it does, we should be able to handle gracefully
-    act(() => {
-      carouselPageIndicator = create(
-        <CarouselPageIndicator currentIndex={null} numberOfItems={5} />
-      );
-    });
+    const { toJSON } = render(
+      <CarouselPageIndicator currentIndex={null} numberOfItems={5} />
+    );
 
-    expect(carouselPageIndicator.toJSON()).toMatchSnapshot();
+    expect(toJSON()).toMatchSnapshot();
   });
 });

--- a/packages/react-native/src/primitives/Carousel/__tests__/__snapshots__/Carousel.spec.tsx.snap
+++ b/packages/react-native/src/primitives/Carousel/__tests__/__snapshots__/Carousel.spec.tsx.snap
@@ -1,5 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Carousel calls the orientation handler on orientation change 1`] = `
+Array [
+  <RCTScrollView
+    bounces={false}
+    data={
+      Array [
+        Object {
+          "key": 1,
+          "str": "qux",
+        },
+      ]
+    }
+    decelerationRate="fast"
+    disableIntervalMomentum={true}
+    getItem={[Function]}
+    getItemCount={[Function]}
+    horizontal={true}
+    keyExtractor={[Function]}
+    onContentSizeChange={[Function]}
+    onLayout={[Function]}
+    onMomentumScrollBegin={[Function]}
+    onMomentumScrollEnd={[Function]}
+    onScroll={[Function]}
+    onScrollBeginDrag={[Function]}
+    onScrollEndDrag={[Function]}
+    onViewableItemsChanged={[Function]}
+    removeClippedSubviews={false}
+    renderItem={[Function]}
+    renderToHardwareTextureAndroid={true}
+    scrollEventThrottle={50}
+    showsHorizontalScrollIndicator={false}
+    showsVerticalScrollIndicator={false}
+    snapToAlignment="start"
+    snapToInterval={350}
+    stickyHeaderIndices={Array []}
+    viewabilityConfig={
+      Object {
+        "itemVisiblePercentThreshold": 60,
+      }
+    }
+    viewabilityConfigCallbackPairs={
+      Array [
+        Object {
+          "onViewableItemsChanged": [Function],
+          "viewabilityConfig": Object {
+            "itemVisiblePercentThreshold": 60,
+          },
+        },
+      ]
+    }
+  >
+    <View>
+      <View
+        onLayout={[Function]}
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            null,
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "width": 350,
+            }
+          }
+        >
+          <Text>
+            qux
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>,
+  <CarouselPageIndicator
+    currentIndex={0}
+    numberOfItems={1}
+    style={
+      Object {
+        "bottom": 0,
+        "flexDirection": "row",
+        "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+      }
+    }
+  />,
+]
+`;
+
 exports[`Carousel renders with just one item in the data 1`] = `
 Array [
   <RCTScrollView

--- a/packages/react-native/src/primitives/Carousel/types.ts
+++ b/packages/react-native/src/primitives/Carousel/types.ts
@@ -7,6 +7,7 @@ export interface CarouselProps<T> {
   onClose?: () => void;
   renderItem: ListRenderItem<T>;
   style?: StyleProp<ViewStyle>;
+  testID?: string | undefined;
 }
 
 export interface CarouselPageIndicatorProps {

--- a/packages/react-native/src/primitives/Carousel/types.ts
+++ b/packages/react-native/src/primitives/Carousel/types.ts
@@ -7,7 +7,7 @@ export interface CarouselProps<T> {
   onClose?: () => void;
   renderItem: ListRenderItem<T>;
   style?: StyleProp<ViewStyle>;
-  testID?: string | undefined;
+  testID?: string;
 }
 
 export interface CarouselPageIndicatorProps {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change refactors existing React Native tests to use @testing-library instead of react-test-renderer. Also adds some assertions and tests to improve coverage.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
