### PR TITLE
fix(ui-react-native): remove themed selectionColor from TextField

### DIFF
--- a/.changeset/olive-adults-walk.md
+++ b/.changeset/olive-adults-walk.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-native": patch
+---
+
+fix(ui-react-native): remove themed selectionColor from TextField

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/__snapshots__/ConfirmResetPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmResetPassword/__tests__/__snapshots__/ConfirmResetPassword.spec.tsx.snap
@@ -96,7 +96,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Code"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -181,7 +180,6 @@ Array [
           placeholder="New Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -330,7 +328,6 @@ Array [
           placeholder="Confirm Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -664,7 +661,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Code"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -749,7 +745,6 @@ Array [
           placeholder="New Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -898,7 +893,6 @@ Array [
           placeholder="Confirm Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {

--- a/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/__snapshots__/ConfirmSignIn.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ConfirmSignIn/__tests__/__snapshots__/ConfirmSignIn.spec.tsx.snap
@@ -96,7 +96,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Code"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -375,7 +374,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Code"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {

--- a/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/__snapshots__/ForceNewPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ForceNewPassword/__tests__/__snapshots__/ForceNewPassword.spec.tsx.snap
@@ -73,7 +73,6 @@ Array [
           onChangeText={[Function]}
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -393,7 +392,6 @@ Array [
           onChangeText={[Function]}
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -656,7 +654,6 @@ Array [
           onChangeText={[Function]}
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {

--- a/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/__snapshots__/ResetPassword.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/ResetPassword/__tests__/__snapshots__/ResetPassword.spec.tsx.snap
@@ -96,7 +96,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Username"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -375,7 +374,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Username"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {

--- a/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/__snapshots__/SetupTOTP.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SetupTOTP/__tests__/__snapshots__/SetupTOTP.spec.tsx.snap
@@ -141,7 +141,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Code"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -465,7 +464,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Code"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {

--- a/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/__snapshots__/SignIn.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SignIn/__tests__/__snapshots__/SignIn.spec.tsx.snap
@@ -96,7 +96,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Username"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -181,7 +180,6 @@ Array [
           placeholder="Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -514,7 +512,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Username"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -599,7 +596,6 @@ Array [
           placeholder="Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -884,7 +880,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Username"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -969,7 +964,6 @@ Array [
           placeholder="Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {

--- a/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/__snapshots__/SignUp.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/SignUp/__tests__/__snapshots__/SignUp.spec.tsx.snap
@@ -96,7 +96,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Username"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -181,7 +180,6 @@ Array [
           placeholder="Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -330,7 +328,6 @@ Array [
           placeholder="Confirm Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -482,7 +479,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Phone"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -706,7 +702,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Username"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -791,7 +786,6 @@ Array [
           placeholder="Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -940,7 +934,6 @@ Array [
           placeholder="Confirm Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -1092,7 +1085,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Phone"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -1259,7 +1251,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Username"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -1345,7 +1336,6 @@ Array [
           placeholder="Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -1497,7 +1487,6 @@ Array [
           placeholder="Confirm Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -1652,7 +1641,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Phone"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -1876,7 +1864,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Username"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -1961,7 +1948,6 @@ Array [
           placeholder="Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -2110,7 +2096,6 @@ Array [
           placeholder="Confirm Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -2262,7 +2247,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Phone"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -2545,7 +2529,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Username"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -2660,7 +2643,6 @@ Array [
           placeholder="Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -2812,7 +2794,6 @@ Array [
           placeholder="Confirm Password"
           placeholderTextColor="hsl(210, 10%, 40%)"
           secureTextEntry={true}
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {
@@ -2967,7 +2948,6 @@ Array [
           onChangeText={[Function]}
           placeholder="Phone"
           placeholderTextColor="hsl(210, 10%, 40%)"
-          selectionColor="hsl(210, 50%, 10%)"
           style={
             Array [
               Object {

--- a/packages/react-native/src/primitives/PasswordField/__tests__/__snapshots__/PasswordField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/PasswordField/__tests__/__snapshots__/PasswordField.spec.tsx.snap
@@ -68,7 +68,6 @@ exports[`PasswordField applies theme and style props 1`] = `
       editable={true}
       placeholderTextColor="hsl(210, 10%, 40%)"
       secureTextEntry={true}
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {
@@ -202,7 +201,6 @@ exports[`PasswordField renders as expected 1`] = `
       editable={true}
       placeholderTextColor="hsl(210, 10%, 40%)"
       secureTextEntry={true}
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {
@@ -335,7 +333,6 @@ exports[`PasswordField renders as expected when disabled 1`] = `
       editable={false}
       placeholderTextColor="hsl(210, 10%, 40%)"
       secureTextEntry={true}
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {
@@ -474,7 +471,6 @@ exports[`PasswordField should be able to hide show password icon 1`] = `
       editable={true}
       placeholderTextColor="hsl(210, 10%, 40%)"
       secureTextEntry={true}
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {
@@ -558,7 +554,6 @@ exports[`PasswordField should be able to obscure text programmatically 1`] = `
       editable={true}
       placeholderTextColor="hsl(210, 10%, 40%)"
       secureTextEntry={false}
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {

--- a/packages/react-native/src/primitives/PhoneNumberField/__tests__/__snapshots__/PhoneNumberField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/PhoneNumberField/__tests__/__snapshots__/PhoneNumberField.spec.tsx.snap
@@ -40,7 +40,6 @@ exports[`PhoneNumberField applies theming 1`] = `
       editable={true}
       keyboardType="phone-pad"
       placeholderTextColor="hsl(210, 10%, 40%)"
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {
@@ -101,7 +100,6 @@ exports[`PhoneNumberField renders as expected 1`] = `
       editable={true}
       keyboardType="phone-pad"
       placeholderTextColor="hsl(210, 10%, 40%)"
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {
@@ -163,7 +161,6 @@ exports[`PhoneNumberField renders as expected when disabled 1`] = `
       editable={false}
       keyboardType="phone-pad"
       placeholderTextColor="hsl(210, 10%, 40%)"
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {

--- a/packages/react-native/src/primitives/TextField/TextField.tsx
+++ b/packages/react-native/src/primitives/TextField/TextField.tsx
@@ -27,7 +27,7 @@ export default function TextField({
   ...rest
 }: TextFieldProps): JSX.Element {
   const theme = useTheme();
-  const themedStyle = getThemedStyles(theme);
+  const themedStyle = useMemo(() => getThemedStyles(theme), [theme]);
 
   const fieldContainerStyle: ViewStyle = useMemo(
     () => ({
@@ -64,7 +64,6 @@ export default function TextField({
           autoCapitalize={autoCapitalize}
           editable={!disabled}
           placeholderTextColor={theme.tokens.colors.font.tertiary}
-          selectionColor={theme.tokens.colors.font.primary}
           style={[themedStyle.field, fieldStyle]}
         />
         {endAccessory ?? null}

--- a/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
+++ b/packages/react-native/src/primitives/TextField/__tests__/__snapshots__/TextField.spec.tsx.snap
@@ -63,7 +63,6 @@ exports[`TextField doesn't render the errorMessage if error prop is false 1`] = 
       editable={true}
       placeholder="Placeholder"
       placeholderTextColor="hsl(210, 10%, 40%)"
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {
@@ -144,7 +143,6 @@ exports[`TextField doesn't render the errorMessage if errorMessage prop is undef
       editable={true}
       placeholder="Placeholder"
       placeholderTextColor="hsl(210, 10%, 40%)"
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {
@@ -225,7 +223,6 @@ exports[`TextField renders as expected 1`] = `
       editable={true}
       placeholder="Placeholder"
       placeholderTextColor="hsl(210, 10%, 40%)"
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {
@@ -307,7 +304,6 @@ exports[`TextField renders as expected as password field 1`] = `
       placeholder="Placeholder"
       placeholderTextColor="hsl(210, 10%, 40%)"
       secureTextEntry={true}
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {
@@ -389,7 +385,6 @@ exports[`TextField renders as expected when disabled 1`] = `
       editable={false}
       placeholder="Placeholder"
       placeholderTextColor="hsl(210, 10%, 40%)"
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {
@@ -470,7 +465,6 @@ exports[`TextField renders as expected with error message 1`] = `
       editable={true}
       placeholder="Placeholder"
       placeholderTextColor="hsl(210, 10%, 40%)"
-      selectionColor="hsl(210, 50%, 10%)"
       style={
         Array [
           Object {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Remove themed `selectionColor` and memo themed style in `TextField`.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-ui/issues/3618
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
