### PR TITLE
internal: add Field primitive

### DIFF
--- a/.changeset/small-buses-dance.md
+++ b/.changeset/small-buses-dance.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+Adding an internal Field primitive

--- a/docs/tests/__snapshots__/cssvars-table.test.ts.snap
+++ b/docs/tests/__snapshots__/cssvars-table.test.ts.snap
@@ -1879,6 +1879,10 @@ exports[`CSS Variables Table 1`] = `
         \\"value\\": \\"100%\\"
     },
     {
+        \\"variable\\": \\"--amplify-components-field-flex-direction\\",
+        \\"value\\": \\"column\\"
+    },
+    {
         \\"variable\\": \\"--amplify-components-field-font-size\\",
         \\"value\\": \\"var(--amplify-font-sizes-medium)\\"
     },

--- a/examples/next/pages/ui/components/storage/storage-manager/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/index.page.tsx
@@ -1,5 +1,6 @@
 import { Amplify } from 'aws-amplify';
 import { withAuthenticator } from '@aws-amplify/ui-react';
+import { Field } from '@aws-amplify/ui-react/internal';
 import { StorageManager } from '@aws-amplify/ui-react-storage';
 import '@aws-amplify/ui-react/styles.css';
 import awsExports from './aws-exports';
@@ -7,13 +8,21 @@ Amplify.configure(awsExports);
 
 export function StorageManagerExample() {
   return (
-    <StorageManager
-      acceptedFileTypes={['image/*']}
-      accessLevel="private"
-      maxFileCount={3}
-      isResumable
-      showThumbnails={true}
-    />
+    <Field
+      label="Images"
+      isReadOnly={false}
+      isRequired={false}
+      errorMessage={'error'}
+      hasError={false}
+    >
+      <StorageManager
+        acceptedFileTypes={['image/*']}
+        accessLevel="private"
+        maxFileCount={3}
+        isResumable
+        showThumbnails={true}
+      />
+    </Field>
   );
 }
 export default withAuthenticator(StorageManagerExample);

--- a/packages/react/__tests__/__snapshots__/exports.ts.snap
+++ b/packages/react/__tests__/__snapshots__/exports.ts.snap
@@ -87,6 +87,7 @@ Array [
 
 exports[`@aws-amplify/ui-react/internal exports should match snapshot 1`] = `
 Array [
+  "Field",
   "IconAdd",
   "IconCheck",
   "IconCheckCircle",

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -29,4 +29,6 @@ export {
   mergeVariantsAndOverrides,
 } from './studio';
 
+export { Field } from './primitives/Field';
+
 export { PrimitiveCatalog } from './PrimitiveCatalog';

--- a/packages/react/src/primitives/Field/Field.tsx
+++ b/packages/react/src/primitives/Field/Field.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import {
+  Primitive,
+  FlexContainerStyleProps,
+  ViewProps,
+  InputProps,
+  FieldProps,
+} from '../types';
+import { classNameModifier } from '../shared/utils';
+import { ComponentClassNames } from '../shared/constants';
+import { Flex } from '../Flex';
+import { FieldDescription } from './FieldDescription';
+import { FieldErrorMessage } from './FieldErrorMessage';
+import { Label } from '../Label';
+
+interface FieldPrimitiveProps
+  extends FieldProps,
+    InputProps,
+    FlexContainerStyleProps,
+    ViewProps {}
+
+const FieldPrimitive: Primitive<FieldPrimitiveProps, typeof Flex> = (
+  props,
+  ref
+) => {
+  const {
+    className,
+    size,
+    testId,
+    children,
+    label,
+    labelHidden,
+    errorMessage,
+    hasError,
+    descriptiveText,
+    ...rest
+  } = props;
+
+  return (
+    <Flex
+      className={classNames(
+        ComponentClassNames.Field,
+        classNameModifier(ComponentClassNames.Field, size),
+        className
+      )}
+      data-size={size}
+      testId={testId}
+      ref={ref}
+      {...rest}
+    >
+      {label ? <Label visuallyHidden={labelHidden}>{label}</Label> : null}
+      {descriptiveText ? (
+        <FieldDescription labelHidden={labelHidden}>
+          {descriptiveText}
+        </FieldDescription>
+      ) : null}
+      {children}
+      {errorMessage ? (
+        <FieldErrorMessage hasError={hasError} errorMessage={errorMessage} />
+      ) : null}
+    </Flex>
+  );
+};
+
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/field)
+ */
+export const Field = React.forwardRef(FieldPrimitive);
+
+Field.displayName = 'Field';

