### PR TITLE
chore(canary): disable lockfile generation in `canary/apps`

### DIFF
--- a/canary/apps/.gitignore
+++ b/canary/apps/.gitignore
@@ -1,2 +1,4 @@
 yarn.lock
 package-lock.json
+# .npmrc is used to disable lockfiles
+!.npmrc 

--- a/canary/apps/.yarnrc
+++ b/canary/apps/.yarnrc
@@ -1,0 +1,2 @@
+--add.no-lockfile true
+--install.no-lockfile true

--- a/canary/apps/angular/angularcli/.npmrc
+++ b/canary/apps/angular/angularcli/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/canary/apps/react/cra-ts/.npmrc
+++ b/canary/apps/react/cra-ts/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/canary/apps/react/cra/.npmrc
+++ b/canary/apps/react/cra/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/canary/apps/react/next/.npmrc
+++ b/canary/apps/react/next/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/canary/apps/react/vite/.npmrc
+++ b/canary/apps/react/vite/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/canary/apps/react/vite3/.npmrc
+++ b/canary/apps/react/vite3/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/canary/apps/vue/vite/.npmrc
+++ b/canary/apps/vue/vite/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/canary/apps/vue/vite3/.npmrc
+++ b/canary/apps/vue/vite3/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/canary/apps/vue/vuecli/.npmrc
+++ b/canary/apps/vue/vuecli/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR disables lockfile generation in canary apps in `canary/apps`, for both yarn and npm. This will prevent **local development** from generating lockfiles in your directory, which can be misleading when you're debugging canary apps. 

The purpose of canary test is to check whether these apps work against latest downstream dependency, so this PR aligns with that purpose. Note that CI/CD [already does this](https://github.com/aws-amplify/amplify-ui/blob/fd9e863629976447bac3b3a8183ff30634d83ebb/.github/workflows/build-and-runtime-test.yml#L38).

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
