### PR TITLE
fix(ui): Add select primitive icon default color

### DIFF
--- a/.changeset/gentle-berries-invent.md
+++ b/.changeset/gentle-berries-invent.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui': patch
+---
+
+fix(ui): Add select primitive icon default color

--- a/packages/ui/src/theme/css/component/select.scss
+++ b/packages/ui/src/theme/css/component/select.scss
@@ -7,6 +7,7 @@
 }
 
 .amplify-select__icon-wrapper {
+  color: var(--amplify-components-fieldcontrol-color);
   align-items: var(--amplify-components-select-icon-wrapper-align-items);
   position: var(--amplify-components-select-icon-wrapper-position);
   top: var(--amplify-components-select-icon-wrapper-top);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change fixes an issue where the select dropdown icon is not visible in dark mode. This is because the svg icon's fill is set to `currentColor` but there is no element defining what the color is. Note: It works on our docs site because the docs use a separate theme which defines [color](https://github.com/aws-amplify/amplify-ui/blob/main/docs/src/styles/docs/base.scss#L238).
* Added color css atribute to icon wrapper.
* Verified that the icon color can still be overridden by using `iconColor` prop.

Stackblitz: https://stackblitz.com/edit/react-ts-c74shc?file=App.tsx

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fixes #3582 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
