### PR TITLE
chore(docs): add clarification for auth hook usage

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.angular.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.angular.mdx
@@ -1,3 +1,14 @@
+import { Alert } from '@aws-amplify/ui-react';
+
+<Alert
+  variation="info"
+  isDismissible={false}
+  hasIcon={true}
+  heading=""
+  >
+  You must render the `<amplify-authenticator>` UI component before using `AuthenticatorService`. `AuthenticatorService` was designed to retrieve `<amplify-authenticator>` UI specific state such as `route` and `user` and should not be used without the UI component.
+</Alert>
+
 ## Authenticator Service
 
 `@aws-amplify/ui-angular` ships with `AuthenticatorService` Angular service that can be used to access, modify, and update Authenticator's auth state. To use them, first inject the service into your component:

--- a/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.react-native.mdx
@@ -1,8 +1,17 @@
-import { Tabs, TabItem } from '@aws-amplify/ui-react';
+import { Alert, Tabs, TabItem } from '@aws-amplify/ui-react';
 
 ## useAuthenticator Hook
 
-`@aws-amplify/ui-react-native` ships with `useAuthenticator` React hook that can be used to access, modify, and update Authenticator's auth state. To use them, first wrap your application with [`<Authenticator.Provider>`](#authenticator-provider):
+<Alert
+  variation="info"
+  isDismissible={false}
+  hasIcon={true}
+  heading=""
+  >
+  You must render the `Authenticator` UI component before using the `useAuthenticator` hook. This hook was designed to retrieve `Authenticator` UI specific state such as `route` and `user` and should not be used without the UI component.
+</Alert>
+
+`@aws-amplify/ui-react-native` ships with `useAuthenticator` React hook that can be used to access, modify, and update Authenticator's auth state. To use them, you must render the Authenticator and wrap your application with [`<Authenticator.Provider>`](#authenticator-provider):
 
 ```jsx
 import { Authenticator } from '@aws-amplify/ui-react-native';

--- a/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.react.mdx
@@ -1,8 +1,20 @@
-import { Tabs, TabItem } from '@aws-amplify/ui-react';
+import { Alert, Tabs, TabItem } from '@aws-amplify/ui-react';
+
+<Alert
+  variation="info"
+  isDismissible={false}
+  hasIcon={true}
+  heading=""
+  >
+  You must render the `Authenticator` UI component before using the `useAuthenticator` hook. This hook was designed to retrieve `Authenticator` UI specific state such as `route` and `user` and should not be used without the UI component.
+  <br/>
+  For a full example of `useAuthenticator`, see the [protected routes guide](./react/guides/auth-protected)
+</Alert>
+
 
 ## useAuthenticator Hook
 
-`@aws-amplify/ui-react` ships with `useAuthenticator` React hook that can be used to access, modify, and update Authenticator's auth state. To use them, first wrap your application with [`<Authenticator.Provider>`](#authenticator-provider):
+`@aws-amplify/ui-react` ships with `useAuthenticator` React hook that can be used to access, modify, and update Authenticator's auth state. To use them, you must render the Authenticator and wrap your application with [`<Authenticator.Provider>`](#authenticator-provider):
 
 ```tsx
 import { Authenticator } from '@aws-amplify/ui-react';

--- a/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.vue.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.vue.mdx
@@ -1,3 +1,14 @@
+import { Alert } from '@aws-amplify/ui-react';
+
+<Alert
+  variation="info"
+  isDismissible={false}
+  hasIcon={true}
+  heading=""
+  >
+  You must render the `<authenticator>` UI component before using the `useAuthenticator` composable. `useAuthenticator` was designed to retrieve `<authenticator>` UI specific state such as `route` and `user` and should not be used without the UI component.
+</Alert>
+
 ## useAuthenticator
 
 `@aws-amplify/ui-vue` ships with `useAuthenticator` Vue composable that can be used to access, modify, and update Authenticator's auth state. To use them, make sure the `<authenticator>` is present in the component or parent component:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
There's been significant customer confusion on how to use the `useAuthenticator` hook/composable/service. In particular customers have been trying to use it without the Authenticator UI, which causes unexpected behavior (since the state machine isn't initialized). This PR adds a notice to the headless page for each framework each headless that the hook should be used alongside the Authenticator UI components. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Angular:
![image](https://user-images.githubusercontent.com/6165315/211880545-4b847161-ba95-4831-b955-bcb645b5a97b.png)

React:
![image](https://user-images.githubusercontent.com/6165315/211880585-fb4461eb-5a47-46f3-b0b3-504d202cab1f.png)

React Native:
![image](https://user-images.githubusercontent.com/6165315/211880644-ea45ba9a-c942-4147-82ad-50d896e634f7.png)

Vue:
![image](https://user-images.githubusercontent.com/6165315/211880709-acf523dd-86e2-46c0-a403-84a8a59f39bb.png)


#### Issue #, if available
Fixes: https://github.com/aws-amplify/amplify-ui/issues/2657
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`yarn doc dev`
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
