### PR TITLE
feat(primitives): support inert prop

### DIFF
--- a/.changeset/gorgeous-pants-check.md
+++ b/.changeset/gorgeous-pants-check.md
@@ -1,0 +1,9 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+feat(primitives): adds support inert prop on all React primitives
+
+```jsx
+<View inert>
+```

--- a/docs/src/data/test/__snapshots__/props-table.test.ts.snap
+++ b/docs/src/data/test/__snapshots__/props-table.test.ts.snap
@@ -27,6 +27,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -274,6 +281,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -730,6 +744,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -886,6 +907,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -1209,6 +1237,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -1358,6 +1393,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -1716,6 +1758,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"type\\": {
                         \\"name\\": \\"type\\",
                         \\"type\\": \\"'list' | 'grid' | 'table'\\",
@@ -1980,6 +2029,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"label\\": {
                         \\"name\\": \\"label\\",
                         \\"type\\": \\"string\\",
@@ -2143,6 +2199,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -2338,6 +2401,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -2501,6 +2571,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -2751,6 +2828,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -3088,6 +3172,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -3254,6 +3345,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -3410,6 +3508,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -3597,6 +3702,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -3801,6 +3913,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -3971,6 +4090,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -4165,6 +4291,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -4406,6 +4539,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -4654,6 +4794,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -4921,6 +5068,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -5140,6 +5294,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -5551,6 +5712,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -5986,6 +6154,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -6142,6 +6317,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -6498,6 +6680,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -6755,6 +6944,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -7005,6 +7201,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -7154,6 +7357,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -7568,6 +7778,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"label\\": {
                         \\"name\\": \\"label\\",
                         \\"type\\": \\"React.ReactNode\\",
@@ -7892,6 +8109,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -8369,6 +8593,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"label\\": {
                         \\"name\\": \\"label\\",
                         \\"type\\": \\"React.ReactNode\\",
@@ -8794,6 +9025,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"label\\": {
                         \\"name\\": \\"label\\",
                         \\"type\\": \\"React.ReactNode\\",
@@ -9184,6 +9422,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"caption\\": {
                         \\"name\\": \\"caption\\",
                         \\"type\\": \\"React.ReactNode\\",
@@ -9376,6 +9621,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -9516,6 +9768,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -9676,6 +9935,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -9816,6 +10082,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -9962,6 +10235,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -10104,6 +10384,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -10348,6 +10635,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"title\\": {
                         \\"name\\": \\"title\\",
                         \\"type\\": \\"React.ReactNode\\",
@@ -10497,6 +10791,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -10656,6 +10957,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -10983,6 +11291,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
@@ -11404,6 +11719,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -11680,6 +12002,13 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
                     \\"style\\": {
                         \\"name\\": \\"style\\",
                         \\"type\\": \\"React.CSSProperties\\",
@@ -11948,6 +12277,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"Base\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\n    https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"Base\\",
                         \\"isOptional\\": true
                     },
@@ -12474,6 +12810,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"testId\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Used to provide a \`data-testid\` attribute for testing purposes\\",
+                        \\"category\\": \\"BaseComponentProps\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"inert\\": {
+                        \\"name\\": \\"inert\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"Support for the HTML \`inert\` attribute\\\\nhttps://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert\\",
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },

--- a/packages/react/__tests__/__snapshots__/exports.ts.snap
+++ b/packages/react/__tests__/__snapshots__/exports.ts.snap
@@ -422,6 +422,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -1013,6 +1016,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "innerEndComponent": Object {
         "type": "string",
       },
@@ -1594,6 +1600,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -2137,6 +2146,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -2684,6 +2696,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -3194,6 +3209,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -3764,6 +3782,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -4163,6 +4184,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "isDisabled": Object {
         "type": "boolean",
@@ -4608,6 +4632,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -5122,6 +5149,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -5633,6 +5663,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -6134,6 +6167,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -6660,6 +6696,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -7193,6 +7232,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -7721,6 +7763,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -8233,6 +8278,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -8738,6 +8786,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -9455,6 +9506,9 @@ Object {
       },
       "in2": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "intercept": Object {
         "type": "string",
@@ -10357,6 +10411,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -10885,6 +10942,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -11627,6 +11687,9 @@ Object {
       },
       "in2": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "intercept": Object {
         "type": "string",
@@ -12547,6 +12610,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -13106,6 +13172,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -13469,6 +13538,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "isDisabled": Object {
         "type": "boolean",
@@ -13927,6 +13999,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -14517,6 +14592,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "innerEndComponent": Object {
         "type": "string",
@@ -15198,6 +15276,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "innerEndComponent": Object {
         "type": "string",
       },
@@ -15781,6 +15862,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -16331,6 +16415,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -16922,6 +17009,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -17480,6 +17570,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -17996,6 +18089,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -18574,6 +18670,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "innerEndComponent": Object {
         "type": "string",
@@ -19198,6 +19297,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -19777,6 +19879,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "innerEndComponent": Object {
         "type": "string",
@@ -20432,6 +20537,9 @@ Object {
       "increaseButtonLabel": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "innerEndComponent": Object {
         "type": "string",
       },
@@ -21053,6 +21161,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -21632,6 +21743,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -22149,6 +22263,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -22653,6 +22770,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -23162,6 +23282,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -23661,6 +23784,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -24157,6 +24283,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -24652,6 +24781,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -25173,6 +25305,9 @@ Object {
       "indicatorPosition": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -25684,6 +25819,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -26229,6 +26367,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",
@@ -26856,6 +26997,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "innerEndComponent": Object {
         "type": "string",
       },
@@ -27481,6 +27625,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -28028,6 +28175,9 @@ Object {
       "id": Object {
         "type": "string",
       },
+      "inert": Object {
+        "type": "boolean",
+      },
       "inputMode": Object {
         "type": "string",
       },
@@ -28554,6 +28704,9 @@ Object {
       },
       "id": Object {
         "type": "string",
+      },
+      "inert": Object {
+        "type": "boolean",
       },
       "inputMode": Object {
         "type": "string",

--- a/packages/react/src/primitives/View/View.tsx
+++ b/packages/react/src/primitives/View/View.tsx
@@ -15,6 +15,7 @@ const ViewPrimitive = <Element extends ElementType = 'div'>(
     ariaLabel,
     isDisabled,
     style,
+    inert,
     ...rest
   }: PrimitivePropsWithRef<ViewProps, Element>,
   ref?: React.ForwardedRef<HTMLElementType<Element>>
@@ -28,6 +29,7 @@ const ViewPrimitive = <Element extends ElementType = 'div'>(
       'data-testid': testId,
       disabled: isDisabled,
       ref,
+      inert: inert ? '' : null,
       style: propStyles,
       ...nonStyleProps,
     },

--- a/packages/react/src/primitives/View/__tests__/View.test.tsx
+++ b/packages/react/src/primitives/View/__tests__/View.test.tsx
@@ -135,4 +135,11 @@ describe('View: ', () => {
       )
     ).toBe('blue');
   });
+
+  it('should work with inert', async () => {
+    const testId = 'inertTest';
+    render(<View testId={testId} inert />);
+    const view = await screen.findByTestId(testId);
+    expect(view).toHaveAttribute('inert');
+  });
 });

--- a/packages/react/src/primitives/types/base.ts
+++ b/packages/react/src/primitives/types/base.ts
@@ -25,7 +25,7 @@ export interface BaseComponentProps {
    * Support for the HTML `inert` attribute
    * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
    */
-  inert?: string | null;
+  inert?: boolean;
 }
 
 export interface AriaProps {

--- a/packages/react/src/primitives/types/base.ts
+++ b/packages/react/src/primitives/types/base.ts
@@ -19,6 +19,13 @@ export interface BaseComponentProps {
    * Used to provide a `data-testid` attribute for testing purposes
    */
   testId?: string;
+
+  /**
+   * @description
+   * Support for the HTML `inert` attribute
+   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+   */
+  inert?: string | null;
 }
 
 export interface AriaProps {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adds support for the HTML `inert` attribute: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert

React elements do not support the prop by default, so adding it in to make it work like any other HTML attribute. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#2632

#### Description of how you validated changes

Added unit test and also tried it on the docs site:
<img width="1330" alt="CleanShot 2023-01-06 at 13 22 42@2x" src="https://user-images.githubusercontent.com/321279/211102576-a53f4368-0d23-4f43-bb41-6cfa76131641.png">


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
