### PR TITLE
fix(storage): fix defaultFiles

### DIFF
--- a/.changeset/fifty-berries-shout.md
+++ b/.changeset/fifty-berries-shout.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui-react-storage": patch
+---
+
+fix(storage): fix defaultFiles
+
+Previously if you added `defaultFiles` to the StorageManager you would get weird behavior saying it was uploading when it actually wasn't. Also if you passed null or improper file objects you would get an error. 

--- a/examples/next/pages/ui/components/storage/storage-manager/default-files/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/default-files/index.page.tsx
@@ -14,20 +14,6 @@ export function StorageManagerExample() {
         showThumbnails
         defaultFiles={[{ key: 'default.jpg' }]}
       />
-      <StorageManager
-        acceptedFileTypes={['image/*']}
-        accessLevel="public"
-        maxFileCount={1}
-        showThumbnails
-        defaultFiles={[{ key: null }, null]}
-      />
-      <StorageManager
-        acceptedFileTypes={['image/*']}
-        accessLevel="public"
-        maxFileCount={1}
-        showThumbnails
-        defaultFiles={null}
-      />
     </>
   );
 }

--- a/examples/next/pages/ui/components/storage/storage-manager/default-files/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/default-files/index.page.tsx
@@ -14,6 +14,20 @@ export function StorageManagerExample() {
         showThumbnails
         defaultFiles={[{ key: 'default.jpg' }]}
       />
+      <StorageManager
+        acceptedFileTypes={['image/*']}
+        accessLevel="public"
+        maxFileCount={1}
+        showThumbnails
+        defaultFiles={[{ key: null }, null]}
+      />
+      <StorageManager
+        acceptedFileTypes={['image/*']}
+        accessLevel="public"
+        maxFileCount={1}
+        showThumbnails
+        defaultFiles={null}
+      />
     </>
   );
 }

--- a/packages/e2e/features/ui/components/storage/storage-manager/upload-file-to-S3-private-multipart.feature
+++ b/packages/e2e/features/ui/components/storage/storage-manager/upload-file-to-S3-private-multipart.feature
@@ -16,6 +16,6 @@ Feature: Upload a file to S3 with private access level settings
     Given I intercept '{ "method": "PUT", "url": "**/test.jpg?partNumber=1**"  }' with fixture "Storage.private-uploads.xml"
     Given I intercept '{ "method": "POST", "url": "**/test.jpg?uploadId**"  }' with fixture "Storage.private-upload-complete-multipart.xml"
     Given I intercept '{ "method": "GET", "url": "**/?list-type=2**"  }' with fixture "Storage.private-uploads-list.xml"
-    Then I see "Uploaded successfully"
+    Then I see "Uploaded"
     Then I see "1 file uploaded"
     Then I click "Sign out"

--- a/packages/e2e/features/ui/components/storage/storage-manager/upload-file-to-S3-public-default-files.feature
+++ b/packages/e2e/features/ui/components/storage/storage-manager/upload-file-to-S3-public-default-files.feature
@@ -7,7 +7,7 @@ Feature: Storage Manager with default files
   Scenario: Storage Manager renders with default files
     Then I see "Browse files"
     And I see "default.jpg"
-    And I see "Uploaded successfully"
+    And I see "Uploaded"
    
   @react
   Scenario: I should not be able to upload more files

--- a/packages/e2e/features/ui/components/storage/storage-manager/upload-file-to-S3-public-multipart.feature
+++ b/packages/e2e/features/ui/components/storage/storage-manager/upload-file-to-S3-public-multipart.feature
@@ -12,6 +12,6 @@ Feature: Upload a file to S3 with public access level settings
     Given I intercept '{ "method": "PUT", "url": "**/test.jpg?partNumber=1**"  }' with fixture "Storage.public-uploads.xml"
     Given I intercept '{ "method": "POST", "url": "**/test.jpg?uploadId**"  }' with fixture "Storage.public-upload-complete-multipart.xml"
     Given I intercept '{ "method": "GET", "url": "**/?list-type=2**"  }' with fixture "Storage.public-uploads-list.xml"
-    Then I see "Uploaded successfully"
+    Then I see "Uploaded"
     Then I see "1 file uploaded"
 

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -10,6 +10,7 @@
     "test:authenticator": "cypress run --spec 'features/ui/components/authenticator/*.feature'",
     "test:hooks": "cypress run --spec 'features/ui/hooks/*.feature'",
     "test:geo": "cypress run --spec 'features/ui/components/geo/*.feature'",
+    "test:storage": "cypress run --spec 'features/ui/components/storage/**/*.feature'",
     "test:theme": "cypress run --spec 'features/ui/theme/*.feature'",
     "test:guides": "cypress run --spec 'features/ui/guides/*.feature'"
   },

