### PR TITLE
chore(docs): Add example for custom attributes for signup

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/sign-up-fields.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/sign-up-fields.web.mdx
@@ -4,7 +4,7 @@ import {
   useAuthenticator,
 } from '@aws-amplify/ui-react';
 
-import { Example } from '@/components/Example';
+import { Example, ExampleCode } from '@/components/Example';
 import { Fragment } from '@/components/Fragment';
 
 ## Sign Up Fields
@@ -60,3 +60,26 @@ The following example customizes the Sign Up screen by:
 </Example>
 
 > If you'd like to add an attribute please first consider using the [Sign Up Attributes](configuration#sign-up-attributes) prop. In some instances you may want to add an app-specific attribute. In those cases you can add a new form element to the Sign Up form fields. Be aware the HTML `name` attribute on the new form field must match the name of the Cognito attribute. If the cognito attribute is a [custom attribute](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html) it must have the `custom:` prefix in the HTML attribute name.
+
+<Example>
+  <ExampleCode>
+  ```js
+    const formFields = {
+      signUp: {
+        email: {
+          order:1
+        },
+        password: {
+          order: 2
+        },
+        confirm_password: {
+          order: 3
+        },
+        'custom:your_custom_attribute': {
+          order: 4
+        }
+      },
+    }
+  ```
+  </ExampleCode>
+</Example>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change adds an example for customizing signup attributes, the docs currently mention that the name of the attribute must have the `custom` prefix but the implementation detail is missing and is causing confusion for customers.


* https://github.com/aws-amplify/docs/issues/2208
* https://discord.com/channels/705853757799399426/1100996158052106310/1100996158052106310

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran docs locally

<img width="1377" alt="Screen Shot 2023-04-27 at 11 11 49 AM" src="https://user-images.githubusercontent.com/68251134/234956490-ed9d2da9-ca47-4d6f-8e2a-2c3e559acb9a.png">


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
