### PR TITLE
fix(docs): allow variation prop to work on Text demo

### DIFF
--- a/docs/src/pages/[platform]/components/text/TextPropControls.tsx
+++ b/docs/src/pages/[platform]/components/text/TextPropControls.tsx
@@ -99,7 +99,7 @@ export const TextPropControls: TextPropControlsInterface = ({
       </SelectField>
       <TextField
         label="color"
-        placeholder={String(color)}
+        placeholder="blue"
         onChange={(event) => setColor(event.target.value)}
       />
       <SwitchField

--- a/docs/src/pages/[platform]/components/text/demo.tsx
+++ b/docs/src/pages/[platform]/components/text/demo.tsx
@@ -27,12 +27,8 @@ const propsToCode = (
 ) => `
 <Text
     variation="${variation}"
-    as="${as}"
-    color="${color}"${
-  isTruncated
-    ? `
-    isTruncated={true}`
-    : ''
+    as="${as}"${color ? `\n    color="${color}"` : ''}${
+  isTruncated ? `\n    isTruncated={true}` : ''
 }
     lineHeight="${lineHeight}"
     fontWeight={${fontWeight}}

--- a/docs/src/pages/[platform]/components/text/useTextPropControlProps.tsx
+++ b/docs/src/pages/[platform]/components/text/useTextPropControlProps.tsx
@@ -9,7 +9,7 @@ export const useTextProps = (): TextPropControlsProps => {
   const [as, setAs] = React.useState<TextProps['as']>('p');
   const [isTruncated, setIsTruncated] =
     React.useState<TextProps['isTruncated']>(false);
-  const [color, setColor] = React.useState<string>('blue');
+  const [color, setColor] = React.useState<string>('');
   const [lineHeight, setLineHeight] = React.useState<string>('1.5em');
   const [fontWeight, setFontWeight] = React.useState<number>(400);
   const [fontStyle, setFontStyle] = React.useState<string>('normal');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Removes the default value set for the color prop control on the Text demo and hides the prop in the demo code if field is empty. Adds a static placeholder

Currently on [the Text demo](https://ui.docs.amplify.aws/react/components/text), changing the variation dropdown does nothing unless you first type something into the color field and then delete it.

**Before**
Changing the variation does nothing even though the color prop text field is empty because we set an initial color of blue in our component state
<img width="400" alt="Screenshot 2023-04-28 at 1 38 20 PM" src="https://user-images.githubusercontent.com/376920/235217930-41eedd6f-3713-4ac0-bc80-35d3419378f2.png">

**After**
With variation selected
<img width="400" alt="Screenshot 2023-04-28 at 1 59 58 PM" src="https://user-images.githubusercontent.com/376920/235220395-ae01ba03-670d-4bb0-8559-8ae7fd77fee6.png">

With custom color entered
<img width="400" alt="Screenshot 2023-04-28 at 2 00 13 PM" src="https://user-images.githubusercontent.com/376920/235220538-c7c4fa9a-a7ac-46c4-abc4-ea4e8e488556.png">

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
