### PR TITLE
fix:(file-uploader): Swap Save and Cancel Button

### DIFF
--- a/.changeset/afraid-maps-speak.md
+++ b/.changeset/afraid-maps-speak.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+fix: Swapped save and cancel buttons.

--- a/packages/react/src/components/Storage/FileUploader/UploadTracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadTracker/index.tsx
@@ -79,21 +79,21 @@ export function UploadTracker({
           <>
             <Button
               size="small"
-              variation="primary"
-              onClick={() => {
-                onSaveEdit(tempName);
-              }}
-            >
-              Save
-            </Button>
-            <Button
-              size="small"
               onClick={() => {
                 setTempName(name);
                 onCancelEdit();
               }}
             >
               Cancel
+            </Button>
+            <Button
+              size="small"
+              variation="primary"
+              onClick={() => {
+                onSaveEdit(tempName);
+              }}
+            >
+              Save
             </Button>
           </>
         );

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -361,7 +361,7 @@ describe('File Uploader', () => {
     render(<FileUploader {...commonProps} isPreviewerVisible />);
 
     // click pencel icon
-    const button = screen.getAllByRole('button')[1];
+    const button = screen.getAllByRole('button')[0];
     fireEvent.click(button);
     // input file name box
     const input = screen.getByLabelText<HTMLInputElement>('file name');
@@ -391,7 +391,7 @@ describe('File Uploader', () => {
     render(<FileUploader {...commonProps} isPreviewerVisible />);
 
     // click pencel icon
-    const button = screen.getAllByRole('button')[1];
+    const button = screen.getAllByRole('button')[0];
     fireEvent.click(button);
     // input file name box
     const input = screen.getByLabelText('file name');


### PR DESCRIPTION
#### Description of changes

To adhere to best practices, we are swapping the placement of the save and cancel buttons when editing a file.

Before
<img width="275" alt="Screen Shot 2023-01-25 at 10 34 32 AM" src="https://user-images.githubusercontent.com/65630/214653901-715238ca-381f-49b4-bbde-8cee968fb023.png">

After
<img width="262" alt="Screen Shot 2023-01-25 at 10 37 33 AM" src="https://user-images.githubusercontent.com/65630/214653973-8fbb5ace-ed7c-4f04-a74f-b80f714bdd5f.png">

#### Description of how you validated changes
We have extensive tests that test edit and save.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
