### PR TITLE
Add Support for Custom S3 Key

### DIFF
--- a/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
@@ -33,6 +33,7 @@ export function FileUploader({
   accessLevel,
   variation = 'drop',
   isResumable = false,
+  s3Key,
   ...rest
 }: FileUploaderProps): JSX.Element {
   if (!acceptedFileTypes || !accessLevel) {
@@ -187,7 +188,7 @@ export function FileUploader({
       if (status?.fileState === FileState.SUCCESS) return;
       const uploadTask = uploadFile({
         file: status.file,
-        fileName: status.name,
+        fileName: s3Key ? s3Key(status) : status.name,
         level: accessLevel,
         isResumable,
         progressCallback: progressCallback(i),
@@ -213,6 +214,7 @@ export function FileUploader({
       }))
     );
   }, [
+    s3Key,
     fileStatuses,
     setFileStatuses,
     accessLevel,

--- a/packages/react/src/components/Storage/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/types.ts
@@ -24,6 +24,7 @@ export interface FileUploaderProps {
   shouldAutoProceed?: boolean;
   showImages?: boolean;
   variation?: 'drop' | 'button';
+  s3Key?: (file: FileStatus) => string;
 }
 
 export interface IconProps {


### PR DESCRIPTION
#### Description of changes
* Added an `s3Key` prop to the `FileUploader` to allow the "fileName" (which translates to the key used in S3) to be fully customized to the needs of the user. This could be used for use cases such as:
    1. Modifying the filename.
    2. Using a path for the file.

#### Issue #, if available

fixes #3135
fixes #3236

#### Description of how you validated changes
I'm honestly unsure of what your workflow is for testing. The change itself is pretty trivial. I tried testing in the Next.js example, but it just imports the current release version of the dependency.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.