### PR TITLE
fix: add more bundle size checks

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -132,6 +132,24 @@
       "path": "dist/esm/index.js",
       "import": "{ MapView, LocationSearch }",
       "limit": "330 kB"
+    },
+    {
+      "name": "Storage - FileUploader",
+      "path": "dist/esm/index.js",
+      "import": "{ FileUploader }",
+      "limit": "140 kB"
+    },
+    {
+      "name": "AccountSettings",
+      "path": "dist/esm/index.js",
+      "import": "{ AccountSettings }",
+      "limit": "60 kB"
+    },
+    {
+      "name": "InAppMessaging",
+      "path": "dist/esm/index.js",
+      "import": "{ InAppMessagingProvider, InAppMessageDisplay }",
+      "limit": "110 kB"
     }
   ]
 }


### PR DESCRIPTION
Add missing bundle size checks for FileUploader, AccountSettings, and InAppMessaging

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This adds bundle size checks for ui-react package - InAppMessaging, AccountSettings and FileUploader
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
ran `yarn react size`, and added 10kB over the current size.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
