### PR TITLE
fix(file-uploader): Added better error text for over max files

### DIFF
--- a/.changeset/purple-hotels-tease.md
+++ b/.changeset/purple-hotels-tease.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Updated error text for over max files to be more explicit.

--- a/.changeset/purple-hotels-tease.md
+++ b/.changeset/purple-hotels-tease.md
@@ -2,4 +2,4 @@
 '@aws-amplify/ui-react': patch
 ---
 
-Updated error text for over max files to be more explicit.
+fix: Updated error text for max file count to be more explicit.

--- a/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
@@ -379,6 +379,7 @@ export function FileUploader({
         isLoading={isLoading}
         isSuccessful={isSuccessful}
         hasMaxFilesError={hasMaxFilesError}
+        maxFiles={maxFiles}
         onClear={onClear}
         onFileClick={onFileClick}
         aggregatePercentage={aggregatePercentage}

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/UploadPreviewer.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/UploadPreviewer.test.tsx
@@ -35,6 +35,7 @@ const commonProps = {
   isLoading: false,
   isSuccessful: false,
   hasMaxFilesError: false,
+  maxFiles: 10,
   onClear: () => null,
   onFileClick: () => null,
 };
@@ -104,11 +105,7 @@ describe('UploadPreviewer', () => {
   });
   it('shows when loading an uploading with percentage', async () => {
     render(
-      <UploadPreviewer
-        {...commonProps}
-        isLoading
-        aggregatePercentage={23}
-      />
+      <UploadPreviewer {...commonProps} isLoading aggregatePercentage={23} />
     );
 
     expect(await screen.findByText(/Uploading: 23%/)).toBeVisible();

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
@@ -18,10 +18,13 @@ export function UploadPreviewer({
   isLoading,
   isSuccessful,
   hasMaxFilesError,
+  maxFiles,
   onClear,
   onFileClick,
 }: PreviewerProps): JSX.Element {
-  const headingMaxFiles = translate('Over Max files');
+  const headingMaxFiles = `${translate('Over')} ${maxFiles} ${translate(
+    ' file limit'
+  )}`;
   const getUploadedFilesLength = () =>
     fileStatuses.filter((file) => file?.fileState === 'success').length;
 

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
@@ -22,9 +22,7 @@ export function UploadPreviewer({
   onClear,
   onFileClick,
 }: PreviewerProps): JSX.Element {
-  const headingMaxFiles = `${translate('Over')} ${maxFiles} ${translate(
-    'file limit'
-  )}`;
+  const headingMaxFiles = `${translate('Cannot choose more than')} ${maxFiles}`;
   const getUploadedFilesLength = () =>
     fileStatuses.filter((file) => file?.fileState === 'success').length;
 

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
@@ -23,7 +23,7 @@ export function UploadPreviewer({
   onFileClick,
 }: PreviewerProps): JSX.Element {
   const headingMaxFiles = `${translate('Over')} ${maxFiles} ${translate(
-    ' file limit'
+    'file limit'
   )}`;
   const getUploadedFilesLength = () =>
     fileStatuses.filter((file) => file?.fileState === 'success').length;

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -602,7 +602,7 @@ describe('File Uploader', () => {
 
     render(<FileUploader {...commonProps} maxFiles={1} isPreviewerVisible />);
 
-    const errorText = await screen.findByText(/Over 1 file limit/);
+    const errorText = await screen.findByText(/Cannot choose more than 1/);
 
     expect(errorText).toBeVisible();
   });

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -602,7 +602,7 @@ describe('File Uploader', () => {
 
     render(<FileUploader {...commonProps} maxFiles={1} isPreviewerVisible />);
 
-    const errorText = await screen.findByText(/Over Max files/);
+    const errorText = await screen.findByText(/Over 1 file limit/);
 
     expect(errorText).toBeVisible();
   });

--- a/packages/react/src/components/Storage/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/types.ts
@@ -39,6 +39,7 @@ export interface PreviewerProps {
   isLoading: boolean;
   isSuccessful: boolean;
   hasMaxFilesError: boolean;
+  maxFiles: number;
   onClear: () => void;
   onFileClick: () => void;
 }


### PR DESCRIPTION
#### Description of changes
The maximum number of files error message was not clear. Added more explicit text.


Updated error text
<img width="632" alt="image" src="https://user-images.githubusercontent.com/65630/214635705-e04454a7-3fb7-4494-8c6d-d6dbcc3fc768.png">


#### Description of how you validated changes

Updated text for test that tests out message when user is over max file limit

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
