### PR TITLE
fix(primitives): remove `checked` prop from textfield

### DIFF
--- a/.changeset/sour-moose-bathe.md
+++ b/.changeset/sour-moose-bathe.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Remove `checked` props from TextField.

--- a/docs/src/data/test/__snapshots__/props-table.test.ts.snap
+++ b/docs/src/data/test/__snapshots__/props-table.test.ts.snap
@@ -368,13 +368,6 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"InputProps\\",
                         \\"isOptional\\": true
                     },
-                    \\"checked\\": {
-                        \\"name\\": \\"checked\\",
-                        \\"type\\": \\"boolean\\",
-                        \\"description\\": \\"If checked is provided, this will be a controlled checkbox or radio.\\",
-                        \\"category\\": \\"InputProps\\",
-                        \\"isOptional\\": true
-                    },
                     \\"enterKeyHint\\": {
                         \\"name\\": \\"enterKeyHint\\",
                         \\"type\\": \\"EnterKeyHint\\",
@@ -5388,13 +5381,6 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"InputProps\\",
                         \\"isOptional\\": true
                     },
-                    \\"checked\\": {
-                        \\"name\\": \\"checked\\",
-                        \\"type\\": \\"boolean\\",
-                        \\"description\\": \\"If checked is provided, this will be a controlled checkbox or radio.\\",
-                        \\"category\\": \\"InputProps\\",
-                        \\"isOptional\\": true
-                    },
                     \\"enterKeyHint\\": {
                         \\"name\\": \\"enterKeyHint\\",
                         \\"type\\": \\"EnterKeyHint\\",
@@ -5810,13 +5796,6 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"autoComplete\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Specifies permissions for browser UA to autocomplete field. See: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)\\",
-                        \\"category\\": \\"InputProps\\",
-                        \\"isOptional\\": true
-                    },
-                    \\"checked\\": {
-                        \\"name\\": \\"checked\\",
-                        \\"type\\": \\"boolean\\",
-                        \\"description\\": \\"If checked is provided, this will be a controlled checkbox or radio.\\",
                         \\"category\\": \\"InputProps\\",
                         \\"isOptional\\": true
                     },
@@ -7444,13 +7423,6 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"InputProps\\",
                         \\"isOptional\\": true
                     },
-                    \\"checked\\": {
-                        \\"name\\": \\"checked\\",
-                        \\"type\\": \\"boolean\\",
-                        \\"description\\": \\"If checked is provided, this will be a controlled checkbox or radio.\\",
-                        \\"category\\": \\"InputProps\\",
-                        \\"isOptional\\": true
-                    },
                     \\"enterKeyHint\\": {
                         \\"name\\": \\"enterKeyHint\\",
                         \\"type\\": \\"EnterKeyHint\\",
@@ -8203,13 +8175,6 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"InputProps\\",
                         \\"isOptional\\": true
                     },
-                    \\"checked\\": {
-                        \\"name\\": \\"checked\\",
-                        \\"type\\": \\"boolean\\",
-                        \\"description\\": \\"If checked is provided, this will be a controlled checkbox or radio.\\",
-                        \\"category\\": \\"InputProps\\",
-                        \\"isOptional\\": true
-                    },
                     \\"enterKeyHint\\": {
                         \\"name\\": \\"enterKeyHint\\",
                         \\"type\\": \\"EnterKeyHint\\",
@@ -8681,13 +8646,6 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"autoComplete\\",
                         \\"type\\": \\"string\\",
                         \\"description\\": \\"Specifies permissions for browser UA to autocomplete field. See: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)\\",
-                        \\"category\\": \\"InputProps\\",
-                        \\"isOptional\\": true
-                    },
-                    \\"checked\\": {
-                        \\"name\\": \\"checked\\",
-                        \\"type\\": \\"boolean\\",
-                        \\"description\\": \\"If checked is provided, this will be a controlled checkbox or radio.\\",
                         \\"category\\": \\"InputProps\\",
                         \\"isOptional\\": true
                     },
@@ -11392,13 +11350,6 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"Input\\",
                         \\"isOptional\\": true
                     },
-                    \\"checked\\": {
-                        \\"name\\": \\"checked\\",
-                        \\"type\\": \\"boolean\\",
-                        \\"description\\": \\"If checked is provided, this will be a controlled checkbox or radio.\\",
-                        \\"category\\": \\"Input\\",
-                        \\"isOptional\\": true
-                    },
                     \\"enterKeyHint\\": {
                         \\"name\\": \\"enterKeyHint\\",
                         \\"type\\": \\"EnterKeyHint\\",
@@ -11485,7 +11436,7 @@ exports[`Props Table 1`] = `
                     },
                     \\"TextFieldProps\\": {
                         \\"name\\": \\"TextFieldProps\\",
-                        \\"type\\": \\"extends TextFieldOptions, InputProps\\",
+                        \\"type\\": \\"extends TextFieldOptions,\\\\n    Omit<InputProps, 'checked'>\\",
                         \\"description\\": \\"\\",
                         \\"category\\": \\"TextField\\",
                         \\"isOptional\\": true
@@ -11509,6 +11460,13 @@ exports[`Props Table 1`] = `
                         \\"type\\": \\"number\\",
                         \\"description\\": \\"Controls height based on number of rows of text to display.\\",
                         \\"category\\": \\"TextArea\\",
+                        \\"isOptional\\": true
+                    },
+                    \\"checked\\": {
+                        \\"name\\": \\"checked\\",
+                        \\"type\\": \\"boolean\\",
+                        \\"description\\": \\"If checked is provided, this will be a controlled checkbox or radio.\\",
+                        \\"category\\": \\"Input\\",
                         \\"isOptional\\": true
                     },
                     \\"FieldClearButtonProps\\": {

--- a/packages/react/src/primitives/types/textField.ts
+++ b/packages/react/src/primitives/types/textField.ts
@@ -36,4 +36,6 @@ export interface TextFieldOptions extends FieldProps, FlexContainerStyleProps {
   type?: InputProps['type'];
 }
 
-export interface TextFieldProps extends TextFieldOptions, InputProps {}
+export interface TextFieldProps
+  extends TextFieldOptions,
+    Omit<InputProps, 'checked'> {}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Remove `checked` prop from TextField, PasswordField, PhoneNumberField, StepperField, SliderField , SwitchField and SearchField.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Verified on local and by snapshot.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
