### PR TITLE
chore: pin babel plugin to working version

### DIFF
--- a/canary/apps/react/cra/package.json
+++ b/canary/apps/react/cra/package.json
@@ -51,5 +51,8 @@
       "path": "build/static/js/main.*.js",
       "limit": "281 kB"
     }
-  ]
+  ],
+  "overrides": {
+    "@babel/plugin-transform-block-scoping": "7.20.5"
+  }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Pins `@babel/plugin-transform-block-scoping` to `7.20.5`, which is a known working version. Will revert once this [babel bug](https://github.com/babel/babel/issues/15302) is fixed.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
