### PR TITLE
chore(ui-react): remove type workaround in MapView

### DIFF
--- a/.changeset/fair-rings-play.md
+++ b/.changeset/fair-rings-play.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+Removed optional undefined type workaround for MapView props (fog & terrain) due to fix in react-map-gl library.

--- a/packages/react/src/components/Geo/MapView/index.tsx
+++ b/packages/react/src/components/Geo/MapView/index.tsx
@@ -96,9 +96,8 @@ const MapView = forwardRef<MapRef, MapViewProps>(
         ref={ref}
         style={styleProps}
         transformRequest={transformRequest}
-        // workaround until type is fixed on react-map-gl: https://github.com/visgl/react-map-gl/issues/1973
-        fog={props.fog ?? undefined}
-        terrain={props.terrain ?? undefined}
+        fog={props.fog}
+        terrain={props.terrain}
       />
     ) : null;
   }


### PR DESCRIPTION
#### Description of changes
Removed outdated workaround code for undefined type in MapView.

#### Issue #, if available
https://github.com/visgl/react-map-gl/issues/1973

#### Description of how you validated changes
Ran yarn test and all tests passed

#### Checklist
- [X] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [X] PR description included
- [X] Relevant documentation is changed or added (and PR referenced)
- [X] `yarn test` passes and tests are updated/added
- [X] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.