### PR TITLE
fix(e2e): fix `yarn e2e dev` command

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@aws-amplify/ui": "^5.6.0",
     "@badeball/cypress-cucumber-preprocessor": "^12.1.0",
-    "@bahmutov/cypress-esbuild-preprocessor": "^2.1.3",
+    "@bahmutov/cypress-esbuild-preprocessor": "~2.1.3",
     "@nuintun/qrcode": "^3.3.0",
     "@testing-library/cypress": "^8.0.3",
     "aws-crt": "^1.10.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4692,10 +4692,10 @@
     resolve-pkg "^2.0.0"
     uuid "^8.3.2"
 
-"@bahmutov/cypress-esbuild-preprocessor@^2.1.3":
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/@bahmutov/cypress-esbuild-preprocessor/-/cypress-esbuild-preprocessor-2.2.0.tgz#ba5b6bf96e83da3cb4d0cc2baedd0eeee8c84a4f"
-  integrity sha512-pTvxRi6+OFsXy6uCn/HlO5zi0fUZWbiCtTiLTDf/+kgEfZ/Y8WIxZ2pjuir9MEM8prQenBw60TLcM0wcazh7+Q==
+"@bahmutov/cypress-esbuild-preprocessor@~2.1.3":
+  version "2.1.5"
+  resolved "https://registry.npmjs.org/@bahmutov/cypress-esbuild-preprocessor/-/cypress-esbuild-preprocessor-2.1.5.tgz#6e4746a470f097f3833a25f5e72bdcac178cbc41"
+  integrity sha512-cJMlZOZ3kUb/s2KQ8p7DJNiOzwApSoYCiK1toJKBvz58MbqBIeBjD7F8NFJE1MrFzYBYAOQcSMVWHp4y1l/Fjg==
   dependencies:
     debug "4.3.4"
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

`e2e dev` command broke after we last bumped lockfile in #3711. This is because `@bahmutov/cypress-esbuild-preprocessor` got bumped to the latest version which is incompatible with our current esbuild version (0.13/0.14).

See https://github.com/bahmutov/cypress-esbuild-preprocessor#esbuild-version-support.


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

![image](https://user-images.githubusercontent.com/43682783/232171404-bcd99650-6730-455b-8564-f6a940f38d2c.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
