### PR TITLE
chore: fix typo on field primitive docs

### DIFF
--- a/docs/src/pages/[platform]/components/phonenumberfield/react.mdx
+++ b/docs/src/pages/[platform]/components/phonenumberfield/react.mdx
@@ -146,7 +146,7 @@ To provide additional descriptive text of the field's requirements, use the `des
 
 ### States
 
-The available `PhoneNumberField` states include `isDisabled` and `isReadonly`. A disabled field will be not be focusable, mutable,
+The available `PhoneNumberField` states include `isDisabled` and `isReadOnly`. A disabled field will be not be focusable, mutable,
 or submitted with form data. A readonly field cannot be edited by the user.
 
 <Example>

--- a/docs/src/pages/[platform]/components/radiogroupfield/react.mdx
+++ b/docs/src/pages/[platform]/components/radiogroupfield/react.mdx
@@ -103,7 +103,7 @@ Use the `labelPosition` prop to control where the label is in relation to the Ra
 
 ### State
 
-The available RadioGroupField states include `isDisabled` and `isReadonly`. A disabled field will be not be focusable not mutable and will not be submitted with form data. A readonly field cannot be edited by the user, but will be submitted with form data.
+The available RadioGroupField states include `isDisabled` and `isReadOnly`. A disabled field will be not be focusable not mutable and will not be submitted with form data. A readonly field cannot be edited by the user, but will be submitted with form data.
 
 #### Disabled radios and radio group
 

--- a/docs/src/pages/[platform]/components/stepperfield/react.mdx
+++ b/docs/src/pages/[platform]/components/stepperfield/react.mdx
@@ -84,7 +84,7 @@ Use the `size` prop to change the StepperField size. Available options are `smal
 
 ### State
 
-The available StepperField states include `isDisabled` and `isReadonly`. A disabled field will not be focusable or mutable and will not be submitted with form data. A read-only field cannot be edited by the user.
+The available StepperField states include `isDisabled` and `isReadOnly`. A disabled field will not be focusable or mutable and will not be submitted with form data. A read-only field cannot be edited by the user.
 
 #### Disabled StepperField
 

--- a/docs/src/pages/[platform]/components/textareafield/react.mdx
+++ b/docs/src/pages/[platform]/components/textareafield/react.mdx
@@ -127,7 +127,7 @@ To provide additional descriptive text of requirements of the field, use the `de
 
 ### States
 
-The available `TextAreaField` states include `isDisabled` and `isReadonly`. A disabled field will be not be focusable not mutable and will not be submitted with form data. A readonly field cannot be edited by the user.
+The available `TextAreaField` states include `isDisabled` and `isReadOnly`. A disabled field will be not be focusable not mutable and will not be submitted with form data. A readonly field cannot be edited by the user.
 
 <Example>
   <TextAreaFieldStatesExample />

--- a/docs/src/pages/[platform]/components/textfield/react.mdx
+++ b/docs/src/pages/[platform]/components/textfield/react.mdx
@@ -148,7 +148,7 @@ To provide additional descriptive text of requirements of the field, use the `de
 
 ### States
 
-The available TextField states include `isDisabled` and `isReadonly`. A disabled field will be not be focusable not mutable and will not be submitted with form data. A readonly field cannot be edited by the user.
+The available TextField states include `isDisabled` and `isReadOnly`. A disabled field will be not be focusable not mutable and will not be submitted with form data. A readonly field cannot be edited by the user.
 
 <Example>
   <TextFieldStatesExample />


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fixes typo on all the field primitive docs that support the `isReadOnly` prop.

#### Description of how you validated changes
1. ran yarn docs dev
2. smoke tested each page

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/6165315/217368403-835bdf54-d954-4c6a-b79e-e2c5f4c459de.png">

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/6165315/217368471-a7aca4c2-2d9b-46fa-9059-0a78e8de7383.png">

<img width="1195" alt="image" src="https://user-images.githubusercontent.com/6165315/217368576-3d4bfb11-a8bd-4cf1-b11d-7e257e8a5c07.png">

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/6165315/217368689-53285f5a-400f-4283-b409-62791da471ad.png">

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/6165315/217368745-7ff9055d-8798-4394-a435-b1f9d229b619.png">


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
