### PR TITLE
fix(forced password reset): Update logic for emails sent out on forced password reset

### DIFF
--- a/.changeset/rich-peaches-trade.md
+++ b/.changeset/rich-peaches-trade.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui': patch
+---
+
+Updated logic so users will now receive a code, when they are displayed the reset password page that asks for a code after signing in. This occurs when the users are imported into Cognito.

--- a/packages/e2e/cypress/fixtures/force-reset-password.json
+++ b/packages/e2e/cypress/fixtures/force-reset-password.json
@@ -1,0 +1,4 @@
+{
+  "__type": "PasswordResetRequiredException",
+  "message": "Password reset required for the user"
+}

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
@@ -11,6 +11,16 @@ Feature: Sign In with Email
     Given I'm running the example "/ui/components/authenticator/sign-in-with-email"
 
   @angular @react @vue
+  Scenario: Sign in with force password reset calls forgot password
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth" } }' with error fixture "force-reset-password"
+    Given I spy "Amplify.Auth.forgotPassword" method
+    When I type my "email" with status "CONFIRMED"
+    And I type my password
+    And I click the "Sign in" button
+    Then I see "Code *"
+    And "Amplify.Auth.forgotPassword" method is called
+
+  @angular @react @vue
   Scenario: Sign in with unknown credentials
     When I type my "email" with status "UNKNOWN"
     And I type my password
@@ -34,6 +44,7 @@ Feature: Sign In with Email
     And I mock 'Amplify.Auth.currentAuthenticatedUser' with fixture "Auth.currentAuthenticatedUser-verified-email"
     And I click the "Confirm" button
     Then I see "Sign out"
+
 
 
   @angular @react @vue

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
@@ -13,9 +13,9 @@ Feature: Sign In with Email
   @angular @react @vue
   Scenario: Sign in with force password reset calls forgot password
     Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth" } }' with error fixture "force-reset-password"
-    Given I spy "Amplify.Auth.forgotPassword" method
     When I type my "email" with status "CONFIRMED"
     And I type my password
+    Given I spy "Amplify.Auth.forgotPassword" method
     And I click the "Sign in" button
     Then I see "Code *"
     And "Amplify.Auth.forgotPassword" method is called

--- a/packages/ui/src/machines/authenticator/actions.ts
+++ b/packages/ui/src/machines/authenticator/actions.ts
@@ -1,3 +1,4 @@
+import { Auth } from 'aws-amplify';
 import { assign, stop } from 'xstate/lib/actions';
 
 import {
@@ -153,6 +154,13 @@ export const handleBlur = assign({
     };
   },
 });
+
+export const resendCode = async (context) => {
+  const { username } = context;
+  console.log('username', username);
+
+  return Auth.forgotPassword(username);
+};
 
 /**
  * This action occurs on the entry to a state where a form submit action

--- a/packages/ui/src/machines/authenticator/actions.ts
+++ b/packages/ui/src/machines/authenticator/actions.ts
@@ -157,7 +157,6 @@ export const handleBlur = assign({
 
 export const resendCode = async (context) => {
   const { username } = context;
-  console.log('username', username);
 
   return Auth.forgotPassword(username);
 };

--- a/packages/ui/src/machines/authenticator/actions.ts
+++ b/packages/ui/src/machines/authenticator/actions.ts
@@ -158,7 +158,7 @@ export const handleBlur = assign({
 export const resendCode = async (context) => {
   const { username } = context;
 
-  return Auth.forgotPassword(username);
+  return await Auth.forgotPassword(username);
 };
 
 /**

--- a/packages/ui/src/machines/authenticator/actors/resetPassword.ts
+++ b/packages/ui/src/machines/authenticator/actors/resetPassword.ts
@@ -13,6 +13,7 @@ import {
   setFieldErrors,
   setRemoteError,
   setUsername,
+  resendCode,
 } from '../actions';
 import { defaultServices } from '../defaultServices';
 
@@ -32,6 +33,7 @@ export function resetPasswordActor({ services }: ResetPasswordMachineOptions) {
             {
               target: 'confirmResetPassword',
               cond: 'shouldAutoConfirmReset',
+              actions: 'resendCode',
             },
             { target: 'resetPassword' },
           ],
@@ -104,39 +106,6 @@ export function resetPasswordActor({ services }: ResetPasswordMachineOptions) {
                 },
               },
             },
-            sendConfirmPassword: {
-              tags: ['pending'],
-              entry: ['sendUpdate', 'clearError'],
-              initial: 'init',
-              states: {
-                init: {
-                  always: [
-                    {
-                      target: 'pending',
-                      cond: 'shouldAutoConfirmReset',
-                    },
-                    {
-                      target: 'valid',
-                    },
-                  ],
-                },
-                pending: {
-                  tags: ['pending'],
-                  entry: ['sendUpdate', 'clearError'],
-                  invoke: {
-                    src: 'resetPassword',
-                    onDone: {
-                      target: 'valid',
-                    },
-                    onError: {
-                      actions: ['setRemoteError'],
-                      target: 'valid',
-                    },
-                  },
-                },
-                valid: { entry: 'sendUpdate' },
-              },
-            },
             submission: {
               initial: 'idle',
               states: {
@@ -207,6 +176,7 @@ export function resetPasswordActor({ services }: ResetPasswordMachineOptions) {
         handleInput,
         handleSubmit,
         handleBlur,
+        resendCode,
         setFieldErrors,
         setRemoteError,
         setUsername,

--- a/packages/ui/src/machines/authenticator/actors/resetPassword.ts
+++ b/packages/ui/src/machines/authenticator/actors/resetPassword.ts
@@ -29,7 +29,10 @@ export function resetPasswordActor({ services }: ResetPasswordMachineOptions) {
       states: {
         init: {
           always: [
-            { target: 'confirmResetPassword', cond: 'shouldAutoConfirmReset' },
+            {
+              target: 'confirmResetPassword',
+              cond: 'shouldAutoConfirmReset',
+            },
             { target: 'resetPassword' },
           ],
         },
@@ -89,6 +92,7 @@ export function resetPasswordActor({ services }: ResetPasswordMachineOptions) {
                 valid: { entry: 'sendUpdate' },
                 invalid: { entry: 'sendUpdate' },
               },
+
               on: {
                 CHANGE: {
                   actions: 'handleInput',
@@ -98,6 +102,39 @@ export function resetPasswordActor({ services }: ResetPasswordMachineOptions) {
                   actions: 'handleBlur',
                   target: '.pending',
                 },
+              },
+            },
+            sendConfirmPassword: {
+              tags: ['pending'],
+              entry: ['sendUpdate', 'clearError'],
+              initial: 'init',
+              states: {
+                init: {
+                  always: [
+                    {
+                      target: 'pending',
+                      cond: 'shouldAutoConfirmReset',
+                    },
+                    {
+                      target: 'valid',
+                    },
+                  ],
+                },
+                pending: {
+                  tags: ['pending'],
+                  entry: ['sendUpdate', 'clearError'],
+                  invoke: {
+                    src: 'resetPassword',
+                    onDone: {
+                      target: 'valid',
+                    },
+                    onError: {
+                      actions: ['setRemoteError'],
+                      target: 'valid',
+                    },
+                  },
+                },
+                valid: { entry: 'sendUpdate' },
               },
             },
             submission: {


### PR DESCRIPTION
#### Description of changes
When customer imports a set of users, and the users log in for the first time, they never receive an email for them to reset their password.

#### Issue #, if available
#2488 

#### Description of how you validated changes
Added e2e test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
