### PR TITLE
chore(ci): upload cypress videos/screenshots on failure

### DIFF
--- a/.github/workflows/build-and-runtime-test.yml
+++ b/.github/workflows/build-and-runtime-test.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ failure() && steps.e2e.outcome != 'success' }}
         with:
-          name: build-and-runtime-test-cypress-error-files
+          name: canary-cypress-error-{{ matrix.path }}
           path: |
             canary/e2e/cypress/videos/**
             canary/e2e/cypress/screenshots/**

--- a/.github/workflows/build-and-runtime-test.yml
+++ b/.github/workflows/build-and-runtime-test.yml
@@ -93,6 +93,7 @@ jobs:
         working-directory: ./canary/apps/${{ matrix.path }}
       - name: Run E2E tests against ${{ matrix.example }} example
         run: yarn test
+        id: e2e
         working-directory: ./canary
         env:
           # Env values for testing flows
@@ -101,6 +102,15 @@ jobs:
           USERNAME: ${{ secrets.USERNAME }}
           NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
           VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
+      - name: Upload videos and screenshots
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() && steps.e2e.outcome != 'success' }}
+        with:
+          name: build-and-runtime-test-cypress-error-files
+          path: |
+            canary/e2e/cypress/videos/**
+            canary/e2e/cypress/screenshots/**
+          retention-days: 5
 
   log-failure-metric:
     # Send a failure data point to metric BuildAndRuntimeTestFailure in github-workflows@ us-east-2, if it's a failure
@@ -133,18 +143,3 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
           AWS_REGION: us-east-2
-
-  upload-files-on-error:
-    #send video and screenshots on failure as an artifact to be checked later
-    runs-on: ubuntu-latest
-    needs: build
-    if: ${{ failure() }}
-    steps:
-      - name: Upload videos and screenshots
-        uses: actions/upload-artifact@v3
-        with:
-          name: build-and-runtime-test-cypress-error-files
-          path: |
-            canary/e2e/cypress/videos/**
-            canary/e2e/cypress/screenshots/**
-          retention-days: 5

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -103,6 +103,7 @@ jobs:
 
       - name: Run E2E tests against guides
         run: yarn workspace e2e test:guides
+        id: e2e
         env:
           # Override on the default value in `cypress.json` with framework-specific tag
           TAGS: '${{ matrix.tags }}'
@@ -113,6 +114,15 @@ jobs:
           USERNAME: ${{ secrets.USERNAME }}
           NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
           VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
+      - name: Upload videos and screenshots
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() && steps.e2e.outcome != 'success' }}
+        with:
+          name: build-and-runtime-test-cypress-error-files
+          path: |
+            packages/e2e/cypress/videos/**
+            packages/e2e/cypress/screenshots/**
+          retention-days: 5
 
   publish:
     needs: [test, guides]

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ failure() && steps.e2e.outcome != 'success' }}
         with:
-          name: build-and-runtime-test-cypress-error-files
+          name: guides-cypress-error
           path: |
             packages/e2e/cypress/videos/**
             packages/e2e/cypress/screenshots/**

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -425,3 +425,13 @@ jobs:
           USERNAME: ${{ secrets.USERNAME }}
           NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
           VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
+
+      - name: Upload failure screenshots and errors
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: build-and-runtime-test-cypress-error-files
+          path: |
+            packages/e2e/cypress/videos/**
+            packages/e2e/cypress/screenshots/**
+          retention-days: 5

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -368,7 +368,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ failure() && steps.e2e.outcome != 'success' }}
         with:
-          name: build-and-runtime-test-cypress-error-files
+          name: e2e-cypress-error-${{ matrix.package }}
           path: |
             packages/e2e/cypress/videos/**
             packages/e2e/cypress/screenshots/**
@@ -442,7 +442,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ failure() && steps.e2e.outcome != 'success' }}
         with:
-          name: build-and-runtime-test-cypress-error-files
+          name: docs-e2e-cypress-error
           path: |
             packages/e2e/cypress/videos/**
             packages/e2e/cypress/screenshots/**

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -351,6 +351,7 @@ jobs:
         run: yarn workspace ${{ matrix.example }}-example start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000/ui/components/authenticator/sign-in-with-username
 
       - name: Run E2E tests against ${{ matrix.example }} example
+        id: e2e
         run: yarn workspace e2e test:examples
         env:
           # Override on the default value in `cypress.json` with framework-specific tag
@@ -362,6 +363,16 @@ jobs:
           USERNAME: ${{ secrets.USERNAME }}
           NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
           VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
+
+      - name: Upload failure screenshots and errors
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() && steps.e2e.outcome != 'success' }}
+        with:
+          name: build-and-runtime-test-cypress-error-files
+          path: |
+            packages/e2e/cypress/videos/**
+            packages/e2e/cypress/screenshots/**
+          retention-days: 5
   docs:
     # Only run docs tests if e2e tests pass
     needs: [setup, unit]
@@ -418,6 +429,7 @@ jobs:
 
       - name: Run E2E tests against docs
         run: yarn workspace e2e test:theme
+        id: e2e
         env:
           # Env values for testing flows
           DOMAIN: ${{ secrets.DOMAIN }}
@@ -428,7 +440,7 @@ jobs:
 
       - name: Upload failure screenshots and errors
         uses: actions/upload-artifact@v3
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.e2e.outcome != 'success' }}
         with:
           name: build-and-runtime-test-cypress-error-files
           path: |


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Uploads cypress videos and screenshots on CI failures. We did this for canaries in https://github.com/aws-amplify/amplify-ui/pull/3138, but not for other tests.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Did a poc in #3234, where I intentionally failed the tests and confirmed that videos/images get uploaded as expected.

- e2e: [link](https://github.com/aws-amplify/amplify-ui/actions/runs/3802683371)
- canary: [link](https://github.com/aws-amplify/amplify-ui/actions/runs/3802683352)
- guides: [link](https://github.com/aws-amplify/amplify-ui/actions/runs/3802683354)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
