### PR TITLE
fix(rna): add Field component to address iOS TextInput secureTextEntry bug

### DIFF
--- a/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/__snapshots__/ConfirmResetPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/__snapshots__/ConfirmResetPassword.spec.tsx.snap
@@ -249,6 +249,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [
@@ -387,6 +398,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
   </View>,
   <View
     accessibilityRole="alert"
@@ -795,6 +817,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [
@@ -933,6 +966,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
   </View>,
   <View
     accessibilityRole="button"

--- a/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/__snapshots__/ForceNewPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/__snapshots__/ForceNewPassword.spec.tsx.snap
@@ -141,6 +141,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
   </View>,
   <View
     accessibilityRole="alert"
@@ -450,6 +461,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
   </View>,
   <View
     accessibilityRole="button"
@@ -704,6 +726,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Object {

--- a/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/__snapshots__/SignIn.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/__snapshots__/SignIn.spec.tsx.snap
@@ -249,6 +249,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
   </View>,
   <View
     accessibilityRole="button"
@@ -656,6 +667,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
   </View>,
   <View
     accessibilityRole="button"
@@ -1015,6 +1037,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
   </View>,
   <View
     accessibilityRole="alert"

--- a/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/__snapshots__/SignUp.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/__snapshots__/SignUp.spec.tsx.snap
@@ -249,6 +249,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [
@@ -387,6 +398,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [
@@ -837,6 +859,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [
@@ -975,6 +1008,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [
@@ -1371,6 +1415,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [
@@ -1512,6 +1567,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [
@@ -1963,6 +2029,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [
@@ -2101,6 +2178,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [
@@ -2642,6 +2730,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [
@@ -2783,6 +2882,17 @@ Array [
         </View>
       </View>
     </View>
+    <TextInput
+      accessibilityElementsHidden={true}
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "transparent",
+          "height": 0.1,
+          "width": 0.1,
+        }
+      }
+    />
     <View
       style={
         Array [

--- a/packages/react-native/src/Authenticator/common/DefaultFormFields/DefaultTextFormFields.tsx
+++ b/packages/react-native/src/Authenticator/common/DefaultFormFields/DefaultTextFormFields.tsx
@@ -3,12 +3,7 @@ import { View } from 'react-native';
 
 import { getErrors } from '@aws-amplify/ui';
 
-import {
-  PasswordField,
-  PhoneNumberField,
-  TextField,
-} from '../../../primitives';
-
+import Field from './Field';
 import { FieldErrors } from './FieldErrors';
 import { DefaultTextFormFieldsComponent } from './types';
 
@@ -27,13 +22,6 @@ const DefaultTextFormFields: DefaultTextFormFieldsComponent = ({
 
     const hasError = errors?.length > 0;
 
-    const Field =
-      type === 'password'
-        ? PasswordField
-        : type === 'phone'
-        ? PhoneNumberField
-        : TextField;
-
     return (
       <Fragment key={name}>
         <Field
@@ -43,6 +31,7 @@ const DefaultTextFormFields: DefaultTextFormFieldsComponent = ({
           fieldStyle={fieldStyle}
           key={name}
           style={fieldContainerStyle}
+          type={type}
         />
         <FieldErrors
           errors={errors}

--- a/packages/react-native/src/Authenticator/common/DefaultFormFields/Field.tsx
+++ b/packages/react-native/src/Authenticator/common/DefaultFormFields/Field.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { TextInput, TextInputProps } from 'react-native';
+
+import {
+  PasswordField,
+  PhoneNumberField,
+  TextField,
+} from '../../../primitives';
+import { platform } from '../../../utils';
+import { FieldProps } from './types';
+
+const { IS_IOS } = platform;
+
+// to prevent issues with iOS when multiple `TextInput` components have `secureTextEntry`
+// set to `true`, insert a "hidden" `TextInput` after each `PasswordField`
+// Issue reference: https://github.com/facebook/react-native/issues/21911
+const HIDDEN_INPUT_PROPS: TextInputProps = {
+  // prevent iOS screen reader from picking up element
+  accessibilityElementsHidden: true,
+  // prevent `TextInput` from capturing touch events
+  pointerEvents: 'none',
+  // this workaround requires the `height` and `width` applied to the `TextInput`
+  // are greater than `0`
+  // NOTE: do not attempt to set an opacity value here to further hide the element,
+  // it will cause the issues mitigated by this workaround to re-surface
+  style: { backgroundColor: 'transparent', height: 0.1, width: 0.1 },
+};
+
+const HiddenInput = () => <TextInput {...HIDDEN_INPUT_PROPS} />;
+
+const Field = ({ type, ...rest }: FieldProps): JSX.Element => {
+  const isPassword = type === 'password';
+  const Field = isPassword
+    ? PasswordField
+    : type === 'phone'
+    ? PhoneNumberField
+    : TextField;
+
+  return IS_IOS && isPassword ? (
+    <>
+      <Field {...rest} />
+      <HiddenInput />
+    </>
+  ) : (
+    <Field {...rest} />
+  );
+};
+
+Field.displayName = 'Field';
+export default Field;

--- a/packages/react-native/src/Authenticator/common/DefaultFormFields/types.ts
+++ b/packages/react-native/src/Authenticator/common/DefaultFormFields/types.ts
@@ -3,6 +3,10 @@ import { AuthenticatorFormFieldsComponent } from '@aws-amplify/ui-react-core';
 
 import { RadioFieldOptions, TextFieldOptionsType } from '../../hooks';
 
+export type FieldProps = Omit<TextFieldOptionsType, 'name'> & {
+  disabled: boolean;
+};
+
 export interface FieldErrorsProps {
   errors: string[];
   errorStyle?: StyleProp<TextStyle>;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add a `Field` component with specific handling to fix the issue found in https://github.com/aws-amplify/amplify-ui/issues/3214

As the underlying RN issue does not look like it will be fixed in the immediate term, add a workaround by inserting a "hidden" `TextInput` component after each `PasswordField` component in the `Authenticator` (see code comments for more info).

Further test cases will be added when keyboard input focus events are added.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-ui/issues/3214
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- manually tested in iOS and Android
- `yarn react-native lint && yarn react-native test`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
