### PR TITLE
docs(angular): add migration notes for legacy components

### DIFF
--- a/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
@@ -1,6 +1,8 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 import { Alert } from '@aws-amplify/ui-react';
 
+import { Example, ExampleCode } from '@/components/Example';
+
 ## 2.x to 3.x
 ### Installation
 Install the 3.x version of the `@aws-amplify/ui-angular` library and the 5.x version of the `aws-amplify` library.
@@ -76,6 +78,62 @@ We replaced following legacy Authenticator texts:
 - `Forgot your password? ` with the trailing space is replaced by `Forgot your password`.
 
 If you were using `I18n` to translate those keys, please update your translations accordingly to match the new strings.
+
+#### 5. `@aws-amplify/ui-angular@3.x` removes legacy component exports
+
+The following deprecated components imported from `@aws-amplify/ui-angular/legacy` are removed:
+
+- [AmplifyChatbot](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-chatbot/readme.md)
+- [AmplifyPhotoPicker](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-photo-picker/readme.md)
+- [AmplifyPicker](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-picker/readme.md)
+- [AmplifyS3Album](https://github.com/aws-amplify/amplify-js/tree/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-album/readme.md)
+- [AmplifyS3Image](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-image/readme.md)
+- [AmplifyS3ImagePicker](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-image-picker/readme.md)
+- [AmplifyS3Text](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-text/readme.md)
+- [AmplifyS3TextPicker](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-text-picker/readme.md)
+
+If you wish to still use the legacy components, you can do so by installing `@aws-amplify@2.x` under an alias:
+
+<Tabs>
+<TabItem title="npm">
+
+```shell
+npm i @aws-amplify/ui-angular-v2@npm:@aws-amplify/ui-angular@^2.4.27
+```
+
+</TabItem>
+<TabItem title="yarn">
+
+
+```shell
+yarn add @aws-amplify/ui-angular-v2@npm:@aws-amplify/ui-angular@^2.4.27
+```
+
+</TabItem>
+</Tabs>
+
+Then you can use the legacy components by registering `LegacyAmplifyUiModule` in your `app.module.ts`:
+
+
+```ts{4,11}
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+
+import { AmplifyAuthenticatorModule } from '@aws-amplify/ui-angular';
+import { LegacyAmplifyUiModule } from '@aws-amplify/ui-angular-v2/legacy';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, AmplifyAuthenticatorModule, LegacyAmplifyUiModule],
+  providers: [],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+```
+
+For more details on how to use the components, please see the [v1 documentation](https://github.com/aws-amplify/amplify-ui/tree/legacy/legacy/amplify-ui-angular).
 
 ## 1.x to 2.x
 ## Installation

--- a/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
@@ -1,8 +1,6 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
 import { Alert } from '@aws-amplify/ui-react';
 
-import { Example, ExampleCode } from '@/components/Example';
-
 ## 2.x to 3.x
 ### Installation
 Install the 3.x version of the `@aws-amplify/ui-angular` library and the 5.x version of the `aws-amplify` library.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds migration guide to how to use legacy s3 or chatbot components. This uses npm alias trick to do so.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Related Issues

#3169

#### Description of how you validated changes

Ran locally:

<img width="1904" alt="Screen Shot 2023-01-18 at 6 13 00 PM" src="https://user-images.githubusercontent.com/43682783/213339634-e895e5f5-15ea-4ed4-a9a5-7f361cea2771.png">

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
