### PR TITLE
fix(docs): Framework chooser link for components overview

### DIFF
--- a/docs/cypress/e2e/links.cy.ts
+++ b/docs/cypress/e2e/links.cy.ts
@@ -30,7 +30,7 @@ describe(`All pages on Sitemap`, () => {
     });
   });
 
-  it('should succesfully load each url in the sitemap', () => {
+  it('should successfully load each url in the sitemap', () => {
     allLinks.forEach((link, idx) => {
       cy.task('log', `🧪[TESTING...] page #${idx} ${BASE_URL}/${link}`);
       cy.visit({ url: link || '/', qs: { cypress: true } });

--- a/docs/src/components/Layout/FrameworkChooser.tsx
+++ b/docs/src/components/Layout/FrameworkChooser.tsx
@@ -26,7 +26,7 @@ const FrameworkLink = ({
     : `/${framework}`;
 
   return (
-    <Link href={isDisabled ? '#' : href} passHref>
+    <Link href={href} passHref>
       <Button
         size="small"
         as="a"

--- a/docs/src/components/Layout/FrameworkChooser.tsx
+++ b/docs/src/components/Layout/FrameworkChooser.tsx
@@ -6,29 +6,6 @@ import { FRAMEWORKS, FRAMEWORK_DISPLAY_NAMES } from '@/data/frameworks';
 import metaData from '@/data/pages.preval';
 import { FrameworkLogo } from '@/components/Logo';
 
-const FrameworkButton = ({
-  isDisabled,
-  onClick,
-  classNames,
-  framework,
-}: {
-  isDisabled: boolean;
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
-  classNames: string;
-  framework: string;
-}) => (
-  <Button
-    size="small"
-    as="a"
-    className={classNames}
-    onClick={onClick}
-    isDisabled={isDisabled}
-  >
-    <FrameworkLogo framework={framework} className="docs-framework-img" />
-    {FRAMEWORK_DISPLAY_NAMES[framework]}
-  </Button>
-);
-
 interface FrameworkLinkProps extends FrameworkChooserProps {
   framework: string;
   isDisabled: boolean;
@@ -48,25 +25,24 @@ const FrameworkLink = ({
     ? pathname.replace(platformPath, framework)
     : `/${framework}`;
 
-  if (isDisabled) {
-    return (
-      <FrameworkButton
-        classNames={classNames}
-        isDisabled={isDisabled}
-        framework={framework}
-        onClick={onClick}
-      />
-    );
-  }
+  const frameworkButton = (
+    <Button
+      size="small"
+      as="a"
+      className={classNames}
+      onClick={onClick}
+      isDisabled={isDisabled}
+    >
+      <FrameworkLogo framework={framework} className="docs-framework-img" />
+      {FRAMEWORK_DISPLAY_NAMES[framework]}
+    </Button>
+  );
 
-  return (
+  return isDisabled ? (
+    frameworkButton
+  ) : (
     <Link href={href} passHref>
-      <FrameworkButton
-        classNames={classNames}
-        isDisabled={isDisabled}
-        framework={framework}
-        onClick={onClick}
-      />
+      {frameworkButton}
     </Link>
   );
 };

--- a/docs/src/components/Layout/FrameworkChooser.tsx
+++ b/docs/src/components/Layout/FrameworkChooser.tsx
@@ -6,6 +6,29 @@ import { FRAMEWORKS, FRAMEWORK_DISPLAY_NAMES } from '@/data/frameworks';
 import metaData from '@/data/pages.preval';
 import { FrameworkLogo } from '@/components/Logo';
 
+const FrameworkButton = ({
+  isDisabled,
+  onClick,
+  classNames,
+  framework,
+}: {
+  isDisabled: boolean;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  classNames: string;
+  framework: string;
+}) => (
+  <Button
+    size="small"
+    as="a"
+    className={classNames}
+    onClick={onClick}
+    isDisabled={isDisabled}
+  >
+    <FrameworkLogo framework={framework} className="docs-framework-img" />
+    {FRAMEWORK_DISPLAY_NAMES[framework]}
+  </Button>
+);
+
 interface FrameworkLinkProps extends FrameworkChooserProps {
   framework: string;
   isDisabled: boolean;
@@ -25,18 +48,25 @@ const FrameworkLink = ({
     ? pathname.replace(platformPath, framework)
     : `/${framework}`;
 
+  if (isDisabled) {
+    return (
+      <FrameworkButton
+        classNames={classNames}
+        isDisabled={isDisabled}
+        framework={framework}
+        onClick={onClick}
+      />
+    );
+  }
+
   return (
     <Link href={href} passHref>
-      <Button
-        size="small"
-        as="a"
-        className={classNames}
-        onClick={onClick}
+      <FrameworkButton
+        classNames={classNames}
         isDisabled={isDisabled}
-      >
-        <FrameworkLogo framework={framework} className="docs-framework-img" />
-        {FRAMEWORK_DISPLAY_NAMES[framework]}
-      </Button>
+        framework={framework}
+        onClick={onClick}
+      />
     </Link>
   );
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**Issue**: on the components overview page (https://ui.docs.amplify.aws/react/components), the framework chooser 1)  add a `#` to the disabled links and 2) all the links are pointing to react (unimportant since they are disabled). 

Also The wrong links breaks the tests in links.cy.ts.

![image](https://user-images.githubusercontent.com/11983489/208777607-9f2a042a-84d7-4f44-b279-f587dd384b0a.png)

**Fix**: remove the link from disabled frameworks


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
