### PR TITLE
chore: Add husky pre-push check for changeset

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,23 +1,28 @@
 #!/bin/sh
-while read local_ref; do
-  # Check if the local branch name starts with "docs-release-pr", in which case exit successfully
-  if [[ "$local_ref" =~ ^refs/heads/docs-release-pr-.* ]]; then
-    exit 0
-  fi
-  
-  # get a list of all changed files between the local and upstream main branches
-  changed_files=$(git diff --name-only main..HEAD --no-merges)
 
-  # Check if any of the changed files are in the src folder of the angular, react, react-core, react-native, ui or vue packages
-  if echo "${changed_files}" | grep -E '^packages/(angular/projects/ui-angular|react|react-core|react-native|ui|vue)/src/'; then
-    # Check if a changeset file is present and has .md extension
-    if echo "${changed_files}" | grep -E '^\.changeset/.*\.md$'; then
-      exit 0
-    else
-      echo "ERROR: These changes should result in a version bump but no changeset was found! \nPlease add a changeset file by running yarn changeset."
-      exit 1
-    fi
+# Fail fast, exit immediately on any error
+set -e
+
+# Get the name of the current branch
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# Check if the local branch name starts with "docs-release-pr" or "changeset-release/main", in which case exit successfully
+if [[ "$current_branch" =~ ^(docs-release-pr-.*|changeset-release/main)$ ]]; then
+  exit 0
+fi
+
+# Get the list of all changed files between the local and upstream main branches
+changed_files=$(git diff --name-only main..HEAD --no-merges)
+
+# Check if any of the changed files are in the src folder of the angular, react, react-core, react-native, ui or vue packages
+if echo "${changed_files}" | grep -E '^packages/(angular/projects/ui-angular|react|react-core|react-native|ui|vue)/src/'; then
+  # Check if a changeset file is present and has .md extension
+  if echo "${changed_files}" | grep -E '^\.changeset/.*\.md$'; then
+    exit 0
+  else
+    echo "ERROR: These changes should result in a version bump but no changeset was found! \nPlease add a changeset file by running yarn changeset."
+    exit 1
   fi
-done
+fi
 
 exit 0

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,6 @@
 #!/bin/sh
 while read local_ref local_sha remote_ref remote_sha; do
-  # Check if the local branch name starts with "docs-release-pr", in which case exist successfully
+  # Check if the local branch name starts with "docs-release-pr", in which case exit successfully
   if [[ "$local_ref" =~ ^refs/heads/docs-release-pr-.* ]]; then
     exit 0
   fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,15 +1,15 @@
 #!/bin/sh
-while read local_ref local_sha remote_ref remote_sha; do
+while read local_ref; do
   # Check if the local branch name starts with "docs-release-pr", in which case exit successfully
   if [[ "$local_ref" =~ ^refs/heads/docs-release-pr-.* ]]; then
     exit 0
   fi
   
-  # Get the list of changed files in this commit
-  changed_files="$(git diff --name-only "${local_sha}" "${remote_sha}")"
+  # get a list of all changed files between the local and upstream main branches
+  changed_files=$(git diff --name-only main..HEAD --no-merges)
 
-  # Check if any of the changed files are in the angular, react, react-native, ui or vue packages
-  if echo "${changed_files}" | grep -E '^packages/angular/|^packages/react/|^packages/react-core/|^packages/react-native/|^packages/ui/|^packages/vue/'; then
+  # Check if any of the changed files are in the src folder of the angular, react, react-core, react-native, ui or vue packages
+  if echo "${changed_files}" | grep -E '^packages/(angular/projects/ui-angular|react|react-core|react-native|ui|vue)/src/'; then
     # Check if a changeset file is present and has .md extension
     if echo "${changed_files}" | grep -E '^\.changeset/.*\.md$'; then
       exit 0

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,23 @@
+#!/bin/sh
+while read local_ref local_sha remote_ref remote_sha; do
+  # Check if the local branch name starts with "docs-release-pr", in which case exist successfully
+  if [[ "$local_ref" =~ ^refs/heads/docs-release-pr-.* ]]; then
+    exit 0
+  fi
+  
+  # Get the list of changed files in this commit
+  changed_files="$(git diff --name-only "${local_sha}" "${remote_sha}")"
+
+  # Check if any of the changed files are in the angular, react, react-native, ui or vue packages
+  if echo "${changed_files}" | grep -E '^packages/angular/|^packages/react/|^packages/react-core/|^packages/react-native/|^packages/ui/|^packages/vue/'; then
+    # Check if a changeset file is present and has .md extension
+    if echo "${changed_files}" | grep -E '^\.changeset/.*\.md$'; then
+      exit 0
+    else
+      echo "ERROR: These changes should result in a version bump but no changeset was found! \nPlease add a changeset file by running yarn changeset."
+      exit 1
+    fi
+  fi
+done
+
+exit 0


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change adds a husky `pre-push` script to check for changeset before pushing changes to ui, angular, react, react-core, react-native, vue packages, specifically the `src` folder of these packages (to reduce false positives, andalso  CI jobs or dependabot wouldn't be affected). Additionally release related branches are allowlisted.

Added husky script instead of github action to fail fast instead of in CI.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Validated against my fork

* with changes to ui packages and no changeset
```
❯ git push
ERROR: These changes should result in a version bump but no changeset was found! 
Please add a changeset file by running yarn changeset.
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
