### PR TITLE
chore(ui-react-core-notifications): fix imports in ui-react & ui-react-native

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aws-amplify/ui": "5.6.0",
     "@aws-amplify/ui-react-core": "2.1.19",
-    "@aws-amplify/ui-react-core-notifications": "^0.0.1"
+    "@aws-amplify/ui-react-core-notifications": "0.0.1"
   },
   "peerDependencies": {
     "aws-amplify": ">= 5.0.1",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -38,7 +38,8 @@
   },
   "dependencies": {
     "@aws-amplify/ui": "5.6.0",
-    "@aws-amplify/ui-react-core": "2.1.19"
+    "@aws-amplify/ui-react-core": "2.1.19",
+    "@aws-amplify/ui-react-core-notifications": "^0.0.1"
   },
   "peerDependencies": {
     "aws-amplify": ">= 5.0.1",

--- a/packages/react-native/src/InAppMessaging/components/BannerMessage/types.ts
+++ b/packages/react-native/src/InAppMessaging/components/BannerMessage/types.ts
@@ -1,5 +1,5 @@
 import { ViewStyle } from 'react-native';
-import { BannerMessageCommonProps } from '@aws-amplify/ui-react-core';
+import { BannerMessageCommonProps } from '@aws-amplify/ui-react-core-notifications';
 
 import { MessageDefaultStyle, MessageOverrideStyle } from '../../hooks';
 

--- a/packages/react-native/src/InAppMessaging/components/CarouselMessage/CarouselMessage.tsx
+++ b/packages/react-native/src/InAppMessaging/components/CarouselMessage/CarouselMessage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { MessageContentProps } from '@aws-amplify/ui-react-core';
+import { MessageContentProps } from '@aws-amplify/ui-react-core-notifications';
 
 import { Carousel } from '../../../primitives';
 import { IN_APP_MESSAGING_TEST_ID } from '../../constants';

--- a/packages/react-native/src/InAppMessaging/components/CarouselMessage/types.ts
+++ b/packages/react-native/src/InAppMessaging/components/CarouselMessage/types.ts
@@ -3,7 +3,7 @@ import { StyleProp, ViewStyle } from 'react-native';
 import {
   CarouselMessageCommonProps,
   MessageComponentBaseProps,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 
 import { MessageDefaultStyle, MessageOverrideStyle } from '../../hooks';
 

--- a/packages/react-native/src/InAppMessaging/components/FullScreenMessage/types.ts
+++ b/packages/react-native/src/InAppMessaging/components/FullScreenMessage/types.ts
@@ -1,4 +1,4 @@
-import { FullScreenMessageCommonProps } from '@aws-amplify/ui-react-core';
+import { FullScreenMessageCommonProps } from '@aws-amplify/ui-react-core-notifications';
 import { MessageDefaultStyle, MessageOverrideStyle } from '../../hooks';
 
 export interface FullScreenMessageProps

--- a/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/InAppMessageDisplay.tsx
+++ b/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/InAppMessageDisplay.tsx
@@ -4,7 +4,7 @@ import {
   handleMessageAction,
   OnMessageAction,
   useMessage,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 
 import { BannerMessage } from '../BannerMessage';
 import { FullScreenMessage } from '../FullScreenMessage';

--- a/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/__tests__/InAppMessageDisplay.spec.tsx
+++ b/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/__tests__/InAppMessageDisplay.spec.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { Text, View } from 'react-native';
 import { render } from '@testing-library/react-native';
-import { MessageLayout, useMessage } from '@aws-amplify/ui-react-core';
+import {
+  MessageLayout,
+  useMessage,
+} from '@aws-amplify/ui-react-core-notifications';
 
 import InAppMessageDisplay from '../InAppMessageDisplay';
 
-jest.mock('@aws-amplify/ui-react-core');
+jest.mock('@aws-amplify/ui-react-core-notifications');
 
 const mockUseMessage = useMessage as jest.Mock;
 

--- a/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/handleMessageLinkAction.ts
+++ b/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/handleMessageLinkAction.ts
@@ -1,6 +1,6 @@
 import { Linking } from 'react-native';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
-import { HandleMessageLinkAction } from '@aws-amplify/ui-react-core';
+import { HandleMessageLinkAction } from '@aws-amplify/ui-react-core-notifications';
 
 const logger = new Logger('Notifications.InAppMessaging');
 

--- a/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/types.ts
+++ b/packages/react-native/src/InAppMessaging/components/InAppMessageDisplay/types.ts
@@ -3,7 +3,7 @@ import {
   CarouselMessageComponent,
   FullScreenMessageComponent,
   ModalMessageComponent,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 
 import { BannerMessageProps } from '../BannerMessage';
 import { CarouselMessageProps } from '../CarouselMessage';

--- a/packages/react-native/src/InAppMessaging/components/MessageLayout/types.ts
+++ b/packages/react-native/src/InAppMessaging/components/MessageLayout/types.ts
@@ -1,4 +1,4 @@
-import { MessageComponentBaseProps } from '@aws-amplify/ui-react-core';
+import { MessageComponentBaseProps } from '@aws-amplify/ui-react-core-notifications';
 
 import { DeviceOrientation } from '../../../hooks';
 import {

--- a/packages/react-native/src/InAppMessaging/components/ModalMessage/types.ts
+++ b/packages/react-native/src/InAppMessaging/components/ModalMessage/types.ts
@@ -1,4 +1,4 @@
-import { ModalMessageCommonProps } from '@aws-amplify/ui-react-core';
+import { ModalMessageCommonProps } from '@aws-amplify/ui-react-core-notifications';
 
 import { MessageDefaultStyle, MessageOverrideStyle } from '../../hooks';
 

--- a/packages/react-native/src/InAppMessaging/components/withInAppMessaging/withInAppMessaging.tsx
+++ b/packages/react-native/src/InAppMessaging/components/withInAppMessaging/withInAppMessaging.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InAppMessagingProvider } from '@aws-amplify/ui-react-core';
+import { InAppMessagingProvider } from '@aws-amplify/ui-react-core-notifications';
 
 import { InAppMessageDisplay, MessageComponents } from '../InAppMessageDisplay';
 

--- a/packages/react-native/src/InAppMessaging/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
+++ b/packages/react-native/src/InAppMessaging/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
@@ -1,7 +1,7 @@
 import { Image } from 'react-native';
 import { renderHook } from '@testing-library/react-hooks';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
-import { MessageImage } from '@aws-amplify/ui-react-core';
+import { MessageImage } from '@aws-amplify/ui-react-core-notifications';
 
 import { getLayoutImageDimensions, prefetchNetworkImage } from '../utils';
 import useMessageImage from '../useMessageImage';

--- a/packages/react-native/src/InAppMessaging/hooks/useMessageImage/useMessageImage.ts
+++ b/packages/react-native/src/InAppMessaging/hooks/useMessageImage/useMessageImage.ts
@@ -2,7 +2,10 @@ import { useEffect, useRef, useState } from 'react';
 import { Image } from 'react-native';
 
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
-import { MessageImage, MessageLayout } from '@aws-amplify/ui-react-core';
+import {
+  MessageImage,
+  MessageLayout,
+} from '@aws-amplify/ui-react-core-notifications';
 
 import { ImageDimensions, ImagePrefetchStatus, UseMessageImage } from './types';
 import { getLayoutImageDimensions, prefetchNetworkImage } from './utils';

--- a/packages/react-native/src/InAppMessaging/hooks/useMessageImage/utils.ts
+++ b/packages/react-native/src/InAppMessaging/hooks/useMessageImage/utils.ts
@@ -1,6 +1,6 @@
 import { Image } from 'react-native';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
-import { MessageLayout } from '@aws-amplify/ui-react-core';
+import { MessageLayout } from '@aws-amplify/ui-react-core-notifications';
 
 import {
   BANNER_IMAGE_SCREEN_SIZE,

--- a/packages/react-native/src/InAppMessaging/hooks/useMessageProps/__tests__/useMessageProps.spec.ts
+++ b/packages/react-native/src/InAppMessaging/hooks/useMessageProps/__tests__/useMessageProps.spec.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import {
   MessageButtonProps,
   MessageComponentBaseProps,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 
 import { useMessageImage } from '../../useMessageImage';
 import { MessageOverrideStyle } from '../types';

--- a/packages/react-native/src/InAppMessaging/hooks/useMessageProps/__tests__/utils.spec.ts
+++ b/packages/react-native/src/InAppMessaging/hooks/useMessageProps/__tests__/utils.spec.ts
@@ -4,7 +4,7 @@ import {
   MessageComponentBaseProps,
   MessageLayout,
   MessageTextAlign,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 import { BUTTON_PRESSED_OPACITY } from '../../../constants';
 import { MessageDefaultStyle } from '../types';
 import { StyleParams } from '../types';

--- a/packages/react-native/src/InAppMessaging/hooks/useMessageProps/types.ts
+++ b/packages/react-native/src/InAppMessaging/hooks/useMessageProps/types.ts
@@ -5,7 +5,10 @@ import {
   TextStyle,
   ViewStyle,
 } from 'react-native';
-import { MessageLayout, MessagePayloadStyle } from '@aws-amplify/ui-react-core';
+import {
+  MessageLayout,
+  MessagePayloadStyle,
+} from '@aws-amplify/ui-react-core-notifications';
 
 import { ButtonProps } from '../../../primitives';
 

--- a/packages/react-native/src/InAppMessaging/hooks/useMessageProps/useMessageProps.ts
+++ b/packages/react-native/src/InAppMessaging/hooks/useMessageProps/useMessageProps.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { isEmpty } from '@aws-amplify/ui';
-import { MessageComponentBaseProps } from '@aws-amplify/ui-react-core';
+import { MessageComponentBaseProps } from '@aws-amplify/ui-react-core-notifications';
 
 import { useMessageImage } from '../useMessageImage';
 import {

--- a/packages/react-native/src/InAppMessaging/hooks/useMessageProps/utils.ts
+++ b/packages/react-native/src/InAppMessaging/hooks/useMessageProps/utils.ts
@@ -4,7 +4,7 @@ import {
   MessageComponentBaseProps,
   MessageLayout,
   MessagePayloadStyle,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 
 import { DEFAULT_CAROUSEL_INDICATOR_SIZE } from '../../../primitives';
 import { BUTTON_PRESSED_OPACITY, SPACING_EXTRA_LARGE } from '../../constants';

--- a/packages/react-native/src/InAppMessaging/index.ts
+++ b/packages/react-native/src/InAppMessaging/index.ts
@@ -1,7 +1,7 @@
 export {
   InAppMessagingProvider,
   useInAppMessaging,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 
 export {
   BannerMessageProps,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@aws-amplify/ui": "5.6.0",
     "@aws-amplify/ui-react-core": "2.1.19",
-    "@aws-amplify/ui-react-core-notifications": "^0.0.1",
+    "@aws-amplify/ui-react-core-notifications": "0.0.1",
     "@radix-ui/react-accordion": "1.0.0",
     "@radix-ui/react-direction": "1.0.0",
     "@radix-ui/react-dropdown-menu": "1.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@aws-amplify/ui": "5.6.0",
     "@aws-amplify/ui-react-core": "2.1.19",
+    "@aws-amplify/ui-react-core-notifications": "^0.0.1",
     "@radix-ui/react-accordion": "1.0.0",
     "@radix-ui/react-direction": "1.0.0",
     "@radix-ui/react-dropdown-menu": "1.0.0",

--- a/packages/react/src/components/InAppMessaging/BannerMessage/types.ts
+++ b/packages/react/src/components/InAppMessaging/BannerMessage/types.ts
@@ -1,4 +1,4 @@
-import { BannerMessageCommonProps } from '@aws-amplify/ui-react-core';
+import { BannerMessageCommonProps } from '@aws-amplify/ui-react-core-notifications';
 import { MessageOverrideStyle } from '../hooks';
 
 type BannerMessageAlignment = 'left' | 'center' | 'right';

--- a/packages/react/src/components/InAppMessaging/FullScreenMessage/types.ts
+++ b/packages/react/src/components/InAppMessaging/FullScreenMessage/types.ts
@@ -1,4 +1,4 @@
-import { FullScreenMessageCommonProps } from '@aws-amplify/ui-react-core';
+import { FullScreenMessageCommonProps } from '@aws-amplify/ui-react-core-notifications';
 import { MessageOverrideStyle } from '../hooks';
 
 export interface FullScreenMessageProps

--- a/packages/react/src/components/InAppMessaging/InAppMessageDisplay/InAppMessageDisplay.tsx
+++ b/packages/react/src/components/InAppMessaging/InAppMessageDisplay/InAppMessageDisplay.tsx
@@ -4,7 +4,7 @@ import {
   handleMessageAction,
   OnMessageAction,
   useMessage,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 
 import { ThemeProvider } from '../../ThemeProvider';
 

--- a/packages/react/src/components/InAppMessaging/InAppMessageDisplay/__tests__/InAppMessageDisplay.spec.tsx
+++ b/packages/react/src/components/InAppMessaging/InAppMessageDisplay/__tests__/InAppMessageDisplay.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useMessage } from '@aws-amplify/ui-react-core';
+import { useMessage } from '@aws-amplify/ui-react-core-notifications';
 
 import { Text } from '../../../../primitives/Text';
 import { View } from '../../../../primitives/View';
@@ -7,7 +7,7 @@ import { render } from '@testing-library/react';
 
 import InAppMessageDisplay from '../InAppMessageDisplay';
 
-jest.mock('@aws-amplify/ui-react-core');
+jest.mock('@aws-amplify/ui-react-core-notifications');
 
 const mockUseMessage = useMessage as jest.Mock;
 

--- a/packages/react/src/components/InAppMessaging/InAppMessageDisplay/handleMessageLinkAction.ts
+++ b/packages/react/src/components/InAppMessaging/InAppMessageDisplay/handleMessageLinkAction.ts
@@ -1,5 +1,5 @@
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
-import { HandleMessageLinkAction } from '@aws-amplify/ui-react-core';
+import { HandleMessageLinkAction } from '@aws-amplify/ui-react-core-notifications';
 
 const logger = new Logger('Notifications.InAppMessaging');
 

--- a/packages/react/src/components/InAppMessaging/InAppMessageDisplay/types.ts
+++ b/packages/react/src/components/InAppMessaging/InAppMessageDisplay/types.ts
@@ -3,7 +3,7 @@ import {
   CarouselMessageComponent,
   FullScreenMessageComponent,
   ModalMessageComponent,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 
 import { BannerMessageProps } from '../BannerMessage';
 import { FullScreenMessageProps } from '../FullScreenMessage';

--- a/packages/react/src/components/InAppMessaging/MessageLayout/MessageLayout.tsx
+++ b/packages/react/src/components/InAppMessaging/MessageLayout/MessageLayout.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { isEmpty } from '@aws-amplify/ui';
-import { MessageButtonProps } from '@aws-amplify/ui-react-core';
+import { MessageButtonProps } from '@aws-amplify/ui-react-core-notifications';
 
 import {
   Button,

--- a/packages/react/src/components/InAppMessaging/MessageLayout/types.ts
+++ b/packages/react/src/components/InAppMessaging/MessageLayout/types.ts
@@ -1,4 +1,4 @@
-import { MessageComponentBaseProps } from '@aws-amplify/ui-react-core';
+import { MessageComponentBaseProps } from '@aws-amplify/ui-react-core-notifications';
 
 import { ButtonProps } from '../../../primitives';
 

--- a/packages/react/src/components/InAppMessaging/ModalMessage/types.ts
+++ b/packages/react/src/components/InAppMessaging/ModalMessage/types.ts
@@ -1,4 +1,4 @@
-import { ModalMessageCommonProps } from '@aws-amplify/ui-react-core';
+import { ModalMessageCommonProps } from '@aws-amplify/ui-react-core-notifications';
 import { MessageOverrideStyle } from '../hooks';
 
 export interface ModalMessageProps

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageImage/useMessageImage.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageImage/useMessageImage.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { MessageImage } from '@aws-amplify/ui-react-core';
+import { MessageImage } from '@aws-amplify/ui-react-core-notifications';
 
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageProps/__tests__/useMessageProps.spec.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageProps/__tests__/useMessageProps.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { MessageComponentBaseProps } from '@aws-amplify/ui-react-core';
+import { MessageComponentBaseProps } from '@aws-amplify/ui-react-core-notifications';
 
 import { useMessageImage } from '../../useMessageImage';
 import { MessageOverrideStyle } from '../types';

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageProps/__tests__/utils.spec.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageProps/__tests__/utils.spec.ts
@@ -1,7 +1,7 @@
 import {
   MessageComponentBaseProps,
   MessageTextAlign,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 import { StyleParams } from '../types';
 
 import { getPayloadStyle, getMessageStyles } from '../utils';

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageProps/types.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageProps/types.ts
@@ -1,4 +1,4 @@
-import { MessagePayloadStyle } from '@aws-amplify/ui-react-core';
+import { MessagePayloadStyle } from '@aws-amplify/ui-react-core-notifications';
 
 /**
  * Inline style props for message components. Can be overridden by customer

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageProps/useMessageProps.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageProps/useMessageProps.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 
-import { MessageComponentBaseProps } from '@aws-amplify/ui-react-core';
+import { MessageComponentBaseProps } from '@aws-amplify/ui-react-core-notifications';
 
 import { useMessageImage } from '../useMessageImage';
 import { MessageOverrideStyle, UseMessageProps } from './types';

--- a/packages/react/src/components/InAppMessaging/hooks/useMessageProps/utils.ts
+++ b/packages/react/src/components/InAppMessaging/hooks/useMessageProps/utils.ts
@@ -1,7 +1,7 @@
 import {
   MessageComponentBaseProps,
   MessagePayloadStyle,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 
 import { MessageComponentStyles, MessageStyleParams } from './types';
 

--- a/packages/react/src/components/InAppMessaging/index.ts
+++ b/packages/react/src/components/InAppMessaging/index.ts
@@ -1,7 +1,7 @@
 export {
   InAppMessagingProvider,
   useInAppMessaging,
-} from '@aws-amplify/ui-react-core';
+} from '@aws-amplify/ui-react-core-notifications';
 
 export { BannerMessageProps } from './BannerMessage';
 export { FullScreenMessageProps } from './FullScreenMessage';

--- a/packages/react/src/components/InAppMessaging/withInAppMessaging/withInAppMessaging.tsx
+++ b/packages/react/src/components/InAppMessaging/withInAppMessaging/withInAppMessaging.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InAppMessagingProvider } from '@aws-amplify/ui-react-core';
+import { InAppMessagingProvider } from '@aws-amplify/ui-react-core-notifications';
 
 import { InAppMessageDisplay, MessageComponents } from '../InAppMessageDisplay';
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Import InAppMessaging related types and utilities from `ui-react-core-notifications` in `react` and `react-native` packages
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
- Unit tests in `react` and `react-native` packages
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
