### PR TITLE
chore(ui-react): Add update user hub event handling

### DIFF
--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -57,7 +57,8 @@ export const useAuth = (): UseAuthResult => {
 
         // failure events
         case 'tokenRefresh_failure':
-        case 'signIn_failure': {
+        case 'signIn_failure':
+        case 'updateUserAttributes_failure': {
           setResult({ error: payload.data as Error, isLoading: false });
           break;
         }
@@ -68,7 +69,8 @@ export const useAuth = (): UseAuthResult => {
         }
 
         // events that need another fetch
-        case 'tokenRefresh': {
+        case 'tokenRefresh':
+        case 'updateUserAttributes': {
           fetchCurrentUser();
           break;
         }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change adds update user event handling.

`useAuth` util is only used by AccountSettings at the moment. TODO: move all hub event handling to useAuth such that `useAuthenticator` is scoped down to just auth related responsibilities, and changes to `user` don't trigger child component re-mounts.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fixes #2495 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
