### PR TITLE
Italian translation - fix

### DIFF
--- a/packages/ui/src/i18n/dictionaries/authenticator/it.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/it.ts
@@ -59,7 +59,7 @@ export const itDict: AuthenticatorDictionary = {
   'Confirm Sign In': "Conferma l'accesso",
   'Create account': 'Crea account',
   'Enter your password': 'Inserisci la tua password',
-  'Forgot Password': 'Password dimenticata',
+  'Forgot Password?': 'Password dimenticata?',
   'Have an account? ': 'Già registrato?',
   'Incorrect username or password': 'Nome utente o password errati',
   'Invalid password format': 'Formato della password non valido',


### PR DESCRIPTION
#### Description of changes

Missing quote mark in italian translation

#### Description of how you validated changes

running react native app, looking at the sign in screen, seeing the non translated text
re-running react native app. adding 
```
I18n.putVocabularies({
  it: {
    'Forgot Password?': 'Password Dimenticata?',
  },
});

acknowledging the string is correctly translated

Then reporting the fix into amplify-ui repo 

```

#### Checklist

- [x ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
