### PR TITLE
chore(angular,vue): add back classnames removed in #2875

### DIFF
--- a/.changeset/purple-badgers-greet.md
+++ b/.changeset/purple-badgers-greet.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-vue": patch
+"@aws-amplify/ui-angular": patch
+---
+
+chore(angular,vue): add back classnames removed in #2875

--- a/packages/angular/projects/ui-angular/src/lib/primitives/password-field/__tests__/__snapshots__/password-field.component.test.ts.snap
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/password-field/__tests__/__snapshots__/password-field.component.test.ts.snap
@@ -22,7 +22,7 @@ exports[`amplify-password-field renders as expected 1`] = `
         <input
           aria-invalid="false"
           autocomplete="new-password"
-          class="amplify-input amplify-field-group__control"
+          class="amplify-input amplify-field-group__control amplify-field__show-password"
           id="mockId"
           name="password"
           placeholder=""
@@ -81,7 +81,7 @@ exports[`amplify-password-field renders as expected when show password button is
         <input
           aria-invalid="false"
           autocomplete="new-password"
-          class="amplify-input amplify-field-group__control"
+          class="amplify-input amplify-field-group__control amplify-field__show-password"
           id="mockId"
           name="password"
           placeholder=""

--- a/packages/angular/projects/ui-angular/src/lib/primitives/password-field/password-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/password-field/password-field.component.html
@@ -23,7 +23,8 @@
         [class]="
           classnames(
             ComponentClassName.Input,
-            ComponentClassName.FieldGroupControl
+            ComponentClassName.FieldGroupControl,
+            ComponentClassName.FieldShowPassword
           )
         "
         [id]="fieldId"

--- a/packages/vue/src/components/__tests__/__snapshots__/password-control.spec.ts.snap
+++ b/packages/vue/src/components/__tests__/__snapshots__/password-control.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`PasswordControl should render as expected 1`] = `
 <div>
   <div
-    class="amplify-flex amplify-field amplify-textfield amplify-passwordfield"
+    class="amplify-flex amplify-field amplify-textfield amplify-passwordfield amplify-authenticator__column"
   >
     
     <label
@@ -19,7 +19,6 @@ exports[`PasswordControl should render as expected 1`] = `
       class="amplify-flex amplify-field-group"
     >
       
-      <!-- FieldGroupFieldWrapper -->
       <div
         class="amplify-field-group__field-wrapper"
       >
@@ -43,7 +42,6 @@ exports[`PasswordControl should render as expected 1`] = `
         class="amplify-field-group__outer-end"
       >
         
-        <!-- class="amplify-button amplify-field-group__control amplify-field__show-password amplify-button--fullwidth" -->
         <button
           aria-checked="false"
           aria-label="Show password"
@@ -75,7 +73,7 @@ exports[`PasswordControl should render as expected 1`] = `
 exports[`PasswordControl should render as expected when showPassword button is clicked 1`] = `
 <div>
   <div
-    class="amplify-flex amplify-field amplify-textfield amplify-passwordfield"
+    class="amplify-flex amplify-field amplify-textfield amplify-passwordfield amplify-authenticator__column"
   >
     
     <label
@@ -91,7 +89,6 @@ exports[`PasswordControl should render as expected when showPassword button is c
       class="amplify-flex amplify-field-group"
     >
       
-      <!-- FieldGroupFieldWrapper -->
       <div
         class="amplify-field-group__field-wrapper"
       >
@@ -115,7 +112,6 @@ exports[`PasswordControl should render as expected when showPassword button is c
         class="amplify-field-group__outer-end"
       >
         
-        <!-- class="amplify-button amplify-field-group__control amplify-field__show-password amplify-button--fullwidth" -->
         <button
           aria-checked="true"
           aria-label="Hide password"

--- a/packages/vue/src/components/password-control.vue
+++ b/packages/vue/src/components/password-control.vue
@@ -61,6 +61,7 @@ export default {
       ComponentClassName.Field,
       ComponentClassName.TextField,
       ComponentClassName.PasswordField,
+      'amplify-authenticator__column', // TODO(breaking,parity): remove this
     ]"
   >
     <base-label
@@ -73,7 +74,6 @@ export default {
     <base-wrapper
       :class="[ComponentClassName.Flex, ComponentClassName.FieldGroup]"
     >
-      <!-- FieldGroupFieldWrapper -->
       <base-wrapper :class="ComponentClassName.FieldGroupFieldWrapper">
         <base-input
           v-bind="$attrs"
@@ -94,7 +94,6 @@ export default {
         />
       </base-wrapper>
       <base-wrapper :class="ComponentClassName.FieldGroupOuterEnd">
-        <!-- class="amplify-button amplify-field-group__control amplify-field__show-password amplify-button--fullwidth" -->
         <button
           :aria-label="showHideLabel"
           :aria-checked="showHideType !== 'password'"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

#2875 *removed* some classnames to match passwordfield parity. But this was a breaking change and so this PR adds them back.

All the additive changes in #2875 are still preserved.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
