### PR TITLE
docs(fix): update tabs demo to be uncontrolled

### DIFF
--- a/docs/src/pages/[platform]/components/tabs/TabsPropControls.tsx
+++ b/docs/src/pages/[platform]/components/tabs/TabsPropControls.tsx
@@ -2,9 +2,6 @@ import * as React from 'react';
 import { Flex, SelectField, TabsProps } from '@aws-amplify/ui-react';
 
 export interface TabsPropControlsProps extends TabsProps {
-  setCurrentIndex: (
-    value: React.SetStateAction<TabsProps['currentIndex']>
-  ) => void;
   setSpacing: (value: React.SetStateAction<TabsProps['spacing']>) => void;
   setJustifyContent: (
     value: React.SetStateAction<TabsProps['justifyContent']>
@@ -19,8 +16,6 @@ interface TabsPropControlsInterface {
 }
 
 export const TabsPropControls: TabsPropControlsInterface = ({
-  currentIndex,
-  setCurrentIndex,
   spacing,
   setSpacing,
   justifyContent,
@@ -30,19 +25,6 @@ export const TabsPropControls: TabsPropControlsInterface = ({
 }) => {
   return (
     <Flex direction="column">
-      <SelectField
-        name="currentIndex"
-        label="Current Index"
-        value={currentIndex.toString()}
-        onChange={(event) =>
-          setCurrentIndex(+event.target.value as TabsProps['currentIndex'])
-        }
-      >
-        <option value="0">0</option>
-        <option value="1">1</option>
-        <option value="2">2</option>
-      </SelectField>
-
       <SelectField
         label="Spacing"
         name="spacing"

--- a/docs/src/pages/[platform]/components/tabs/demo.tsx
+++ b/docs/src/pages/[platform]/components/tabs/demo.tsx
@@ -9,7 +9,6 @@ import { demoState } from '@/utils/demoState';
 const propsToCode = (props) => {
   return (
     `<Tabs` +
-    `\n  currentIndex="${props.currentIndex}"` +
     `${props.spacing ? `\n  spacing="${props.spacing}"` : ``}` +
     `\n  justifyContent="${props.justifyContent}"` +
     `${
@@ -44,7 +43,6 @@ const demoChildren = [
 ];
 
 const defaultTabsProps = {
-  currentIndex: 0,
   justifyContent: 'flex-start',
   children: demoChildren,
 };
@@ -60,8 +58,6 @@ export const TabsDemo = () => {
       propControls={<TabsPropControls {...tabsProps} />}
     >
       <Tabs
-        currentIndex={tabsProps.currentIndex}
-        onChange={(i) => tabsProps.setCurrentIndex(i)}
         spacing={tabsProps.spacing}
         justifyContent={tabsProps.justifyContent}
         indicatorPosition={tabsProps.indicatorPosition}

--- a/docs/src/pages/[platform]/components/tabs/useTabsProps.tsx
+++ b/docs/src/pages/[platform]/components/tabs/useTabsProps.tsx
@@ -9,9 +9,6 @@ interface UseTabsProps {
 }
 
 export const useTabsProps: UseTabsProps = (initialValues) => {
-  const [currentIndex, setCurrentIndex] = React.useState<
-    TabsProps['currentIndex']
-  >(initialValues.currentIndex);
   const [spacing, setSpacing] = React.useState<TabsProps['spacing']>(
     initialValues.spacing
   );
@@ -25,18 +22,15 @@ export const useTabsProps: UseTabsProps = (initialValues) => {
 
   React.useEffect(() => {
     demoState.set(Tabs.displayName, {
-      currentIndex,
       spacing,
       justifyContent,
       indicatorPosition,
       children,
     });
-  }, [currentIndex, spacing, justifyContent, indicatorPosition, children]);
+  }, [spacing, justifyContent, indicatorPosition, children]);
 
   return React.useMemo(
     () => ({
-      currentIndex,
-      setCurrentIndex,
       spacing,
       setSpacing,
       children,
@@ -46,8 +40,6 @@ export const useTabsProps: UseTabsProps = (initialValues) => {
       setIndicatorPosition,
     }),
     [
-      currentIndex,
-      setCurrentIndex,
       spacing,
       setSpacing,
       children,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Docs demo should not be controlled otherwise the copied code is not workable out of the box. This confused me either if I do not look into it carefully. Also, it does not make sense to have a select to update the current index because you can switch to a disabled tab via it 🥴 

#### Issue #, if available

![Kapture 2023-02-01 at 12 44 46](https://user-images.githubusercontent.com/40295569/216160084-4919b294-61de-4ff8-b516-f512ef025e8d.gif)

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
