### PR TITLE
fix(react): add missing size field classes to some form field components

### DIFF
--- a/.changeset/popular-news-perform.md
+++ b/.changeset/popular-news-perform.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(react): add missing size field classes to RadioGroupField, SelectField, TextAreaField and SliderField

--- a/packages/react/src/primitives/Autocomplete/__tests__/Autocomplete.test.tsx
+++ b/packages/react/src/primitives/Autocomplete/__tests__/Autocomplete.test.tsx
@@ -187,6 +187,35 @@ describe('Autocomplete:', () => {
     expect(textInput).toHaveAttribute('data-size', 'large');
   });
 
+  it('should render size classes for Autocomplete', async () => {
+    render(
+      <div>
+        <Autocomplete
+          label={label}
+          options={options}
+          size="small"
+          testId="small"
+        />
+        <Autocomplete
+          label={label}
+          options={options}
+          size="large"
+          testId="large"
+        />
+      </div>
+    );
+
+    const small = await screen.findByTestId('small');
+    const large = await screen.findByTestId('large');
+
+    expect(small.firstChild).toHaveClass(
+      `${ComponentClassNames['Field']}--small`
+    );
+    expect(large.firstChild).toHaveClass(
+      `${ComponentClassNames['Field']}--large`
+    );
+  });
+
   it('should be able to set a quiet variation', async () => {
     render(<Autocomplete label={label} options={options} variation="quiet" />);
 

--- a/packages/react/src/primitives/PasswordField/__tests__/PasswordField.test.tsx
+++ b/packages/react/src/primitives/PasswordField/__tests__/PasswordField.test.tsx
@@ -70,6 +70,21 @@ describe('PasswordField component', () => {
     expect(passwordField.dataset['size']).toBe('large');
   });
 
+  it('should render size classes for PasswordField', async () => {
+    render(
+      <div>
+        <PasswordField size="small" testId="small" label="small" />
+        <PasswordField size="large" testId="large" label="large" />
+      </div>
+    );
+
+    const small = await screen.findByTestId('small');
+    const large = await screen.findByTestId('large');
+
+    expect(small.classList).toContain(`${ComponentClassNames['Field']}--small`);
+    expect(large.classList).toContain(`${ComponentClassNames['Field']}--large`);
+  });
+
   it('should have show password button', async () => {
     render(
       <PasswordField

--- a/packages/react/src/primitives/PhoneNumberField/__tests__/PhoneNumberField.test.tsx
+++ b/packages/react/src/primitives/PhoneNumberField/__tests__/PhoneNumberField.test.tsx
@@ -133,6 +133,21 @@ describe('PhoneNumberField primitive', () => {
     expect(countryCodeSelector).toHaveAttribute('data-size', 'large');
   });
 
+  it('should render size classes for PhoneNumberField', async () => {
+    render(
+      <div>
+        <PhoneNumberField size="small" testId="small" label="small" />
+        <PhoneNumberField size="large" testId="large" label="large" />
+      </div>
+    );
+
+    const small = await screen.findByTestId('small');
+    const large = await screen.findByTestId('large');
+
+    expect(small.classList).toContain(`${ComponentClassNames['Field']}--small`);
+    expect(large.classList).toContain(`${ComponentClassNames['Field']}--large`);
+  });
+
   it('should be able to set a variation', async () => {
     const { countryCodeSelector, phoneInput } = await setup({
       variation: 'quiet',

--- a/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
+++ b/packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import { classNameModifier } from '../shared/utils';
 import { ComponentClassNames } from '../shared/constants';
 import { FieldErrorMessage, FieldDescription } from '../Field';
 import { Flex } from '../Flex';
@@ -74,6 +75,7 @@ const RadioGroupFieldPrimitive: Primitive<RadioGroupFieldProps, typeof Flex> = (
       as="fieldset"
       className={classNames(
         ComponentClassNames.Field,
+        classNameModifier(ComponentClassNames.Field, size),
         ComponentClassNames.RadioGroupField,
         className
       )}

--- a/packages/react/src/primitives/RadioGroupField/__tests__/RadioGroupField.test.tsx
+++ b/packages/react/src/primitives/RadioGroupField/__tests__/RadioGroupField.test.tsx
@@ -186,6 +186,25 @@ describe('RadioFieldGroup', () => {
       expect(radioButtons[2]).toHaveAttribute('data-size', 'large');
     });
 
+    it('should render size classes for RadioGroupField', async () => {
+      render(
+        <>
+          <RadioFieldGroup {...basicProps} size="small" testId="small" />
+          <RadioFieldGroup {...basicProps} size="large" testId="large" />
+        </>
+      );
+
+      const small = await screen.findByTestId('small');
+      const large = await screen.findByTestId('large');
+
+      expect(small.classList).toContain(
+        `${ComponentClassNames['Field']}--small`
+      );
+      expect(large.classList).toContain(
+        `${ComponentClassNames['Field']}--large`
+      );
+    });
+
     it('should be disabled if isDisabled is passed', async () => {
       render(RadioFieldGroup({ ...basicProps, isDisabled: true }));
 

--- a/packages/react/src/primitives/SearchField/__tests__/SearchField.test.tsx
+++ b/packages/react/src/primitives/SearchField/__tests__/SearchField.test.tsx
@@ -83,6 +83,21 @@ describe('SearchField component', () => {
     expect(searchField.dataset['size']).toBe('large');
   });
 
+  it('should render size classes for SearchField', async () => {
+    render(
+      <div>
+        <SearchField label={label} size="small" testId="small" />
+        <SearchField label={label} size="large" testId="large" />
+      </div>
+    );
+
+    const small = await screen.findByTestId('small');
+    const large = await screen.findByTestId('large');
+
+    expect(small.classList).toContain(`${ComponentClassNames['Field']}--small`);
+    expect(large.classList).toContain(`${ComponentClassNames['Field']}--large`);
+  });
+
   it('should be able to set a quiet variation', () => {
     render(<SearchField label={label} name="q" variation="quiet" />);
 

--- a/packages/react/src/primitives/SelectField/SelectField.tsx
+++ b/packages/react/src/primitives/SelectField/SelectField.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import { classNameModifier } from '../shared/utils';
 import { ComponentClassNames } from '../shared/constants';
 import { FieldErrorMessage, FieldDescription } from '../Field';
 import { Flex } from '../Flex';
@@ -66,6 +67,7 @@ const SelectFieldPrimitive: Primitive<SelectFieldProps, 'select'> = (
     <Flex
       className={classNames(
         ComponentClassNames.Field,
+        classNameModifier(ComponentClassNames.Field, size),
         ComponentClassNames.SelectField,
         className
       )}

--- a/packages/react/src/primitives/SelectField/__tests__/SelectField.test.tsx
+++ b/packages/react/src/primitives/SelectField/__tests__/SelectField.test.tsx
@@ -172,6 +172,29 @@ describe('SelectField', () => {
     expect(select).toHaveAttribute('data-variation', 'quiet');
   });
 
+  it('should render size classes for SelectField', async () => {
+    render(
+      <div>
+        <SelectField label={label} testId="small" size="small">
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+        </SelectField>
+        <SelectField label={label} testId="large" size="large">
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+        </SelectField>
+      </div>
+    );
+
+    const small = await screen.findByTestId('small');
+    const large = await screen.findByTestId('large');
+
+    expect(small.classList).toContain(`${ComponentClassNames['Field']}--small`);
+    expect(large.classList).toContain(`${ComponentClassNames['Field']}--large`);
+  });
+
   it('can set defaultValue', async () => {
     render(
       <SelectField label={label} defaultValue="1">

--- a/packages/react/src/primitives/SliderField/SliderField.tsx
+++ b/packages/react/src/primitives/SliderField/SliderField.tsx
@@ -112,6 +112,7 @@ const SliderFieldPrimitive: Primitive<SliderFieldProps, typeof Root> = (
       // Custom classnames will be added to Root below
       className={classNames(
         ComponentClassNames.Field,
+        classNameModifier(ComponentClassNames.Field, size),
         ComponentClassNames.SliderField
       )}
       testId={testId}

--- a/packages/react/src/primitives/SliderField/__tests__/SliderField.test.tsx
+++ b/packages/react/src/primitives/SliderField/__tests__/SliderField.test.tsx
@@ -174,6 +174,37 @@ describe('SliderField:', () => {
       expect(slider).toHaveAttribute('aria-valuenow', '0');
     });
 
+    it('should render size classes for SliderField', async () => {
+      render(
+        <div>
+          <SliderField
+            defaultValue={0}
+            size="small"
+            testId="small"
+            label="slider"
+            step={3}
+          />
+          <SliderField
+            defaultValue={0}
+            size="large"
+            testId="large"
+            label="slider"
+            step={3}
+          />
+        </div>
+      );
+
+      const small = await screen.findByTestId('small');
+      const large = await screen.findByTestId('large');
+
+      expect(small.classList).toContain(
+        `${ComponentClassNames['Field']}--small`
+      );
+      expect(large.classList).toContain(
+        `${ComponentClassNames['Field']}--large`
+      );
+    });
+
     describe('Root', () => {
       it('should render default and custom classname', async () => {
         const className = 'class-test';

--- a/packages/react/src/primitives/StepperField/__tests__/StepperField.test.tsx
+++ b/packages/react/src/primitives/StepperField/__tests__/StepperField.test.tsx
@@ -40,6 +40,25 @@ describe('StepperField:', () => {
       expect(stepperField).toHaveAttribute('data-size', 'small');
     });
 
+    it('should render size classes for StepperField', async () => {
+      render(
+        <div>
+          <StepperField label="stepper" testId="small" size="small" />
+          <StepperField label="stepper" testId="large" size="large" />
+        </div>
+      );
+
+      const small = await screen.findByTestId('small');
+      const large = await screen.findByTestId('large');
+
+      expect(small.classList).toContain(
+        `${ComponentClassNames['Field']}--small`
+      );
+      expect(large.classList).toContain(
+        `${ComponentClassNames['Field']}--large`
+      );
+    });
+
     it('should render all flex style props', async () => {
       render(
         <StepperField

--- a/packages/react/src/primitives/TextAreaField/TextAreaField.tsx
+++ b/packages/react/src/primitives/TextAreaField/TextAreaField.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import { classNameModifier } from '../shared/utils';
 import { ComponentClassNames } from '../shared/constants';
 import { FieldDescription, FieldErrorMessage } from '../Field';
 import { Flex } from '../Flex';
@@ -45,6 +46,7 @@ const TextAreaFieldPrimitive: Primitive<TextAreaFieldProps, 'textarea'> = (
     <Flex
       className={classNames(
         ComponentClassNames.Field,
+        classNameModifier(ComponentClassNames.Field, size),
         ComponentClassNames.TextAreaField,
         className
       )}

--- a/packages/react/src/primitives/TextAreaField/__tests__/TextAreaField.test.tsx
+++ b/packages/react/src/primitives/TextAreaField/__tests__/TextAreaField.test.tsx
@@ -131,6 +131,25 @@ describe('TextAreaField component', () => {
       expect(textArea).toHaveAttribute('data-variation', 'quiet');
     });
 
+    it('should render size classes for TextAreaField', async () => {
+      render(
+        <div>
+          <TextAreaField size="small" testId="small" label="small" />
+          <TextAreaField size="large" testId="large" label="large" />
+        </div>
+      );
+
+      const small = await screen.findByTestId('small');
+      const large = await screen.findByTestId('large');
+
+      expect(small.classList).toContain(
+        `${ComponentClassNames['Field']}--small`
+      );
+      expect(large.classList).toContain(
+        `${ComponentClassNames['Field']}--large`
+      );
+    });
+
     it('can set defaultValue', async () => {
       render(<TextAreaField label="Field" defaultValue="test" />);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds missing `amplify-field--${size}` class to some components that were missing it on their `.amplify-field` wrapper. This was causing those components to not get the proper flex gap and font size.  Updated tests across components for size class. 

**Affected components:**
- SelectField
- RadioGroupField
- TextAreaField
- SliderField

**Before**
Notice how labels/form controls for affected components do not line up across the text fields when placed in a row.
![localhost_3000_ (9)](https://user-images.githubusercontent.com/376920/216149651-26f94f3b-4c19-429c-be46-10e4ae2d51b2.png)

**After**
![fixed](https://user-images.githubusercontent.com/376920/216150173-ce9ab0e4-3f0e-47e9-a62f-9accf4cf3ace.jpg)


#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-ui/issues/3346

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
