### PR TITLE
fix: update cra app babel plugin override

### DIFF
--- a/canary/apps/react/cra-ts/package.json
+++ b/canary/apps/react/cra-ts/package.json
@@ -59,5 +59,8 @@
   ],
   "resolutions": {
     "@babel/plugin-transform-block-scoping": "7.20.5"
+  },
+  "overrides": {
+    "@babel/plugin-transform-block-scoping": "7.20.5"
   }
 }

--- a/canary/apps/react/cra/package.json
+++ b/canary/apps/react/cra/package.json
@@ -52,7 +52,7 @@
       "limit": "281 kB"
     }
   ],
-  "overrides": {
+  "resolutions": {
     "@babel/plugin-transform-block-scoping": "7.20.5"
   }
 }

--- a/canary/apps/react/cra/package.json
+++ b/canary/apps/react/cra/package.json
@@ -54,5 +54,8 @@
   ],
   "resolutions": {
     "@babel/plugin-transform-block-scoping": "7.20.5"
+  },
+  "overrides": {
+    "@babel/plugin-transform-block-scoping": "7.20.5"
   }
 }

--- a/guides/react/protected-routes/package.json
+++ b/guides/react/protected-routes/package.json
@@ -43,5 +43,11 @@
     "customize-cra": "^1.0.0",
     "react-app-rewired": "^2.2.1",
     "serve": "^13.0.2"
+  },
+  "resolutions": {
+    "@babel/plugin-transform-block-scoping": "7.20.5"
+  },
+  "overrides": {
+    "@babel/plugin-transform-block-scoping": "7.20.5"
   }
 }


### PR DESCRIPTION
cra app no longer using `npm install`, so updating the fix for "@babel/plugin-transform-block-scoping" to yarn compatible `resolutions`

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update cra app babel plugin override since `cra` now using `yarn install` and not `npm install` like I previously thought.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
