### PR TITLE
chore: fileuploader deprecation warning only dev mode

### DIFF
--- a/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
@@ -39,7 +39,7 @@ export function FileUploader({
   useDeprecationWarning({
     shouldWarn: true,
     message:
-      'FileUploader has exited Dev Preview and was renamed to StorageManager with some API changes. Please migrate to the StorageManager component, as the FileUploader component is no longer supported and will be removed in a future major release. https://dev.ui.docs.amplify.aws/react/connected-components/storage/storagemanager',
+      'FileUploader has exited Dev Preview and was renamed to StorageManager with some API changes. Please migrate to the StorageManager component, as the FileUploader component is no longer supported and will be removed in a future major release. https://ui.docs.amplify.aws/react/connected-components/storage/storagemanager',
   });
 
   if (!acceptedFileTypes || !accessLevel) {

--- a/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/Storage/FileUploader/FileUploader.tsx
@@ -14,6 +14,7 @@ import { UploadPreviewer } from './UploadPreviewer';
 import { UploadDropZone } from './UploadDropZone';
 import { UploadTracker } from './UploadTracker';
 import { FileState, FileUploaderProps } from './types';
+import { useDeprecationWarning } from '../../../hooks/useDeprecationWarning';
 
 const isUploadTask = (value: unknown): value is UploadTask =>
   typeof (value as UploadTask)?.resume === 'function';
@@ -35,11 +36,11 @@ export function FileUploader({
   isResumable = false,
   ...rest
 }: FileUploaderProps): JSX.Element {
-  useEffect(() => {
-    logger.warn(
-      'FileUploader has exited Dev Preview and was renamed to StorageManager with some API changes. Please migrate to the StorageManager component, as the FileUploader component is no longer supported and will be removed in a future major release.'
-    );
-  }, []);
+  useDeprecationWarning({
+    shouldWarn: true,
+    message:
+      'FileUploader has exited Dev Preview and was renamed to StorageManager with some API changes. Please migrate to the StorageManager component, as the FileUploader component is no longer supported and will be removed in a future major release. https://dev.ui.docs.amplify.aws/react/connected-components/storage/storagemanager',
+  });
 
   if (!acceptedFileTypes || !accessLevel) {
     logger.warn(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update FileUploader deprecation warning to only show up in dev mode.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
![image](https://user-images.githubusercontent.com/6165315/229887677-85c00baa-d3d8-4da7-9578-692d05f47b58.png)



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
* yarn next-example build && yarn next-example start
* Validated warning is missing in prod mode.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
