### PR TITLE
chore(docs): revert commit restricting tracking code to only prod

### DIFF
--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -7,7 +7,6 @@ import { ThemeProvider, ColorMode, defaultTheme } from '@aws-amplify/ui-react';
 
 import MyStorageProvider from '@/utils/storageMock';
 import { configure, trackPageVisit } from '@/utils/track';
-import { IS_PROD_STAGE } from '@/utils/stage';
 import { Header } from '@/components/Layout/Header';
 import { baseTheme } from '../theme';
 
@@ -86,10 +85,8 @@ function MyApp({ Component, pageProps }) {
   }, []);
 
   React.useEffect(() => {
-    if (IS_PROD_STAGE) {
-      configure();
-      trackPageVisit();
-    }
+    configure();
+    trackPageVisit();
   }, [pathname]); // only track page visit if path has changed
 
   return (
@@ -129,12 +126,8 @@ function MyApp({ Component, pageProps }) {
           </main>
         </ThemeProvider>
       </div>
-      {IS_PROD_STAGE && (
-        <>
-          <Script src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js" />
-          <Script src="/scripts/shortbreadv2.js" />
-        </>
-      )}
+      <Script src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js" />
+      <Script src="/scripts/shortbreadv2.js" />
     </>
   );
 }

--- a/docs/src/utils/stage.ts
+++ b/docs/src/utils/stage.ts
@@ -1,7 +1,0 @@
-const PROD_STAGE_SITE_URL = 'https://ui.docs.amplify.aws';
-const DEV_STAGE_SITE_URL = 'dev.ui.docs.amplify.aws';
-const SITE_URL = process.env.SITE_URL || '';
-export const IS_PROD_STAGE = SITE_URL === PROD_STAGE_SITE_URL;
-// Dev Site url starts with "www" due to Algolia search, so we use `includes` to match it:
-export const IS_DEV_STAGE = SITE_URL.includes(DEV_STAGE_SITE_URL);
-export const IS_LOCAL = !IS_PROD_STAGE && !IS_DEV_STAGE;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Reverting #2391 so that we can test changes to tracking code. There is currently no way to test if changes to our tracking code works unless it goes to prod. 

It is ok that our dev site tracks usage because we can filter by URL. We were counting dev hits along with prod, but we can just change the filter:

<img width="1462" alt="CleanShot 2023-01-18 at 15 02 21@2x" src="https://user-images.githubusercontent.com/321279/213314272-d469d61d-063e-4052-95f6-c5f47b5eb739.png">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
