### PR TITLE
chore: move types to component folders

### DIFF
--- a/packages/react/src/components/Storage/FileUploader/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader/FileUploader.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
-import { UploadTask, Storage } from '@aws-amplify/storage';
-import { translate, uploadFile, isValidExtension } from '@aws-amplify/ui';
 import { Logger } from 'aws-amplify';
+import type { UploadTask } from '@aws-amplify/storage';
+import { Storage } from '@aws-amplify/storage';
+import { translate, uploadFile, isValidExtension } from '@aws-amplify/ui';
 
 import {
   Button as UploadButton,
@@ -13,10 +14,9 @@ import { useFileUploader } from '../hooks/useFileUploader';
 import { UploadPreviewer } from '../UploadPreviewer';
 import { UploadDropZone } from '../UploadDropZone';
 import { UploadTracker } from '../UploadTracker';
-import { FileState, FileUploaderProps } from '../types';
-
-const isUploadTask = (value: unknown): value is UploadTask =>
-  typeof (value as UploadTask)?.resume === 'function';
+import { FileState } from '../types';
+import { FileUploaderProps } from './types';
+import { isUploadTask } from './utils';
 
 const logger = new Logger('AmplifyUI:Storage');
 

--- a/packages/react/src/components/Storage/FileUploader/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader/types.ts
@@ -1,0 +1,16 @@
+import { StorageAccessLevel } from '@aws-amplify/storage';
+
+export interface FileUploaderProps {
+  acceptedFileTypes: string[];
+  hasMultipleFiles?: boolean;
+  isPreviewerVisible?: boolean;
+  isResumable?: boolean;
+  accessLevel: StorageAccessLevel;
+  maxFileCount?: number;
+  maxSize?: number;
+  onError?: (error: string) => void;
+  onSuccess?: (event: { key: string }) => void;
+  shouldAutoProceed?: boolean;
+  showImages?: boolean;
+  variation?: 'drop' | 'button';
+}

--- a/packages/react/src/components/Storage/FileUploader/FileUploader/utils.ts
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader/utils.ts
@@ -1,0 +1,4 @@
+import type { UploadTask } from '@aws-amplify/storage';
+
+export const isUploadTask = (value: unknown): value is UploadTask =>
+  typeof (value as UploadTask)?.resume === 'function';

--- a/packages/react/src/components/Storage/FileUploader/UploadDropZone/UploadDropZone.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadDropZone/UploadDropZone.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
-import { UploadDropZoneProps } from '../types';
+import { translate } from '@aws-amplify/ui';
+
 import { View, ComponentClassNames, Text } from '../../../../primitives';
 import { classNameModifier } from '../../../../primitives/shared/utils';
 import { IconUpload } from '../../../../primitives/Icon/internal';
-import { translate } from '@aws-amplify/ui';
+import { UploadDropZoneProps } from './types';
 
 export function UploadDropZone({
   children,

--- a/packages/react/src/components/Storage/FileUploader/UploadDropZone/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/UploadDropZone/types.ts
@@ -1,0 +1,6 @@
+import { DragActionHandlers } from '../hooks/useFileUploader/types';
+
+export interface UploadDropZoneProps extends DragActionHandlers {
+  children?: React.ReactNode;
+  inDropZone?: boolean;
+}

--- a/packages/react/src/components/Storage/FileUploader/UploadMessage/UploadMessage.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadMessage/UploadMessage.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { translate } from '@aws-amplify/ui';
+import classNames from 'classnames';
+
+import { classNameModifier } from '../../../../primitives/shared/utils';
 import { Text, ComponentClassNames } from '../../../../primitives';
 import { IconCheck, IconError } from '../../../../primitives/Icon/internal';
-import { FileState, FileStateProps } from '../types';
-import classNames from 'classnames';
-import { classNameModifier } from '../../../../primitives/shared/utils';
+import { FileState } from '../types';
+import { UploadMessageProps } from './types';
 
 export const UploadMessage = ({
   fileState,
   errorMessage,
   percentage,
-}: FileStateProps): JSX.Element => {
+}: UploadMessageProps): JSX.Element => {
   switch (fileState) {
     case FileState.LOADING: {
       const text =

--- a/packages/react/src/components/Storage/FileUploader/UploadMessage/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/UploadMessage/types.ts
@@ -1,0 +1,7 @@
+import { FileState } from '../types';
+
+export interface UploadMessageProps {
+  fileState: FileState;
+  errorMessage: string;
+  percentage?: number;
+}

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/UploadPreviewer.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/UploadPreviewer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentClassName, translate } from '@aws-amplify/ui';
-import { FileState, PreviewerProps } from '../types';
+
 import {
   Alert,
   Button,
@@ -9,6 +9,9 @@ import {
   Text,
   View,
 } from '../../../../primitives';
+
+import { FileState } from '../types';
+import { UploadPreviewerProps } from './types';
 
 export function UploadPreviewer({
   aggregatePercentage,
@@ -21,7 +24,7 @@ export function UploadPreviewer({
   maxFileCount,
   onClear,
   onFileClick,
-}: PreviewerProps): JSX.Element {
+}: UploadPreviewerProps): JSX.Element {
   const headingMaxFiles = `${translate(
     'Cannot choose more than'
   )} ${maxFileCount}`;

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/types.ts
@@ -1,0 +1,14 @@
+import { FileStatuses } from '../types';
+
+export interface UploadPreviewerProps {
+  aggregatePercentage: number;
+  children?: React.ReactNode;
+  dropZone: React.ReactNode;
+  fileStatuses: FileStatuses;
+  isLoading: boolean;
+  isSuccessful: boolean;
+  hasMaxFilesError: boolean;
+  maxFileCount: number;
+  onClear: () => void;
+  onFileClick: () => void;
+}

--- a/packages/react/src/components/Storage/FileUploader/UploadTracker/UploadTracker.tsx
+++ b/packages/react/src/components/Storage/FileUploader/UploadTracker/UploadTracker.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
-import { translate } from '@aws-amplify/ui';
-import { humanFileSize } from '@aws-amplify/ui';
-import { FileState, TrackerProps } from '../types';
+import { translate, humanFileSize } from '@aws-amplify/ui';
+
 import {
   View,
   Image,
@@ -17,7 +16,10 @@ import {
   IconEdit,
   IconFile,
 } from '../../../../primitives/Icon/internal';
+
+import { FileState } from '../types';
 import { UploadMessage } from '../UploadMessage';
+import { UploadTrackerProps } from './types';
 
 export function UploadTracker({
   errorMessage,
@@ -34,8 +36,8 @@ export function UploadTracker({
   percentage,
   isResumable,
   showImage,
-}: TrackerProps): JSX.Element {
-  const [tempName, setTempName] = React.useState(name);
+}: UploadTrackerProps): JSX.Element {
+  const [tempName, setTempName] = React.useState<string>(name);
   const inputRef = React.useRef<HTMLInputElement>(null);
   const url = URL.createObjectURL(file);
 

--- a/packages/react/src/components/Storage/FileUploader/UploadTracker/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/UploadTracker/types.ts
@@ -1,0 +1,18 @@
+import { FileState } from '../types';
+
+export interface UploadTrackerProps {
+  errorMessage: string;
+  file: File;
+  fileState: FileState;
+  hasImage: boolean;
+  name: string;
+  onCancel: () => void;
+  onCancelEdit?: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onSaveEdit: (value: string) => void;
+  onStartEdit: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  percentage: number;
+  isResumable?: boolean;
+  showImage: boolean;
+}

--- a/packages/react/src/components/Storage/FileUploader/hooks/useFileUploader/useFileUploader.ts
+++ b/packages/react/src/components/Storage/FileUploader/hooks/useFileUploader/useFileUploader.ts
@@ -1,5 +1,6 @@
-import { checkMaxSize, returnAcceptedFiles } from '@aws-amplify/ui';
 import React, { useState } from 'react';
+import { checkMaxSize, returnAcceptedFiles } from '@aws-amplify/ui';
+
 import { Files, FileState, FileStatuses } from '../../types';
 import { UseFileUploader } from './types';
 

--- a/packages/react/src/components/Storage/FileUploader/types.ts
+++ b/packages/react/src/components/Storage/FileUploader/types.ts
@@ -1,75 +1,12 @@
-import React from 'react';
-import { StorageAccessLevel, UploadTask } from '@aws-amplify/storage';
-import { DragActionHandlers } from './hooks/useFileUploader/types';
-import { ButtonProps } from '../../../primitives';
+import type { UploadTask } from '@aws-amplify/storage';
 
 export type SetShowPreviewer = (show: boolean) => void;
 export type Files = File[];
-
-export interface UploadDropZoneProps extends DragActionHandlers {
-  children?: React.ReactNode;
-  inDropZone?: boolean;
-}
-
-export interface FileUploaderProps {
-  acceptedFileTypes: string[];
-  hasMultipleFiles?: boolean;
-  isPreviewerVisible?: boolean;
-  isResumable?: boolean;
-  accessLevel: StorageAccessLevel;
-  maxFileCount?: number;
-  maxSize?: number;
-  onError?: (error: string) => void;
-  onSuccess?: (event: { key: string }) => void;
-  shouldAutoProceed?: boolean;
-  showImages?: boolean;
-  variation?: 'drop' | 'button';
-}
 
 export interface IconProps {
   className?: string;
   fontSize?: string;
 }
-
-export interface PreviewerProps {
-  aggregatePercentage: number;
-  children?: React.ReactNode;
-  dropZone: React.ReactNode;
-  fileStatuses: FileStatuses;
-  isLoading: boolean;
-  isSuccessful: boolean;
-  hasMaxFilesError: boolean;
-  maxFileCount: number;
-  onClear: () => void;
-  onFileClick: () => void;
-}
-
-export interface TrackerProps {
-  errorMessage: string;
-  file: File;
-  fileState: FileState;
-  hasImage: boolean;
-  name: string;
-  onCancel: () => void;
-  onCancelEdit?: () => void;
-  onPause: () => void;
-  onResume: () => void;
-  onSaveEdit: (value: string) => void;
-  onStartEdit: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-  percentage: number;
-  isResumable?: boolean;
-  showImage: boolean;
-}
-
-export interface FileStatus extends Partial<FileStateProps> {
-  percentage?: number;
-  uploadTask?: UploadTask;
-  fileErrors?: string;
-  name?: string;
-  file?: File;
-}
-
-export type FileStatuses = FileStatus[];
 
 export enum FileState {
   PAUSED = 'paused',
@@ -87,25 +24,12 @@ export interface FileStateProps {
   percentage?: number;
 }
 
-type UploadButtonComponent<Props = {}> = React.ComponentType<
-  Props & Partial<ButtonProps>
->;
-
-type UploadDropZoneComponent<Props = {}> = React.ComponentType<
-  Props & Partial<UploadDropZoneProps>
->;
-
-type PreviewerComponent<Props = {}> = React.ComponentType<
-  Props & Partial<PreviewerProps>
->;
-
-type TrackerComponent<Props = {}> = React.ComponentType<
-  Props & Partial<TrackerProps>
->;
-
-export interface Components {
-  UploadDropZone?: UploadDropZoneComponent;
-  UploadButton?: UploadButtonComponent;
-  UploadPreviewer?: PreviewerComponent;
-  UploadTracker?: TrackerComponent;
+export interface FileStatus extends Partial<FileStateProps> {
+  percentage?: number;
+  uploadTask?: UploadTask;
+  fileErrors?: string;
+  name?: string;
+  file?: File;
 }
+
+export type FileStatuses = FileStatus[];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Small refactor, moving types to comonent folders and reording import statements

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
