### PR TITLE
fix: reenable link checker, ignore apple 401 link

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -399,8 +399,6 @@ jobs:
           VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
 
       - name: Run Docs link checker
-        # TODO: remove continue-on-error after all the links are available
-        continue-on-error: true
         run: yarn docs test:links
 
       - name: Upload failure screenshots and errors

--- a/docs/src/data/ignoredLinks.ts
+++ b/docs/src/data/ignoredLinks.ts
@@ -10,10 +10,12 @@ export const IGNORED_LINKS = [
   'https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-inapp.html', // 403
   'https://docs.aws.amazon.com/amplify/latest/userguide/getting-started.html', // 403
   'https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html', // 403
+  'https://docs.aws.amazon.com/general/latest/gr/rekognition.html', // 403,
+  'https://docs.aws.amazon.com/rekognition/latest/dg/face-liveness-programming-api.html', // 403
+  'https://docs.aws.amazon.com/rekognition/latest/dg/recommendations-liveness.html', // 403
   'https://github.com/aws-amplify/amplify-ui/issues/new/choose', // 302. Only at test. Can't reproduce the status code. Can't find the redirected link.
   'https://github.com/aws-amplify/amplify-ui-android/issues/new/choose', // 302
   'https://github.com/aws-amplify/amplify-ui-swift/issues/new/choose', // 302
   'https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/new/choose', // 302
   'https://developer.apple.com/design/human-interface-guidelines/patterns/accessing-private-data/', // 401 Apple doesn't like bots maybe
-  'https://youtu.be/JfzwVl1wy0s', // 303, Fix after Liveness release to use expanded url
 ];

--- a/docs/src/data/ignoredLinks.ts
+++ b/docs/src/data/ignoredLinks.ts
@@ -15,7 +15,7 @@ export const IGNORED_LINKS = [
   'https://docs.aws.amazon.com/rekognition/latest/dg/recommendations-liveness.html', // 403
   'https://github.com/aws-amplify/amplify-ui/issues/new/choose', // 302. Only at test. Can't reproduce the status code. Can't find the redirected link.
   'https://github.com/aws-amplify/amplify-ui-android/issues/new/choose', // 302
-  'https://github.com/aws-amplify/amplify-ui-swift/issues/new/choose', // 302
-  'https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/new/choose', // 302
+  'https://github.com/aws-amplify/amplify-ui-swift/issues/new/choose', // 302 amplify-ui-wift redirects to amplify-ui-swift-liveness
+  'https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/new/choose', // 302 amplify-ui-swift-liveness does not have issue templates yet
   'https://developer.apple.com/design/human-interface-guidelines/patterns/accessing-private-data/', // 401 Apple doesn't like bots maybe
 ];

--- a/docs/src/data/ignoredLinks.ts
+++ b/docs/src/data/ignoredLinks.ts
@@ -11,4 +11,5 @@ export const IGNORED_LINKS = [
   'https://docs.aws.amazon.com/amplify/latest/userguide/getting-started.html', // 403
   'https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html', // 403
   'https://github.com/aws-amplify/amplify-ui/issues/new/choose', // 302. Only at test. Can't reproduce the status code. Can't find the redirected link.
+  'https://developer.apple.com/design/human-interface-guidelines/patterns/accessing-private-data/', // 401 Apple doesn't like bots maybe
 ];

--- a/docs/src/data/ignoredLinks.ts
+++ b/docs/src/data/ignoredLinks.ts
@@ -11,5 +11,9 @@ export const IGNORED_LINKS = [
   'https://docs.aws.amazon.com/amplify/latest/userguide/getting-started.html', // 403
   'https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html', // 403
   'https://github.com/aws-amplify/amplify-ui/issues/new/choose', // 302. Only at test. Can't reproduce the status code. Can't find the redirected link.
+  'https://github.com/aws-amplify/amplify-ui-android/issues/new/choose', // 302
+  'https://github.com/aws-amplify/amplify-ui-swift/issues/new/choose', // 302
+  'https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/new/choose', // 302
   'https://developer.apple.com/design/human-interface-guidelines/patterns/accessing-private-data/', // 401 Apple doesn't like bots maybe
+  'https://youtu.be/JfzwVl1wy0s', // 303, Fix after Liveness release to use expanded url
 ];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- PR to enable link checker once liveness URLs are live
- Ignores apple link that results in 401

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
