### PR TITLE
chore(docs): Add expand animation to headings

### DIFF
--- a/docs/src/components/home/sections/A11ySection.tsx
+++ b/docs/src/components/home/sections/A11ySection.tsx
@@ -41,7 +41,10 @@ export const A11ySection = ({ platform }) => {
         className="docs-home-subsection--thin"
         textAlign="center"
       >
-        <Heading level={2}>
+        <Heading
+          level={2}
+          className={classNames('expand-out', isVisible && 'shown')}
+        >
           <strong>Accessibility</strong> built-in
         </Heading>
         <Text className="docs-home-text">

--- a/docs/src/components/home/sections/AmplifySection.tsx
+++ b/docs/src/components/home/sections/AmplifySection.tsx
@@ -29,7 +29,10 @@ export const AmplifySection = ({ platform }) => {
       )}
     >
       <Flex direction="column" className="docs-home-subsection--thin">
-        <Heading level={2}>
+        <Heading
+          level={2}
+          className={classNames('expand-out', isVisible && 'shown')}
+        >
           Better <strong>together</strong> with AWS Amplify
         </Heading>
 

--- a/docs/src/components/home/sections/AuthenticationSection.tsx
+++ b/docs/src/components/home/sections/AuthenticationSection.tsx
@@ -171,7 +171,10 @@ export const AuthenticationSection = ({ platform }) => {
     >
       <Flex direction="column">
         <Flex direction="column" className="docs-home-subsection--thin">
-          <Heading level={2}>
+          <Heading
+            level={2}
+            className={classNames('expand-out', isVisible && 'shown')}
+          >
             <strong>Authentication</strong> made easy
           </Heading>
           <Text className="docs-home-text">

--- a/docs/src/components/home/sections/CompatibleSection.tsx
+++ b/docs/src/components/home/sections/CompatibleSection.tsx
@@ -31,7 +31,11 @@ export const CompatibleSection = ({ platform }) => {
       )}
     >
       <Flex direction="column" className="docs-home-subsection">
-        <Heading level={2} textAlign="center">
+        <Heading
+          level={2}
+          textAlign="center"
+          className={classNames('expand-out', isVisible && 'shown')}
+        >
           <strong>Compatible</strong> with your front-end
         </Heading>
         <Flex

--- a/docs/src/components/home/sections/FigmaSection.tsx
+++ b/docs/src/components/home/sections/FigmaSection.tsx
@@ -82,7 +82,10 @@ export const FigmaSection = () => {
       ref={ref}
     >
       <Flex className="docs-home-subsection" direction="column" gap="large">
-        <Heading level={2}>
+        <Heading
+          level={2}
+          className={classNames('expand-out', isVisible && 'shown')}
+        >
           Build UI <strong>visually</strong> in Figma
         </Heading>
         <Flex

--- a/docs/src/components/home/sections/HeroSection.tsx
+++ b/docs/src/components/home/sections/HeroSection.tsx
@@ -21,6 +21,7 @@ import { CardLink } from '@/components/CardLink';
 import { FRAMEWORKS, FRAMEWORK_INSTALL_SCRIPTS } from '@/data/frameworks';
 import { FrameworkLogo } from '@/components/Logo';
 import { TerminalCommand } from '@/components/InstallScripts';
+import classNames from 'classnames';
 
 export const HeroSection = () => {
   const {
@@ -42,7 +43,11 @@ export const HeroSection = () => {
           className="docs-home-subsection--thin"
           alignItems="center"
         >
-          <Heading level={1} marginBlockEnd="0">
+          <Heading
+            level={1}
+            marginBlockEnd="0"
+            className={classNames('expand-out', 'shown')}
+          >
             Themeable, accessible components
             <br />
             <strong>Ready to connect to the cloud</strong>

--- a/docs/src/components/home/sections/LiveSection.tsx
+++ b/docs/src/components/home/sections/LiveSection.tsx
@@ -34,7 +34,12 @@ export const LiveSection = ({ platform, ...rest }) => {
       ref={ref}
     >
       <View className="docs-home-subsection">
-        <Heading level={2}>Take it for a test drive</Heading>
+        <Heading
+          level={2}
+          className={classNames('expand-out', isVisible && 'shown')}
+        >
+          Take it for a test drive
+        </Heading>
       </View>
 
       <View className="docs-home-subsection">

--- a/docs/src/components/home/sections/PrimitiveSection.tsx
+++ b/docs/src/components/home/sections/PrimitiveSection.tsx
@@ -206,7 +206,10 @@ export const PrimitiveSection = ({ platform, ...rest }) => {
       ref={ref}
     >
       <Flex direction="column" gap="large" className="docs-home-subsection">
-        <Heading level={2}>
+        <Heading
+          level={2}
+          className={classNames('expand-out', isVisible && 'shown')}
+        >
           Speed up development with over <br />
           <strong>40 production-ready components</strong>
         </Heading>

--- a/docs/src/components/home/sections/ThemingSection.tsx
+++ b/docs/src/components/home/sections/ThemingSection.tsx
@@ -31,7 +31,10 @@ export const ThemingSection = ({ colorMode, platform }) => {
       )}
     >
       <Flex direction="column" className="docs-home-subsection--thin">
-        <Heading level={2}>
+        <Heading
+          level={2}
+          className={classNames('expand-out', isVisible && 'shown')}
+        >
           <strong>Theming</strong> controls to match your brand
         </Heading>
         <Text className="docs-home-text">

--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -303,6 +303,30 @@ h4:hover > a .icon-link {
   }
 }
 
+.expand-out {
+  // Only expand things for people without reduced motion preference
+  @media (prefers-reduced-motion: no-preference) {
+    &.shown {
+      animation: expand-out calc(2 * var(--amplify-time-long))
+        cubic-bezier(0.2, 0.6, 0.3, 1) both;
+    }
+  }
+}
+
+@keyframes expand-out {
+  0% {
+    letter-spacing: calc(-1 * var(--amplify-space-xs));
+    opacity: var(--amplify-opacities-0);
+  }
+  50% {
+    opacity: var(--amplify-opacities-60);
+  }
+  100% {
+    transform: translateZ(0);
+    opacity: var(--amplify-opacities-1);
+  }
+}
+
 .video {
   @supports (aspect-ratio: 1) {
     aspect-ratio: 16 / 9;

--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -316,6 +316,7 @@ h4:hover > a .icon-link {
 @keyframes expand-out {
   0% {
     letter-spacing: calc(-1 * var(--amplify-space-xs));
+    // arbitrary number found through heuristic methods, without this transform the expansion is less smooth and less noticeable.
     transform: translateZ(-500px);
     opacity: var(--amplify-opacities-0);
   }

--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -316,6 +316,7 @@ h4:hover > a .icon-link {
 @keyframes expand-out {
   0% {
     letter-spacing: calc(-1 * var(--amplify-space-xs));
+    transform: translateZ(-500px);
     opacity: var(--amplify-opacities-0);
   }
   50% {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change an animation to the heading on the main docs page, making the text expand outward as it's being rendered.

![Kapture 2022-12-15 at 13 07 02](https://user-images.githubusercontent.com/68251134/207969179-182f6ef2-e064-4b40-bd4a-9c6fa02e4d1d.gif)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Manual test in Chrome, Safari and firefox.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