--- a/packages/react/src/primitives/Field/Field.tsx
+++ b/packages/react/src/primitives/Field/Field.tsx
@@ -63,9 +63,6 @@ const FieldPrimitive: Primitive<FieldPrimitiveProps, typeof Flex> = (
   );
 };
 
-/**
- * [📖 Docs](https://ui.docs.amplify.aws/react/components/field)
- */
 export const Field = React.forwardRef(FieldPrimitive);
 
 Field.displayName = 'Field';

--- a/packages/react/src/primitives/Field/index.ts
+++ b/packages/react/src/primitives/Field/index.ts
@@ -1,3 +1,4 @@
 export { FieldClearButton } from './FieldClearButton';
 export { FieldDescription } from './FieldDescription';
 export { FieldErrorMessage } from './FieldErrorMessage';
+export { Field } from './Field';

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -368,6 +368,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-expander-icon-transition-timing-function: cubic-bezier(0.87, 0, 0.13, 1);
         --amplify-components-field-gap: var(--amplify-space-xs);
         --amplify-components-field-font-size: var(--amplify-font-sizes-medium);
+        --amplify-components-field-flex-direction: column;
         --amplify-components-field-small-gap: var(--amplify-space-xxxs);
         --amplify-components-field-small-font-size: var(--amplify-font-sizes-small);
         --amplify-components-field-large-gap: var(--amplify-space-small);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -402,6 +402,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-expander-icon-transition-timing-function: cubic-bezier(0.87, 0, 0.13, 1);
         --amplify-components-field-gap: var(--amplify-space-xs);
         --amplify-components-field-font-size: var(--amplify-font-sizes-medium);
+        --amplify-components-field-flex-direction: column;
         --amplify-components-field-small-gap: var(--amplify-space-xxxs);
         --amplify-components-field-small-font-size: var(--amplify-font-sizes-small);
         --amplify-components-field-large-gap: var(--amplify-space-small);

--- a/packages/ui/src/theme/css/component/field.scss
+++ b/packages/ui/src/theme/css/component/field.scss
@@ -1,6 +1,8 @@
 .amplify-field {
   font-size: var(--amplify-components-field-font-size);
   gap: var(--amplify-components-field-gap);
+  flex-direction: var(--amplify-components-field-flex-direction);
+  
   &--small {
     font-size: var(--amplify-components-field-small-font-size);
     gap: var(--amplify-components-field-small-gap);

--- a/packages/ui/src/theme/css/component/textField.scss
+++ b/packages/ui/src/theme/css/component/textField.scss
@@ -1,5 +1,4 @@
 .amplify-textfield {
-  flex-direction: column;
   --amplify-components-fieldcontrol-color: var(
     --amplify-components-textfield-color
   );

--- a/packages/ui/src/theme/tokens/components/field.ts
+++ b/packages/ui/src/theme/tokens/components/field.ts
@@ -6,16 +6,18 @@ type FieldSizeTokens<Output> = DesignTokenProperties<
 >;
 
 export type FieldTokens<Output extends OutputVariantKey> =
-  FieldSizeTokens<Output> & {
-    small?: FieldSizeTokens<Output>;
-    large?: FieldSizeTokens<Output>;
-    label?: DesignTokenProperties<'color', Output>;
-  };
+  FieldSizeTokens<Output> &
+    DesignTokenProperties<'flexDirection', Output> & {
+      small?: FieldSizeTokens<Output>;
+      large?: FieldSizeTokens<Output>;
+      label?: DesignTokenProperties<'color', Output>;
+    };
 
 export const field: Required<FieldTokens<'default'>> = {
   // default styles
   gap: { value: '{space.xs.value}' },
   fontSize: { value: '{fontSizes.medium.value}' },
+  flexDirection: { value: 'column' },
 
   // Adjust base fontSize and gap for small and large sizes
   small: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adding an internal Field primitive for custom fields like a StorageManagerField

```jsx
    <Field
      label="Images"
      isReadOnly={false}
      isRequired={false}
      errorMessage={'error'}
      hasError={false}
    >
      <StorageManager
        acceptedFileTypes={['image/*']}
        accessLevel="private"
        maxFileCount={3}
        isResumable
        showThumbnails={true}
      />
    </Field>
```

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
