### PR TITLE
feat(android): add android getting started pages

### DIFF
--- a/docs/src/components/Layout/Sidebar.tsx
+++ b/docs/src/components/Layout/Sidebar.tsx
@@ -143,13 +143,13 @@ const SecondaryNav = (props) => {
   const isAndroid = platform === 'android';
   const isSwift = platform === 'swift';
 
-  const hideGettingStarted = isAndroid || isSwift;
+  const hideGettingStarted = isSwift;
   const hideTheming = isAndroid || isSwift;
   const hideGuidesExpander = isFlutter || isReactNative || isAndroid || isSwift;
 
   return (
     <Expander type="multiple" value={value} onValueChange={setValue}>
-      {/* Android and Swift don't have getting started at this time */}
+      {/* Swift doesn't have getting started at this time */}
       {hideGettingStarted ? null : (
         <ExpanderItem
           title={

--- a/docs/src/components/home/sections/HeroSection.tsx
+++ b/docs/src/components/home/sections/HeroSection.tsx
@@ -106,7 +106,7 @@ export const HeroSection = () => {
             <TerminalCommand command={frameworkInstallScript} variant="hero" />
           )}
 
-          {platform === 'swift' || platform === 'android' ? null : (
+          {platform === 'swift' ? null : (
             <Flex direction="row">
               <Button
                 size="large"

--- a/docs/src/data/links.tsx
+++ b/docs/src/data/links.tsx
@@ -491,12 +491,26 @@ export const gettingStarted: ComponentNavItem[] = [
   {
     href: '/getting-started/introduction',
     label: 'Introduction',
-    platforms: ['react', 'vue', 'angular', 'flutter', 'react-native'],
+    platforms: [
+      'react',
+      'vue',
+      'angular',
+      'flutter',
+      'react-native',
+      'android',
+    ],
   },
   {
     href: '/getting-started/installation',
     label: 'Installation',
-    platforms: ['react', 'vue', 'angular', 'flutter', 'react-native'],
+    platforms: [
+      'react',
+      'vue',
+      'angular',
+      'flutter',
+      'react-native',
+      'android',
+    ],
   },
   {
     href: '/getting-started/usage',

--- a/docs/src/pages/[platform]/getting-started/installation/dependencies.android.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/dependencies.android.mdx
@@ -1,7 +1,6 @@
-import { Alert, Link, Text } from '@aws-amplify/ui-react';
 import { ExampleCode } from '@/components/Example';
 
-Amplify UI Android requires Android API level 24 (Android 7.0) or above. You will also need to add dependencies for `FaceLivenessDetector` to the app's `build.gradle` file as shown below.
+Amplify UI Android requires Android API level 24 (Android 7.0) or above. The Amplify UI Android connected components are built using [Jetpack Compose](https://developer.android.com/jetpack/compose). You will need to update the app's `build.gradle` file as shown below to use Jetpack Compose.
 
 <ExampleCode>
     ```groovy
@@ -19,21 +18,8 @@ Amplify UI Android requires Android API level 24 (Android 7.0) or above. You wil
       }
       
       dependencies {
-          // FaceLivenessDetector dependency
-          implementation 'com.amplifyframework.ui:liveness:1.0.0'
-          
-          // Material3 dependency for theming FaceLivenessDetector
+          // Material3 dependency for theming the connected components
           implementation 'androidx.compose.material3:material3:1.0.1'
       }
     ```
 </ExampleCode>
-
-<Alert role="none" variation="info">
-  <Text color="inherit">
-    The Face Liveness component is currently the only supported component for
-    Android.
-  </Text>
-  <Link href="/android/connected-components/liveness">
-    View Face Liveness Component docs
-  </Link>
-</Alert>

--- a/docs/src/pages/[platform]/getting-started/installation/index.page.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Installation
 metaDescription: Installation Guide - How to install Amplify UI Packages, Styles, and Fonts.
-supportedFrameworks: angular|flutter|react|react-native|vue
+supportedFrameworks: android|angular|flutter|react|react-native|vue
 ---
 
 import Link from 'next/link';

--- a/docs/src/pages/[platform]/getting-started/introduction/index.page.mdx
+++ b/docs/src/pages/[platform]/getting-started/introduction/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 description: What is Amplify UI?
-supportedFrameworks: angular|flutter|react|react-native|vue
+supportedFrameworks: android|angular|flutter|react|react-native|vue
 ---
 
 import { Alert } from '@aws-amplify/ui-react';

--- a/docs/src/pages/[platform]/index.page.tsx
+++ b/docs/src/pages/[platform]/index.page.tsx
@@ -67,6 +67,8 @@ const HomePage = ({ colorMode }) => {
       pageContent = <ReactNativeHomePage colorMode={colorMode} />;
       break;
     case 'android':
+      pageContent = <AndroidHomePage colorMode={colorMode} />;
+      break;
     case 'swift':
       pageContent = null;
       break;

--- a/docs/tests/__snapshots__/sitemap.test.ts.snap
+++ b/docs/tests/__snapshots__/sitemap.test.ts.snap
@@ -5,6 +5,8 @@ exports[`Sitemap Snapshot 1`] = `
 /android, 
 /android/connected-components/liveness, 
 /android/connected-components/liveness/customization, 
+/android/getting-started/installation, 
+/android/getting-started/introduction, 
 /angular, 
 /angular/connected-components/authenticator, 
 /angular/connected-components/authenticator/advanced, 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Add getting started intro and installation pages for Android.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are updated
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
