### PR TITLE
ci: use absolute path to call reusable action

### DIFF
--- a/.github/workflows/test-fork-prs.yml
+++ b/.github/workflows/test-fork-prs.yml
@@ -121,7 +121,7 @@ jobs:
 
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
       - name: Set status to commit sha
-        uses: ./.github/actions/set-status
+        uses: aws-amplify/amplify-ui/.github/actions/set-status@main
         with:
           sha: ${{ steps.read-commit-id.outputs.result }}
           state: 'pending'
@@ -233,7 +233,7 @@ jobs:
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
       - name: Update status when tests are successful
-        uses: ./.github/actions/set-status
+        uses: aws-amplify/amplify-ui/.github/actions/set-status@main
         with:
           sha: ${{ needs.setup.outputs.commit_id }}
           state: 'success'
@@ -251,7 +251,7 @@ jobs:
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
       - name: Update status when PR tests are not successful
-        uses: ./.github/actions/set-status
+        uses: aws-amplify/amplify-ui/.github/actions/set-status@main
         with:
           sha: ${{ needs.setup.outputs.commit_id }}
           state: 'failure'

--- a/.github/workflows/test-internal-prs.yml
+++ b/.github/workflows/test-internal-prs.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
       - name: Set status to commit sha
-        uses: ./.github/actions/set-status
+        uses: aws-amplify/amplify-ui/.github/actions/set-status@main
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           state: 'pending'
@@ -143,7 +143,7 @@ jobs:
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
       - name: Update status when tests are successful
-        uses: ./.github/actions/set-status
+        uses: aws-amplify/amplify-ui/.github/actions/set-status@main
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           state: 'success'
@@ -160,7 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
       - name: Update status when tests are not successful
-        uses: ./.github/actions/set-status
+        uses: aws-amplify/amplify-ui/.github/actions/set-status@main
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           state: 'failure'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This updates test runner workflows to use absolute path to call `set-status` action. 

This ensures that workflows only run the version of action defined on `main`. We can consider using relative paths in the future for better DX, but for now let's keep this consistent with the others.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Description of how you validated changes

n/a

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
