### PR TITLE
fix(ui): use lodash imports directly 

### DIFF
--- a/.changeset/good-cooks-crash.md
+++ b/.changeset/good-cooks-crash.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+fix(ui): use lodash imports directly 

--- a/packages/react/src/components/AccountSettings/ChangePassword/ChangePassword.tsx
+++ b/packages/react/src/components/AccountSettings/ChangePassword/ChangePassword.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import isEqual from 'lodash/isEqual.js';
 
 import { Logger } from 'aws-amplify';
 import {
@@ -8,7 +9,6 @@ import {
   getDefaultPasswordValidators,
   runFieldValidators,
   translate,
-  isEqual,
 } from '@aws-amplify/ui';
 
 import { useAuth } from '../../../internal';

--- a/packages/react/src/primitives/Collection/Collection.tsx
+++ b/packages/react/src/primitives/Collection/Collection.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
-
-import { debounce } from '@aws-amplify/ui';
+import debounce from 'lodash/debounce.js';
 
 import { Flex } from '../Flex';
 import { Grid } from '../Grid';

--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -1,4 +1,5 @@
 import { Auth } from 'aws-amplify';
+import get from 'lodash/get.js';
 import { createMachine, sendUpdate } from 'xstate';
 
 import {
@@ -34,7 +35,7 @@ import {
   setUsernameAuthAttributes,
 } from '../actions';
 import { defaultServices } from '../defaultServices';
-import { get, isEmpty } from '../../../utils';
+import { isEmpty } from '../../../utils';
 
 export type SignInMachineOptions = {
   services?: Partial<typeof defaultServices>;

--- a/packages/ui/src/machines/authenticator/signUp.ts
+++ b/packages/ui/src/machines/authenticator/signUp.ts
@@ -1,4 +1,6 @@
 import { Auth } from 'aws-amplify';
+import get from 'lodash/get.js';
+import pickBy from 'lodash/pickBy.js';
 import { assign, createMachine, sendUpdate } from 'xstate';
 
 import { AuthEvent, SignUpContext } from '../../types';
@@ -19,7 +21,6 @@ import {
   handleSubmit,
 } from './actions';
 import { defaultServices } from './defaultServices';
-import { get, pickBy } from '../../utils';
 
 export type SignUpMachineOptions = {
   services?: Partial<typeof defaultServices>;

--- a/packages/ui/src/theme/utils.ts
+++ b/packages/ui/src/theme/utils.ts
@@ -1,7 +1,8 @@
+import kebabCase from 'lodash/kebabCase.js';
 // internal style dictionary function
 import usesReference from 'style-dictionary/lib/utils/references/usesReference.js';
 
-import { isObject, isString, has, kebabCase } from '../utils';
+import { isObject, isString, has } from '../utils';
 import { ShadowValue, WebDesignToken } from './tokens/types/designToken';
 
 type ShadowPropertyKey = keyof Exclude<ShadowValue, string>;

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,16 +1,4 @@
 /**
- * We re-export any lodash imports to avoid appending .js extension across codebase
- * The ultimate goal is have replacement implementation to remove the entire dependency
- */
-export { default as isEqual } from 'lodash/isEqual.js';
-export { default as debounce } from 'lodash/debounce.js';
-export { default as includes } from 'lodash/includes.js';
-export { default as get } from 'lodash/get.js';
-export { default as pickBy } from 'lodash/pickBy.js';
-export { default as kebabCase } from 'lodash/kebabCase.js';
-export { default as merge } from 'lodash/merge.js';
-
-/**
  * Some libraries may not follow Node ES module spec and could be loaded as CommonJS modules,
  * To ensure the interoperability between ESM and CJS, modules from those libraries have to be loaded via namespace import
  * And sanitized by the function below because unlike ESM namespace, CJS namespace set `module.exports` object on the `default` key

--- a/packages/ui/src/validators/index.ts
+++ b/packages/ui/src/validators/index.ts
@@ -1,4 +1,4 @@
-import merge from 'lodash/merge';
+import merge from 'lodash/merge.js';
 
 import { AuthFormData, PasswordSettings, Validator } from '../types';
 import { isEmpty } from '../utils';

--- a/packages/ui/src/validators/index.ts
+++ b/packages/ui/src/validators/index.ts
@@ -1,5 +1,7 @@
+import merge from 'lodash/merge';
+
 import { AuthFormData, PasswordSettings, Validator } from '../types';
-import { isEmpty, merge } from '../utils';
+import { isEmpty } from '../utils';
 
 // Runs all validators given. Resolves if there are no error. Rejects otherwise.
 export const runValidators = async (


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This PR is a follow up fix to https://github.com/aws-amplify/amplify-ui/pull/3373. This PR broke TS Strict, and was creating TS errors at build time like so:

`yarn build` against ec881c6a8aab507636816e3b3560fcabb87f59c8 (against [tagged release](https://github.com/aws-amplify/amplify-ui/actions/runs/4068624270/jobs/7007902895#step:10:22)):

```
# ...

Error: node_modules/@aws-amplify/ui/dist/types/utils/index.d.ts:7:37 - error TS7016: Could not find a declaration file for module 'lodash/debounce.js'. '/Users/willeea/Documents/spark/angular-15/amplify-app/node_modules/lodash/debounce.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/lodash` if it exists or add a new declaration (.d.ts) file containing `declare module 'lodash/debounce.js';`

7 export { default as debounce } from 'lodash/debounce.js';
                                      ~~~~~~~~~~~~~~~~~~~~

# ... and same error for other lodash imports...
```

Commits before this did not have this issue.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
Manually through `npm pack` for Angular 15 App.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
