### PR TITLE
fix(docs): Added note on zero configuration on sign up fields

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/form-fields.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/form-fields.web.mdx
@@ -17,7 +17,7 @@ have an `order` key that specifies which order it will be displayed on the page.
 
 In the example below the order will be set as `email`, `family_name`, `birthdate`, `preferred_username`, `password` and finally `confirm_password`.
 
-**Note:** Fields that do not have a `order` key will be displayed at the bottom of the Sign Up page. The `order` key can also be combined with other form field updates. In addition, all attributes listed below have already been inferred through [Zero Configuration](./configuration#sign-up-attributes). If needed, you can explicitly set the [sign up attributes prop](./configuration#sign-up-attributes) to add these to the sign up page.
+**Note:** Fields that do not have a `order` key will be displayed at the bottom of the Sign Up page. The `order` key can also be combined with other form field updates. In addition, typically attributes added to the sign up page have already been inferred through [Zero Configuration](./configuration#sign-up-attributes). However, you can explicitly set the [sign up attributes prop](./configuration#sign-up-attributes) to add these to the sign up page if needed.
 
 <Fragment>
   {({ platform }) => import(`./orderformfields/form-fields.${platform}.mdx`)}

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/form-fields.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/form-fields.web.mdx
@@ -17,7 +17,7 @@ have an `order` key that specifies which order it will be displayed on the page.
 
 In the example below the order will be set as `email`, `family_name`, `birthdate`, `preferred_username`, `password` and finally `confirm_password`.
 
-**Note:** Fields that do not have a `order` key will be displayed at the bottom of the Sign Up page. The `order` key can also be combined with other form field updates.
+**Note:** Fields that do not have a `order` key will be displayed at the bottom of the Sign Up page. The `order` key can also be combined with other form field updates. In addition, all attributes listed below have already been inferred through [Zero Configuration](./configuration#sign-up-attributes). If needed, you can explicitly set the [sign up attributes prop](./configuration#sign-up-attributes) to add these to the sign up page.
 
 <Fragment>
   {({ platform }) => import(`./orderformfields/form-fields.${platform}.mdx`)}

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.angular.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.angular.mdx
@@ -54,7 +54,7 @@ export class AppComponent {
   }
 }
 
-// Adding the signUpAttributes prop is not needed since attributes are normally inferred via Zero Configuration.
+// Adding the signUpAttributes prop is not needed since attributes are typically inferred via Zero Configuration.
 // For the sake of this example they have been explicitly added so you can copy and paste this into your own application and see it work. 
 public signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
 ```

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.angular.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.angular.mdx
@@ -1,7 +1,7 @@
 _app.component.html_
 
 ```html{1}
-<amplify-authenticator [formFields]="formFields">
+<amplify-authenticator [formFields]="formFields" [signUpAttributes]="signUpAttributes">
   <ng-template
     amplifySlot="authenticated"
     let-user="user"
@@ -29,6 +29,7 @@ export class AppComponent {
   constructor() {
     Amplify.configure(awsExports);
   }
+
   public formFields = {
     signUp: {
       email: {
@@ -52,4 +53,6 @@ export class AppComponent {
     },
   }
 }
+
+public signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
 ```

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.angular.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.angular.mdx
@@ -54,7 +54,7 @@ export class AppComponent {
   }
 }
 
-// Adding the signUpAttributes prop is not needed since attributes are typically inferred via Zero Configuration.
+// Adding the signUpAttributes prop is typically not needed since attributes are inferred via Zero Configuration.
 // For the sake of this example they have been explicitly added so you can copy and paste this into your own application and see it work. 
 public signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
 ```

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.angular.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.angular.mdx
@@ -54,5 +54,7 @@ export class AppComponent {
   }
 }
 
+// Adding the signUpAttributes prop is not needed since attributes are normally inferred via Zero Configuration.
+// For the sake of this example they have been explicitly added so you can copy and paste this into your own application and see it work. 
 public signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
 ```

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.react.mdx
@@ -24,7 +24,7 @@ const formFields = {
   }
 
 
-// Adding the signUpAttributes prop is not needed since attributes are typically inferred via Zero Configuration.
+// Adding the signUpAttributes prop is typically not needed since attributes are inferred via Zero Configuration.
 // For the sake of this example they have been explicitly added so you can copy and paste this into your own application and see it work. 
 const signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
 

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.react.mdx
@@ -23,9 +23,11 @@ const formFields = {
    },
   }
 
+const signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
+
 export default function App() {
   return (
-    <Authenticator formFields={formFields}>
+    <Authenticator formFields={formFields} signUpAttributes={signUpAttributes}>
       {({ signOut }) => <button onClick={signOut}>Sign out</button>}
     </Authenticator>
   );

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.react.mdx
@@ -23,6 +23,9 @@ const formFields = {
    },
   }
 
+
+// Adding the signUpAttributes prop is not needed since attributes are normally inferred via Zero Configuration.
+// For the sake of this example they have been explicitly added so you can copy and paste this into your own application and see it work. 
 const signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
 
 export default function App() {

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.react.mdx
@@ -24,7 +24,7 @@ const formFields = {
   }
 
 
-// Adding the signUpAttributes prop is not needed since attributes are normally inferred via Zero Configuration.
+// Adding the signUpAttributes prop is not needed since attributes are typically inferred via Zero Configuration.
 // For the sake of this example they have been explicitly added so you can copy and paste this into your own application and see it work. 
 const signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
 

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.vue.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.vue.mdx
@@ -25,7 +25,7 @@ const formFields = {
 
 
 
-// Adding the signUpAttributes prop is not needed since attributes are normally inferred via Zero Configuration.
+// Adding the signUpAttributes prop is not needed since attributes are typically inferred via Zero Configuration.
 // For the sake of this example they have been explicitly added so you can copy and paste this into your own application and see it work. 
 const signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
 </script>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.vue.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.vue.mdx
@@ -23,6 +23,10 @@ const formFields = {
     },
 }
 
+
+
+// Adding the signUpAttributes prop is not needed since attributes are normally inferred via Zero Configuration.
+// For the sake of this example they have been explicitly added so you can copy and paste this into your own application and see it work. 
 const signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
 </script>
 <template>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.vue.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.vue.mdx
@@ -22,9 +22,11 @@ const formFields = {
       }
     },
 }
+
+const signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
 </script>
 <template>
-  <authenticator :form-fields="formFields">
+  <authenticator :form-fields="formFields" :sign-up-attributes="signUpAttributes">
     <template v-slot="{ user, signOut }">
       <h1>Hello {{ user.username }}!</h1>
       <button @click="signOut">Sign Out</button>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.vue.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/orderformfields/form-fields.vue.mdx
@@ -25,7 +25,7 @@ const formFields = {
 
 
 
-// Adding the signUpAttributes prop is not needed since attributes are typically inferred via Zero Configuration.
+// Adding the signUpAttributes prop is typically not needed since attributes are inferred via Zero Configuration.
 // For the sake of this example they have been explicitly added so you can copy and paste this into your own application and see it work. 
 const signUpAttributes={['birthdate', 'family_name', 'preferred_username']}
 </script>


### PR DESCRIPTION
#### Description of changes
Documentation for the sign up fields order for the authenticator is not clear. If customers copy this code they may see an issue where the fields repeat. Added note to make it clear how to use the code and added sign up attributes prop.

#### Issue #, if available
 #2699

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Docs update, manually

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
