### PR TITLE
chore(primitives): move getTestId util to separate file

### DIFF
--- a/packages/react/src/primitives/Checkbox/Checkbox.tsx
+++ b/packages/react/src/primitives/Checkbox/Checkbox.tsx
@@ -8,7 +8,7 @@ import { Text } from '../Text';
 import { VisuallyHidden } from '../VisuallyHidden';
 import { CheckboxProps } from '../types/checkbox';
 import { Primitive } from '../types/view';
-import { getTestId } from '../utils/testUtils';
+import { getTestId } from '../utils/getTestId';
 import { useStableId } from '../utils/useStableId';
 import { useCheckbox } from './useCheckbox';
 import { ComponentClassNames } from '../shared/constants';

--- a/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
+++ b/packages/react/src/primitives/CheckboxField/CheckboxField.tsx
@@ -7,7 +7,7 @@ import { CheckboxFieldProps, Primitive } from '../types';
 import { ComponentClassNames } from '../shared';
 import { FieldErrorMessage } from '../Field';
 import { Flex } from '../Flex';
-import { getTestId } from '../utils/testUtils';
+import { getTestId } from '../utils/getTestId';
 
 const CheckboxFieldPrimitive: Primitive<CheckboxFieldProps, 'input'> = (
   {

--- a/packages/react/src/primitives/HighlightMatch/HighlightMatch.tsx
+++ b/packages/react/src/primitives/HighlightMatch/HighlightMatch.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { View } from '../View';
 import { strHasLength } from '../shared/utils';
-import { getTestId } from '../utils/testUtils';
+import { getTestId } from '../utils/getTestId';
 import { ComponentClassNames } from '../shared/constants';
 import type { HighlightMatchProps, Primitive } from '../types';
 

--- a/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
+++ b/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
@@ -8,7 +8,7 @@ import { Label } from '../Label';
 import { VisuallyHidden } from '../VisuallyHidden';
 import { RadioGroupContext, RadioGroupContextType } from './context';
 import { RadioGroupFieldProps, Primitive } from '../types';
-import { getTestId } from '../utils/testUtils';
+import { getTestId } from '../utils/getTestId';
 import { useStableId } from '../utils/useStableId';
 
 // Note: RadioGroupField doesn't extend the JSX.IntrinsicElements<'input'> types (instead extending 'typeof Flex')

--- a/packages/react/src/primitives/utils/getTestId.ts
+++ b/packages/react/src/primitives/utils/getTestId.ts
@@ -1,0 +1,5 @@
+export const getTestId = (
+  testId?: string,
+  component?: string
+): string | undefined =>
+  testId && component ? `${testId}-${component}` : undefined;

--- a/packages/react/src/primitives/utils/testUtils.ts
+++ b/packages/react/src/primitives/utils/testUtils.ts
@@ -1,3 +1,6 @@
+// To be used in unit tests to make it easier to display
+// specific error messages in the console when running
+// expect assertions in a loop
 export const errorMessageWrapper = (
   fn: () => void,
   message: string

--- a/packages/react/src/primitives/utils/testUtils.ts
+++ b/packages/react/src/primitives/utils/testUtils.ts
@@ -1,6 +1,3 @@
-export const getTestId = (testId: string, component: string): string =>
-  testId && component ? `${testId}-${component}` : undefined;
-
 export const errorMessageWrapper = (
   fn: () => void,
   message: string


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Move `getTestId` out of `testUtils` into its own file. `getTestId` is used in actual code, whereas `testUtils` contains unit test utils.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
