### PR TITLE
fix(file-uploader): Make over max file size errors more verbose

### DIFF
--- a/.changeset/small-stingrays-admire.md
+++ b/.changeset/small-stingrays-admire.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui-react': patch
+'@aws-amplify/ui': patch
+---
+
+Updated text to be more verbose for the max file size error for the file uploader component.

--- a/examples/next/pages/ui/components/storage/file-uploader/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/file-uploader/index.page.tsx
@@ -15,7 +15,7 @@ export default function FileUploaderEmail() {
       acceptedFileTypes={['image/*']}
       accessLevel="public"
       hasMultipleFiles={true}
-      maxSize={100}
+      maxSize={100000000}
       maxFiles={3}
       isResumable={true}
     />

--- a/examples/next/pages/ui/components/storage/file-uploader/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/file-uploader/index.page.tsx
@@ -15,7 +15,7 @@ export default function FileUploaderEmail() {
       acceptedFileTypes={['image/*']}
       accessLevel="public"
       hasMultipleFiles={true}
-      maxSize={100000000}
+      maxSize={100}
       maxFiles={3}
       isResumable={true}
     />

--- a/packages/react/src/components/Storage/FileUploader/UploadTracker/__tests__/__snapshots__/UploadTracker.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/UploadTracker/__tests__/__snapshots__/UploadTracker.test.tsx.snap
@@ -6,90 +6,94 @@ exports[`UploadTracker exists 1`] = `
     class="amplify-fileuploader__file"
   >
     <div
-      class="amplify-fileuploader__file__image"
+      class="amplify-fileuploader__file__wrapper"
     >
-      <img
-        alt="hello.png"
-        class="amplify-image"
-      />
-    </div>
-    <div
-      class="amplify-fileuploader__file__main"
-    >
-      <p
-        class="amplify-text amplify-fileuploader__file__name"
+      <div
+        class="amplify-fileuploader__file__image"
       >
-        hello.png
-      </p>
-    </div>
-    <span
-      class="amplify-text amplify-fileuploader__file__size"
-    >
-      5 B
-    </span>
-    <button
-      class="amplify-button amplify-field-group__control amplify-button--link amplify-button--small"
-      data-fullwidth="false"
-      data-size="small"
-      data-variation="link"
-      type="button"
-    >
-      <span
-        class="amplify-visually-hidden"
+        <img
+          alt="hello.png"
+          class="amplify-image"
+        />
+      </div>
+      <div
+        class="amplify-fileuploader__file__main"
       >
-        Edit file name 
-        hello.png
-      </span>
-      <span
-        aria-hidden="true"
-        class="amplify-icon"
-        style="width: 1em; height: 1em;"
-      >
-        <svg
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
+        <p
+          class="amplify-text amplify-fileuploader__file__name"
         >
-          <path
-            d="M3 21h3.75L17.81 9.94l-3.75-3.75L3 17.25V21zm2-2.92l9.06-9.06.92.92L5.92 19H5v-.92zM18.37 3.29a.996.996 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 000-1.41l-2.34-2.34z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-    </button>
-    <button
-      class="amplify-button amplify-field-group__control amplify-button--small"
-      data-fullwidth="false"
-      data-size="small"
-      type="button"
-    >
+          hello.png
+        </p>
+      </div>
       <span
-        class="amplify-visually-hidden"
+        class="amplify-text amplify-fileuploader__file__size"
       >
-        Remove file name 
-        hello.png
+        5 B
       </span>
-      <span
-        aria-hidden="true"
-        class="amplify-icon"
-        style="width: 1em; height: 1em;"
+      <button
+        class="amplify-button amplify-field-group__control amplify-button--link amplify-button--small"
+        data-fullwidth="false"
+        data-size="small"
+        data-variation="link"
+        type="button"
       >
-        <svg
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          class="amplify-visually-hidden"
         >
-          <path
-            d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-    </button>
+          Edit file name 
+          hello.png
+        </span>
+        <span
+          aria-hidden="true"
+          class="amplify-icon"
+          style="width: 1em; height: 1em;"
+        >
+          <svg
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 21h3.75L17.81 9.94l-3.75-3.75L3 17.25V21zm2-2.92l9.06-9.06.92.92L5.92 19H5v-.92zM18.37 3.29a.996.996 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 000-1.41l-2.34-2.34z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </button>
+      <button
+        class="amplify-button amplify-field-group__control amplify-button--small"
+        data-fullwidth="false"
+        data-size="small"
+        type="button"
+      >
+        <span
+          class="amplify-visually-hidden"
+        >
+          Remove file name 
+          hello.png
+        </span>
+        <span
+          aria-hidden="true"
+          class="amplify-icon"
+          style="width: 1em; height: 1em;"
+        >
+          <svg
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/packages/react/src/components/Storage/FileUploader/UploadTracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadTracker/index.tsx
@@ -63,18 +63,13 @@ export function UploadTracker({
           <Text className={ComponentClassNames.FileUploaderFileName}>
             {name}
           </Text>
-          <UploadMessage
-            fileState={fileState}
-            errorMessage={errorMessage}
-            percentage={percentage}
-          />
         </View>
         <Text as="span" className={ComponentClassNames.FileUploaderFileSize}>
           {humanFileSize(size, true)}
         </Text>
       </>
     ),
-    [errorMessage, fileState, name, percentage, size]
+    [name, size]
   );
 
   const Actions = useCallback(() => {
@@ -153,51 +148,58 @@ export function UploadTracker({
 
   return (
     <View className={ComponentClassNames.FileUploaderFile}>
-      {showImage ? (
-        <View className={ComponentClassNames.FileUploaderFileImage}>
-          {icon}
-        </View>
-      ) : null}
+      <View className={ComponentClassNames.FileUploaderFileWrapper}>
+        {showImage ? (
+          <View className={ComponentClassNames.FileUploaderFileImage}>
+            {icon}
+          </View>
+        ) : null}
 
-      {/* Main View */}
-      {fileState === 'editing' ? (
-        // Wrapping this text field in a form with onSubmit will allow keyboard
-        // users to press enter to save changes.
-        <View
-          as="form"
-          flex="1"
-          onSubmit={() => {
-            onSaveEdit(tempName);
-          }}
-        >
-          <TextField
-            maxLength={1024}
-            ref={inputRef}
-            label="file name"
-            size="small"
-            variation="quiet"
-            labelHidden
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setTempName(e.target.value);
+        {/* Main View */}
+        {fileState === 'editing' ? (
+          // Wrapping this text field in a form with onSubmit will allow keyboard
+          // users to press enter to save changes.
+          <View
+            as="form"
+            flex="1"
+            onSubmit={() => {
+              onSaveEdit(tempName);
             }}
-            value={tempName}
+          >
+            <TextField
+              maxLength={1024}
+              ref={inputRef}
+              label="file name"
+              size="small"
+              variation="quiet"
+              labelHidden
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setTempName(e.target.value);
+              }}
+              value={tempName}
+            />
+          </View>
+        ) : (
+          <DisplayView />
+        )}
+
+        <Actions />
+
+        {fileState === 'loading' ? (
+          <Loader
+            className={ComponentClassNames.FileUploaderLoader}
+            variation="linear"
+            percentage={percentage}
+            isDeterminate={isDeterminate}
+            isPercentageTextHidden
           />
-        </View>
-      ) : (
-        <DisplayView />
-      )}
-
-      <Actions />
-
-      {fileState === 'loading' ? (
-        <Loader
-          className={ComponentClassNames.FileUploaderLoader}
-          variation="linear"
-          percentage={percentage}
-          isDeterminate={isDeterminate}
-          isPercentageTextHidden
-        />
-      ) : null}
+        ) : null}
+      </View>
+      <UploadMessage
+        fileState={fileState}
+        errorMessage={errorMessage}
+        percentage={percentage}
+      />
     </View>
   );
 }

--- a/packages/react/src/primitives/shared/constants.ts
+++ b/packages/react/src/primitives/shared/constants.ts
@@ -249,6 +249,10 @@ export const ComponentClassObject: ComponentClassNameItems = {
     className: ComponentClassName.FileUploaderFile,
     components: ['FileUploader'],
   },
+  FileUploaderFileWrapper: {
+    className: ComponentClassName.FileUploaderFileWrapper,
+    components: ['FileUploader'],
+  },
   FileUploaderFileName: {
     className: ComponentClassName.FileUploaderFileName,
     components: ['FileUploader'],
@@ -725,6 +729,8 @@ export const ComponentClassNames: ComponentClassNamesType = {
   FileUploaderDropZoneButton:
     ComponentClassObject.FileUploaderDropZoneButton.className,
   FileUploaderFile: ComponentClassObject.FileUploaderFile.className,
+  FileUploaderFileWrapper:
+    ComponentClassObject.FileUploaderFileWrapper.className,
   FileUploaderFileName: ComponentClassObject.FileUploaderFileName.className,
   FileUploaderLoader: ComponentClassObject.FileUploaderLoader.className,
   FileUploaderFileSize: ComponentClassObject.FileUploaderFileSize.className,

--- a/packages/react/src/primitives/shared/types.ts
+++ b/packages/react/src/primitives/shared/types.ts
@@ -106,6 +106,7 @@ type ComponentClassNameKey =
   | 'FileUploaderDropZoneText'
   | 'FileUploaderDropZoneButton'
   | 'FileUploaderFile'
+  | 'FileUploaderFileWrapper'
   | 'FileUploaderFileName'
   | 'FileUploaderFileSize'
   | 'FileUploaderFileInfo'

--- a/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
+++ b/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
@@ -75,9 +75,7 @@ export function humanFileSize(bytes, si = false, dp = 1) {
 export const checkMaxSize = (maxSize: number, file: File): string | null => {
   if (!maxSize) return null;
   if (file.size > maxSize) {
-    return (
-      translate('Above file size limit of ') + humanFileSize(maxSize, true)
-    );
+    return translate('File size must be below ') + humanFileSize(maxSize, true);
   }
   return null;
 };

--- a/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
+++ b/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
@@ -75,7 +75,9 @@ export function humanFileSize(bytes, si = false, dp = 1) {
 export const checkMaxSize = (maxSize: number, file: File): string | null => {
   if (!maxSize) return null;
   if (file.size > maxSize) {
-    return translate('Above max ') + humanFileSize(maxSize, true);
+    return (
+      translate('Above file size limit of ') + humanFileSize(maxSize, true)
+    );
   }
   return null;
 };

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -451,7 +451,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-fileuploader-file-padding-block: var(--amplify-space-xs);
         --amplify-components-fileuploader-file-padding-inline: var(--amplify-space-small);
         --amplify-components-fileuploader-file-gap: var(--amplify-space-small);
-        --amplify-components-fileuploader-file-align-items: center;
+        --amplify-components-fileuploader-file-align-items: baseline;
         --amplify-components-fileuploader-file-name-font-size: var(--amplify-font-sizes-medium);
         --amplify-components-fileuploader-file-name-font-weight: var(--amplify-font-weights-bold);
         --amplify-components-fileuploader-file-name-color: var(--amplify-colors-font-primary);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -485,7 +485,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-fileuploader-file-padding-block: var(--amplify-space-xs);
         --amplify-components-fileuploader-file-padding-inline: var(--amplify-space-small);
         --amplify-components-fileuploader-file-gap: var(--amplify-space-small);
-        --amplify-components-fileuploader-file-align-items: center;
+        --amplify-components-fileuploader-file-align-items: baseline;
         --amplify-components-fileuploader-file-name-font-size: var(--amplify-font-sizes-medium);
         --amplify-components-fileuploader-file-name-font-weight: var(--amplify-font-weights-bold);
         --amplify-components-fileuploader-file-name-color: var(--amplify-colors-font-primary);

--- a/packages/ui/src/theme/css/component/fileUploader.scss
+++ b/packages/ui/src/theme/css/component/fileUploader.scss
@@ -60,7 +60,6 @@
     border-radius: var(--amplify-components-fileuploader-file-border-radius);
     display: flex;
     flex-direction: column;
-    align-items: center;
     padding-inline: var(--amplify-components-fileuploader-file-padding-inline);
     padding-block: var(--amplify-components-fileuploader-file-padding-block);
     align-items: var(--amplify-components-fileuploader-file-align-items);
@@ -69,6 +68,7 @@
       width: 100%;
       display: flex;
       flex-direction: row;
+      align-items: center;
       gap: var(--amplify-components-fileuploader-file-gap);
     }
     &__name {

--- a/packages/ui/src/theme/css/component/fileUploader.scss
+++ b/packages/ui/src/theme/css/component/fileUploader.scss
@@ -69,57 +69,53 @@
       display: flex;
       flex-direction: row;
       gap: var(--amplify-components-fileuploader-file-gap);
-      &__name {
-        text-overflow: ellipsis;
-        overflow: hidden;
-        font-weight: var(
-          --amplify-components-fileuploader-file-name-font-weight
-        );
-        font-size: var(--amplify-components-fileuploader-file-name-font-size);
-        color: var(--amplify-components-fileuploader-file-name-color);
-      }
+    }
+    &__name {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      font-weight: var(--amplify-components-fileuploader-file-name-font-weight);
+      font-size: var(--amplify-components-fileuploader-file-name-font-size);
+      color: var(--amplify-components-fileuploader-file-name-color);
+    }
 
-      &__size {
-        font-weight: var(
-          --amplify-components-fileuploader-file-size-font-weight
-        );
+    &__size {
+      font-weight: var(--amplify-components-fileuploader-file-size-font-weight);
+      font-size: var(--amplify-components-fileuploader-file-size-font-size);
+      color: var(--amplify-components-fileuploader-file-size-color);
+    }
+
+    &__main {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    &__image {
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: var(--amplify-components-fileuploader-file-image-width);
+      height: var(--amplify-components-fileuploader-file-image-height);
+      background-color: var(
+        --amplify-components-fileuploader-file-image-background-color
+      );
+      border-radius: var(
+        --amplify-components-fileuploader-file-image-border-radius
+      );
+      color: var(--amplify-components-fileuploader-file-image-color);
+      img {
+        max-height: 100%;
+      }
+    }
+
+    &__status {
+      &--error {
+        color: var(--amplify-colors-font-error);
         font-size: var(--amplify-components-fileuploader-file-size-font-size);
-        color: var(--amplify-components-fileuploader-file-size-color);
       }
-
-      &__main {
-        flex: 1;
-        white-space: nowrap;
-        overflow: hidden;
-      }
-
-      &__image {
-        position: relative;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: var(--amplify-components-fileuploader-file-image-width);
-        height: var(--amplify-components-fileuploader-file-image-height);
-        background-color: var(
-          --amplify-components-fileuploader-file-image-background-color
-        );
-        border-radius: var(
-          --amplify-components-fileuploader-file-image-border-radius
-        );
-        color: var(--amplify-components-fileuploader-file-image-color);
-        img {
-          max-height: 100%;
-        }
-      }
-
-      &__status {
-        &--error {
-          color: var(--amplify-colors-font-error);
-          font-size: var(--amplify-components-fileuploader-file-size-font-size);
-        }
-        &--success {
-          color: var(--amplify-colors-font-success);
-        }
+      &--success {
+        color: var(--amplify-colors-font-success);
       }
     }
   }

--- a/packages/ui/src/theme/css/component/fileUploader.scss
+++ b/packages/ui/src/theme/css/component/fileUploader.scss
@@ -60,6 +60,7 @@
     border-radius: var(--amplify-components-fileuploader-file-border-radius);
     display: flex;
     flex-direction: column;
+    align-items: center;
     padding-inline: var(--amplify-components-fileuploader-file-padding-inline);
     padding-block: var(--amplify-components-fileuploader-file-padding-block);
     align-items: var(--amplify-components-fileuploader-file-align-items);

--- a/packages/ui/src/theme/css/component/fileUploader.scss
+++ b/packages/ui/src/theme/css/component/fileUploader.scss
@@ -59,58 +59,67 @@
     border-color: var(--amplify-components-fileuploader-file-border-color);
     border-radius: var(--amplify-components-fileuploader-file-border-radius);
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     padding-inline: var(--amplify-components-fileuploader-file-padding-inline);
     padding-block: var(--amplify-components-fileuploader-file-padding-block);
     align-items: var(--amplify-components-fileuploader-file-align-items);
-    gap: var(--amplify-components-fileuploader-file-gap);
 
-    &__name {
-      text-overflow: ellipsis;
-      overflow: hidden;
-      font-weight: var(--amplify-components-fileuploader-file-name-font-weight);
-      font-size: var(--amplify-components-fileuploader-file-name-font-size);
-      color: var(--amplify-components-fileuploader-file-name-color);
-    }
-
-    &__size {
-      font-weight: var(--amplify-components-fileuploader-file-size-font-weight);
-      font-size: var(--amplify-components-fileuploader-file-size-font-size);
-      color: var(--amplify-components-fileuploader-file-size-color);
-    }
-
-    &__main {
-      flex: 1;
-      white-space: nowrap;
-      overflow: hidden;
-    }
-
-    &__image {
-      position: relative;
+    &__wrapper {
+      width: 100%;
       display: flex;
-      align-items: center;
-      justify-content: center;
-      width: var(--amplify-components-fileuploader-file-image-width);
-      height: var(--amplify-components-fileuploader-file-image-height);
-      background-color: var(
-        --amplify-components-fileuploader-file-image-background-color
-      );
-      border-radius: var(
-        --amplify-components-fileuploader-file-image-border-radius
-      );
-      color: var(--amplify-components-fileuploader-file-image-color);
-      img {
-        max-height: 100%;
+      flex-direction: row;
+      gap: var(--amplify-components-fileuploader-file-gap);
+      &__name {
+        text-overflow: ellipsis;
+        overflow: hidden;
+        font-weight: var(
+          --amplify-components-fileuploader-file-name-font-weight
+        );
+        font-size: var(--amplify-components-fileuploader-file-name-font-size);
+        color: var(--amplify-components-fileuploader-file-name-color);
       }
-    }
 
-    &__status {
-      &--error {
-        color: var(--amplify-colors-font-error);
+      &__size {
+        font-weight: var(
+          --amplify-components-fileuploader-file-size-font-weight
+        );
         font-size: var(--amplify-components-fileuploader-file-size-font-size);
+        color: var(--amplify-components-fileuploader-file-size-color);
       }
-      &--success {
-        color: var(--amplify-colors-font-success);
+
+      &__main {
+        flex: 1;
+        white-space: nowrap;
+        overflow: hidden;
+      }
+
+      &__image {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: var(--amplify-components-fileuploader-file-image-width);
+        height: var(--amplify-components-fileuploader-file-image-height);
+        background-color: var(
+          --amplify-components-fileuploader-file-image-background-color
+        );
+        border-radius: var(
+          --amplify-components-fileuploader-file-image-border-radius
+        );
+        color: var(--amplify-components-fileuploader-file-image-color);
+        img {
+          max-height: 100%;
+        }
+      }
+
+      &__status {
+        &--error {
+          color: var(--amplify-colors-font-error);
+          font-size: var(--amplify-components-fileuploader-file-size-font-size);
+        }
+        &--success {
+          color: var(--amplify-colors-font-success);
+        }
       }
     }
   }

--- a/packages/ui/src/theme/tokens/components/fileUploader.ts
+++ b/packages/ui/src/theme/tokens/components/fileUploader.ts
@@ -119,7 +119,7 @@ export const fileuploader: Required<FileUploaderTokens<'default'>> = {
     paddingBlock: { value: '{space.xs}' },
     paddingInline: { value: '{space.small}' },
     gap: { value: '{space.small}' },
-    alignItems: { value: 'center' },
+    alignItems: { value: 'baseline' },
 
     name: {
       fontSize: { value: '{fontSizes.medium}' },

--- a/packages/ui/src/types/primitives/componentClassName.ts
+++ b/packages/ui/src/types/primitives/componentClassName.ts
@@ -58,6 +58,7 @@ export enum ComponentClassName {
   FileUploaderDropZoneText = 'amplify-fileuploader__dropzone__text',
   FileUploaderDropZoneButton = 'amplify-fileuploader__dropzone__button',
   FileUploaderFile = 'amplify-fileuploader__file',
+  FileUploaderFileWrapper = 'amplify-fileuploader__file__wrapper',
   FileUploaderFileName = 'amplify-fileuploader__file__name',
   FileUploaderFileSize = 'amplify-fileuploader__file__size',
   FileUploaderFileInfo = 'amplify-fileuploader__file__info',


### PR DESCRIPTION
#### Description of changes

The max file size error message, is short, and confusing. This PR adds more information to the max file size errors. 

Also in smaller screens the message gets cut off. So now it's on its own line. 

#### Issue #, if available

[Asana](https://app.asana.com/0/1202067479136208/1203495483940613/f)

Before:
<img width="843" alt="image" src="https://user-images.githubusercontent.com/65630/211667651-45d3ed64-3c4b-420a-a28d-324c49fe6648.png">


Updated text:
<img width="835" alt="image" src="https://user-images.githubusercontent.com/65630/212192225-08e6195a-2c6c-418f-bda1-b6f322c9088a.png">


#### Description of how you validated changes
Updated snapshots

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
