### PR TITLE
fix(ui): make theme design tokens optional

### DIFF
--- a/.changeset/brown-mails-pull.md
+++ b/.changeset/brown-mails-pull.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(ui): make theme design tokens optional for checkbox and autocomplete

--- a/packages/ui/src/theme/tokens/components/autocomplete.ts
+++ b/packages/ui/src/theme/tokens/components/autocomplete.ts
@@ -11,11 +11,11 @@ export type AutocompleteTokens<OutputType extends OutputVariantKey> = {
     | 'width',
     OutputType
   > & {
-    options: DesignTokenProperties<
+    options?: DesignTokenProperties<
       'display' | 'flexDirection' | 'maxHeight',
       OutputType
     >;
-    option: DesignTokenProperties<
+    option?: DesignTokenProperties<
       | 'backgroundColor'
       | 'color'
       | 'cursor'
@@ -24,14 +24,14 @@ export type AutocompleteTokens<OutputType extends OutputVariantKey> = {
       | 'transitionTimingFunction',
       OutputType
     > & {
-      _active: DesignTokenProperties<'backgroundColor' | 'color', OutputType>;
+      _active?: DesignTokenProperties<'backgroundColor' | 'color', OutputType>;
     };
-    _empty: DesignTokenProperties<'display', OutputType>;
-    _loading: DesignTokenProperties<
+    _empty?: DesignTokenProperties<'display', OutputType>;
+    _loading?: DesignTokenProperties<
       'alignItems' | 'display' | 'gap',
       OutputType
     >;
-    spaceShared: DesignTokenProperties<
+    spaceShared?: DesignTokenProperties<
       'paddingBlock' | 'paddingInline',
       OutputType
     >;

--- a/packages/ui/src/theme/tokens/components/checkbox.ts
+++ b/packages/ui/src/theme/tokens/components/checkbox.ts
@@ -24,11 +24,11 @@ type ButtonToken<Output> = DesignTokenProperties<
   'position' | 'alignItems' | 'justifyContent' | 'color',
   Output
 > & {
-  before: BeforeToken<Output>;
-  _focus: ButtonFocusToken<Output>;
-  _disabled: DesignTokenProperties<'borderColor', Output>;
-  _error: DesignTokenProperties<'borderColor', Output> & {
-    _focus: DesignTokenProperties<'borderColor' | 'boxShadow', Output>;
+  before?: BeforeToken<Output>;
+  _focus?: ButtonFocusToken<Output>;
+  _disabled?: DesignTokenProperties<'borderColor', Output>;
+  _error?: DesignTokenProperties<'borderColor', Output> & {
+    _focus?: DesignTokenProperties<'borderColor' | 'boxShadow', Output>;
   };
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Make theme design tokens optional for AutoComplete and Checkbox primitives. This was causing an issue where customers couldn't provide partial overrides to the theme without getting a TS error. See:
https://github.com/aws-amplify/amplify-ui/pull/3468/files#r1116349656

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Opened the theme examples and checked that TS errors were gone.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [z] PR description included
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
