### PR TITLE
chore(ui,ui-react-core): Add type guard utils

### DIFF
--- a/.changeset/sixty-buttons-study.md
+++ b/.changeset/sixty-buttons-study.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui-react-core': patch
+'@aws-amplify/ui': patch
+---
+
+chore(ui,ui-react-core): Add type guard utils

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticator/utils.ts
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticator/utils.ts
@@ -7,8 +7,8 @@ import {
   getSortedFormFields,
   UnverifiedContactMethods,
   getActorContext,
+  isString,
 } from '@aws-amplify/ui';
-import isString from 'lodash/isString';
 
 import { areEmptyArrays, areEmptyObjects } from '../../../utils';
 import { AuthenticatorLegacyField, AuthenticatorLegacyFields } from '../types';

--- a/packages/react-core/src/InAppMessaging/utils/handleMessageAction.ts
+++ b/packages/react-core/src/InAppMessaging/utils/handleMessageAction.ts
@@ -1,5 +1,5 @@
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
-import isString from 'lodash/isString';
+import { isString } from '@aws-amplify/ui';
 
 import { MessageAction } from '../types';
 

--- a/packages/react-core/src/hooks/useHasValueUpdated.ts
+++ b/packages/react-core/src/hooks/useHasValueUpdated.ts
@@ -1,5 +1,6 @@
+import { isUndefined } from '@aws-amplify/ui';
+
 import usePreviousValue from './usePreviousValue';
-import isUndefined from 'lodash/isUndefined';
 
 export default function useHasValueUpdated<Value>(
   value: Value,

--- a/packages/react-core/src/utils/index.ts
+++ b/packages/react-core/src/utils/index.ts
@@ -1,6 +1,6 @@
 import isEmpty from 'lodash/isEmpty';
-import isObject from 'lodash/isObject';
-import isString from 'lodash/isString';
+
+import { isObject, isString } from '@aws-amplify/ui';
 
 function isEmptyArray<T>(value: T): boolean {
   return Array.isArray(value) && isEmpty(value);
@@ -11,7 +11,7 @@ export function areEmptyArrays<T>(...values: T[]): boolean {
 }
 
 function isEmptyObject<T>(value: T): boolean {
-  return isObject(value) && !Array.isArray(value) && isEmpty(value);
+  return isObject(value) && isEmpty(value);
 }
 
 export function areEmptyObjects<T>(...values: T[]): boolean {

--- a/packages/ui/src/helpers/__tests__/typeGuards.test.ts
+++ b/packages/ui/src/helpers/__tests__/typeGuards.test.ts
@@ -1,0 +1,59 @@
+import { isObject, isString, isUndefined } from '../typeGuards';
+
+describe('isObject', () => {
+  it('should return `true` for objects', () => {
+    expect(isObject(new Number(0))).toStrictEqual(true);
+    expect(isObject(new String(''))).toStrictEqual(true);
+    expect(isObject(new Date())).toStrictEqual(true);
+    expect(isObject(new Error())).toStrictEqual(true);
+    expect(isObject({})).toStrictEqual(true);
+    expect(isObject({ test: 1 })).toStrictEqual(true);
+    expect(isObject(Object(false))).toStrictEqual(true);
+    expect(isObject(Object(0))).toStrictEqual(true);
+    expect(isObject(Object('test'))).toStrictEqual(true);
+  });
+
+  it('should return `false` for non-objects', () => {
+    expect(isObject(null)).toStrictEqual(false);
+    expect(isObject(undefined)).toStrictEqual(false);
+    expect(isObject(true)).toStrictEqual(false);
+    expect(isObject(0)).toStrictEqual(false);
+    expect(isObject('test')).toStrictEqual(false);
+    expect(isObject([1, 2, 3])).toStrictEqual(false);
+    expect(isObject(() => {})).toStrictEqual(false);
+  });
+});
+
+describe('isString', () => {
+  it('should return `true` for strings', () => {
+    expect(isString('')).toStrictEqual(true);
+    expect(isString('test')).toStrictEqual(true);
+  });
+
+  it('should return `false` for non-strings', () => {
+    expect(isString(null)).toStrictEqual(false);
+    expect(isString(undefined)).toStrictEqual(false);
+    expect(isString(true)).toStrictEqual(false);
+    expect(isString(0)).toStrictEqual(false);
+    expect(isString(new String(''))).toStrictEqual(false);
+  });
+});
+
+describe('isUndefined', () => {
+  it('should return `true` for undefined values', function () {
+    expect(isUndefined(undefined)).toStrictEqual(true);
+  });
+
+  it('should return `false` for non-undefined values', function () {
+    expect(isUndefined(null)).toStrictEqual(false);
+    expect(isUndefined(true)).toStrictEqual(false);
+    expect(isUndefined('')).toStrictEqual(false);
+    expect(isUndefined(0)).toStrictEqual(false);
+    expect(isUndefined([1, 2, 3])).toStrictEqual(false);
+    expect(isUndefined(new Number(0))).toStrictEqual(false);
+    expect(isUndefined(new String(''))).toStrictEqual(false);
+    expect(isUndefined(new Date())).toStrictEqual(false);
+    expect(isUndefined(new Error())).toStrictEqual(false);
+    expect(isUndefined({})).toStrictEqual(false);
+  });
+});

--- a/packages/ui/src/helpers/index.ts
+++ b/packages/ui/src/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from './authenticator';
 export * from './accountSettings';
 export * from './storage';
+export * from './typeGuards';
 export { getLogger } from './utils';

--- a/packages/ui/src/helpers/typeGuards.ts
+++ b/packages/ui/src/helpers/typeGuards.ts
@@ -1,0 +1,26 @@
+/**
+ * Checks if `value` is an Object (excludes arrays and functions)
+ *
+ * @param value
+ * @returns
+ */
+export const isObject = (value: unknown): value is object =>
+  value != null && !Array.isArray(value) && typeof value === 'object';
+
+/**
+ * Checks if `value` is a string
+ *
+ * @param value
+ * @returns
+ */
+export const isString = (value: unknown): value is string =>
+  typeof value === 'string';
+
+/**
+ * Checks if `value` is undefined
+ *
+ * @param value
+ * @returns
+ */
+export const isUndefined = <T>(value: T | undefined): value is T =>
+  value === undefined;

--- a/packages/ui/src/theme/utils.ts
+++ b/packages/ui/src/theme/utils.ts
@@ -1,11 +1,10 @@
 import has from 'lodash/has';
-import isObject from 'lodash/isObject';
-import isString from 'lodash/isString';
 import kebabCase from 'lodash/kebabCase';
 
 // internal style dictionary function
 import usesReference from 'style-dictionary/lib/utils/references/usesReference';
 
+import { isObject, isString } from '../helpers/typeGuards';
 import {
   DesignToken,
   ShadowValue,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change adds the following type guard utils:
* `isObject`
* `isString`
* `isUndefined`

in an effort to make some progress towards removing `lodash` dependency.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
