### PR TITLE
fix(react): Manually add overflow: clip to fix chrome regression

### DIFF
--- a/.changeset/smart-masks-drop.md
+++ b/.changeset/smart-masks-drop.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(react): Manually add `overflow: clip` to remediate chrome 108 breaking change.
+
+Ref: https://developer.chrome.com/blog/overflow-replaced-elements/

--- a/packages/ui/src/theme/css/component/image.scss
+++ b/packages/ui/src/theme/css/component/image.scss
@@ -3,4 +3,8 @@
   max-width: var(--amplify-components-image-max-width);
   object-fit: var(--amplify-components-image-object-fit);
   object-position: var(--amplify-components-image-object-position);
+
+  // need to set overflow to clip to resolve chrome 108 breaking change:
+  // https://developer.chrome.com/blog/overflow-replaced-elements/
+  overflow: clip;
 }

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -55,6 +55,13 @@ select {
   box-sizing: border-box; /* set box-sizing after unset above */
 }
 
+// manually set amplify-image's `overflow` property to clip to
+// resolve chrome 108 breaking change with how it handles image:
+// https://developer.chrome.com/blog/overflow-replaced-elements/
+[amplify-image] {
+  overflow: clip;
+}
+
 // Layout
 // They are commonly used in other primitives
 // Move them to the top here makes it easy to override their styling

--- a/packages/ui/src/theme/css/styles.scss
+++ b/packages/ui/src/theme/css/styles.scss
@@ -55,13 +55,6 @@ select {
   box-sizing: border-box; /* set box-sizing after unset above */
 }
 
-// manually set amplify-image's `overflow` property to clip to
-// resolve chrome 108 breaking change with how it handles image:
-// https://developer.chrome.com/blog/overflow-replaced-elements/
-[amplify-image] {
-  overflow: clip;
-}
-
 // Layout
 // They are commonly used in other primitives
 // Move them to the top here makes it easy to override their styling


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Chrome 108 has a breaking change https://developer.chrome.com/blog/overflow-replaced-elements/ on how it handles image clipping. 

This specifically breaks our customers because we do `unset: all` on `amplify-image`, which also unsets `overflow` too. This needs to be set to `clip` (see above blog). 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
