### PR TITLE
refactor(ui-react-native): update default keyboardVerticalOffset handling of RNA DefaultContainer

### DIFF
--- a/.changeset/selfish-timers-deliver.md
+++ b/.changeset/selfish-timers-deliver.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-native": patch
+---
+
+refactor(ui-react-native): update default keyboardVerticalOffset handling of RNA DefaultContainer

--- a/packages/react-native/src/Authenticator/common/DefaultContainer/DefaultContainer.tsx
+++ b/packages/react-native/src/Authenticator/common/DefaultContainer/DefaultContainer.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import { KeyboardAvoidingView, ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { useDeviceOrientation } from '../../../hooks';
 import { useTheme } from '../../../theme';
 import { platform } from '../../../utils';
 
@@ -17,10 +16,6 @@ const BEHAVIOR = platform.IS_IOS ? 'padding' : 'height';
 // otherwise dismiss
 const KEYBOARD_SHOULD_PERSIST_TAPS = 'handled';
 
-// TEMPORARY: value to prevent initial `TextField` from being pushed too high
-// in default use case
-const KEYBOARD_VERTICAL_OFFSET = platform.IS_IOS ? -160 : -80;
-
 export default function DefaultContainer({
   alwaysBounceVertical = ALWAYS_BOUNCE_VERTICAL,
   behavior = BEHAVIOR,
@@ -33,13 +28,7 @@ export default function DefaultContainer({
   ...rest
 }: ContainerProps): JSX.Element | null {
   const theme = useTheme();
-  const { isPortraitMode } = useDeviceOrientation();
   const insets = useSafeAreaInsets();
-
-  const verticalOffset =
-    keyboardVerticalOffset ?? isPortraitMode
-      ? KEYBOARD_VERTICAL_OFFSET
-      : undefined;
 
   const themedStyle = useMemo(() => {
     const { bottom, left, right, top } = insets;
@@ -54,7 +43,7 @@ export default function DefaultContainer({
   return (
     <KeyboardAvoidingView
       behavior={behavior}
-      keyboardVerticalOffset={verticalOffset}
+      keyboardVerticalOffset={keyboardVerticalOffset}
       style={[themedStyle.keyboardAvoidingView, keyboardAvoidingViewStyle]}
     >
       <ScrollView


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Removes `keyboardVerticalOffset` logic passed to the `KeyboardAvoidingView` of the RNA `DefaultContainer` component to improve the end user DX input focus events
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Closes https://github.com/aws-amplify/amplify-ui/issues/3444
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested on iOS and Android
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
