### PR TITLE
fix(fileUploader): Rename maxFiles to maxFilesCount

### DIFF
--- a/.changeset/stale-rabbits-pretend.md
+++ b/.changeset/stale-rabbits-pretend.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Renamed the maxFiles prop to maxFilesCount

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/FileUploaderThemeExample.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/FileUploaderThemeExample.tsx
@@ -28,7 +28,7 @@ export const FileUploaderThemeExample = () => {
         accessLevel="public"
         hasMultipleFiles={true}
         maxSize={100000000}
-        maxFiles={3}
+        maxFileCount={3}
         provider="fast" // IGNORE
       />
     </ThemeProvider>

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/MaxFilesExample.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/MaxFilesExample.tsx
@@ -3,7 +3,7 @@ import { FileUploader } from '@aws-amplify/ui-react';
 export const MaxFilesExample = () => {
   return (
     <FileUploader
-      maxFiles={3}
+      maxFileCount={3}
       variation="drop"
       acceptedFileTypes={['image/*']}
       accessLevel="public"

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/react.mdx
@@ -136,7 +136,7 @@ The following props set limits on what the File Uploader will accept.
 
 ### Max Number of Files
 
-The `maxFiles` prop accepts how many files at one time you can select to upload.  The default is unlimited.
+The `maxFileCount` prop accepts how many files at one time you can select to upload.  The default is unlimited.
 
 <Example>
   <MaxFilesExample />

--- a/examples/next/pages/ui/components/storage/file-uploader/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/file-uploader/index.page.tsx
@@ -16,7 +16,7 @@ export default function FileUploaderEmail() {
       accessLevel="public"
       hasMultipleFiles={true}
       maxSize={100000000}
-      maxFiles={3}
+      maxFileCount={3}
       isResumable={true}
     />
   );

--- a/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
@@ -24,7 +24,7 @@ export function FileUploader({
   acceptedFileTypes,
   shouldAutoProceed = false,
   isPreviewerVisible,
-  maxFiles,
+  maxFileCount,
   maxSize,
   hasMultipleFiles = true,
   onError,
@@ -76,7 +76,8 @@ export function FileUploader({
   // Displays if over max files
 
   const hasMaxFilesError =
-    fileStatuses.filter((file) => file.percentage !== 100).length > maxFiles;
+    fileStatuses.filter((file) => file.percentage !== 100).length >
+    maxFileCount;
 
   useEffect(() => {
     // Loading ends when all files are at 100%
@@ -379,7 +380,7 @@ export function FileUploader({
         isLoading={isLoading}
         isSuccessful={isSuccessful}
         hasMaxFilesError={hasMaxFilesError}
-        maxFiles={maxFiles}
+        maxFileCount={maxFileCount}
         onClear={onClear}
         onFileClick={onFileClick}
         aggregatePercentage={aggregatePercentage}

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/UploadPreviewer.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/UploadPreviewer.test.tsx
@@ -35,7 +35,7 @@ const commonProps = {
   isLoading: false,
   isSuccessful: false,
   hasMaxFilesError: false,
-  maxFiles: 10,
+  maxFileCount: 10,
   onClear: () => null,
   onFileClick: () => null,
 };

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/index.tsx
@@ -18,11 +18,13 @@ export function UploadPreviewer({
   isLoading,
   isSuccessful,
   hasMaxFilesError,
-  maxFiles,
+  maxFileCount,
   onClear,
   onFileClick,
 }: PreviewerProps): JSX.Element {
-  const headingMaxFiles = `${translate('Cannot choose more than')} ${maxFiles}`;
+  const headingMaxFiles = `${translate(
+    'Cannot choose more than'
+  )} ${maxFileCount}`;
   const getUploadedFilesLength = () =>
     fileStatuses.filter((file) => file?.fileState === 'success').length;
 

--- a/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/FileUploader.test.tsx
@@ -573,7 +573,9 @@ describe('File Uploader', () => {
       ...mockReturnUseFileUploader,
     });
 
-    render(<FileUploader {...commonProps} maxFiles={1} isPreviewerVisible />);
+    render(
+      <FileUploader {...commonProps} maxFileCount={1} isPreviewerVisible />
+    );
 
     const uploadFilesText = await screen.findByText(/Upload 1 file/);
 
@@ -600,7 +602,9 @@ describe('File Uploader', () => {
       ...mockReturnUseFileUploader,
     });
 
-    render(<FileUploader {...commonProps} maxFiles={1} isPreviewerVisible />);
+    render(
+      <FileUploader {...commonProps} maxFileCount={1} isPreviewerVisible />
+    );
 
     const errorText = await screen.findByText(/Cannot choose more than 1/);
 

--- a/packages/react/src/components/Storage/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/types.ts
@@ -17,7 +17,7 @@ export interface FileUploaderProps {
   isPreviewerVisible?: boolean;
   isResumable?: boolean;
   accessLevel: StorageAccessLevel;
-  maxFiles?: number;
+  maxFileCount?: number;
   maxSize?: number;
   onError?: (error: string) => void;
   onSuccess?: (event: { key: string }) => void;
@@ -39,7 +39,7 @@ export interface PreviewerProps {
   isLoading: boolean;
   isSuccessful: boolean;
   hasMaxFilesError: boolean;
-  maxFiles: number;
+  maxFileCount: number;
   onClear: () => void;
   onFileClick: () => void;
 }


### PR DESCRIPTION
#### Description of changes
Renamed the `maxFiles` prop to `maxFilesCount` as discussed [here](https://github.com/aws-amplify/amplify-ui/pull/3344#discussion_r1086899622)

#### Description of how you validated changes
updated tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
