### PR TITLE
fix(docs): Change docs link to Authenticator translation keys

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
@@ -23,7 +23,7 @@ These [translations](https://github.com/aws-amplify/amplify-ui/blob/main/package
 
 <Fragment>{({ platform }) => import(`./i18n/i18n.${platform}.mdx`)}</Fragment>
 
-The list of available keys are available [here](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts).
+The list of available keys are available [here](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/dictionaries/authenticator/en.ts).
 
 ### Confirm Sign Up Page Translations
 

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
@@ -25,7 +25,7 @@ These [translations](https://github.com/aws-amplify/amplify-ui/blob/main/package
 
 <Fragment>{({ platform }) => import(`./i18n/i18n.${platform}.mdx`)}</Fragment>
 
-The list of available keys are available [here](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts).
+The list of available keys are available [here](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/dictionaries/authenticator/en.ts).
 
 ### Confirm Sign Up Page Translations
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Previous link: https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts
Updated link: https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/dictionaries/authenticator/en.ts

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fixes: https://github.com/aws-amplify/amplify-ui/issues/3310

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
