### PR TITLE
fix(authenticator): remove order keys from formFields after sorting

### DIFF
--- a/.changeset/tricky-days-rule.md
+++ b/.changeset/tricky-days-rule.md
@@ -1,0 +1,9 @@
+---
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-angular": patch
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui-react-native": patch
+"@aws-amplify/ui-vue": patch
+---
+
+fix(authenticator): remove order keys from formFields after sorting

--- a/packages/ui/src/helpers/authenticator/formFields/__tests__/formFields.spec.ts
+++ b/packages/ui/src/helpers/authenticator/formFields/__tests__/formFields.spec.ts
@@ -1,0 +1,54 @@
+import { FormFieldsArray } from '../../../../types';
+
+import { removeOrderKeys } from '../formFields';
+
+const fields: FormFieldsArray = [
+  [
+    'name',
+    {
+      order: 1,
+      isRequired: true,
+      placeholder: 'First Name',
+      autocomplete: 'given-name',
+      labelHidden: true,
+    },
+  ],
+  [
+    'family_name',
+    {
+      order: 2,
+      isRequired: true,
+      placeholder: 'Last Name',
+      labelHidden: true,
+    },
+  ],
+  [
+    'username',
+    {
+      order: 3,
+      isRequired: true,
+      placeholder: 'Email Address',
+      labelHidden: true,
+    },
+  ],
+  [
+    'email',
+    {
+      order: 4,
+      isRequired: true,
+      placeholder: 'Confirm Email Address',
+      labelHidden: true,
+    },
+  ],
+  ['password', { order: 5, isRequired: true, labelHidden: true }],
+  ['confirm_password', { order: 6, isRequired: true, labelHidden: true }],
+  ['phone_number', { order: 7, dialCode: '+44', labelHidden: true }],
+];
+
+describe('getSortedFormFields', () => {
+  it('removes the order keys from the field values', () => {
+    const output = removeOrderKeys(fields);
+
+    expect(output[0][1].order).toBeUndefined();
+  });
+});

--- a/packages/ui/src/helpers/authenticator/formFields/formFields.ts
+++ b/packages/ui/src/helpers/authenticator/formFields/formFields.ts
@@ -35,11 +35,18 @@ export const getFormFields = (
   return formFields;
 };
 
+export const removeOrderKeys = (formFields: FormFieldsArray): FormFieldsArray =>
+  formFields.map((field) => {
+    const key = field[0];
+    const values = { ...field[1], order: undefined };
+    return [key, values];
+  });
+
 /** Calls `getFormFields` above, then sorts it into an indexed array */
 export const getSortedFormFields = (
   route: FormFieldComponents,
   state: AuthMachineState
 ): FormFieldsArray => {
   const formFields = getFormFields(route, state);
-  return sortFormFields(formFields);
+  return removeOrderKeys(sortFormFields(formFields));
 };

--- a/packages/ui/src/helpers/authenticator/formFields/formFields.ts
+++ b/packages/ui/src/helpers/authenticator/formFields/formFields.ts
@@ -38,6 +38,7 @@ export const getFormFields = (
 export const removeOrderKeys = (formFields: FormFieldsArray): FormFieldsArray =>
   formFields.map((field) => {
     const key = field[0];
+    // Drop order key to prevent passing to form field UI components
     const values = { ...field[1], order: undefined };
     return [key, values];
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Remove `order` value from `formFields` after sorting to prevent passing it to `TextField` components
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes #3281 
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested React, Angular, Vue and React Native example apps. Added unit test
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
