### PR TITLE
chore: add github actions for status checks

### DIFF
--- a/.github/actions/add-check/action.yml
+++ b/.github/actions/add-check/action.yml
@@ -1,4 +1,4 @@
-name: 'Add Status Checks'
+name: 'Add Status Check'
 description: 'Add status check on a specified head-sha'
 inputs:
   name:
@@ -17,20 +17,28 @@ inputs:
       'cancelled', 'failure', 'neutral', 'success', 'skipped', 'stale', 'timed_out'.
       This is only required if status is 'completed'.
     required: false
+outputs:
+  check-id:
+    description: 'Check ID of status check'
+    value: ${{ steps.create-check.outputs.result }}
 runs:
   using: 'composite'
   steps:
-    - uses: actions/github-script@v6
+    - name: Create a status check
+      id: create-check
+      uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0 https://github.com/actions/github-script/commit/98814c53be79b1d30f795b907e553d8679345975
       env:
         name: ${{ inputs.name }}
         head_sha: ${{ inputs.head-sha }}
         status: ${{ inputs.status }}
         conclusion: ${{ inputs.conclusion }}
+        owner: ${{ github.event.repository.owner.login }}
+        repo: ${{ github.event.repository.name }}
       with:
+        result-encoding: string
         script: |
-          const { name, head_sha, status, conclusion } = process.env;
-          const { owner, repo } = context.repo;
-          github.rest.checks.create({
+          const { name, head_sha, status, conclusion, owner, repo } = process.env;
+          const { data } = await github.rest.checks.create({
             name,
             owner,
             repo,
@@ -38,3 +46,4 @@ runs:
             status,
             conclusion: conclusion.length > 0 ? conclusion : undefined
           });
+          return data.id;

--- a/.github/actions/add-checks/action.yml
+++ b/.github/actions/add-checks/action.yml
@@ -1,0 +1,40 @@
+name: 'Add Status Checks'
+description: 'Add status check on a specified head-sha'
+inputs:
+  name:
+    description: 'Name of status check'
+    required: true
+  status:
+    description: >-
+      Status of check with possible values of 'queued', 'in_progress', 'completed'
+    required: true
+  head-sha:
+    description: 'The commit ID to add the checks to'
+    required: true
+  conclusion:
+    description: >-
+      Conclusion of status check with possible values of 'action_required',
+      'cancelled', 'failure', 'neutral', 'success', 'skipped', 'stale', 'timed_out'.
+      This is only required if status is 'completed'.
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/github-script@v6
+      env:
+        name: ${{ inputs.name }}
+        head_sha: ${{ inputs.head-sha }}
+        status: ${{ inputs.status }}
+        conclusion: ${{ inputs.conclusion }}
+      with:
+        script: |
+          const { name, head_sha, status, conclusion } = process.env;
+          const { owner, repo } = context.repo;
+          github.rest.checks.create({
+            name,
+            owner,
+            repo,
+            head_sha,
+            status,
+            conclusion: conclusion.length > 0 ? conclusion : undefined
+          });

--- a/.github/actions/update-check/action.yml
+++ b/.github/actions/update-check/action.yml
@@ -27,7 +27,6 @@ runs:
       with:
         script: |
           const { status, conclusion, check_run_id, owner, repo } = process.env;
-          console.log('check_run_id in update checks: ', check_run_id);
           github.rest.checks.update({
             owner,
             repo,

--- a/.github/actions/update-check/action.yml
+++ b/.github/actions/update-check/action.yml
@@ -1,0 +1,37 @@
+name: 'Update Status Checks'
+description: 'Update status check on a specified check ID'
+inputs:
+  status:
+    description: >-
+      Status of check with possible values of 'queued', 'in_progress', 'completed'
+    required: true
+  check-id:
+    description: 'Check ID of status check to be updated'
+    required: true
+  conclusion:
+    description: >-
+      Conclusion of status check with possible values of 'action_required',
+      'cancelled', 'failure', 'neutral', 'success', 'skipped', 'stale', 'timed_out'.
+      This is only required if status is 'completed'.
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0 https://github.com/actions/github-script/commit/98814c53be79b1d30f795b907e553d8679345975
+      env:
+        status: ${{ inputs.status }}
+        check_run_id: ${{ inputs.check-id }}
+        conclusion: ${{ inputs.conclusion }}
+        owner: ${{ github.event.repository.owner.login }}
+        repo: ${{ github.event.repository.name }}
+      with:
+        script: |
+          const { status, conclusion, check_run_id, owner, repo } = process.env;
+          console.log('check_run_id in update checks: ', check_run_id);
+          github.rest.checks.update({
+            owner,
+            repo,
+            status,
+            check_run_id,
+            conclusion: conclusion.length > 0 ? conclusion : undefined
+          });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add github actions for status checks to use it approval based workflows.
- create-check: Creates a status check of a specified head-sha
- update-check: Updates status of an existing check

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
Tested against POC to run actions on pull request --> https://github.com/wlee221/amplify-ui/pull/8
[![POC / Test checks](https://github.com/wlee221/amplify-ui/actions/workflows/test-checks.yml/badge.svg)](https://github.com/wlee221/amplify-ui/actions/workflows/test-checks.yml)

Tested that a workflow can update the status of a check multiple times.
For example, we tested that a check called 'POC check' is updated from 'in_progress' to 'completed'.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
