### PR TITLE
chore(ui): migrate isFunction util to ui package

### DIFF
--- a/.changeset/nasty-lies-hunt.md
+++ b/.changeset/nasty-lies-hunt.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+chore(ui): migrate isFunction util to ui package

--- a/packages/react/src/components/Authenticator/Authenticator.tsx
+++ b/packages/react/src/components/Authenticator/Authenticator.tsx
@@ -3,6 +3,7 @@ import {
   AuthenticatorMachineOptions,
   AmplifyUser,
   configureComponent,
+  isFunction,
 } from '@aws-amplify/ui';
 
 import {
@@ -79,7 +80,7 @@ export function AuthenticatorInternal({
 
     return (
       <>
-        {typeof children === 'function'
+        {isFunction(children)
           ? children({ signOut, user }) // children is a render prop
           : children}
       </>

--- a/packages/react/src/helpers/constants.ts
+++ b/packages/react/src/helpers/constants.ts
@@ -1,5 +1,6 @@
+import { isFunction } from '@aws-amplify/ui';
 export const AMPLIFY_SYMBOL = (
-  typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
+  typeof Symbol !== 'undefined' && isFunction(Symbol.for)
     ? Symbol.for('amplify_default')
     : '@@amplify_default'
 ) as Symbol;

--- a/packages/react/src/hooks/useComposeRefsCallback.tsx
+++ b/packages/react/src/hooks/useComposeRefsCallback.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { isFunction } from '@aws-amplify/ui';
 
 export interface UseComposeRefsCallbackProps<RefType> {
   externalRef?: React.ForwardedRef<RefType>;
@@ -17,7 +18,7 @@ export function useComposeRefsCallback<RefType>({
   return React.useCallback(
     (node) => {
       // Handle callback ref
-      if (typeof externalRef === 'function') {
+      if (isFunction(externalRef)) {
         externalRef(node);
       } else if (externalRef) {
         externalRef.current = node;

--- a/packages/react/src/primitives/Alert/Alert.tsx
+++ b/packages/react/src/primitives/Alert/Alert.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import { isFunction } from '@aws-amplify/ui';
 
 import { ComponentClassNames, ComponentText } from '../shared/constants';
 import { classNameModifier } from '../shared/utils';
@@ -9,7 +10,6 @@ import { Flex } from '../Flex';
 import { Button } from '../Button';
 import { AlertIcon } from './AlertIcon';
 import { IconClose } from '../Icon/internal';
-import { isFunction } from '../shared/utils';
 
 const AlertPrimitive: Primitive<AlertProps, typeof Flex> = (
   {

--- a/packages/react/src/primitives/Autocomplete/Autocomplete.tsx
+++ b/packages/react/src/primitives/Autocomplete/Autocomplete.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
+import { isFunction } from '@aws-amplify/ui';
 
 import { AutocompleteOption } from './AutocompleteOption';
 import { AutocompleteMenu } from './AutocompleteMenu';
@@ -7,7 +8,6 @@ import { useAutocomplete } from './useAutocomplete';
 import { HighlightMatch } from '../HighlightMatch/HighlightMatch';
 import { SearchField } from '../SearchField';
 import { View } from '../View';
-import { isFunction } from '../shared/utils';
 import { ComponentClassNames } from '../shared/constants';
 import type {
   AutocompleteComboboxProps,

--- a/packages/react/src/primitives/Autocomplete/useAutocomplete.tsx
+++ b/packages/react/src/primitives/Autocomplete/useAutocomplete.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { isFunction } from '@aws-amplify/ui';
 
 import {
   ARROW_DOWN,
@@ -6,7 +7,7 @@ import {
   ENTER_KEY,
   ESCAPE_KEY,
 } from '../shared/constants';
-import { isFunction, strHasLength } from '../shared/utils';
+import { strHasLength } from '../shared/utils';
 import { useStableId } from '../utils/useStableId';
 import type {
   ComboBoxOption,

--- a/packages/react/src/primitives/Checkbox/useCheckbox.ts
+++ b/packages/react/src/primitives/Checkbox/useCheckbox.ts
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, useState } from 'react';
+import { isFunction } from '@aws-amplify/ui';
 
-import { isFunction } from '../shared/utils';
 import { UseCheckbox } from '../types/checkbox';
 
 export const useCheckbox = (

--- a/packages/react/src/primitives/SearchField/useSearchField.tsx
+++ b/packages/react/src/primitives/SearchField/useSearchField.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
+import { isFunction } from '@aws-amplify/ui';
 
 import { ESCAPE_KEY, ENTER_KEY } from '../shared/constants';
-import { isFunction } from '../shared/utils';
 import { UseSearchFieldProps } from '../types';
 import { useComposeRefsCallback } from '../../hooks/useComposeRefsCallback';
 

--- a/packages/react/src/primitives/SliderField/SliderField.tsx
+++ b/packages/react/src/primitives/SliderField/SliderField.tsx
@@ -2,14 +2,13 @@ import classNames from 'classnames';
 import * as RadixSlider from '@radix-ui/react-slider';
 import * as React from 'react';
 
-import { sanitizeNamespaceImport } from '@aws-amplify/ui';
+import { isFunction, sanitizeNamespaceImport } from '@aws-amplify/ui';
 
 import { classNameModifier } from '../shared/utils';
 import { ComponentClassNames } from '../shared/constants';
 import { FieldDescription, FieldErrorMessage } from '../Field';
 import { FieldGroup } from '../FieldGroup';
 import { Flex } from '../Flex';
-import { isFunction } from '../shared/utils';
 import { Label } from '../Label';
 import { Primitive } from '../types/view';
 import { SliderFieldProps } from '../types/sliderField';

--- a/packages/react/src/primitives/StepperField/useStepper.ts
+++ b/packages/react/src/primitives/StepperField/useStepper.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
+import { isFunction } from '@aws-amplify/ui';
 
 import { StepperFieldProps } from '../types/stepperField';
-import { isFunction } from '../shared/utils';
 
 type ChangeHandler = React.ChangeEventHandler<HTMLInputElement>;
 type ClickHandler = React.MouseEventHandler<HTMLButtonElement>;
@@ -95,7 +95,7 @@ export const useStepper = ({
       (event) => {
         setInputValue(event.target.value);
 
-        if (typeof onChange === 'function') {
+        if (isFunction(onChange)) {
           onChange(event);
         }
       },

--- a/packages/react/src/primitives/SwitchField/useSwitch.ts
+++ b/packages/react/src/primitives/SwitchField/useSwitch.ts
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, useCallback, useState } from 'react';
+import { isFunction } from '@aws-amplify/ui';
 
 type ChangeHandler = React.ChangeEventHandler<HTMLInputElement>;
 
@@ -28,7 +29,7 @@ export const useSwitch = (props: UseSwitchProps): UseSwitch => {
         return;
       }
 
-      if (typeof onChange === 'function') {
+      if (isFunction(onChange)) {
         onChange(event);
       }
 

--- a/packages/react/src/primitives/ToggleButton/useToggleButton.ts
+++ b/packages/react/src/primitives/ToggleButton/useToggleButton.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { isFunction } from '@aws-amplify/ui';
 
-import { isFunction } from '../shared/utils';
 import { ToggleButtonProps } from '../types';
 
 type ClickHandler = React.MouseEventHandler<HTMLButtonElement>;

--- a/packages/react/src/primitives/ToggleButtonGroup/useToggleButtonGroup.tsx
+++ b/packages/react/src/primitives/ToggleButtonGroup/useToggleButtonGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { isFunction } from '@aws-amplify/ui';
 
-import { isFunction } from '../shared/utils';
 import { ToggleButtonProps, ToggleButtonGroupProps } from '../types';
 
 type UseToggleButtonParams = Pick<

--- a/packages/react/src/primitives/shared/utils.ts
+++ b/packages/react/src/primitives/shared/utils.ts
@@ -11,9 +11,6 @@ import { stylePropsToThemeKeys } from './constants';
 export const strHasLength = (str: unknown): str is string =>
   typeof str === 'string' && str.length > 0;
 
-export const isFunction = (fn: unknown): fn is Function =>
-  typeof fn === 'function';
-
 export const isEmptyString = (value: unknown): boolean =>
   typeof value === 'string' && value.length === 0;
 

--- a/packages/ui/src/utils/__tests__/index.test.ts
+++ b/packages/ui/src/utils/__tests__/index.test.ts
@@ -4,6 +4,7 @@ import {
   capitalize,
   has,
   isEmpty,
+  isFunction,
   isMap,
   isNil,
   isObject,
@@ -44,149 +45,149 @@ describe('capitalize', () => {
 
 describe('isObject', () => {
   it('should return `true` for objects', () => {
-    expect(isObject(new Number(0))).toStrictEqual(true);
-    expect(isObject(new String(''))).toStrictEqual(true);
-    expect(isObject(new Date())).toStrictEqual(true);
-    expect(isObject(new Error())).toStrictEqual(true);
-    expect(isObject({})).toStrictEqual(true);
-    expect(isObject({ test: 1 })).toStrictEqual(true);
-    expect(isObject(Object(false))).toStrictEqual(true);
-    expect(isObject(Object(0))).toStrictEqual(true);
-    expect(isObject(Object('test'))).toStrictEqual(true);
+    expect(isObject(new Number(0))).toBe(true);
+    expect(isObject(new String(''))).toBe(true);
+    expect(isObject(new Date())).toBe(true);
+    expect(isObject(new Error())).toBe(true);
+    expect(isObject({})).toBe(true);
+    expect(isObject({ test: 1 })).toBe(true);
+    expect(isObject(Object(false))).toBe(true);
+    expect(isObject(Object(0))).toBe(true);
+    expect(isObject(Object('test'))).toBe(true);
   });
 
   it('should return `false` for non-objects', () => {
-    expect(isObject(null)).toStrictEqual(false);
-    expect(isObject(undefined)).toStrictEqual(false);
-    expect(isObject(true)).toStrictEqual(false);
-    expect(isObject(0)).toStrictEqual(false);
-    expect(isObject('test')).toStrictEqual(false);
-    expect(isObject([1, 2, 3])).toStrictEqual(false);
-    expect(isObject(() => {})).toStrictEqual(false);
+    expect(isObject(null)).toBe(false);
+    expect(isObject(undefined)).toBe(false);
+    expect(isObject(true)).toBe(false);
+    expect(isObject(0)).toBe(false);
+    expect(isObject('test')).toBe(false);
+    expect(isObject([1, 2, 3])).toBe(false);
+    expect(isObject(() => {})).toBe(false);
   });
 });
 
 describe('isString', () => {
   it('should return `true` for strings', () => {
-    expect(isString('')).toStrictEqual(true);
-    expect(isString('test')).toStrictEqual(true);
-    expect(isString(new String('test'))).toStrictEqual(true);
+    expect(isString('')).toBe(true);
+    expect(isString('test')).toBe(true);
+    expect(isString(new String('test'))).toBe(true);
   });
 
   it('should return `false` for non-strings', () => {
-    expect(isString(null)).toStrictEqual(false);
-    expect(isString(undefined)).toStrictEqual(false);
-    expect(isString(true)).toStrictEqual(false);
-    expect(isString(0)).toStrictEqual(false);
-    expect(isString([1, 2, 3])).toStrictEqual(false);
+    expect(isString(null)).toBe(false);
+    expect(isString(undefined)).toBe(false);
+    expect(isString(true)).toBe(false);
+    expect(isString(0)).toBe(false);
+    expect(isString([1, 2, 3])).toBe(false);
   });
 });
 
 describe('isSet', () => {
   it('should return `true` for sets', () => {
-    expect(isSet(new Set())).toStrictEqual(true);
+    expect(isSet(new Set())).toBe(true);
   });
 
   it('should return `false` for non-sets', () => {
-    expect(isSet('')).toStrictEqual(false);
-    expect(isSet(null)).toStrictEqual(false);
-    expect(isSet(undefined)).toStrictEqual(false);
-    expect(isSet(true)).toStrictEqual(false);
-    expect(isSet(0)).toStrictEqual(false);
-    expect(isSet([1, 2, 3])).toStrictEqual(false);
-    expect(isSet(new WeakSet())).toStrictEqual(false);
-    expect(isSet(new Map())).toStrictEqual(false);
-    expect(isSet(new Array())).toStrictEqual(false);
+    expect(isSet('')).toBe(false);
+    expect(isSet(null)).toBe(false);
+    expect(isSet(undefined)).toBe(false);
+    expect(isSet(true)).toBe(false);
+    expect(isSet(0)).toBe(false);
+    expect(isSet([1, 2, 3])).toBe(false);
+    expect(isSet(new WeakSet())).toBe(false);
+    expect(isSet(new Map())).toBe(false);
+    expect(isSet(new Array())).toBe(false);
   });
 });
 
 describe('isMap', () => {
   it('should return `true` for maps', () => {
-    expect(isMap(new Map())).toStrictEqual(true);
+    expect(isMap(new Map())).toBe(true);
   });
 
   it('should return `false` for non-maps', () => {
-    expect(isMap('')).toStrictEqual(false);
-    expect(isMap(null)).toStrictEqual(false);
-    expect(isMap(undefined)).toStrictEqual(false);
-    expect(isMap(true)).toStrictEqual(false);
-    expect(isMap(0)).toStrictEqual(false);
-    expect(isMap([1, 2, 3])).toStrictEqual(false);
-    expect(isMap(new WeakMap())).toStrictEqual(false);
-    expect(isMap(new Set())).toStrictEqual(false);
-    expect(isMap(new Array())).toStrictEqual(false);
+    expect(isMap('')).toBe(false);
+    expect(isMap(null)).toBe(false);
+    expect(isMap(undefined)).toBe(false);
+    expect(isMap(true)).toBe(false);
+    expect(isMap(0)).toBe(false);
+    expect(isMap([1, 2, 3])).toBe(false);
+    expect(isMap(new WeakMap())).toBe(false);
+    expect(isMap(new Set())).toBe(false);
+    expect(isMap(new Array())).toBe(false);
   });
 });
 
 describe('isUndefined', () => {
-  it('should return `true` for undefined values', function () {
-    expect(isUndefined(undefined)).toStrictEqual(true);
-    expect(isUndefined(void 0)).toStrictEqual(true);
+  it('should return `true` for undefined values', () => {
+    expect(isUndefined(undefined)).toBe(true);
+    expect(isUndefined(void 0)).toBe(true);
   });
 
-  it('should return `false` for non-undefined values', function () {
-    expect(isUndefined(null)).toStrictEqual(false);
-    expect(isUndefined(true)).toStrictEqual(false);
-    expect(isUndefined('')).toStrictEqual(false);
-    expect(isUndefined(0)).toStrictEqual(false);
-    expect(isUndefined([1, 2, 3])).toStrictEqual(false);
-    expect(isUndefined(new Number(0))).toStrictEqual(false);
-    expect(isUndefined(new String(''))).toStrictEqual(false);
-    expect(isUndefined(new Date())).toStrictEqual(false);
-    expect(isUndefined(new Error())).toStrictEqual(false);
-    expect(isUndefined({})).toStrictEqual(false);
+  it('should return `false` for non-undefined values', () => {
+    expect(isUndefined(null)).toBe(false);
+    expect(isUndefined(true)).toBe(false);
+    expect(isUndefined('')).toBe(false);
+    expect(isUndefined(0)).toBe(false);
+    expect(isUndefined([1, 2, 3])).toBe(false);
+    expect(isUndefined(new Number(0))).toBe(false);
+    expect(isUndefined(new String(''))).toBe(false);
+    expect(isUndefined(new Date())).toBe(false);
+    expect(isUndefined(new Error())).toBe(false);
+    expect(isUndefined({})).toBe(false);
   });
 });
 
 describe('isNil', () => {
-  it('should return `true` for nullish values', function () {
-    expect(isNil(null)).toStrictEqual(true);
-    expect(isNil(undefined)).toStrictEqual(true);
-    expect(isNil(void 0)).toStrictEqual(true);
+  it('should return `true` for nullish values', () => {
+    expect(isNil(null)).toBe(true);
+    expect(isNil(undefined)).toBe(true);
+    expect(isNil(void 0)).toBe(true);
   });
 
-  it('should return `false` for non-nullish values', function () {
-    expect(isNil(true)).toStrictEqual(false);
-    expect(isNil('')).toStrictEqual(false);
-    expect(isNil(0)).toStrictEqual(false);
-    expect(isNil([1, 2, 3])).toStrictEqual(false);
-    expect(isNil(new Number(0))).toStrictEqual(false);
-    expect(isNil(new String(''))).toStrictEqual(false);
-    expect(isNil(new Date())).toStrictEqual(false);
-    expect(isNil(new Error())).toStrictEqual(false);
-    expect(isNil({})).toStrictEqual(false);
-    expect(isNil(NaN)).toStrictEqual(false);
+  it('should return `false` for non-nullish values', () => {
+    expect(isNil(true)).toBe(false);
+    expect(isNil('')).toBe(false);
+    expect(isNil(0)).toBe(false);
+    expect(isNil([1, 2, 3])).toBe(false);
+    expect(isNil(new Number(0))).toBe(false);
+    expect(isNil(new String(''))).toBe(false);
+    expect(isNil(new Date())).toBe(false);
+    expect(isNil(new Error())).toBe(false);
+    expect(isNil({})).toBe(false);
+    expect(isNil(NaN)).toBe(false);
   });
 });
 
 describe('isEmpty', () => {
-  it('should return `true` for empty values', function () {
-    expect(isEmpty(null)).toStrictEqual(true);
-    expect(isEmpty(undefined)).toStrictEqual(true);
-    expect(isEmpty(true)).toStrictEqual(true);
-    expect(isEmpty(void 0)).toStrictEqual(true);
-    expect(isEmpty(NaN)).toStrictEqual(true);
-    expect(isEmpty(0)).toStrictEqual(true);
-    expect(isEmpty('')).toStrictEqual(true);
-    expect(isEmpty([])).toStrictEqual(true);
-    expect(isEmpty(new Number(0))).toStrictEqual(true);
-    expect(isEmpty(new String(''))).toStrictEqual(true);
-    expect(isEmpty(new Date())).toStrictEqual(true);
-    expect(isEmpty(new Array())).toStrictEqual(true);
-    expect(isEmpty(new Map())).toStrictEqual(true);
-    expect(isEmpty(new Set())).toStrictEqual(true);
-    expect(isEmpty(new Error())).toStrictEqual(true);
-    expect(isEmpty({})).toStrictEqual(true);
-    expect(isEmpty(new Map([]))).toStrictEqual(true);
-    expect(isEmpty(new Set([]))).toStrictEqual(true);
+  it('should return `true` for empty values', () => {
+    expect(isEmpty(null)).toBe(true);
+    expect(isEmpty(undefined)).toBe(true);
+    expect(isEmpty(true)).toBe(true);
+    expect(isEmpty(void 0)).toBe(true);
+    expect(isEmpty(NaN)).toBe(true);
+    expect(isEmpty(0)).toBe(true);
+    expect(isEmpty('')).toBe(true);
+    expect(isEmpty([])).toBe(true);
+    expect(isEmpty(new Number(0))).toBe(true);
+    expect(isEmpty(new String(''))).toBe(true);
+    expect(isEmpty(new Date())).toBe(true);
+    expect(isEmpty(new Array())).toBe(true);
+    expect(isEmpty(new Map())).toBe(true);
+    expect(isEmpty(new Set())).toBe(true);
+    expect(isEmpty(new Error())).toBe(true);
+    expect(isEmpty({})).toBe(true);
+    expect(isEmpty(new Map([]))).toBe(true);
+    expect(isEmpty(new Set([]))).toBe(true);
   });
 
-  it('should return `false` for non-empty values', function () {
-    expect(isEmpty([1, 2, 3])).toStrictEqual(false);
-    expect(isEmpty('test')).toStrictEqual(false);
-    expect(isEmpty({ test: 1 })).toStrictEqual(false);
-    expect(isEmpty({ length: 0 })).toStrictEqual(false);
-    expect(isEmpty({ size: 0 })).toStrictEqual(false);
+  it('should return `false` for non-empty values', () => {
+    expect(isEmpty([1, 2, 3])).toBe(false);
+    expect(isEmpty('test')).toBe(false);
+    expect(isEmpty({ test: 1 })).toBe(false);
+    expect(isEmpty({ length: 0 })).toBe(false);
+    expect(isEmpty({ size: 0 })).toBe(false);
     expect(
       isEmpty(
         new Map([
@@ -194,11 +195,11 @@ describe('isEmpty', () => {
           ['key2', 'value2'],
         ])
       )
-    ).toStrictEqual(false);
+    ).toBe(false);
+    expect(isEmpty(new Set([1, 2, 3]))).toBe(false);
+    expect(isEmpty(new Array([]))).toBe(false);
+    expect(isEmpty(new Array([1, 2, 3]))).toBe(false);
   });
-  expect(isEmpty(new Set([1, 2, 3]))).toStrictEqual(false);
-  expect(isEmpty(new Array([]))).toStrictEqual(false);
-  expect(isEmpty(new Array([1, 2, 3]))).toStrictEqual(false);
 });
 
 describe('areEmptyArrays', () => {
@@ -224,16 +225,39 @@ describe('areEmptyObjects', () => {
 });
 
 describe('has', () => {
-  it('should return `true` for objects that have the specified key', function () {
-    expect(has({ a: 1 }, 'a')).toStrictEqual(true);
+  it('should return `true` for objects that have the specified key', () => {
+    expect(has({ a: 1 }, 'a')).toBe(true);
   });
 
-  it('should return `false` for objects that do not have the specified key', function () {
-    expect(has({ a: 1 }, 'b')).toStrictEqual(false);
+  it('should return `false` for objects that do not have the specified key', () => {
+    expect(has({ a: 1 }, 'b')).toBe(false);
   });
 
-  it('should return `false` for nullish objects', function () {
-    expect(has(null, 'a')).toStrictEqual(false);
-    expect(has(undefined, 'a')).toStrictEqual(false);
+  it('should return `false` for nullish objects', () => {
+    expect(has(null, 'a')).toBe(false);
+    expect(has(undefined, 'a')).toBe(false);
   });
+
+  it('should return `false` for booleans passed as the value param', () => {
+    expect(has(false, 'a')).toBe(false);
+    expect(has(true, 'a')).toBe(false);
+  });
+
+  it('should return `false` when the value param is an array', () => {
+    expect(has([1, 2, 3], 'a')).toBe(false);
+    expect(has([], 'a')).toBe(false);
+  });
+});
+
+describe('isFunction', () => {
+  it('returns `true` when the value param is a function', () => {
+    expect(isFunction(() => null)).toBe(true);
+  });
+
+  it.each(['string', null, undefined, true, false])(
+    'returns `false` when the value param is %s',
+    (value) => {
+      expect(isFunction(value)).toBe(false);
+    }
+  );
 });

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -135,16 +135,18 @@ function isEmptyObject<T>(value: T): boolean {
 /**
  * Checks if all members of the `values` param are empty objects
  *
- * @param {unknown} value The values to check
+ * @param {unknown} values The values to check
  * @returns {boolean} Returns `true` if all members of the `values` param are empty, `false` otherwise
  */
 export function areEmptyObjects<T>(...values: T[]): boolean {
   return values.every(isEmptyObject);
 }
 
-/*
- * @param value capitalizes `value` and its type.
- * @returns Capitalized `value`
+/**
+ * Capitalizes `value` and its return type
+ *
+ * @param {string} value string to capitalize
+ * @returns {string} capitalized string
  */
 export function capitalize<T extends string>(value: T): Capitalize<T> {
   return (
@@ -152,9 +154,23 @@ export function capitalize<T extends string>(value: T): Capitalize<T> {
   ) as Capitalize<T>;
 }
 
-/*
- * Checks if `key` is a direct property of `object`.
+/**
+ * Checks if `key` is a direct property of `value`
+ *
+ * @param {unknown} value `object` potentially containing property
+ * @param {string} key property key
+ * @returns whether `key` param is a property of the `obj` param
  */
-export function has(object: unknown, key: string): boolean {
-  return object != null && Object.prototype.hasOwnProperty.call(object, key);
+export function has(value: unknown, key: string): boolean {
+  return value != null && Object.prototype.hasOwnProperty.call(value, key);
+}
+
+/**
+ * Checks if `value` is a function
+ *
+ * @param {unknown} value param to check
+ * @returns {boolean} whether `value` is a function
+ */
+export function isFunction(value: unknown): value is Function {
+  return typeof value === 'function';
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Migrate `isFunction` to `@aws-amplify/ui`:
- add `isFunction` unit tests
- update util tests in `@aws-amplify/ui` to use `toBe` in place of `toStrictEqual`, which is used for object matching: https://jestjs.io/docs/expect#tostrictequalvalue
- replace usage of `typeof SOME_VALUE === 'function` in `@aws-amplify/ui-react`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
