### PR TITLE
fix(file-uploader): Add default contentType for Uploads

### DIFF
--- a/.changeset/strong-mugs-enjoy.md
+++ b/.changeset/strong-mugs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui': patch
+---
+
+Updated functionality so all file uploader uploads will have the correct type matching the file.type.

--- a/packages/ui/src/helpers/storage/fileUploader/utils/__tests__/uploader.test.tsx
+++ b/packages/ui/src/helpers/storage/fileUploader/utils/__tests__/uploader.test.tsx
@@ -57,6 +57,7 @@ describe('Uploader utils', () => {
         level: 'public',
         progressCallback: expect.any(Function),
         resumable: true,
+        contentType: 'image/png',
       });
     });
     it('calls isResumable false with storage put', () => {
@@ -75,7 +76,54 @@ describe('Uploader utils', () => {
         level: 'public',
         progressCallback: expect.any(Function),
         resumable: false,
+        contentType: 'image/png',
       });
+    });
+    it('calls uploadFile with contentType image/png', () => {
+      storageSpy.mockImplementation(() => Promise.resolve() as any);
+      uploadFile({
+        file: imageFile,
+        fileName: imageFile.name,
+        level: 'public',
+        progressCallback: () => '',
+        errorCallback: () => '',
+        completeCallback: () => '',
+        isResumable: false,
+      });
+
+      expect(storageSpy).toBeCalledWith(imageFile.name, imageFile, {
+        level: 'public',
+        progressCallback: expect.any(Function),
+        resumable: false,
+        contentType: 'image/png',
+      });
+    });
+    it('calls uploadFile with contentType binary/octet-stream when file.type is undefined', () => {
+      storageSpy.mockImplementation(() => Promise.resolve() as any);
+
+      const imageFileTypeUndefined = new File(['hello2'], 'hello2.png', {
+        type: undefined,
+      });
+      uploadFile({
+        file: imageFileTypeUndefined,
+        fileName: imageFileTypeUndefined.name,
+        level: 'public',
+        progressCallback: () => '',
+        errorCallback: () => '',
+        completeCallback: () => '',
+        isResumable: false,
+      });
+
+      expect(storageSpy).toBeCalledWith(
+        imageFileTypeUndefined.name,
+        imageFileTypeUndefined,
+        {
+          level: 'public',
+          progressCallback: expect.any(Function),
+          resumable: false,
+          contentType: 'binary/octet-stream',
+        }
+      );
     });
   });
 

--- a/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
+++ b/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
@@ -27,6 +27,7 @@ export function uploadFile({
       progressCallback,
       errorCallback,
       completeCallback,
+      contentType: file.type || 'binary/octet-stream',
       ...rest,
     });
   } else {
@@ -34,6 +35,7 @@ export function uploadFile({
       level,
       resumable: false,
       progressCallback,
+      contentType: file.type || 'binary/octet-stream',
       ...rest,
     }).then(completeCallback, errorCallback);
   }

--- a/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
+++ b/packages/ui/src/helpers/storage/fileUploader/utils/uploader.ts
@@ -20,6 +20,7 @@ export function uploadFile({
   errorCallback: (err: string) => void;
   completeCallback: (event) => void;
 }) {
+  const contentType = file.type || 'binary/octet-stream';
   if (isResumable === true) {
     return Storage.put(fileName, file, {
       level,
@@ -27,7 +28,7 @@ export function uploadFile({
       progressCallback,
       errorCallback,
       completeCallback,
-      contentType: file.type || 'binary/octet-stream',
+      contentType,
       ...rest,
     });
   } else {
@@ -35,7 +36,7 @@ export function uploadFile({
       level,
       resumable: false,
       progressCallback,
-      contentType: file.type || 'binary/octet-stream',
+      contentType,
       ...rest,
     }).then(completeCallback, errorCallback);
   }


### PR DESCRIPTION
#### Description of changes
When uploading files using the file uploader the content type is never set. Instead all content types default to `binary/octet-stream`. This causes an issue since files like svg won't have the correct contentType in S3 storage. When using `Storage.get` the file cannot be displayed in an `image` tag with the wrong content type.

To fix this now all uploads will default to the correct file type listed in the `file.type`. If none exists it will fall back to `binary/octet-stream`
 Users can still change this by updating the prop `contentType` if needed back to `binary/octet-stream` for all uploads.

#### Issue #, if available
#3257 


#### Description of how you validated changes
Added additional tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
