### PR TITLE
docs(angular): Add troubleshooting for Angular 15 polyfills

### DIFF
--- a/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.angular.mdx
@@ -1,6 +1,13 @@
+import { TabItem, Tabs } from '@aws-amplify/ui-react';
+
 ### Global and Process Shim
 
-Angular 6+ no longer include shims for 'global' or 'process'. Add the following to your `src/polyfills.ts`:
+Angular 6+ does not include shims for `global` or `process`. Follow the instructions below to resolve `global` or `process` reference errors.
+
+<Tabs>
+<TabItem title="Angular 15">
+
+First, create `src/polyfills.ts` and add the following:
 
 ```ts
 (window as any).global = window;
@@ -8,6 +15,45 @@ Angular 6+ no longer include shims for 'global' or 'process'. Add the following 
   env: { DEBUG: undefined },
 };
 ```
+
+Then, open your `angular.json` file, and add `src/polyfills.ts` to `polyfills` array(s) in your `angular.json`. These  arrays are located in `projects.<project-name>.architect.<task-name>.options`.
+
+```json{3}
+"polyfills": [
+  "zone.js",
+  "src/polyfills.ts"
+],
+```
+
+
+
+And finally, make sure to add `src/polyfills` to `files` in your `tsconfig`:
+
+```json{4}
+{
+  "files": [
+    "src/main.ts",
+    "src/polyfills.ts"
+  ],
+}
+```
+
+  </TabItem>
+
+  <TabItem title="Angular 7-14">
+
+Add the following to your `src/polyfills.ts`:
+
+```ts
+(window as any).global = window;
+(window as any).process = {
+  env: { DEBUG: undefined },
+};
+```
+
+  </TabItem>
+</Tabs>
+
 
 ### Unhandled Promise rejection console errors
 

--- a/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.angular.mdx
@@ -25,8 +25,6 @@ Then, open your `angular.json` file, and add `src/polyfills.ts` to `polyfills` a
 ],
 ```
 
-
-
 And finally, make sure to add `src/polyfills` to `files` in your `tsconfig`:
 
 ```json{4}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds docs on how to polyfill `global` and `process` on Angular 15.

Angular 15 doesn't create `src/polyfills.ts` anymore (see "CLI improvements" section on [blog](https://blog.angular.io/angular-v15-is-now-available-df7be7f2f4c8)), so developers need to manually create that file now.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes


https://user-images.githubusercontent.com/43682783/223600470-a0a00509-8ee7-4678-a0a5-02886038c7fd.mp4



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
