### PR TITLE
fix(docs): fix invalidfileuploader code sample

### DIFF
--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/LevelExample.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/LevelExample.tsx
@@ -5,7 +5,7 @@ export const LevelExample = () => {
     <FileUploader
       variation="drop"
       acceptedFileTypes={['image/*']}
-      level="private"
+      accessLevel="private"
       provider="fast" // IGNORE
     />
   );

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/react.mdx
@@ -27,7 +27,7 @@ The File Uploader component allows your customers to seamlessly upload files to 
 </Alert>
 
 
-To use the File Uploader component import it into your React application with the included styles. At a minimum you must include the `level` and the `acceptedFileTypes` prop.
+To use the File Uploader component import it into your React application with the included styles. At a minimum you must include the `accessLevel` and the `acceptedFileTypes` prop.
 
 <Example>
   <DefaultFileUploaderExample />
@@ -46,7 +46,7 @@ import '@aws-amplify/ui-react/styles.css'
 The props listed below must be added to the File Uploader component.
 
 ### File Level Access
-The `level` prop accepts a string of type `public`, `private`, or `protected`. This will affect what level of [access](https://docs.amplify.aws/lib/storage/configureaccess/q/platform/js/) the files uploaded will have inside S3. This is a *required* prop and must be added to the File Uploader.
+The `accessLevel` prop accepts a string of type `public`, `private`, or `protected`. This will affect what level of [access](https://docs.amplify.aws/lib/storage/configureaccess/q/platform/js/) the files uploaded will have inside S3. This is a *required* prop and must be added to the File Uploader.
 
 <Example>
   <LevelExample />
@@ -58,7 +58,7 @@ The `level` prop accepts a string of type `public`, `private`, or `protected`. T
 </Example>
 
 <Alert role="none" variation="info" heading="Private and Protected Acccess">
-  If the `level` prop is set to `private` or `protected` the user must be authenticated. Otherwise an error will occur, and the upload will fail!
+  If the `accessLevel` prop is set to `private` or `protected` the user must be authenticated. Otherwise an error will occur, and the upload will fail!
 </Alert>
 
 ### Accepted File Types


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fixes issue where the first sample code in FileUploader docs will break for customers because it doesn't include the required `accessLevel` prop. It currently uses the `level` prop, which was renamed to `accessLevel`, which means if customers copy the existing code sample it will not work, leading to a broken customer experience.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Before fix (current UI Docs site: https://ui.docs.amplify.aws/react/connected-components/storage/fileuploader#file-level-access)
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/6165315/220988311-abfa5aa3-ad3b-409a-a436-fc25283df9be.png">

TS error as shown in LevelExample demo file:
<img width="1545" alt="image" src="https://user-images.githubusercontent.com/6165315/220988907-1cb7460f-29d8-49d6-9a87-d5d00e0e0478.png">


After fix:
<img width="1240" alt="image" src="https://user-images.githubusercontent.com/6165315/220988378-397ebffa-6314-4980-b22e-43ef84cefc9a.png">


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