--- a/packages/react-storage/src/components/StorageManager/StorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/StorageManager.tsx
@@ -183,7 +183,7 @@ function StorageManager({
   const allUploadsSuccessful =
     files.length === 0
       ? false
-      : files.every((status) => status?.progress === 100);
+      : files.every((file) => file?.status === FileStatus.UPLOADED);
 
   // Displays if over max files
   const hasMaxFilesError =

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/__tests__/useStorageManager.test.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/__tests__/useStorageManager.test.ts
@@ -134,7 +134,9 @@ describe('useUploadFiles', () => {
         useStorageManager([
           // @ts-expect-error
           null,
+          // @ts-expect-error
           { key: null },
+          // @ts-expect-error
           { foo: 'bar' },
         ])
       );

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/__tests__/useStorageManager.test.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/__tests__/useStorageManager.test.ts
@@ -114,4 +114,31 @@ describe('useUploadFiles', () => {
     );
     expect(result.current.files.length).toBe(1);
   });
+
+  describe('defaultFiles', () => {
+    it('should handle good defaultFiles', () => {
+      const { result } = renderHook(() =>
+        useStorageManager([{ key: 'file.jpg' }])
+      );
+      expect(result.current.files).toHaveLength(1);
+    });
+
+    it('should handle null defaultFiles', () => {
+      // @ts-expect-error
+      const { result } = renderHook(() => useStorageManager(null));
+      expect(result.current.files).toHaveLength(0);
+    });
+
+    it('should handle bad defaultFiles', () => {
+      const { result } = renderHook(() =>
+        useStorageManager([
+          // @ts-expect-error
+          null,
+          { key: null },
+          { foo: 'bar' },
+        ])
+      );
+      expect(result.current.files).toHaveLength(0);
+    });
+  });
 });

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/useStorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/useStorageManager.tsx
@@ -36,14 +36,16 @@ export function useStorageManager(
       action: Action
     ) => UseStorageManagerState
   >(storageManagerStateReducer, {
-    files: defaultFiles.map((file) => {
-      return {
-        ...file,
-        id: file.key,
-        key: file.key,
-        status: FileStatus.UPLOADED,
-      };
-    }) as StorageFiles,
+    files: (defaultFiles ?? [])
+      .filter((file) => file && typeof file.key === 'string')
+      .map((file) => {
+        return {
+          ...file,
+          id: file.key,
+          key: file.key,
+          status: FileStatus.UPLOADED,
+        };
+      }) as StorageFiles,
   });
 
   const addFiles: UseStorageManager['addFiles'] = ({

--- a/packages/react-storage/src/components/StorageManager/utils/displayText.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/displayText.ts
@@ -29,7 +29,7 @@ export const defaultStorageManagerDisplayText = {
   dropFilesText: 'Drop files here or',
   pauseText: 'Pause',
   resumeText: 'Resume',
-  uploadSuccessfulText: 'Uploaded successfully',
+  uploadSuccessfulText: 'Uploaded',
   getPausedText(percentage: number): string {
     return `Paused: ${percentage}%`;
   },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

`defaultFiles` had some weird behavior. This fixes it and ensures the prop being passed isn't null and the key isn't null. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

| Current | Fixed |
| - | - |
| <img width="815" alt="CleanShot 2023-04-05 at 22 36 59@2x" src="https://user-images.githubusercontent.com/321279/230284543-28e96f78-73ac-4c81-8086-0672ece6fdf0.png"> |  <img width="813" alt="CleanShot 2023-04-05 at 22 34 51@2x" src="https://user-images.githubusercontent.com/321279/230284591-dacd528d-df1c-48ff-963e-2a2a27e9e567.png"> |
|  <img width="813" alt="CleanShot 2023-04-05 at 22 35 58@2x" src="https://user-images.githubusercontent.com/321279/230284634-abb08078-ab7c-4f42-9f3d-c5366d6c1fdf.png"> | <img width="813" alt="CleanShot 2023-04-05 at 22 34 51@2x" src="https://user-images.githubusercontent.com/321279/230284591-dacd528d-df1c-48ff-963e-2a2a27e9e567.png"> |
| ![CleanShot 2023-04-05 at 22 24 06](https://user-images.githubusercontent.com/321279/230285527-3be675a3-5e1c-42de-9d51-b8ab24699735.gif)  | ![CleanShot 2023-04-05 at 22 21 37](https://user-images.githubusercontent.com/321279/230285370-8d8df383-4fd3-435b-868d-85669bb47e0f.gif) |





#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
