### PR TITLE
fix(ci): set build-and-runtime workflow node version to 16

### DIFF
--- a/.github/workflows/build-and-runtime-test.yml
+++ b/.github/workflows/build-and-runtime-test.yml
@@ -41,6 +41,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - name: Setup Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       - name: Install canary package
         uses: ./.github/actions/install-with-retries
         with:

--- a/.github/workflows/build-and-runtime-test.yml
+++ b/.github/workflows/build-and-runtime-test.yml
@@ -3,12 +3,11 @@
 #
 # Triggered by: it runs every 15 minutes.
 
-name: POC / Build and Runtime Test
+name: Build and Runtime Test
 
 on:
-  pull_request
-  # schedule:
-  #   - cron: '*/15 * * * *' # Run every 15 minutes
+  schedule:
+    - cron: '*/15 * * * *' # Run every 15 minutes
 
 jobs:
   build:
@@ -120,34 +119,34 @@ jobs:
             canary/e2e/cypress/screenshots/**
           retention-days: 5
 
-  # log-failure-metric:
-  #   # Send a failure data point to metric BuildAndRuntimeTestFailure in github-workflows@ us-east-2, if it's a failure
-  #   runs-on: ubuntu-latest
-  #   environment: ci
-  #   needs: build
-  #   if: ${{ failure() }}
-  #   steps:
-  #     - name: Log failure data point to metric BuildAndRuntimeTestFailure
-  #       uses: aws-amplify/amplify-ui/.github/actions/log-metric@main
-  #       with:
-  #         metric-name: BuildAndRuntimeTestFailure
-  #         value: 1
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
-  #         AWS_REGION: us-east-2
+  log-failure-metric:
+    # Send a failure data point to metric BuildAndRuntimeTestFailure in github-workflows@ us-east-2, if it's a failure
+    runs-on: ubuntu-latest
+    environment: ci
+    needs: build
+    if: ${{ failure() }}
+    steps:
+      - name: Log failure data point to metric BuildAndRuntimeTestFailure
+        uses: aws-amplify/amplify-ui/.github/actions/log-metric@main
+        with:
+          metric-name: BuildAndRuntimeTestFailure
+          value: 1
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
+          AWS_REGION: us-east-2
 
-  # log-success-metric:
-  #   # Send a success data point to metric BuildAndRuntimeTestFailure in github-workflows@ us-east-2, if it's a success
-  #   runs-on: ubuntu-latest
-  #   environment: ci
-  #   needs: build
-  #   if: ${{ success() }}
-  #   steps:
-  #     - name: Log success data point to metric BuildAndRuntimeTestFailure
-  #       uses: aws-amplify/amplify-ui/.github/actions/log-metric@main
-  #       with:
-  #         metric-name: BuildAndRuntimeTestFailure
-  #         value: 0
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
-  #         AWS_REGION: us-east-2
+  log-success-metric:
+    # Send a success data point to metric BuildAndRuntimeTestFailure in github-workflows@ us-east-2, if it's a success
+    runs-on: ubuntu-latest
+    environment: ci
+    needs: build
+    if: ${{ success() }}
+    steps:
+      - name: Log success data point to metric BuildAndRuntimeTestFailure
+        uses: aws-amplify/amplify-ui/.github/actions/log-metric@main
+        with:
+          metric-name: BuildAndRuntimeTestFailure
+          value: 0
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
+          AWS_REGION: us-east-2

--- a/.github/workflows/poc-build-and-runtime-test.yml
+++ b/.github/workflows/poc-build-and-runtime-test.yml
@@ -3,11 +3,12 @@
 #
 # Triggered by: it runs every 15 minutes.
 
-name: Build and Runtime Test
+name: POC / Build and Runtime Test
 
 on:
-  schedule:
-    - cron: '*/15 * * * *' # Run every 15 minutes
+  pull_request
+  # schedule:
+  #   - cron: '*/15 * * * *' # Run every 15 minutes
 
 jobs:
   build:
@@ -119,34 +120,34 @@ jobs:
             canary/e2e/cypress/screenshots/**
           retention-days: 5
 
-  log-failure-metric:
-    # Send a failure data point to metric BuildAndRuntimeTestFailure in github-workflows@ us-east-2, if it's a failure
-    runs-on: ubuntu-latest
-    environment: ci
-    needs: build
-    if: ${{ failure() }}
-    steps:
-      - name: Log failure data point to metric BuildAndRuntimeTestFailure
-        uses: aws-amplify/amplify-ui/.github/actions/log-metric@main
-        with:
-          metric-name: BuildAndRuntimeTestFailure
-          value: 1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
-          AWS_REGION: us-east-2
+  # log-failure-metric:
+  #   # Send a failure data point to metric BuildAndRuntimeTestFailure in github-workflows@ us-east-2, if it's a failure
+  #   runs-on: ubuntu-latest
+  #   environment: ci
+  #   needs: build
+  #   if: ${{ failure() }}
+  #   steps:
+  #     - name: Log failure data point to metric BuildAndRuntimeTestFailure
+  #       uses: aws-amplify/amplify-ui/.github/actions/log-metric@main
+  #       with:
+  #         metric-name: BuildAndRuntimeTestFailure
+  #         value: 1
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
+  #         AWS_REGION: us-east-2
 
-  log-success-metric:
-    # Send a success data point to metric BuildAndRuntimeTestFailure in github-workflows@ us-east-2, if it's a success
-    runs-on: ubuntu-latest
-    environment: ci
-    needs: build
-    if: ${{ success() }}
-    steps:
-      - name: Log success data point to metric BuildAndRuntimeTestFailure
-        uses: aws-amplify/amplify-ui/.github/actions/log-metric@main
-        with:
-          metric-name: BuildAndRuntimeTestFailure
-          value: 0
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
-          AWS_REGION: us-east-2
+  # log-success-metric:
+  #   # Send a success data point to metric BuildAndRuntimeTestFailure in github-workflows@ us-east-2, if it's a success
+  #   runs-on: ubuntu-latest
+  #   environment: ci
+  #   needs: build
+  #   if: ${{ success() }}
+  #   steps:
+  #     - name: Log success data point to metric BuildAndRuntimeTestFailure
+  #       uses: aws-amplify/amplify-ui/.github/actions/log-metric@main
+  #       with:
+  #         metric-name: BuildAndRuntimeTestFailure
+  #         value: 0
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
+  #         AWS_REGION: us-east-2


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Set explicit usage of `node@v16` in the "Build and Runtime Tests" workflow to prevent issues with `node@v18` and the Vue CLI

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
https://github.com/aws-amplify/amplify-ui/actions/runs/4207700712
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
