### PR TITLE
chore(deps): Add nth-check to resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     ]
   },
   "resolutions": {
+    "@types/react": "17.0.47",
     "**/@angular-devkit/build-angular/minimatch": "3.0.5",
     "**/serve/serve-handler/minimatch": "3.0.5",
-    "@types/react": "17.0.47",
     "browserslist": "^4.16.15",
     "cssnano-simple": "3.0.2",
     "ejs": "^3.1.7",
@@ -67,6 +67,7 @@
     "immer": "^9.0.6",
     "loader-utils": "2.0.4",
     "node-forge": "1.3.0",
+    "nth-check": "^2.0.1",
     "prismjs": "^1.25.0",
     "react-dev-utils": "^11.0.4",
     "shell-quote": "1.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20711,19 +20711,12 @@ npmlog@^6.0.0:
     gauge "^4.0.3"
     set-blocking "^2.0.0"
 
-nth-check@^2.0.1:
+nth-check@^2.0.1, nth-check@~1.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"
-
-nth-check@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
-  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
-  dependencies:
-    boolbase "~1.0.0"
 
 nullthrows@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This is a miss from #3233. `nth-check` resolution is still needed:

```
=> Found "svgo#nth-check@1.0.2"
info Reasons this module exists
   - "react-scripts#@svgr#webpack#@svgr#plugin-svgo#svgo#css-select" depends on it
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

CI

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
