### PR TITLE
fix(auth): add SELECT_MFA_TYPE error

### DIFF
--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -105,6 +105,11 @@ export function signInActor({ services }: SignInMachineOptions) {
                     target: '#signInActor.setupTOTP',
                   },
                   {
+                    cond: 'shouldSelectMfaType',
+                    actions: ['setUser', 'setChallengeName'],
+                    target: 'rejected',
+                  },
+                  {
                     cond: 'shouldConfirmSignIn',
                     actions: ['setUser', 'setChallengeName'],
                     target: '#signInActor.confirmSignIn',
@@ -548,6 +553,16 @@ export function signInActor({ services }: SignInMachineOptions) {
         },
         shouldSetupTOTP: (_, event): boolean => {
           return isExpectedChallengeName(getChallengeName(event), 'MFA_SETUP');
+        },
+        shouldSelectMfaType: (_, event): boolean => {
+          console.error(
+            `ERROR: 'SELECT_MFA_TYPE' is not supported by Amplify UI yet.
+            Please use only one MFA type or set up the MFA selector using this document: https://docs.amplify.aws/lib/auth/mfa/q/platform/js/#advanced-use-cases/`
+          );
+          return isExpectedChallengeName(
+            getChallengeName(event),
+            'SELECT_MFA_TYPE'
+          );
         },
       },
       services: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**Issue**: If the admin force user to set up MFA without specify a type (SMS or TOTP), user would not able to login
**Reason**: 'SELECT_MFA_TYPE' is not supported by Amplify UI yet.
**Fix**: 
1. Add an error to the console for now to help users understand the situation
2. Add a `shouldSelectMfaType` to unblock/reject the sign-in process

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/3767

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
