### PR TITLE
fix(docs): broken internal links

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/configuration/index.page.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/configuration/index.page.mdx
@@ -24,7 +24,7 @@ export async function getStaticProps() {
 <DeveloperPreview />
 
 <Alert role="none" heading="Wait!">
-  Did you follow the [quick start instructions](/connected-components/authenticator#quick-start) to set up the Authenticator first?
+  Did you follow the [quick start instructions](../../connected-components/authenticator#quick-start) to set up the Authenticator first?
 </Alert>
 
 ## Initial State

--- a/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/headless/advanced/useAuthenticator.react.mdx
@@ -8,7 +8,7 @@ import { Alert, Tabs, TabItem } from '@aws-amplify/ui-react';
   >
   You must render the `Authenticator` UI component before using the `useAuthenticator` hook. This hook was designed to retrieve `Authenticator` UI specific state such as `route` and `user` and should not be used without the UI component.
   <br/>
-  For a full example of `useAuthenticator`, see the [protected routes guide](./react/guides/auth-protected)
+  For a full example of `useAuthenticator`, see the [protected routes guide](../../guides/auth-protected)
 </Alert>
 
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
* Fix link to protected guides on the Headless Usage react page.
![CleanShot 2023-02-17 at 10 10 39](https://user-images.githubusercontent.com/6165315/219719453-fb068876-2540-4221-8a53-e44a22dfc5dd.gif)

* Fix link to quick start page from Authenticator Configuration pages to stay on same framework

![CleanShot 2023-02-17 at 10 11 17](https://user-images.githubusercontent.com/6165315/219719444-dbc53668-1f6d-46aa-bde4-9a860614a074.gif)

#### Issue #, if available
Fixes: 
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
