### PR TITLE
fix(example/react-native): filter unused internal packages from metro package lookup

### DIFF
--- a/examples/react-native/metro.config.js
+++ b/examples/react-native/metro.config.js
@@ -8,6 +8,9 @@ const INTERNAL_DEPENDENCY_FLAG = '*';
 // only 'packages' for now, but can be extended for use with other directories
 const INTERNAL_DIRECTORY_ROOTS = ['packages'];
 
+// internal packages used by the RN example
+const INTERNAL_USED_PACKAGES = ['ui', 'react-core', 'react-native'];
+
 const EXAMPLE_APP_PACKAGE_JSON = require('./package.json');
 const EXAMPLE_APP_ROOT = __dirname;
 
@@ -24,6 +27,9 @@ const dependencies = {
   ...EXAMPLE_APP_PACKAGE_JSON.devDependencies,
 };
 
+const filterUnusedInternalPackages = ({ name }) =>
+  INTERNAL_USED_PACKAGES.includes(name);
+
 function getInternalPackages(root, internalPackagesDirectory) {
   return internalPackagesDirectory
     .map((packageDirectory) => {
@@ -31,12 +37,14 @@ function getInternalPackages(root, internalPackagesDirectory) {
 
       return readdirSync(internalDirectoryRoot, {
         withFileTypes: true,
-      }).map(({ name }) => {
-        const packagePath = path.resolve(internalDirectoryRoot, name);
-        const packageName = require(`${packagePath}/package.json`).name;
+      })
+        .filter(filterUnusedInternalPackages)
+        .map(({ name }) => {
+          const packagePath = path.resolve(internalDirectoryRoot, name);
+          const packageName = require(`${packagePath}/package.json`).name;
 
-        return { packageName, packagePath };
-      });
+          return { packageName, packagePath };
+        });
     })
     .flat();
 }


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Prevent metro bundler start up from breaking due to the lookup of `.DS_Store/package.json` by resolving only used internal packages

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
