### PR TITLE
fix(docs): fix ToC on Introduction and Account Settings pages, remove…

### DIFF
--- a/docs/src/pages/[platform]/connected-components/account-settings/DeveloperPreview.tsx
+++ b/docs/src/pages/[platform]/connected-components/account-settings/DeveloperPreview.tsx
@@ -8,7 +8,7 @@ export const DeveloperPreview = () => {
   if (platform !== 'react') return null;
 
   return (
-    <Alert variation="info" heading="Developer Preview">
+    <Alert variation="info" heading="Developer Preview" role="none">
       Account Settings components are currently in developer preview.
     </Alert>
   );

--- a/docs/src/pages/[platform]/connected-components/account-settings/account-settings.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/account-settings/account-settings.react.mdx
@@ -1,0 +1,42 @@
+import { Alert, Tabs, TabItem } from '@aws-amplify/ui-react';
+import { InstallScripts } from '@/components/InstallScripts';
+import { DeveloperPreview } from './DeveloperPreview';
+
+<DeveloperPreview />
+
+Account Settings components are a set of standalone components that add [user management](https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/) flows to your application with minimal boilerplate.
+
+<Alert variation="warning" role="none">
+  Account Settings components require end user to be authenticated. You can use the [`Authenticator`](/connected-components/authenticator) component to add authentication UI to your application.
+</Alert>
+
+## Quick Start
+
+### Step 1. Configure Backend
+
+Account settings components work seamlessly with the [Amplify CLI](https://docs.amplify.aws/cli/start/install/)
+to **automatically** work with your backend.
+
+First, update `@aws-amplify/cli` with [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)
+if you're using a version before `6.4.0`:
+
+<Tabs>
+<TabItem title="npm">
+
+```shell
+npm install -g @aws-amplify/cli@latest
+```
+
+</TabItem>
+<TabItem title="yarn">
+
+```shell
+yarn global add @aws-amplify/cli@latest
+```
+
+</TabItem>
+</Tabs>
+
+### Step 2. Install Dependencies
+
+<InstallScripts />

--- a/docs/src/pages/[platform]/connected-components/account-settings/index.page.mdx
+++ b/docs/src/pages/[platform]/connected-components/account-settings/index.page.mdx
@@ -4,12 +4,8 @@ description: Amplify UI provides account settings components to manage account s
 supportedFrameworks: react
 ---
 
-import { Alert, Tabs, TabItem } from '@aws-amplify/ui-react';
 import { Fragment } from '@/components/Fragment';
-import { InstallScripts } from '@/components/InstallScripts';
 import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
-import { DeveloperPreview } from './DeveloperPreview';
-
 
 export async function getStaticPaths() {
   return getCustomStaticPath(frontmatter.supportedFrameworks);
@@ -21,41 +17,4 @@ export async function getStaticProps() {
   return { props: {} }
 }
 
-<DeveloperPreview />
-
-Account Settings components are a set of standalone components that add [user management](https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/) flows to your application with minimal boilerplate.
-
-<Alert variation="warning">
-  Account Settings components require end user to be authenticated. You can use the [`Authenticator`](/connected-components/authenticator) component to add authentication UI to your application.
-</Alert>
-
-## Quick Start
-
-### Step 1. Configure Backend
-
-Account settings components work seamlessly with the [Amplify CLI](https://docs.amplify.aws/cli/start/install/)
-to **automatically** work with your backend.
-
-First, update `@aws-amplify/cli` with [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)
-if you're using a version before `6.4.0`:
-
-<Tabs>
-<TabItem title="npm">
-
-```shell
-npm install -g @aws-amplify/cli@latest
-```
-
-</TabItem>
-<TabItem title="yarn">
-
-```shell
-yarn global add @aws-amplify/cli@latest
-```
-
-</TabItem>
-</Tabs>
-
-### Step 2. Install Dependencies
-
-<InstallScripts />
+<Fragment>{({ platform }) => import(`./account-settings.${platform}.mdx`)}</Fragment>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.flutter.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.flutter.mdx
@@ -17,7 +17,7 @@ Then, to add support for another language, create a another file for that langua
 }
 ```
 
-This example only updates the 'Sign In' button. To find the full schema for Authenticator-compatible `.arb` file(s), you can check the default `.arb` files that come packaged with the Amplify Authenticator in the [`/src/l10n/src/`](https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_authenticator/lib/src/l10n/src) directory.
+This example only updates the 'Sign In' button. To find the full schema for Authenticator-compatible `.arb` file(s), you can check the default `.arb` files that come packaged with the Amplify Authenticator in the [`/src/l10n/src/`](https://github.com/aws-amplify/amplify-flutter/tree/main/packages/authenticator/amplify_authenticator/lib/src/l10n/src) directory.
 
 Next, import the following in the `./lib/main.dart` file:
 

--- a/docs/src/pages/[platform]/getting-started/introduction/index.page.mdx
+++ b/docs/src/pages/[platform]/getting-started/introduction/index.page.mdx
@@ -4,8 +4,7 @@ description: What is Amplify UI?
 supportedFrameworks: android|angular|flutter|react|react-native|vue
 ---
 
-import { Alert } from '@aws-amplify/ui-react';
-import { FRAMEWORKS } from '@/data/frameworks';
+import { Fragment } from '@/components/Fragment';
 import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 
 export async function getStaticPaths() {
@@ -18,58 +17,6 @@ export async function getStaticProps() {
   return { props: {} }
 }
 
-Amplify UI is an open-source UI library that brings the simplicity and extensibility of AWS Amplify to UI development. It consists of connected components that simplify complex workflows like authentication and dynamic data, primitive components that form the building blocks of a UI, and themes to make Amplify UI fit any brand. **Extensibility and customization** are at the forefront of Amplify UI allowing easy integration into any application regardless of the front-end tech stack. 
+<Fragment>{({ platform }) => import(`./intro.mdx`)}</Fragment>
 
-We want to take care of the details, like accessibility and cloud connectivity, so developers can focus on their product.
 
-## Connected components
-
-Amplify UI connected components abstract away complex front-end code like authentication and dynamic data to provide an intuitive API. Connected components are built on top of primitive components and Amplify Libraries. 
-
-Connected components are completely customizable at every layer. Customize the look-and-feel with theming controls, override components and function calls, bring your own UI with a headless mode, or even go un-styled, giving you full control over state, layout, styling, and transitions.
-
-## Primitive components
-
-<Alert role="none" variation="info">
-  Primitive components are React-only for now
-</Alert>
-
-Amplify UI primitive components are in the middle of the spectrum between 'headless' UI frameworks like [Radix](https://www.radix-ui.com/) and [Headless UI](https://headlessui.com/), and 'batteries included' frameworks like [MUI](https://mui.com/) and [Chakra](https://chakra-ui.com/). We want to provide a solid base that doesn't force a particular front-end architecture and every detail can be customized.
-
-All the styling is handled by plain CSS and themeable with CSS variables. However we do provide some extra styling utilities in React-like responsive style props, [ThemeProvider and useTheme hook](/react/theming), and [useBreakpointValue](/react/theming/responsive#usebreakpointvalue) for responsive values.
-
-Amplify UI primitive components adhere to WCAG (Web Content Accessibility Guidelines) and WAI-ARIA (Web Accessibility Initiative - Accessible Rich Internet Applications) specifications for accessibility including color contrast for low-vision users, and accessible labels, keyboard navigation, and focus state management for keyboard-only users. 
-
-## Tenets
-
-**Minimal footprint, maximum performance**
-Good components are fast and use native styling systems when possible, adding less dependencies, smaller memory footprint, and minimizing side effects.
-
-**Escape Hatches over ejections**
-Users should be able to control any aspect of our components using their favorite tools without throwing everything away. We meet users where they are and play nicely with platforms and frameworks.
-
-**Accessible by default**
-Component implementations follows platform accessibility standards and best practices (e.g. WCAG 2.1AA for Web, Apple HIG for iOS).
-
-**Respect the platform**
-We want to share as much as possible between platforms (like themes and schemas), and respect each platform identity and rules when possible (e.g. following name conventions and idioms). For example, React components should feel like React components.
-
-## Current status
-
-Currently, the [Authenticator](../connected-components/authenticator) is available for React, Angular, Vue, and Flutter. The Android and React Native Authenticators are currently in developer preview. Primitive components are available for React, with Angular, Vue, and React Native coming soon. 
-
-> If you are an Angular or Vue developer and want to get started, they share the same CSS as React so with the right class names
-> (we use BEM syntax) you can at least get the styling and theming that React has!
-
-## Roadmap
-
-Upcoming projects include:
-
-* Native iOS version of the Authenticator (without webviews)
-* React Native Authenticator
-* Improved Storage components for React, Angular, and Vue
-* Primitives and theming for Angular and Vue
-* Data components and hooks for React
-* More primitives
-
-If you would like to see something on our roadmap, [let us know on Github](https://github.com/aws-amplify/amplify-ui/discussions).

--- a/docs/src/pages/[platform]/getting-started/introduction/intro.mdx
+++ b/docs/src/pages/[platform]/getting-started/introduction/intro.mdx
@@ -1,0 +1,57 @@
+import { Alert } from '@aws-amplify/ui-react';
+
+Amplify UI is an open-source UI library that brings the simplicity and extensibility of AWS Amplify to UI development. It consists of connected components that simplify complex workflows like authentication and dynamic data, primitive components that form the building blocks of a UI, and themes to make Amplify UI fit any brand. **Extensibility and customization** are at the forefront of Amplify UI allowing easy integration into any application regardless of the front-end tech stack. 
+
+We want to take care of the details, like accessibility and cloud connectivity, so developers can focus on their product.
+
+## Connected components
+
+Amplify UI connected components abstract away complex front-end code like authentication and dynamic data to provide an intuitive API. Connected components are built on top of primitive components and Amplify Libraries. 
+
+Connected components are completely customizable at every layer. Customize the look-and-feel with theming controls, override components and function calls, bring your own UI with a headless mode, or even go un-styled, giving you full control over state, layout, styling, and transitions.
+
+## Primitive components
+
+<Alert role="none" variation="info">
+  Primitive components are React-only for now
+</Alert>
+
+Amplify UI primitive components are in the middle of the spectrum between 'headless' UI frameworks like [Radix](https://www.radix-ui.com/) and [Headless UI](https://headlessui.com/), and 'batteries included' frameworks like [MUI](https://mui.com/) and [Chakra](https://chakra-ui.com/). We want to provide a solid base that doesn't force a particular front-end architecture and every detail can be customized.
+
+All the styling is handled by plain CSS and themeable with CSS variables. However we do provide some extra styling utilities in React-like responsive style props, [ThemeProvider and useTheme hook](/react/theming), and [useBreakpointValue](/react/theming/responsive#usebreakpointvalue) for responsive values.
+
+Amplify UI primitive components adhere to WCAG (Web Content Accessibility Guidelines) and WAI-ARIA (Web Accessibility Initiative - Accessible Rich Internet Applications) specifications for accessibility including color contrast for low-vision users, and accessible labels, keyboard navigation, and focus state management for keyboard-only users. 
+
+## Tenets
+
+**Minimal footprint, maximum performance**
+Good components are fast and use native styling systems when possible, adding less dependencies, smaller memory footprint, and minimizing side effects.
+
+**Escape Hatches over ejections**
+Users should be able to control any aspect of our components using their favorite tools without throwing everything away. We meet users where they are and play nicely with platforms and frameworks.
+
+**Accessible by default**
+Component implementations follows platform accessibility standards and best practices (e.g. WCAG 2.1AA for Web, Apple HIG for iOS).
+
+**Respect the platform**
+We want to share as much as possible between platforms (like themes and schemas), and respect each platform identity and rules when possible (e.g. following name conventions and idioms). For example, React components should feel like React components.
+
+## Current status
+
+Currently, the [Authenticator](../connected-components/authenticator) is available for React, Angular, Vue, and Flutter. The Android and React Native Authenticators are currently in developer preview. Primitive components are available for React, with Angular, Vue, and React Native coming soon. 
+
+> If you are an Angular or Vue developer and want to get started, they share the same CSS as React so with the right class names
+> (we use BEM syntax) you can at least get the styling and theming that React has!
+
+## Roadmap
+
+Upcoming projects include:
+
+* Native iOS version of the Authenticator (without webviews)
+* React Native Authenticator
+* Improved Storage components for React, Angular, and Vue
+* Primitives and theming for Angular and Vue
+* Data components and hooks for React
+* More primitives
+
+If you would like to see something on our roadmap, [let us know on Github](https://github.com/aws-amplify/amplify-ui/discussions).


### PR DESCRIPTION
… alert role

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

The Table of Contents are currently not displaying on the [Account Settings](https://ui.docs.amplify.aws/react/connected-components/account-settings) page and the [Introduction](https://ui.docs.amplify.aws/react/getting-started/introduction) page **when** you navigate to them via the sidebar from another page on the site. The same issue was fixed in https://github.com/aws-amplify/amplify-ui/pull/3549. Applied a similar fix of moving that content to a fragment.

Also: removed some unneeded alert roles.

Fixes a broken Flutter link to github code after their recent release.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are updated
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
