### PR TITLE
fix(change password docs): Update component overrides docs on change password ErrorMessage

### DIFF
--- a/docs/src/pages/[platform]/connected-components/account-settings/change-password/props.ts
+++ b/docs/src/pages/[platform]/connected-components/account-settings/change-password/props.ts
@@ -40,7 +40,7 @@ export const OVERRIDES = [
   },
   {
     name: `ErrorMessage?`,
-    description: 'Error alert that displays on delete user errors',
+    description: 'Error alert that displays on change password errors',
     type: `ErrorMessageComponentProps`,
   },
   {


### PR DESCRIPTION
#### Description of changes
Docs shows `Error alert that displays on delete user errors` for `Change Password` component. This fix updates that text.

#### Issue #, if available

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
