### PR TITLE
ci: run codeql on push to `main`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: 'CodeQL'
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: '/language:${{matrix.language}}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      security-events: write # to write security event to the PR
+      security-events: write # to write security event to the repo
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,32 +6,30 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
-      security-events: write
-
+      security-events: write # to write security event to the PR
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript']
-
+        language: [javascript]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@d23060145bc9131d50558d5d4185494a20208101 # v2.12.5 https://github.com/github/codeql-action/commit/d23060145bc9131d50558d5d4185494a20208101
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@d23060145bc9131d50558d5d4185494a20208101 # v2.12.5 https://github.com/github/codeql-action/commit/d23060145bc9131d50558d5d4185494a20208101
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@d23060145bc9131d50558d5d4185494a20208101 # v2.12.5 https://github.com/github/codeql-action/commit/d23060145bc9131d50558d5d4185494a20208101
         with:
-          category: '/language:${{matrix.language}}'
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

After #3591, we run codeql on PRs but do not run codeql on push to main.

Adding this PR to run codeql on push as well as on PRs.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Steps are copied from existing workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
