### PR TITLE
fix(docs): alert on 301, 303 links

### DIFF
--- a/docs/scripts/data/constants.ts
+++ b/docs/scripts/data/constants.ts
@@ -1,3 +1,3 @@
-export const PROMISE_POOL_CONCURRENCY = 10;
-export const DEFAULT_GOOD_STATUS_CODES = [200, 301, 303];
+export const PROMISE_POOL_CONCURRENCY = 5;
+export const DEFAULT_GOOD_STATUS_CODES = [200];
 export const DOCS_AMPLIFY_HOST = 'https://docs.amplify.aws/';

--- a/docs/scripts/util/checkLink.ts
+++ b/docs/scripts/util/checkLink.ts
@@ -26,7 +26,7 @@ async function returnStatus({
   tagName,
   tagText,
 }: LinkInfo): Promise<LinkInfo> {
-  if ([...DEFAULT_GOOD_STATUS_CODES, 308].includes(statusCode)) {
+  if ([...DEFAULT_GOOD_STATUS_CODES, 301, 308].includes(statusCode)) {
     /**
      * If 301 and from 'https://docs.amplify.aws/', add a "/" and check again.
      * Because 'https://docs.amplify.aws/' adds a "/" and return a 301 to all the links not ending with "/".

--- a/docs/src/pages/[platform]/components/alert/index.page.mdx
+++ b/docs/src/pages/[platform]/components/alert/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alert
 description: Alert displays a brief message in a way that attracts the user’s attention without interrupting their task.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/alert
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/alert/
 themeSource: packages/ui/src/theme/tokens/components/alert.ts
 reactSource: packages/react/src/primitives/Alert/Alert.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div

--- a/docs/src/pages/[platform]/components/button/index.page.mdx
+++ b/docs/src/pages/[platform]/components/button/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Button
 description: Button allows users to perform actions.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/button
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 themeSource: packages/ui/src/theme/tokens/components/button.ts
 reactSource: packages/react/src/primitives/Button/Button.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button

--- a/docs/src/pages/[platform]/components/checkboxfield/index.page.mdx
+++ b/docs/src/pages/[platform]/components/checkboxfield/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: CheckboxField
 description: CheckboxField allows users to mark items as selected.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
 themeSource: packages/ui/src/theme/tokens/components/checkbox.ts
 reactSource: packages/react/src/primitives/CheckboxField/CheckboxField.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox

--- a/docs/src/pages/[platform]/components/expander/index.page.mdx
+++ b/docs/src/pages/[platform]/components/expander/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Expander
 description: Expander allows users to expand or collapse a set of sections.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/accordion
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/accordion/
 themeSource: packages/ui/src/theme/tokens/components/expander.ts
 reactSource: packages/react/src/primitives/Expander/Expander.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div

--- a/docs/src/pages/[platform]/components/icon/react.mdx
+++ b/docs/src/pages/[platform]/components/icon/react.mdx
@@ -42,7 +42,7 @@ Import the Icon component and styles.
 
 <Alert variation="warning" role="none" heading="Deprecated">
   The built-in icons were removed in version `3.0`. You can use the
-  [react-icons](https://react-icons.github.io/react-icons) package or other
+  [react-icons](https://react-icons.github.io/react-icons/) package or other
   React icon libraries in its place. 
 </Alert>
 
@@ -118,7 +118,7 @@ You can also optionally use a `paths` array of path-like objects that will be ma
 
 ### Using a library
 
-To use an icon library like [React Icons](https://react-icons.github.io/react-icons), import the desired icon and pass it to the `as` prop.
+To use an icon library like [React Icons](https://react-icons.github.io/react-icons/), import the desired icon and pass it to the `as` prop.
 
 <Example>
   <CustomIconWithLibExample />

--- a/docs/src/pages/[platform]/components/link/index.page.mdx
+++ b/docs/src/pages/[platform]/components/link/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Link
 description: Link renders an anchor element <a> by default and is primarily used for navigation.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/link
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/link/
 themeSource: packages/ui/src/theme/tokens/components/link.ts
 reactSource: packages/react/src/primitives/Link/Link.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a

--- a/docs/src/pages/[platform]/components/phonenumberfield/react.mdx
+++ b/docs/src/pages/[platform]/components/phonenumberfield/react.mdx
@@ -76,7 +76,7 @@ Use the `autoComplete` prop to tell the browser how to populate the `PhoneNumber
 as the `autoComplete` property for the text field and `tel-country-code` as the `autoComplete` property for the dial code selector.
 
 If the `PhoneNumberField` primitive is intended to be used in a form that is compatible with most password managers, the `autoComplete` property should
-be set to `username` (see [Password Form Styles that Chromium Understands](https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands)).
+be set to `username` (see [Password Form Styles that Chromium Understands](https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/)).
 
 <Example>
   <AutoCompleteExample />

--- a/docs/src/pages/[platform]/components/radiogroupfield/index.page.mdx
+++ b/docs/src/pages/[platform]/components/radiogroupfield/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: RadioGroupField
 description: RadioGroupField allows users to select a single option from a list of mutually exclusive options.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/radio/
 themeSource: packages/ui/src/theme/tokens/components/radio.ts
 reactSource: packages/react/src/primitives/RadioGroupField/RadioGroupField.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio

--- a/docs/src/pages/[platform]/components/sliderfield/index.page.mdx
+++ b/docs/src/pages/[platform]/components/sliderfield/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: SliderField
 description: SliderField allows users to select a value within a defined range.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/slider
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/slider/
 themeSource: packages/ui/src/theme/tokens/components/sliderField.ts
 reactSource: packages/react/src/primitives/SliderField/SliderField.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span

--- a/docs/src/pages/[platform]/components/stepperfield/index.page.mdx
+++ b/docs/src/pages/[platform]/components/stepperfield/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: StepperField
 description: StepperField allows users to increment or decrement a number input.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/
 themeSource: packages/ui/src/theme/tokens/components/stepperField.ts
 reactSource: packages/react/src/primitives/StepperField/StepperField.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number

--- a/docs/src/pages/[platform]/components/switchfield/index.page.mdx
+++ b/docs/src/pages/[platform]/components/switchfield/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: SwitchField
 description: SwitchField allows users to toggle an input.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/switch
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/switch/
 themeSource: packages/ui/src/theme/tokens/components/switchField.ts
 reactSource: packages/react/src/primitives/SwitchField/SwitchField.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox

--- a/docs/src/pages/[platform]/components/table/index.page.mdx
+++ b/docs/src/pages/[platform]/components/table/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Table
 description: Table displays tabular data using the HTML <table> element and related elements.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/table
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/table/
 themeSource: packages/ui/src/theme/tokens/components/table.ts
 reactSource: packages/react/src/primitives/Table/Table.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table

--- a/docs/src/pages/[platform]/components/tabs/index.page.mdx
+++ b/docs/src/pages/[platform]/components/tabs/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tabs
 description: Tabs allow users to navigate between sections of related content.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
 themeSource: packages/ui/src/theme/tokens/components/tabs.ts
 reactSource: packages/react/src/primitives/Tabs/Tabs.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div

--- a/docs/src/pages/[platform]/components/togglebutton/index.page.mdx
+++ b/docs/src/pages/[platform]/components/togglebutton/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: ToggleButton
 description: ToggleButton allows users to toggle the on/off state for some configuration.
-ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/button
+ariaPattern: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 themeSource: packages/ui/src/theme/tokens/components/toggleButton.ts
 reactSource: packages/react/src/primitives/ToggleButton/ToggleButton.tsx
 mdnUrl: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button

--- a/docs/src/pages/[platform]/connected-components/authenticator/configuration/socialProviders.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/configuration/socialProviders.web.mdx
@@ -22,4 +22,4 @@ For your [configured social providers](https://docs.amplify.aws/lib/auth/social/
   <SocialProviderDemo/>
 </Example>
 
-_[Step by step video](https://youtu.be/8KwZNn56F78) on setting up social providers._
+_[Step by step video](https://www.youtube.com/watch?v=8KwZNn56F78&feature=youtu.be) on setting up social providers._

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.flutter.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.flutter.mdx
@@ -1,4 +1,4 @@
-To use localization, start by following the steps in the [Flutter Localization guide](https://flutter.dev/docs/development/accessibility-and-localization/internationalization). When the guide says to create an .arb file, enter the following into `lib/l10n/amplify_en.arb`:
+To use localization, start by following the steps in the [Flutter Localization guide](https://docs.flutter.dev/development/accessibility-and-localization/internationalization). When the guide says to create an .arb file, enter the following into `lib/l10n/amplify_en.arb`:
 
 ```json
 {

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
@@ -43,5 +43,5 @@ These include:
 <Alert role="none" variation="info" heading="Translations Needed 📖">
   If you see any missing translations or would like to contribute a new
   language, we greatly appreciate contributions to translations we have
-  [here](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/dictionaries).
+  [here](https://github.com/aws-amplify/amplify-ui/tree/main/packages/ui/src/i18n/dictionaries).
 </Alert>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
@@ -45,5 +45,5 @@ These include:
 <Alert role="none" variation="info" heading="Translations Needed 📖">
   If you see any missing translations or would like to contribute a new
   language, we greatly appreciate contributions to translations we have
-  [here](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/dictionaries).
+  [here](https://github.com/aws-amplify/amplify-ui/tree/main/packages/ui/src/i18n/dictionaries).
 </Alert>

--- a/docs/src/pages/[platform]/connected-components/geo/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/geo/react.mdx
@@ -19,7 +19,7 @@ The `MapView` component adds an interactive map to your application.
 
 `MapView` is fully integrated with the open source library [react-map-gl](https://visgl.github.io/react-map-gl/) v7
 while using [maplibre-gl-js](https://maplibre.org/maplibre-gl-js-docs/api/) as the map tile source. `MapView` is
-used as a replacement to `react-map-gl`'s [default map](https://visgl.github.io/react-map-gl/docs/api-reference/map)
+used as a replacement to `react-map-gl`'s [default map](https://visgl.github.io/react-map-gl/docs/api-reference/map/)
 and supports the same functionality.
 
 You can import the `MapView` component with related styles and use it in your Amplify application without any
@@ -75,7 +75,7 @@ You may want to access the [native maplibre-gl map object](https://maplibre.org/
   {({ platform }) => import(`./fragments/map-ref.${platform}.mdx`)}
 </Fragment>
 
-If you want access to the `map` object in a child component of `<MapView>`, you can use the [useMap hook from react-map-gl](https://visgl.github.io/react-map-gl/docs/api-reference/use-map) instead:
+If you want access to the `map` object in a child component of `<MapView>`, you can use the [useMap hook from react-map-gl](https://visgl.github.io/react-map-gl/docs/api-reference/use-map/) instead:
 
 <Fragment platforms={['react']}>
   {({ platform }) => import(`./fragments/use-map.${platform}.mdx`)}

--- a/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
@@ -77,7 +77,7 @@ The following deprecated components imported from `@aws-amplify/ui-angular/legac
 - [AmplifyChatbot](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-chatbot/readme.md)
 - [AmplifyPhotoPicker](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-photo-picker/readme.md)
 - [AmplifyPicker](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-picker/readme.md)
-- [AmplifyS3Album](https://github.com/aws-amplify/amplify-js/tree/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-album/readme.md)
+- [AmplifyS3Album](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-album/readme.md)
 - [AmplifyS3Image](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-image/readme.md)
 - [AmplifyS3ImagePicker](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-image-picker/readme.md)
 - [AmplifyS3Text](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-text/readme.md)

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -54,7 +54,7 @@ The following deprecated components imported from `@aws-amplify/ui-react/legacy`
 - [AmplifyChatbot](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-chatbot/readme.md)
 - [AmplifyPhotoPicker](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-photo-picker/readme.md)
 - [AmplifyPicker](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-picker/readme.md)
-- [AmplifyS3Album](https://github.com/aws-amplify/amplify-js/tree/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-album/readme.md)
+- [AmplifyS3Album](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-album/readme.md)
 - [AmplifyS3Image](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-image/readme.md)
 - [AmplifyS3ImagePicker](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-image-picker/readme.md)
 - [AmplifyS3Text](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-s3-text/readme.md)

--- a/docs/src/pages/[platform]/guides/auth-protected/auth-protected.react.mdx
+++ b/docs/src/pages/[platform]/guides/auth-protected/auth-protected.react.mdx
@@ -10,7 +10,7 @@ Let's imagine you needed a web application where the login page was in its own r
 
 This guide demonstrates that scenario while using the [Amplify UI Authenticator](../connected-components/authenticator) and the [Amplify CLI](https://docs.amplify.aws/cli/).
 
-> If you'd like to follow along, please use this example [Github repo](https://github.com/aws-amplify/amplify-ui/tree/main/guides/react/protected-routes). Additionally, you can watch this [video](https://youtu.be/6f635LVtwgk) that walks through this process, and includes a bonus section on how to create a lambda function with a custom authorizer.
+> If you'd like to follow along, please use this example [Github repo](https://github.com/aws-amplify/amplify-ui/tree/main/guides/react/protected-routes). Additionally, you can watch this [video](https://www.youtube.com/watch?v=6f635LVtwgk&feature=youtu.be) that walks through this process, and includes a bonus section on how to create a lambda function with a custom authorizer.
 
 _Example Screenshot of App_
 

--- a/docs/src/pages/[platform]/theming/theme-provider/react.mdx
+++ b/docs/src/pages/[platform]/theming/theme-provider/react.mdx
@@ -89,4 +89,4 @@ style-src css-cdn.example.com 'nonce-rAnd0m';
 </style>
 ```
 
-For more information, see the following documention on [allowing inline styles using a nonce](https://content-security-policy.com/examples/allow-inline-style). 
+For more information, see the following documention on [allowing inline styles using a nonce](https://content-security-policy.com/examples/allow-inline-style/). 

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
@@ -72,7 +72,7 @@ Feature: Sign In with Email
   Scenario: Email field autocompletes username
 
   On sign in form, autocomplete prefers usage of username instead of email. 
-  See https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands.
+  See https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/.
 
     And "Email" field autocompletes "username"
 

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-phone.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-phone.feature
@@ -97,7 +97,7 @@ Feature: Sign In with Phone Number
   Scenario: Phone number field autocompletes username
   
   On sign in form, autocomplete prefers usage of username instead of phone number. 
-  See https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands.
+  See https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/.
 
     Then "Phone Number" field autocompletes "username"
 

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-email.feature
@@ -45,7 +45,7 @@ Scenario: Sign up with a new email & password
   Scenario: Email field autocompletes username
 
   On sign up form, autocomplete prefers usage of username instead of email. 
-  See https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands.
+  See https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/.
 
     And "Email" field autocompletes "username"
 

--- a/packages/e2e/features/ui/components/authenticator/sign-up-with-phone.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-up-with-phone.feature
@@ -29,7 +29,7 @@ Feature: Sign Up with Phone
   Scenario: Phone number field autocompletes username
 
   On sign up form, autocomplete prefers usage of username instead of phone number. 
-  See https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands.
+  See https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/.
 
     And "Phone Number" field autocompletes "username"
 

--- a/packages/react/src/components/Geo/MapView/index.tsx
+++ b/packages/react/src/components/Geo/MapView/index.tsx
@@ -28,7 +28,7 @@ interface MapViewProps extends Omit<MapProps, 'mapLib' | 'transformRequest'> {
  * [maplibre-gl-js](https://visgl.github.io/react-map-gl/) to provide an interactive map using
  * [Amplify Geo APIs](https://docs.amplify.aws/lib/geo/getting-started/q/platform/js/) powered by
  * [Amazon Location Service](https://aws.amazon.com/location/). Since `MapView` is a wrapper of the
- * [react-map-gl default Map](https://visgl.github.io/react-map-gl/docs/api-reference/map), it accepts the same
+ * [react-map-gl default Map](https://visgl.github.io/react-map-gl/docs/api-reference/map/), it accepts the same
  * properties except `transformRequest` which is set by Amplify.
  *
  * [📖 Docs](https://ui.docs.amplify.aws/react/connected-components/geo#mapview)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

[301](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301), [303](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303) status code should not be acceptable.

Note: We still double check 301 from docs.amplify.aws ([code](https://github.com/aws-amplify/amplify-ui/blob/main/docs/scripts/util/checkLink.ts#L31)) because its broken link returns 301 (https://github.com/aws-amplify/docs/issues/5221). e.g. 'https://www.w3.org/WAI/ARIA/apg/patterns/radtton' returns 404, but 'https://docs.amplify.aws/lib/auth/getarted/q/platform/js' returns 301

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
