### PR TITLE
chore(ui): Fix input styling

### DIFF
--- a/.changeset/honest-taxis-search.md
+++ b/.changeset/honest-taxis-search.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui': patch
+---
+
+chore(ui): Fixes an issue where the input primitive doesn't render properly for calendar types.

--- a/packages/ui/src/theme/css/component/input.scss
+++ b/packages/ui/src/theme/css/component/input.scss
@@ -5,5 +5,5 @@
   // This only affects Webkit/Chromium-based browsers that implement
   // the property as inherited.
   user-select: text;
-  display: inline-flex;
+  display: inline-block;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change fixes an issue where the input primitive doesn't render properly for date types

| Before  | After |
| ------------- | ------------- |
| <img width="572" alt="Screen Shot 2023-04-28 at 9 21 52 AM" src="https://user-images.githubusercontent.com/68251134/235202458-77734496-1e2c-4989-8e39-563657a9b8e0.png"> |  <img width="572" alt="Screen Shot 2023-04-28 at 9 22 06 AM" src="https://user-images.githubusercontent.com/68251134/235202542-04ae6eca-aed0-44b7-9470-575de6a18116.png"> |

Tested on mobile devices as well:

<img width="355" alt="Screen Shot 2023-04-28 at 9 21 35 AM" src="https://user-images.githubusercontent.com/68251134/235202628-9aeceede-b775-4085-9b66-e88af10c99c4.png">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
