### PR TITLE
chore: reorder angular authenticator docs

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/form-fields.angular.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/form-fields.angular.mdx
@@ -1,18 +1,3 @@
-_app.component.html_
-
-```html{1}
-<amplify-authenticator [formFields]="formFields">
-  <ng-template
-    amplifySlot="authenticated"
-    let-user="user"
-    let-signOut="signOut"
-  >
-    <h2>Welcome, {{ user.username }}!</h2>
-    <button (click)="signOut()">Sign Out</button>
-  </ng-template>
-</amplify-authenticator>
-```
-
 _app.component.ts_
 
 ```js
@@ -39,4 +24,19 @@ export class AppComponent {
     },
   };
 }
+```
+
+_app.component.html_
+
+```html{1}
+<amplify-authenticator [formFields]="formFields">
+  <ng-template
+    amplifySlot="authenticated"
+    let-user="user"
+    let-signOut="signOut"
+  >
+    <h2>Welcome, {{ user.username }}!</h2>
+    <button (click)="signOut()">Sign Out</button>
+  </ng-template>
+</amplify-authenticator>
 ```


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Reorder the Angular Authenticator setup steps because they confused me. 😅 Updated so that the TS formFields changes are done before trying to use formFields in the html template.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Validated that page renders in right order now:
<img width="1043" alt="CleanShot 2023-02-07 at 16 12 01@2x" src="https://user-images.githubusercontent.com/6165315/217680262-19226c81-675f-4274-b446-602a973265b2.png">


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
