### PR TITLE
fix(ui-react): Add fieldset and legend to RadioGroupField

### DIFF
--- a/.changeset/nine-ears-think.md
+++ b/.changeset/nine-ears-think.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(ui-react): Add fieldset and legend to RadioGroupField for improved accessibility

--- a/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
+++ b/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
@@ -5,8 +5,10 @@ import { ComponentClassNames } from '../shared/constants';
 import { FieldErrorMessage, FieldDescription } from '../Field';
 import { Flex } from '../Flex';
 import { Label } from '../Label';
+import { VisuallyHidden } from '../VisuallyHidden';
 import { RadioGroupContext, RadioGroupContextType } from './context';
 import { RadioGroupFieldProps, Primitive } from '../types';
+import { getTestId } from '../utils/testUtils';
 import { useStableId } from '../utils/useStableId';
 
 // Note: RadioGroupField doesn't extend the JSX.IntrinsicElements<'input'> types (instead extending 'typeof Flex')
@@ -29,15 +31,16 @@ const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
     onChange,
     name,
     size,
+    testId,
     value,
     ...rest
   },
   ref
 ) => {
   const fieldId = useStableId(id);
-  const labelId = useStableId();
   const descriptionId = useStableId();
   const ariaDescribedBy = descriptiveText ? descriptionId : undefined;
+  const radioGroupTestId = getTestId(testId, ComponentClassNames.RadioGroup);
 
   const radioGroupContextValue: RadioGroupContextType = React.useMemo(
     () => ({
@@ -68,6 +71,7 @@ const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
 
   return (
     <Flex
+      as="fieldset"
       className={classNames(
         ComponentClassNames.Field,
         ComponentClassNames.RadioGroupField,
@@ -75,9 +79,12 @@ const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
       )}
       data-size={size}
       ref={ref}
+      role="radiogroup"
+      testId={testId}
       {...rest}
     >
-      <Label id={labelId} visuallyHidden={labelHidden}>
+      <VisuallyHidden as="legend">{label}</VisuallyHidden>
+      <Label aria-hidden={true} visuallyHidden={labelHidden}>
         {label}
       </Label>
       <FieldDescription
@@ -87,10 +94,9 @@ const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
       />
       <Flex
         aria-describedby={ariaDescribedBy}
-        aria-labelledby={labelId}
         className={ComponentClassNames.RadioGroup}
         id={fieldId}
-        role="radiogroup"
+        testId={radioGroupTestId}
       >
         <RadioGroupContext.Provider value={radioGroupContextValue}>
           {children}

--- a/packages/react/src/primitives/RadioGroupField/__tests__/RadioGroupField.test.tsx
+++ b/packages/react/src/primitives/RadioGroupField/__tests__/RadioGroupField.test.tsx
@@ -10,9 +10,15 @@ import {
   testFlexProps,
   expectFlexContainerStyleProps,
 } from '../../Flex/__tests__/Flex.test';
+import { getTestId } from '../../utils/testUtils';
 
 describe('RadioFieldGroup test suite', () => {
   const basicProps = { label: 'testLabel', name: 'testName', testId: 'testId' };
+
+  const radioGroupTestId = getTestId(
+    basicProps.testId,
+    ComponentClassNames.RadioGroup
+  );
 
   const getRadioFieldGroup = ({
     label,
@@ -66,7 +72,7 @@ describe('RadioFieldGroup test suite', () => {
     render(<RadioGroupField {...basicProps} ref={ref}></RadioGroupField>);
 
     await screen.findByTestId(basicProps.testId);
-    expect(ref.current?.nodeName).toBe('DIV');
+    expect(ref.current?.nodeName).toBe('FIELDSET');
   });
 
   it('should render all flex style props', async () => {
@@ -93,32 +99,36 @@ describe('RadioFieldGroup test suite', () => {
   });
 
   describe('Label', () => {
+    it('should render visually-hidden legend element with label name', async () => {
+      render(getRadioFieldGroup({ ...basicProps }));
+
+      const labelElement = (await screen.findAllByText(
+        basicProps.label
+      )) as HTMLLabelElement[];
+      expect(labelElement[0].nodeName).toBe('LEGEND');
+    });
+
     it('should render expected label classname', async () => {
       render(getRadioFieldGroup({ ...basicProps }));
 
-      const labelElelment = (await screen.findByText(
+      const labelElement = (await screen.findAllByText(
         basicProps.label
-      )) as HTMLLabelElement;
-      expect(labelElelment).toHaveClass(ComponentClassNames.Label);
-    });
+      )) as HTMLLabelElement[];
 
-    it('should map to label correctly', async () => {
-      render(getRadioFieldGroup({ ...basicProps }));
-      const radioGroup = await screen.findByRole('radiogroup');
-      expect(radioGroup).toHaveAccessibleName(basicProps.label);
+      expect(labelElement[1]).toHaveClass(ComponentClassNames.Label);
     });
 
     it('should have `amplify-visually-hidden` class when labelHidden is true', async () => {
       render(getRadioFieldGroup({ ...basicProps, labelHidden: true }));
 
-      const labelElelment = await screen.findByText(basicProps.label);
-      expect(labelElelment).toHaveClass('amplify-visually-hidden');
+      const labelElement = await screen.findAllByText(basicProps.label);
+      expect(labelElement[1]).toHaveClass('amplify-visually-hidden');
     });
   });
 
   describe('RadioGroup', () => {
-    const expectFunctionality = async (componet) => {
-      render(componet);
+    const expectFunctionality = async (component) => {
+      render(component);
       const radios = await screen.findAllByRole('radio');
       const html = radios[0];
       const css = radios[1];
@@ -140,7 +150,7 @@ describe('RadioFieldGroup test suite', () => {
 
     it('should render default classname', async () => {
       render(getRadioFieldGroup({ ...basicProps }));
-      const radioGroup = await screen.findByRole('radiogroup');
+      const radioGroup = await screen.findByTestId(radioGroupTestId);
       expect(radioGroup).toHaveClass(ComponentClassNames.RadioGroup);
     });
 
@@ -238,7 +248,7 @@ describe('RadioFieldGroup test suite', () => {
     it('should map to descriptive text correctly', async () => {
       const descriptiveText = 'Description';
       render(getRadioFieldGroup({ ...basicProps, descriptiveText }));
-      const radioGroup = await screen.findByRole('radiogroup');
+      const radioGroup = await screen.findByTestId(radioGroupTestId);
       expect(radioGroup).toHaveAccessibleDescription(descriptiveText);
     });
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR addresses the accessibility issues identified in [this PR](https://github.com/aws-amplify/amplify-ui/issues/1805) through the following changes (inspired by this [blog post](https://adrianroselli.com/2022/07/use-legend-and-fieldset.html#Hide)):
- Render the outer `Flex` as a `fieldset` element
- Include a visually-hidden `legend` element
- Add `aria-hidden="true"` to the visible label

I was able to confirm the changes on web and my own iOS device using VoiceOver. For iOS, VoiceOver says `“{label} form start”` and then `Form end` at the end of the RadioGroup. Before these changes it didn't say anything about the user being inside a form or group. 

https://user-images.githubusercontent.com/48109584/211429842-b9877c16-e4e2-46f2-9d07-2dabae1cc623.mov

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fixes: https://github.com/aws-amplify/amplify-ui/issues/1805

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran on web and iOS. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
