### PR TITLE
fix: export Korean tranlsations to the right key(ko)

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
@@ -11,7 +11,7 @@ The `Authenticator` ships with [translations](https://github.com/aws-amplify/amp
 - `id` – Indonesian
 - `it` – Italian
 - `ja` – Japanese
-- `kr` – Korean
+- `ko` – Korean
 - `pl` – Polish
 - `pt` – Portuguese
 - `ru` – Russian

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
@@ -12,7 +12,7 @@ The `Authenticator` ships with [translations](https://github.com/aws-amplify/amp
 - `id` – Indonesian
 - `it` – Italian
 - `ja` – Japanese
-- `kr` – Korean
+- `ko` – Korean
 - `pl` – Polish
 - `pt` – Portuguese
 - `ru` – Russian

--- a/packages/ui/src/i18n/translations.ts
+++ b/packages/ui/src/i18n/translations.ts
@@ -85,7 +85,9 @@ export const translations: Record<string, Dict> = {
   id: idDict,
   it: itDict,
   ja: jaDict,
+  // TODO: remove kr in next major release
   kr: krDict,
+  ko: krDict,
   nl: nlDict,
   pl: plDict,
   pt: ptDict,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

export Korean translations to `ko` key

#### Issue #, if available

fixes #3552 

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
