### PR TITLE
ci: use IAM role for metrics logger

### DIFF
--- a/.github/actions/log-metric/action.yml
+++ b/.github/actions/log-metric/action.yml
@@ -7,23 +7,22 @@ inputs:
   value:
     description: 'the value to log to the metric'
     required: true
-  AWS_ACCESS_KEY_ID:
-    description: 'target AWS account credentials'
+  role-to-assume:
+    description: 'target AWS account IAM role to assume'
     required: true
-  AWS_SECRET_ACCESS_KEY:
-    description: 'target AWS account credentials'
-    required: true
-  AWS_REGION:
+  aws-region:
     description: 'target AWS account region'
     required: true
 runs:
   using: 'composite'
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef
       with:
-        aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ inputs.AWS_REGION }}
+        aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.role-to-assume }}
     - shell: bash
-      run: aws cloudwatch put-metric-data --metric-name ${{ inputs.metric-name }} --namespace GithubCanaryApps --value ${{ inputs.value }}
+      run: aws cloudwatch put-metric-data --metric-name "$metric_name" --namespace GithubCanaryApps --value "$value"
+      env:
+        metric_name: ${{ inputs.metric-name }}
+        value: ${{ inputs.value }}

--- a/.github/actions/log-metric/action.yml
+++ b/.github/actions/log-metric/action.yml
@@ -36,7 +36,7 @@ runs:
         fi
 
         if ! [[ "$value_trimmed" =~ ^[-+]?[0-9]+\.?[0-9]*$ ]]; then
-          echo "Issue number must be a valid number"
+          echo "Metric value must be a valid number"
           exit 1
         fi
 

--- a/.github/actions/log-metric/action.yml
+++ b/.github/actions/log-metric/action.yml
@@ -17,7 +17,7 @@ runs:
   using: 'composite'
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef
+      uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0 https://github.com/aws-actions/configure-aws-credentials/commit/e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef
       with:
         aws-region: ${{ inputs.aws-region }}
         role-to-assume: ${{ inputs.role-to-assume }}

--- a/.github/actions/log-metric/action.yml
+++ b/.github/actions/log-metric/action.yml
@@ -21,8 +21,28 @@ runs:
       with:
         aws-region: ${{ inputs.aws-region }}
         role-to-assume: ${{ inputs.role-to-assume }}
-    - shell: bash
-      run: aws cloudwatch put-metric-data --metric-name "$metric_name" --namespace GithubCanaryApps --value "$value"
+    - name: Put metric data
+      shell: bash
+      # Run bash script to put metric data.
+      # First trim the input by removing trailing or leading spaces, then removing any new line characters.
+      # Then, we do regex test to match against expected input shape. Finally, put metric data using aws cli.
+      run: |
+        metric_name_trimmed="$(echo -e "${metric_name}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr -d '\n')"
+        value_trimmed="$(echo -e "${value}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr -d '\n')"
+
+        echo $metric_name_trimmed
+
+        if ! [[ "$metric_name_trimmed" =~ ^[a-zA-Z0-9\ \_\-]+$ ]]; then
+          echo "Metric name can only contain alphanumeric characters, space character, -, and _."
+          exit 1
+        fi
+
+        if ! [[ "$value_trimmed" =~ ^[-+]?[0-9]+\.?[0-9]*$ ]]; then
+          echo "Issue number must be a valid number"
+          exit 1
+        fi
+
+        aws cloudwatch put-metric-data --metric-name "$metric_name" --namespace GithubCanaryApps --value "$value"
       env:
         metric_name: ${{ inputs.metric-name }}
         value: ${{ inputs.value }}

--- a/.github/actions/log-metric/action.yml
+++ b/.github/actions/log-metric/action.yml
@@ -30,8 +30,6 @@ runs:
         metric_name_trimmed="$(echo -e "${metric_name}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr -d '\n')"
         value_trimmed="$(echo -e "${value}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr -d '\n')"
 
-        echo $metric_name_trimmed
-
         if ! [[ "$metric_name_trimmed" =~ ^[a-zA-Z0-9\ \_\-]+$ ]]; then
           echo "Metric name can only contain alphanumeric characters, space character, -, and _."
           exit 1

--- a/.github/workflows/build-and-runtime-test.yml
+++ b/.github/workflows/build-and-runtime-test.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           metric-name: BuildAndRuntimeTestFailure
           value: 1
-          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN }}
           aws-region: us-east-2
 
   log-success-metric:
@@ -163,5 +163,5 @@ jobs:
         with:
           metric-name: BuildAndRuntimeTestFailure
           value: 0
-          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN }}
           aws-region: us-east-2

--- a/.github/workflows/build-and-runtime-test.yml
+++ b/.github/workflows/build-and-runtime-test.yml
@@ -148,9 +148,8 @@ jobs:
         with:
           metric-name: BuildAndRuntimeTestFailure
           value: 1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
-          AWS_REGION: us-east-2
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          aws-region: us-east-2
 
   log-success-metric:
     # Send a success data point to metric BuildAndRuntimeTestFailure in github-workflows@ us-east-2, if it's a success
@@ -164,6 +163,5 @@ jobs:
         with:
           metric-name: BuildAndRuntimeTestFailure
           value: 0
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
-          AWS_REGION: us-east-2
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          aws-region: us-east-2

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           metric-name: PublishLatestFailure
           value: 1
-          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN }}
           aws-region: us-east-2
 
   log-success-metric:
@@ -148,5 +148,5 @@ jobs:
         with:
           metric-name: PublishLatestFailure
           value: 0
-          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN }}
           aws-region: us-east-2

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -133,9 +133,8 @@ jobs:
         with:
           metric-name: PublishLatestFailure
           value: 1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
-          AWS_REGION: us-east-2
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          aws-region: us-east-2
 
   log-success-metric:
     # Send a success data point to metric PublishLatestFailure in github-workflows@ us-east-2
@@ -149,6 +148,5 @@ jobs:
         with:
           metric-name: PublishLatestFailure
           value: 0
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
-          AWS_REGION: us-east-2
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          aws-region: us-east-2

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -218,7 +218,7 @@ jobs:
         with:
           metric-name: PublishNextFailure
           value: 1
-          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN }}
           aws-region: us-east-2
 
   log-success-metric:
@@ -233,5 +233,5 @@ jobs:
         with:
           metric-name: PublishNextFailure
           value: 0
-          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN }}
           aws-region: us-east-2

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -218,9 +218,8 @@ jobs:
         with:
           metric-name: PublishNextFailure
           value: 1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
-          AWS_REGION: us-east-2
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          aws-region: us-east-2
 
   log-success-metric:
     # Send a success data point to metric PublishNextFailure in github-workflows@ us-east-2, if it's a success
@@ -234,6 +233,5 @@ jobs:
         with:
           metric-name: PublishNextFailure
           value: 0
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_METRIC_LOGGER }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_METRIC_LOGGER }}
-          AWS_REGION: us-east-2
+          role-to-assume: ${{ secrets.METRIC_LOGGER_ROLE_ARN}}
+          aws-region: us-east-2


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This migrates `log-metric` action to use IAM roles instead of IAM user credentials.


#### Description of how you validated changes

https://github.com/aws-amplify/amplify-ui/actions/runs/4625009086/jobs/8180374983

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
