### PR TITLE
chore(ci): Add timeout to setup-node

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -93,6 +93,8 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       - name: Install packages
         uses: ./.github/actions/install-with-retries
         with:

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -63,6 +63,8 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
       - name: Restore cypress runner Cache
         uses: actions/cache@v3

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -68,6 +68,8 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       - name: Restore cypress runner from Cache
         uses: actions/cache@v3
         id: restore-cypress-cache
@@ -132,7 +134,8 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
-
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       - name: Restore node_modules cache
         uses: actions/cache@v3
         id: restore-cache
@@ -235,7 +238,8 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
-
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       - name: Restore cypress runner Cache
         uses: actions/cache@v3
         id: restore-cypress-cache
@@ -378,7 +382,8 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
-
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       - name: Restore cypress runner Cache
         uses: actions/cache@v3
         id: restore-cypress-cache

--- a/.github/workflows/reusable-tagged-publish.yml
+++ b/.github/workflows/reusable-tagged-publish.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       - name: Install packages
         uses: ./.github/actions/install-with-retries
         with:

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       - name: Install packages
         if: ${{ steps.has-changesets.outputs.has-changesets == 'true' }}
         run: yarn --frozen-lockfile


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This is continuation of https://github.com/aws-amplify/amplify-ui/pull/2755. GitHub Actions has a caching issue  https://github.com/actions/cache/issues/810, which causes cache step to be stuck indefinitely. See [example](https://github.com/aws-amplify/amplify-ui/actions/runs/3734904700/jobs/6337614939) for a recent workflow.

Resolving this by adding timeout to cache steps. If cache doesn't get restored during that timeout, it'll abort cache download and recompute the cache. 

#### Timeout number choice

Set the timeout to 2 minutes, because this step usually took 20~40 seconds. Gave it a padding for any network slowdown issues. 

#### Description of how you validated changes

Followed the same code changes I used in #2755.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
