### PR TITLE
chore(ci): manually run codeql when `run-codeql` label is added

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     # We run codeql only if it's:
     #   1) pull request not from a fork (ie. internal PR), or
-    #   2) pull request from a fork (ie. external PR) that was added "run-tests" label
+    #   2) pull request from a fork (ie. external PR) that was added "run-codeql" label
     if: |
       (github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run-tests')
+      (github.event.action == 'labeled' && github.event.label.name == 'run-codeql')
     permissions:
       actions: read
       contents: read
@@ -28,14 +28,14 @@ jobs:
         language: [javascript]
 
     steps:
-      - name: Remove run-tests label, if applicable
-        if: github.event.label.name == 'run-tests'
+      - name: Remove run-codeql label, if applicable
+        if: github.event.label.name == 'run-codeql'
         uses: actions/github-script@0.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo } } = context;
-            const label = 'run-tests';
+            const label = 'run-codeql';
             github.issues.removeLabel({ owner, repo, issue_number, name: label });
 
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,12 +11,6 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    # We run codeql only if it's:
-    #   1) pull request not from a fork (ie. internal PR), or
-    #   2) pull request from a fork (ie. external PR) that was added "run-codeql" label
-    if: |
-      (github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run-codeql')
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,11 +5,18 @@ on:
     branches: ['main', '*/main']
 
   pull_request:
+    types: [opened, synchronize, labeled]
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    # We run codeql only if it's:
+    #   1) pull request not from a fork (ie. internal PR), or
+    #   2) pull request from a fork (ie. external PR) that was added "run-tests" label
+    if: |
+      (github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run-tests')
     permissions:
       actions: read
       contents: read
@@ -21,6 +28,16 @@ jobs:
         language: [javascript]
 
     steps:
+      - name: Remove run-tests label, if applicable
+        if: github.event.label.name == 'run-tests'
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+            const label = 'run-tests';
+            github.issues.removeLabel({ owner, repo, issue_number, name: label });
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
+      pull-requests: write # used to remove label
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This adds logic for manually running `codeql` when `run-codeql` label is added, just like `run-tests` label.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Description of how you validated changes

POC'd on this PR: 
![image](https://user-images.githubusercontent.com/43682783/209739270-7c4cc665-d43a-4791-83a8-045f82f2bc09.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
