### PR TITLE
fix(examples): ignore directories named .DS_Store in metro.config

### DIFF
--- a/examples/react-native/metro.config.js
+++ b/examples/react-native/metro.config.js
@@ -31,12 +31,14 @@ function getInternalPackages(root, internalPackagesDirectory) {
 
       return readdirSync(internalDirectoryRoot, {
         withFileTypes: true,
-      }).map(({ name }) => {
-        const packagePath = path.resolve(internalDirectoryRoot, name);
-        const packageName = require(`${packagePath}/package.json`).name;
+      })
+        .filter(({ name }) => name !== '.DS_Store')
+        .map(({ name }) => {
+          const packagePath = path.resolve(internalDirectoryRoot, name);
+          const packageName = require(`${packagePath}/package.json`).name;
 
-        return { packageName, packagePath };
-      });
+          return { packageName, packagePath };
+        });
     })
     .flat();
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change filters out directories named .DS_Store in the metro.config.js in our react-native example so that it doesn't try to treat it as a package.

When running `yarn react-native-example ios`, this error was encountered:

```
error Cannot find module '/Volumes/workplace/amplify-ui/packages/.DS_Store/package.json'
```
<img width="400" alt="Screen Shot 2023-01-23 at 12 07 32 PM" src="https://user-images.githubusercontent.com/376920/214115486-b3b7347e-1111-4ffe-a24b-e3e4a5c7e765.png">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

After the change,  `yarn react-native-example ios` runs successfully.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
