### PR TITLE
fix(file-uploader): Updated selected and uploaded text for singular files

### DIFF
--- a/.changeset/young-foxes-hide.md
+++ b/.changeset/young-foxes-hide.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Updated file uploader component text to show singular and plural forms of upload and selected files

--- a/packages/e2e/features/ui/components/storage/fileuploader/upload-image-to-s3.feature
+++ b/packages/e2e/features/ui/components/storage/fileuploader/upload-image-to-s3.feature
@@ -14,6 +14,6 @@ Testing upload image feature
     Given I intercept '{ "method": "PUT", "url": "**/test.jpg?partNumber**"  }' with fixture "FileUploader-uploads.xml"
     Given I intercept '{ "method": "POST", "url": "**/test.jpg?uploadId**"  }' with fixture "FileUploader-uploads-complete.xml"
     Given I intercept '{ "method": "GET", "url": "**/?list-type=2**"  }' with fixture "FileUploader-uploads-list.xml"
-    Then I click the 'Upload 1 files' button
+    Then I click the 'Upload 1 file' button
     Then I see "Uploaded successfully"
 

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/UploadPreviewer.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/UploadPreviewer.test.tsx
@@ -54,7 +54,7 @@ describe('UploadPreviewer', () => {
   it('has one file passed in and shows one selected ', async () => {
     render(<UploadPreviewer {...commonProps} fileStatuses={fileStatuses} />);
 
-    expect(await screen.findByText('1 files selected')).toBeVisible();
+    expect(await screen.findByText('1 file selected')).toBeVisible();
   });
   it('shows a disabled button when any file is in an edit state', async () => {
     render(
@@ -69,7 +69,7 @@ describe('UploadPreviewer', () => {
       />
     );
 
-    expect(await screen.findByText(/Upload 1 files/)).toBeDisabled();
+    expect(await screen.findByText(/Upload 1 file/)).toBeDisabled();
   });
   it('shows max files error alert when hasMaxFilesError is true', async () => {
     const { container } = render(
@@ -100,7 +100,7 @@ describe('UploadPreviewer', () => {
       />
     );
 
-    expect(await screen.findByText(/1 files uploaded/)).toBeVisible();
+    expect(await screen.findByText(/1 file uploaded/)).toBeVisible();
   });
   it('shows when loading an uploading with percentage', async () => {
     render(
@@ -125,7 +125,7 @@ describe('UploadPreviewer', () => {
     };
     render(<UploadPreviewer {...commonProps} fileStatuses={[fileStatus]} />);
 
-    expect(await screen.findByText(/Upload 1 files/)).toBeDisabled();
+    expect(await screen.findByText(/Upload 1 file/)).toBeDisabled();
   });
   it('shows disabled upload button when remaining files uploaded is zero', async () => {
     const fileStatus: FileStatus = {
@@ -144,7 +144,7 @@ describe('UploadPreviewer', () => {
   it('shows disabled upload button when max files is showing an error', async () => {
     render(<UploadPreviewer {...commonProps} hasMaxFilesError={true} />);
 
-    expect(await screen.findByText(/Upload 1 files/)).toBeDisabled();
+    expect(await screen.findByText(/Upload 1 file/)).toBeDisabled();
   });
   it('shows done when upload is completed', async () => {
     render(<UploadPreviewer {...commonProps} isSuccessful={true} />);

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/__snapshots__/UploadPreviewer.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/__snapshots__/UploadPreviewer.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`UploadPreviewer renders as expected 1`] = `
       <p
         class="amplify-text amplify-fileuploader__previewer__text"
       >
-        1 files selected
+        1 file selected
       </p>
     </div>
     <div
@@ -28,9 +28,7 @@ exports[`UploadPreviewer renders as expected 1`] = `
           data-variation="primary"
           type="button"
         >
-          Upload
-           1 
-          files
+          Upload 1 file
         </button>
         <button
           class="amplify-button amplify-field-group__control amplify-button--link amplify-button--small"

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
@@ -26,6 +26,14 @@ export function UploadPreviewer({
     fileStatuses.filter((file) => file?.fileState === 'success').length;
 
   const remainingFilesLength = fileStatuses.length - getUploadedFilesLength();
+  const remainingFilesText = `${remainingFilesLength} ${
+    remainingFilesLength === 1 ? translate('file') : translate('files')
+  }`;
+  const uploadedFilesText = `${getUploadedFilesLength()} ${
+    getUploadedFilesLength() === 1
+      ? translate('file uploaded')
+      : translate('files uploaded')
+  }`;
 
   const isDisabled =
     fileStatuses.some((status) =>
@@ -40,9 +48,9 @@ export function UploadPreviewer({
         {dropZone}
         <Text className={ComponentClassNames.FileUploaderPreviewerText}>
           {isSuccessful ? (
-            <>{`${getUploadedFilesLength()} ${translate('files uploaded')}`}</>
+            uploadedFilesText
           ) : (
-            <>{`${remainingFilesLength} ${translate('files selected')}`}</>
+            <>{`${remainingFilesText} ${translate('selected')}`}</>
           )}
         </Text>
         {children}
@@ -76,9 +84,7 @@ export function UploadPreviewer({
                 variation="primary"
                 onClick={onFileClick}
               >
-                {translate('Upload')}
-                {` ${remainingFilesLength} `}
-                {translate('files')}
+                {`${translate('Upload')} ${remainingFilesText}`}
               </Button>
 
               <Button size="small" variation="link" onClick={onClear}>

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import * as UseHooks from '../hooks/useFileUploader';
 import { FileUploader } from '..';
 import * as UIModule from '@aws-amplify/ui';
@@ -693,7 +693,7 @@ describe('File Uploader', () => {
     expect(await screen.findByText(/Upload 1 file/)).toBeVisible();
   });
 
-  it('will show the correct singular form of files uploaded', async () => {
+  it('will show the correct singular form of file uploaded', async () => {
     uploadFileSpy.mockResolvedValue({} as never);
     const fileStatuses = [
       {

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as UseHooks from '../hooks/useFileUploader';
 import { FileUploader } from '..';
 import * as UIModule from '@aws-amplify/ui';
@@ -37,11 +37,12 @@ const fileStatus = {
   fileState: null,
 };
 
-const uploadOneFile = 'Upload 1 files';
+const uploadOneFile = 'Upload 1 file';
 
 describe('File Uploader', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetModules();
   });
   it('exists', async () => {
     const { container } = render(<FileUploader {...commonProps} />);
@@ -598,7 +599,7 @@ describe('File Uploader', () => {
       <FileUploader {...commonProps} maxFiles={1} isPreviewerVisible={true} />
     );
 
-    const uploadFilesText = await screen.findByText(/Upload 1 files/);
+    const uploadFilesText = await screen.findByText(/Upload 1 file/);
 
     expect(uploadFilesText).toBeVisible();
   });
@@ -670,5 +671,91 @@ describe('File Uploader', () => {
     expect(setFileStatusMock.mock.results[0].value).toEqual([
       { fileState: 'success', percentage },
     ]);
+  });
+
+  it('will show correct singular form for files selected and upload files', async () => {
+    uploadFileSpy.mockResolvedValue({} as never);
+    const fileStatuses = [
+      {
+        ...fileStatus,
+        percentage: 0,
+        fileState: null,
+      },
+    ];
+
+    useFileUploaderSpy.mockReturnValue({
+      fileStatuses,
+      ...mockReturnUseFileUploader,
+    });
+    await render(<FileUploader {...commonProps} variation="button" />);
+
+    expect(await screen.findByText(/file selected/)).toBeVisible();
+    expect(await screen.findByText(/Upload 1 file/)).toBeVisible();
+  });
+
+  it('will show the correct singular form of files uploaded', async () => {
+    uploadFileSpy.mockResolvedValue({} as never);
+    const fileStatuses = [
+      {
+        ...fileStatus,
+        percentage: 100,
+        fileState: 'success' as any,
+      },
+    ];
+
+    useFileUploaderSpy.mockReturnValue({
+      fileStatuses,
+      ...mockReturnUseFileUploader,
+    });
+    render(<FileUploader {...commonProps} />);
+
+    expect(await screen.findByText(/file uploaded/)).toBeVisible();
+  });
+  it('will show the correct plural form of files uploaded', async () => {
+    uploadFileSpy.mockResolvedValue({} as never);
+    const fileStatuses = [
+      {
+        ...fileStatus,
+        percentage: 100,
+        fileState: 'success' as any,
+      },
+      {
+        ...fileStatus,
+        percentage: 100,
+        fileState: 'success' as any,
+      },
+    ];
+
+    useFileUploaderSpy.mockReturnValue({
+      fileStatuses,
+      ...mockReturnUseFileUploader,
+    });
+    render(<FileUploader {...commonProps} />);
+
+    expect(await screen.findByText(/files uploaded/)).toBeVisible();
+  });
+  it('will show correct plural form for files selected and upload files', async () => {
+    uploadFileSpy.mockResolvedValue({} as never);
+    const fileStatuses = [
+      {
+        ...fileStatus,
+        percentage: 0,
+        fileState: null,
+      },
+      {
+        ...fileStatus,
+        percentage: 0,
+        fileState: null,
+      },
+    ];
+
+    useFileUploaderSpy.mockReturnValue({
+      fileStatuses,
+      ...mockReturnUseFileUploader,
+    });
+    await render(<FileUploader {...commonProps} variation="button" />);
+
+    expect(await screen.findByText(/files selected/)).toBeVisible();
+    expect(await screen.findByText(/Upload 2 file/)).toBeVisible();
   });
 });


### PR DESCRIPTION

#### Description of changes
The text for file selected and uploaded are wrong when only 1 file is selected or uploaded. 

#### Issue #, if available
[Asana](https://app.asana.com/0/1203642744275140/1203495483940621)

#### Description of how you validated changes
Added test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
