### PR TITLE
fix(tabs): fixing null tabs

### DIFF
--- a/.changeset/tasty-icons-join.md
+++ b/.changeset/tasty-icons-join.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(tabs): `null` and `undefined` children of `Tabs` will no longer show a Typescript error.
+Also `null` children will no longer mess up the index of the tab array which affects the `defaultIndex` uncontrolled behavior. 

--- a/docs/src/data/test/__snapshots__/props-table.test.ts.snap
+++ b/docs/src/data/test/__snapshots__/props-table.test.ts.snap
@@ -10123,7 +10123,7 @@ exports[`Props Table 1`] = `
                     },
                     \\"children\\": {
                         \\"name\\": \\"children\\",
-                        \\"type\\": \\"React.ReactElement<any, string | React.JSXElementConstructor<any>> | React.ReactElement<any, string | React.JSXElementConstructor<any>>[]\\",
+                        \\"type\\": \\"React.ReactNode\\",
                         \\"description\\": \\"The Tabs component only accepts TabItem components as children.\\",
                         \\"category\\": \\"TabsProps\\",
                         \\"isOptional\\": false

--- a/packages/react/__tests__/__snapshots__/exports.ts.snap
+++ b/packages/react/__tests__/__snapshots__/exports.ts.snap
@@ -25083,6 +25083,9 @@ Object {
       "boxShadow": Object {
         "type": "string",
       },
+      "children": Object {
+        "type": "string",
+      },
       "className": Object {
         "type": "string",
       },

--- a/packages/react/src/primitives/Tabs/Tabs.tsx
+++ b/packages/react/src/primitives/Tabs/Tabs.tsx
@@ -12,7 +12,7 @@ import { Flex } from '../Flex';
 import { TabsProps, TabItemProps, Primitive } from '../types';
 import { View } from '../View';
 
-const isTabsType = (child: any): child is React.Component<TabItemProps> => {
+const isTabsType = (child: any): child is React.ReactElement<TabItemProps> => {
   return (
     child !== null &&
     typeof child === 'object' &&
@@ -35,24 +35,6 @@ const TabsPrimitive: Primitive<TabsProps, typeof Flex> = (
   }: TabsProps,
   ref
 ) => {
-  const tabs: Array<TabItemProps> = React.Children.map(children, (child) => {
-    if (child === null) return {};
-
-    // checking if the child is a whitespace character
-    if (typeof child === 'string' && /\s/.test(child)) {
-      return {};
-    }
-
-    if (!isTabsType(child)) {
-      console.warn(
-        'Amplify UI: <Tabs> component only accepts <TabItem> as children.'
-      );
-      return {};
-    }
-
-    return child.props;
-  });
-
   // mapping our props to Radix's props
   // value (currentIndex) and defaultValue (defaultIndex) must be strings
   // https://www.radix-ui.com/docs/primitives/components/tabs#api-reference
@@ -62,6 +44,13 @@ const TabsPrimitive: Primitive<TabsProps, typeof Flex> = (
     value: currentIndex != null ? currentIndex.toString() : undefined,
     onValueChange: onChange,
   };
+
+  // Remove null or undefined children or else they will mess up the index
+  // This is an issue when using defaultIndex
+  const nonNullChildren = React.Children.toArray(children).filter(
+    (child) => !!child
+  );
+
   return (
     <Root {...rootProps}>
       <List aria-label={ariaLabel}>
@@ -71,24 +60,34 @@ const TabsPrimitive: Primitive<TabsProps, typeof Flex> = (
           ref={ref}
           {...rest}
         >
-          {React.Children.map(children, (child, index) => {
-            if (!isTabsType(child)) {
-              return null;
+          {React.Children.map(nonNullChildren, (child, index) => {
+            if (isTabsType(child)) {
+              return React.cloneElement(child as React.ReactElement, {
+                ['data-spacing']: spacing,
+                key: index,
+                value: `${index}`,
+              });
             }
-
-            return React.cloneElement(child, {
-              ['data-spacing']: spacing,
-              key: index,
-              value: `${index}`,
-            });
           })}
         </Flex>
       </List>
-      {tabs.map((tab, index) => (
-        <Panel key={index} value={`${index}`}>
-          {tab.children}
-        </Panel>
-      ))}
+      {React.Children.map(nonNullChildren, (child, index) => {
+        if (isTabsType(child)) {
+          return (
+            <Panel key={index} value={`${index}`}>
+              {child.props.children}
+            </Panel>
+          );
+        } else {
+          // at this point the child defined (not null or undefined)
+          // it is NOT a TabItem, so log a message
+          if (child) {
+            console.warn(
+              'Amplify UI: <Tabs> component only accepts <TabItem> as children.'
+            );
+          }
+        }
+      })}
     </Root>
   );
 };

--- a/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
@@ -50,7 +50,9 @@ describe('Tabs: ', () => {
       </Tabs>
     );
     const tabs = await screen.findByTestId('tabsTest');
-    expect(tabs.children.length).toEqual(1);
+    const panels = await screen.findAllByRole('tabpanel');
+    expect(tabs.children).toHaveLength(1);
+    expect(panels).toHaveLength(1);
   });
 
   it('should work with defaultIndex and null children', async () => {

--- a/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
@@ -53,6 +53,19 @@ describe('Tabs: ', () => {
     expect(tabs.children.length).toEqual(1);
   });
 
+  it('should work with defaultIndex and null children', async () => {
+    render(
+      <Tabs testId="tabsTest" defaultIndex={1}>
+        <TabItem title="Tab 1">Tab 1</TabItem>
+        {null}
+        {undefined}
+        <TabItem title="Tab 2">Tab 2</TabItem>
+      </Tabs>
+    );
+    const tabs = await screen.findAllByRole('tab');
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
   it('should not log a warning for null children', async () => {
     const warningMessage =
       'Amplify UI: <Tabs> component only accepts <TabItem> as children.';

--- a/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
@@ -63,6 +63,7 @@ describe('Tabs: ', () => {
       </Tabs>
     );
     const tabs = await screen.findAllByRole('tab');
+    expect(tabs).toHaveLength(2);
     expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
   });
 

--- a/packages/react/src/primitives/types/tabs.ts
+++ b/packages/react/src/primitives/types/tabs.ts
@@ -11,7 +11,7 @@ export interface TabsProps extends FlexProps {
    * @description
    * The Tabs component only accepts TabItem components as children.
    */
-  children: React.ReactElement | React.ReactElement[];
+  children: React.ReactNode;
 
   /**
    * @description


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

There are 2 separate issues here:
1. TS issue where `null` is not allowed as a child of `Tabs`
2. A tangential issue where passing `null` as a child messes up the tab indices: https://codesandbox.io/s/async-flower-772qr1?file=/src/App.js

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#3256

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
