### PR TITLE
chore(ui-react-native): loosen Authenticator.Container children prop, update docs

### DIFF
--- a/.changeset/tough-flies-begin.md
+++ b/.changeset/tough-flies-begin.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-native": patch
+---
+
+chore(ui-react-native): loosen Authenticator.Container children prop, update docs

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.headers-and-footers.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.headers-and-footers.react-native.mdx
@@ -3,9 +3,11 @@
 The Authenticator has several "slots" that you can customize to add messaging & functionality to meet your app's needs.
 
 The Authenticator itself has the following optional slots which are rendered on each subcomponent:
-- `Container` - default `Container` wraps the `Authenticator`, has keyboard aware behavior
+- `Container` - Wraps the `Authenticator`. Can be overridden by extending `Authenticator.Container` or with a `View` component
 - `Footer` - renders below subcomponent content, no default provided
 - `Header` - renders above subcomponent content, no default provided
+
+> The default `Container` component contains keyboard aware scroll behavior.
 
 ```jsx file=../../../../../../../examples/react-native/src/features/Authenticator/Slots/Example.tsx
 

--- a/packages/react-native/src/Authenticator/__tests__/Authenticator.spec.tsx
+++ b/packages/react-native/src/Authenticator/__tests__/Authenticator.spec.tsx
@@ -27,7 +27,7 @@ const TestComponent = () => {
   return null;
 };
 
-function Container({ children }: { children: React.ReactNode }) {
+function Container({ children }: { children?: React.ReactNode }) {
   return <View testID={CONTAINER_TEST_ID}>{children}</View>;
 }
 

--- a/packages/react-native/src/Authenticator/common/DefaultContainer/types.ts
+++ b/packages/react-native/src/Authenticator/common/DefaultContainer/types.ts
@@ -15,7 +15,6 @@ export interface ContainerStyles {
 export interface ContainerProps
   extends ScrollViewProps,
     Pick<KeyboardAvoidingViewProps, 'behavior' | 'keyboardVerticalOffset'> {
-  children: React.ReactNode;
   keyboardAvoidingViewStyle?: StyleProp<ViewStyle>;
   scrollViewContentContainerStyle?: StyleProp<ViewStyle>;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Loosen strictness on `children` prop of `Authenticator.Container` and update docs to make it clear that `Container` prop of `Authenticator` can be any `View` component
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Related https://github.com/aws-amplify/amplify-ui/discussions/3665
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
