### PR TITLE
chore(file-uploader): Move edit icon in between picture and text

### DIFF
--- a/.changeset/tame-dolphins-swim.md
+++ b/.changeset/tame-dolphins-swim.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Moved edit icon inbetween picture and text

--- a/.changeset/tame-dolphins-swim.md
+++ b/.changeset/tame-dolphins-swim.md
@@ -2,4 +2,4 @@
 '@aws-amplify/ui-react': patch
 ---
 
-Moved edit icon inbetween picture and text
+Moved edit icon in between file name and size.

--- a/packages/react/src/components/Storage/FileUploader/UploadTracker/__tests__/__snapshots__/UploadTracker.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/UploadTracker/__tests__/__snapshots__/UploadTracker.test.tsx.snap
@@ -16,20 +16,6 @@ exports[`UploadTracker exists 1`] = `
           class="amplify-image"
         />
       </div>
-      <div
-        class="amplify-fileuploader__file__main"
-      >
-        <p
-          class="amplify-text amplify-fileuploader__file__name"
-        >
-          hello.png
-        </p>
-      </div>
-      <span
-        class="amplify-text amplify-fileuploader__file__size"
-      >
-        5 B
-      </span>
       <button
         class="amplify-button amplify-field-group__control amplify-button--link amplify-button--small"
         data-fullwidth="false"
@@ -62,6 +48,20 @@ exports[`UploadTracker exists 1`] = `
           </svg>
         </span>
       </button>
+      <div
+        class="amplify-fileuploader__file__main"
+      >
+        <p
+          class="amplify-text amplify-fileuploader__file__name"
+        >
+          hello.png
+        </p>
+      </div>
+      <span
+        class="amplify-text amplify-fileuploader__file__size"
+      >
+        5 B
+      </span>
       <button
         class="amplify-button amplify-field-group__control amplify-button--small"
         data-fullwidth="false"

--- a/packages/react/src/components/Storage/FileUploader/UploadTracker/__tests__/__snapshots__/UploadTracker.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/UploadTracker/__tests__/__snapshots__/UploadTracker.test.tsx.snap
@@ -16,6 +16,15 @@ exports[`UploadTracker exists 1`] = `
           class="amplify-image"
         />
       </div>
+      <div
+        class="amplify-fileuploader__file__main"
+      >
+        <p
+          class="amplify-text amplify-fileuploader__file__name"
+        >
+          hello.png
+        </p>
+      </div>
       <button
         class="amplify-button amplify-field-group__control amplify-button--link amplify-button--small"
         data-fullwidth="false"
@@ -48,15 +57,6 @@ exports[`UploadTracker exists 1`] = `
           </svg>
         </span>
       </button>
-      <div
-        class="amplify-fileuploader__file__main"
-      >
-        <p
-          class="amplify-text amplify-fileuploader__file__name"
-        >
-          hello.png
-        </p>
-      </div>
       <span
         class="amplify-text amplify-fileuploader__file__size"
       >

--- a/packages/react/src/components/Storage/FileUploader/UploadTracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadTracker/index.tsx
@@ -64,12 +64,18 @@ export function UploadTracker({
             {name}
           </Text>
         </View>
+        {showEditButton ? (
+          <Button onClick={onStartEdit} size="small" variation="link">
+            <VisuallyHidden>Edit file name {file.name}</VisuallyHidden>
+            <IconEdit aria-hidden fontSize="medium" />
+          </Button>
+        ) : null}
         <Text as="span" className={ComponentClassNames.FileUploaderFileSize}>
           {humanFileSize(size, true)}
         </Text>
       </>
     ),
-    [name, size]
+    [file.name, name, onStartEdit, showEditButton, size]
   );
 
   const Actions = useCallback(() => {
@@ -143,12 +149,6 @@ export function UploadTracker({
           <View className={ComponentClassNames.FileUploaderFileImage}>
             {icon}
           </View>
-        ) : null}
-        {showEditButton ? (
-          <Button onClick={onStartEdit} size="small" variation="link">
-            <VisuallyHidden>Edit file name {file.name}</VisuallyHidden>
-            <IconEdit aria-hidden fontSize="medium" />
-          </Button>
         ) : null}
 
         {/* Main View */}

--- a/packages/react/src/components/Storage/FileUploader/UploadTracker/index.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadTracker/index.tsx
@@ -115,18 +115,10 @@ export function UploadTracker({
         return null;
       default:
         return (
-          <>
-            {showEditButton ? (
-              <Button onClick={onStartEdit} size="small" variation="link">
-                <VisuallyHidden>Edit file name {file.name}</VisuallyHidden>
-                <IconEdit aria-hidden fontSize="medium" />
-              </Button>
-            ) : null}
-            <Button size="small" onClick={onCancel}>
-              <VisuallyHidden>Remove file name {file.name}</VisuallyHidden>
-              <IconClose aria-hidden fontSize="medium" />
-            </Button>
-          </>
+          <Button size="small" onClick={onCancel}>
+            <VisuallyHidden>Remove file name {file.name}</VisuallyHidden>
+            <IconClose aria-hidden fontSize="medium" />
+          </Button>
         );
     }
   }, [
@@ -139,8 +131,6 @@ export function UploadTracker({
     onPause,
     onResume,
     onSaveEdit,
-    onStartEdit,
-    showEditButton,
     tempName,
   ]);
 
@@ -153,6 +143,12 @@ export function UploadTracker({
           <View className={ComponentClassNames.FileUploaderFileImage}>
             {icon}
           </View>
+        ) : null}
+        {showEditButton ? (
+          <Button onClick={onStartEdit} size="small" variation="link">
+            <VisuallyHidden>Edit file name {file.name}</VisuallyHidden>
+            <IconEdit aria-hidden fontSize="medium" />
+          </Button>
         ) : null}
 
         {/* Main View */}


### PR DESCRIPTION
#### Description of changes
Moved edit pencil icon

Before:
<img width="835" alt="image" src="https://user-images.githubusercontent.com/65630/217335834-dd364ff6-fc5a-4a6c-9dbd-f185d809c8b7.png">


After:

<img width="645" alt="image" src="https://user-images.githubusercontent.com/65630/217671617-c3ad6b83-fe93-4377-a023-76c6487c0f26.png">

#### Issue #, if available

Based on Asana and this [discussion](https://github.com/aws-amplify/amplify-ui/pull/3349#issuecomment-1404326011)

#### Description of how you validated changes
Updated snapshot

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
