### PR TITLE
fix:(file-uploader): Swap Upload and Clear all Buttons

### DIFF
--- a/.changeset/thirty-kangaroos-develop.md
+++ b/.changeset/thirty-kangaroos-develop.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+fix: Swap the upload button with the clear all button.

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/__snapshots__/UploadPreviewer.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/__snapshots__/UploadPreviewer.test.tsx.snap
@@ -22,15 +22,6 @@ exports[`UploadPreviewer renders as expected 1`] = `
         class="amplify-fileuploader__previewer__footer__actions"
       >
         <button
-          class="amplify-button amplify-field-group__control amplify-button--primary amplify-button--small"
-          data-fullwidth="false"
-          data-size="small"
-          data-variation="primary"
-          type="button"
-        >
-          Upload 1 file
-        </button>
-        <button
           class="amplify-button amplify-field-group__control amplify-button--link amplify-button--small"
           data-fullwidth="false"
           data-size="small"
@@ -38,6 +29,15 @@ exports[`UploadPreviewer renders as expected 1`] = `
           type="button"
         >
           Clear all
+        </button>
+        <button
+          class="amplify-button amplify-field-group__control amplify-button--primary amplify-button--small"
+          data-fullwidth="false"
+          data-size="small"
+          data-variation="primary"
+          type="button"
+        >
+          Upload 1 file
         </button>
       </div>
     </div>

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
@@ -78,6 +78,9 @@ export function UploadPreviewer({
         <View className={ComponentClassName.FileUploaderPreviewerFooterActions}>
           {!isLoading && !isSuccessful && (
             <>
+              <Button size="small" variation="link" onClick={onClear}>
+                {translate('Clear all')}
+              </Button>
               <Button
                 disabled={isDisabled}
                 size="small"
@@ -85,10 +88,6 @@ export function UploadPreviewer({
                 onClick={onFileClick}
               >
                 {`${translate('Upload')} ${remainingFilesText}`}
-              </Button>
-
-              <Button size="small" variation="link" onClick={onClear}>
-                {translate('Clear all')}
               </Button>
             </>
           )}


### PR DESCRIPTION
#### Description of changes

To adhere to best practices, we are swapping the placement of the upload and clear all buttons when uploading a file.

Before:
![image width="268"](https://user-images.githubusercontent.com/65630/214668678-33587f09-c142-4173-b865-391703deca62.png)


After:
<img width="268" alt="image" src="https://user-images.githubusercontent.com/65630/214668475-35cb8273-4190-4359-aea7-7a45768b6e26.png">


#### Description of how you validated changes
Test cases cover these buttons , regenerated snap shot

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
