### PR TITLE
fix: add pending-triage label on bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yaml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Create a report to help us improve Amplify UI
+labels: ["pending-triage"]
 
 body:
   - type: markdown


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add `pending-triage` label to bug template. This only handles case where customer uses our template, but at least gives us the tag until we get the more complete github action.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
