### PR TITLE
fix(react): close icon alignment and size SearchField and Autocomplete

### DIFF
--- a/packages/react/src/primitives/Field/FieldClearButton.tsx
+++ b/packages/react/src/primitives/Field/FieldClearButton.tsx
@@ -11,8 +11,8 @@ const FieldClearButtonPrimitive: Primitive<FieldClearButtonProps, 'button'> = (
   { ariaLabel = ariaLabelText, size, ...rest },
   ref
 ) => (
-  <FieldGroupIconButton ariaLabel={ariaLabel} ref={ref} {...rest}>
-    <IconClose size={size} />
+  <FieldGroupIconButton ariaLabel={ariaLabel} size={size} ref={ref} {...rest}>
+    <IconClose />
   </FieldGroupIconButton>
 );
 

--- a/packages/react/src/primitives/Icon/icons/IconClose.tsx
+++ b/packages/react/src/primitives/Icon/icons/IconClose.tsx
@@ -9,13 +9,13 @@ import { InternalIcon } from './types';
  * @internal For internal Amplify UI use only. May be removed in a future release.
  */
 export const IconClose: InternalIcon = (props) => {
-  const { className, ...rest } = props;
+  const { className, size, ...rest } = props;
 
   return (
     <View
       as="span"
-      width="1em"
-      height="1em"
+      width={size || '1em'}
+      height={size || '1em'}
       className={classNames(ComponentClassNames.Icon, className)}
       {...rest}
     >
@@ -25,6 +25,7 @@ export const IconClose: InternalIcon = (props) => {
         viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
+        style={size ? { width: size, height: size } : undefined}
       >
         <path
           d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z"

--- a/packages/react/src/primitives/Icon/icons/IconClose.tsx
+++ b/packages/react/src/primitives/Icon/icons/IconClose.tsx
@@ -9,13 +9,13 @@ import { InternalIcon } from './types';
  * @internal For internal Amplify UI use only. May be removed in a future release.
  */
 export const IconClose: InternalIcon = (props) => {
-  const { className, size, ...rest } = props;
+  const { className, ...rest } = props;
 
   return (
     <View
       as="span"
-      width={size || '1em'}
-      height={size || '1em'}
+      width="1em"
+      height="1em"
       className={classNames(ComponentClassNames.Icon, className)}
       {...rest}
     >
@@ -25,7 +25,6 @@ export const IconClose: InternalIcon = (props) => {
         viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        style={size ? { width: size, height: size } : undefined}
       >
         <path
           d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z"

--- a/packages/react/src/primitives/SearchField/SearchFieldButton.tsx
+++ b/packages/react/src/primitives/SearchField/SearchFieldButton.tsx
@@ -13,11 +13,12 @@ const SearchFieldButtonPrimitive: Primitive<SearchFieldButtonProps, 'button'> =
       <FieldGroupIconButton
         ariaLabel={ariaLabelText}
         className={ComponentClassNames.SearchFieldSearch}
+        size={size}
         ref={ref}
         type="submit"
         {...props}
       >
-        <IconSearch size={size} />
+        <IconSearch />
       </FieldGroupIconButton>
     );
   };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Aligns the close icon correctly in SearchField and Autocomplete. The size of the icons (IconClose, IconSearch) adapt to the size of the fields: small, default, large. 

**Before:** 
<img width="561" alt="old-field-icons" src="https://user-images.githubusercontent.com/6218025/221543415-eff3f433-fb2e-406c-ac01-601d192680a8.png">

**After:**

<img width="560" alt="new-fields-icons" src="https://user-images.githubusercontent.com/6218025/221543669-95bb4d25-5cec-40d5-9df5-f555efb2ff29.png">



**Affected components:**
- SearchField
- Autocomplete
- IconClose (internal)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#3465 

@calebpollman  This is my first contribution to this project. If I have I have missed something, let me know what I can improve.
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
