### PR TITLE
chore(account-settings): fix strict ts errors for account settings components

### DIFF
--- a/packages/react/src/components/AccountSettings/ChangePassword/ChangePassword.tsx
+++ b/packages/react/src/components/AccountSettings/ChangePassword/ChangePassword.tsx
@@ -44,7 +44,7 @@ function ChangePassword({
   validators,
   components,
 }: ChangePasswordProps): JSX.Element | null {
-  const [errorMessage, setErrorMessage] = React.useState<string>(null);
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const [formValues, setFormValues] = React.useState<FormValues>({});
   const [validationError, setValidationError] = React.useState<ValidationError>(
     {}
@@ -158,6 +158,10 @@ function ChangePassword({
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (!user) {
+      return;
+    }
+
     const { currentPassword, newPassword } = formValues;
     if (errorMessage) {
       setErrorMessage(null);

--- a/packages/react/src/components/AccountSettings/ChangePassword/defaults.tsx
+++ b/packages/react/src/components/AccountSettings/ChangePassword/defaults.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, PasswordField } from '../../../primitives';
 import { ValidationErrors } from '../../shared/ValidationErrors';
 import { DefaultErrorMessage } from '../shared/Defaults';
-import { PasswordFieldComponent, SubmitButtonComponent } from '../types';
+import { PasswordFieldComponent } from '../types';
 import { ChangePasswordComponents } from './types';
 
 const DefaultPasswordField: PasswordFieldComponent = ({
@@ -20,15 +20,11 @@ const DefaultPasswordField: PasswordFieldComponent = ({
   );
 };
 
-const DefaultSubmitButton: SubmitButtonComponent = (props) => (
-  <Button {...props} />
-);
-
 const DEFAULTS: Required<ChangePasswordComponents> = {
   CurrentPasswordField: DefaultPasswordField,
   NewPasswordField: DefaultPasswordField,
   ConfirmPasswordField: DefaultPasswordField,
-  SubmitButton: DefaultSubmitButton,
+  SubmitButton: Button,
   ErrorMessage: DefaultErrorMessage,
 };
 

--- a/packages/react/src/components/AccountSettings/ChangePassword/defaults.tsx
+++ b/packages/react/src/components/AccountSettings/ChangePassword/defaults.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, PasswordField } from '../../../primitives';
 import { ValidationErrors } from '../../shared/ValidationErrors';
 import { DefaultErrorMessage } from '../shared/Defaults';
-import { PasswordFieldComponent } from '../types';
+import { PasswordFieldComponent, SubmitButtonComponent } from '../types';
 import { ChangePasswordComponents } from './types';
 
 const DefaultPasswordField: PasswordFieldComponent = ({
@@ -20,11 +20,15 @@ const DefaultPasswordField: PasswordFieldComponent = ({
   );
 };
 
+const DefaultSubmitButton: SubmitButtonComponent = (props) => (
+  <Button {...props} />
+);
+
 const DEFAULTS: Required<ChangePasswordComponents> = {
   CurrentPasswordField: DefaultPasswordField,
   NewPasswordField: DefaultPasswordField,
   ConfirmPasswordField: DefaultPasswordField,
-  SubmitButton: (props) => <Button {...props} />,
+  SubmitButton: DefaultSubmitButton,
   ErrorMessage: DefaultErrorMessage,
 };
 

--- a/packages/react/src/components/AccountSettings/ChangePassword/defaults.tsx
+++ b/packages/react/src/components/AccountSettings/ChangePassword/defaults.tsx
@@ -13,7 +13,9 @@ const DefaultPasswordField: PasswordFieldComponent = ({
   return (
     <>
       <PasswordField {...rest} label={label} />
-      <ValidationErrors errors={fieldValidationErrors} />
+      {fieldValidationErrors ? (
+        <ValidationErrors errors={fieldValidationErrors} />
+      ) : null}
     </>
   );
 };
@@ -22,7 +24,7 @@ const DEFAULTS: Required<ChangePasswordComponents> = {
   CurrentPasswordField: DefaultPasswordField,
   NewPasswordField: DefaultPasswordField,
   ConfirmPasswordField: DefaultPasswordField,
-  SubmitButton: Button,
+  SubmitButton: (props) => <Button {...props} />,
   ErrorMessage: DefaultErrorMessage,
 };
 

--- a/packages/react/src/components/AccountSettings/DeleteUser/DeleteUser.tsx
+++ b/packages/react/src/components/AccountSettings/DeleteUser/DeleteUser.tsx
@@ -17,7 +17,7 @@ function DeleteUser({
   handleDelete,
 }: DeleteUserProps): JSX.Element | null {
   const [state, setState] = React.useState<DeleteUserState>('IDLE');
-  const [errorMessage, setErrorMessage] = React.useState<string>(null);
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
 
   // translations
   const deleteAccountText = translate('Delete Account');
@@ -36,6 +36,9 @@ function DeleteUser({
   };
 
   const runDeleteUser = React.useCallback(async () => {
+    if (!user) {
+      return;
+    }
     setState('DELETING');
     if (errorMessage) {
       setErrorMessage(null);

--- a/packages/react/src/components/AccountSettings/types.ts
+++ b/packages/react/src/components/AccountSettings/types.ts
@@ -31,10 +31,7 @@ type CommonAlertProps = Partial<PrimitiveProps<AlertProps, 'div'>> &
 type CommonButtonProps<T extends 'submit' | 'default' = 'default'> =
   Partial<ButtonPrimitiveProps> &
     Required<
-      Pick<
-        ButtonPrimitiveProps,
-        'isDisabled' | (T extends 'submit' ? never : 'onClick')
-      >
+      Pick<ButtonPrimitiveProps, T extends 'submit' ? never : 'onClick'>
     >;
 
 /*

--- a/packages/react/src/components/AccountSettings/types.ts
+++ b/packages/react/src/components/AccountSettings/types.ts
@@ -31,8 +31,11 @@ type CommonAlertProps = Partial<PrimitiveProps<AlertProps, 'div'>> &
 type CommonButtonProps<T extends 'submit' | 'default' = 'default'> =
   Partial<ButtonPrimitiveProps> &
     Required<
-      Pick<ButtonPrimitiveProps, T extends 'submit' ? never : 'onClick'>
-    > & { isDisabled: boolean | null | undefined };
+      Pick<
+        ButtonPrimitiveProps,
+        'isDisabled' | (T extends 'submit' ? never : 'onClick')
+      >
+    >;
 
 /*
  * These are component override types.

--- a/packages/react/src/components/AccountSettings/types.ts
+++ b/packages/react/src/components/AccountSettings/types.ts
@@ -31,11 +31,8 @@ type CommonAlertProps = Partial<PrimitiveProps<AlertProps, 'div'>> &
 type CommonButtonProps<T extends 'submit' | 'default' = 'default'> =
   Partial<ButtonPrimitiveProps> &
     Required<
-      Pick<
-        ButtonPrimitiveProps,
-        'isDisabled' | (T extends 'submit' ? never : 'onClick')
-      >
-    >;
+      Pick<ButtonPrimitiveProps, T extends 'submit' ? never : 'onClick'>
+    > & { isDisabled: boolean | null | undefined };
 
 /*
  * These are component override types.

--- a/packages/react/src/components/shared/ValidationErrors.tsx
+++ b/packages/react/src/components/shared/ValidationErrors.tsx
@@ -13,7 +13,7 @@ export const ValidationErrors = ({
   errors,
   id,
   dataAttr,
-}: ValidationErrorsProps): JSX.Element => {
+}: ValidationErrorsProps): JSX.Element | null => {
   if (!(errors?.length > 0)) return null;
 
   const dataAttrProp = dataAttr ? { [dataAttr]: true } : {};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes `strict: true` errors in the Account Settings components.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
