### PR TITLE
fix(ui-vue): prevent TS overwrite warnings

### DIFF
--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -13,6 +13,7 @@
     "allowJs": true,
     "sourceMap": true,
     "baseUrl": ".",
+    "outDir": "dist",
     "resolveJsonModule": true,
     "types": ["webpack-env", "vite/client", "@types/jest"],
     "paths": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add `outDir` key to Vue _tsconfig.json_ to remove overwrite warnings:
```
Cannot write file 'SOME_PATH/packages/vue/dist/index.js' because it would overwrite input file.
```
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
