### PR TITLE
feat(storage-manager): let processFile be async or sync

### DIFF
--- a/.changeset/hungry-owls-admire.md
+++ b/.changeset/hungry-owls-admire.md
@@ -1,6 +1,5 @@
 ---
 "@aws-amplify/ui-react-storage": minor
-"@aws-amplify/ui-react": minor
 ---
 
 feat(storage-manager): make processFile async. This allows for reading the file contents and performing async validations or mutations like creating a hash of the file contents. 

--- a/.changeset/hungry-owls-admire.md
+++ b/.changeset/hungry-owls-admire.md
@@ -1,0 +1,34 @@
+---
+"@aws-amplify/ui-react-storage": minor
+"@aws-amplify/ui-react": minor
+---
+
+feat(storage-manager): make processFile async. This allows for reading the file contents and performing async validations or mutations like creating a hash of the file contents. 
+
+```jsx
+const processFile = async ({ file }) => {
+  const fileExtension = file.name.split('.').pop();
+
+  return file
+    .arrayBuffer()
+    .then((filebuffer) => window.crypto.subtle.digest('SHA-1', filebuffer))
+    .then((hashBuffer) => {
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      const hashHex = hashArray
+        .map((a) => a.toString(16).padStart(2, '0'))
+        .join('');
+      return { file, key: `${hashHex}.${fileExtension}` };
+    });
+};
+
+export const StorageManagerHashExample = () => {
+  return (
+    <StorageManager
+      acceptedFileTypes={['image/*']}
+      accessLevel="public"
+      maxFileCount={1}
+      processFile={processFile}
+    />
+  );
+};
+```

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/examples/StorageManagerHashExample.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/examples/StorageManagerHashExample.tsx
@@ -1,0 +1,28 @@
+import { StorageManager } from '@aws-amplify/ui-react-storage';
+
+const processFile = async ({ file }) => {
+  const fileExtension = file.name.split('.').pop();
+
+  return file
+    .arrayBuffer()
+    .then((filebuffer) => window.crypto.subtle.digest('SHA-1', filebuffer))
+    .then((hashBuffer) => {
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      const hashHex = hashArray
+        .map((a) => a.toString(16).padStart(2, '0'))
+        .join('');
+      return { file, key: `${hashHex}.${fileExtension}` };
+    });
+};
+
+export const StorageManagerHashExample = () => {
+  return (
+    <StorageManager
+      acceptedFileTypes={['image/*']}
+      accessLevel="public"
+      maxFileCount={1}
+      processFile={processFile}
+      provider="fast" // IGNORE
+    />
+  );
+};

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/examples/index.ts
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/examples/index.ts
@@ -8,3 +8,4 @@ export { StorageManagerFileTypesExample } from './StorageManagerFileTypesExample
 export { StorageManagerResumableExample } from './StorageManagerResumableExample';
 export { StorageManagerEventExample } from './StorageManagerEventExample';
 export { StorageManagerMetadataExample } from './StorageManagerMetadataExample';
+export { StorageManagerHashExample } from './StorageManagerHashExample';

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/props.ts
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/props.ts
@@ -63,8 +63,8 @@ export const STORAGE_MANAGER = [
   {
     name: `processFile?`,
     description:
-      'Called immediately before uploading a file to allow you to edit the key or the file itself.',
-    type: `(params: {key: string, file: Blob}) => {key: string, file: Blob} & Record<string, string>;`,
+      'Called immediately before uploading a file to allow you to edit the key or the file itself. The function can return synchronously or return a promise.',
+    type: `(params: {key: string, file: Blob}) => Promise<{key: string, file: Blob} & Record<string, any>> | {key: string, file: Blob} & Record<string, string>;`,
   },
   {
     name: `path?`,

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
@@ -15,6 +15,7 @@ import {
   StorageManagerResumableExample,
   StorageManagerEventExample,
   StorageManagerMetadataExample,
+  StorageManagerHashExample,
 } from './examples'
 
 <DefaultStorageManagerExample />
@@ -83,19 +84,22 @@ A resumable upload will upload the file in chunks. This allows users to pause an
 
 ## Pre-upload Processing
 
-You might want to process or modify the file(s) and/or file name(s) before they are uploaded. Some common use cases for this are:
+You might want to process or modify the file(s) and/or file name(s) before they are uploaded. One common situation is you may want to ensure files uploaded are at unique keys by hashing the file contents and using that as the key rather than the filename.
 
-1. Rename the file to be ensure uniqueness by adding a timestamp or has to the file name.
-1. Performing file optimizations like removing unnecessary metadata.
-1. Performing custom file validations like reading the contents of a file to ensure it is in the proper structure.
+You can pass a `processFile` function to the StorageManager which accepts an object with `file: [File](https://developer.mozilla.org/en-US/docs/Web/API/File)` and `key: string` and should return an object with file, key, and any other Storage configurations. The `processFile` can either return synchronously or return a Promise. This example uses a Promise to read the contents of the file and create a hash for the key.
 
 <Example>
-  <StorageManagerProcessFileExample />
+  <StorageManagerHashExample />
   <ExampleCode>
-    ```jsx file=./examples/StorageManagerProcessFileExample.tsx
+    ```jsx file=./examples/StorageManagerHashExample.tsx
     ```
   </ExampleCode>
 </Example>
+
+Other uses-cases for processing the file before upload:
+
+1. Performing file optimizations like removing unnecessary metadata.
+1. Performing custom file validations like reading the contents of a file to ensure it is in the proper structure.
 
 You can also add any other [Amplify Storage options](https://docs.amplify.aws/lib/storage/upload/q/platform/js/#encrypted-uploads) by adding them to the return object of `processFile`
 

--- a/examples/next/pages/ui/components/storage/storage-manager/process-file/aws-exports.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/process-file/aws-exports.js
@@ -1,0 +1,2 @@
+import awsExports from '@environments/storage/file-uploader/src/aws-exports';
+export default awsExports;

--- a/examples/next/pages/ui/components/storage/storage-manager/process-file/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/process-file/index.page.tsx
@@ -1,0 +1,37 @@
+import { Amplify } from 'aws-amplify';
+import { withAuthenticator } from '@aws-amplify/ui-react';
+import {
+  StorageManager,
+  StorageManagerProps,
+} from '@aws-amplify/ui-react-storage';
+import '@aws-amplify/ui-react/styles.css';
+import awsExports from './aws-exports';
+Amplify.configure(awsExports);
+
+const processFile: StorageManagerProps['processFile'] = async ({ file }) => {
+  const fileExtension = file.name.split('.').pop();
+
+  return file
+    .arrayBuffer()
+    .then((filebuffer) => window.crypto.subtle.digest('SHA-1', filebuffer))
+    .then((hashBuffer) => {
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      const hashHex = hashArray
+        .map((a) => a.toString(16).padStart(2, '0'))
+        .join('');
+      return { file, key: `${hashHex}.${fileExtension}` };
+    });
+};
+
+export function StorageManagerExample() {
+  return (
+    <StorageManager
+      acceptedFileTypes={['image/*']}
+      accessLevel="private"
+      maxFileCount={3}
+      showThumbnails={true}
+      processFile={processFile}
+    />
+  );
+}
+export default withAuthenticator(StorageManagerExample);

--- a/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
+++ b/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
@@ -139,16 +139,18 @@ describe('StorageManager', () => {
     fireEvent.change(hiddenInput, {
       target: { files: [file] },
     });
-    expect(storageSpy).toBeCalledWith(file.name, file, {
-      contentType: 'text/plain',
-      level: 'public',
-      progressCallback: expect.any(Function),
-      provider: undefined,
-      resumable: false,
-    });
 
     // Wait for the file to be uploaded
-    await waitFor(() => expect(onUploadSuccess).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(storageSpy).toBeCalledWith(file.name, file, {
+        contentType: 'text/plain',
+        level: 'public',
+        progressCallback: expect.any(Function),
+        provider: undefined,
+        resumable: false,
+      });
+      expect(onUploadSuccess).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('calls onUploadStart callback when file starts uploading', async () => {
@@ -165,16 +167,18 @@ describe('StorageManager', () => {
     fireEvent.change(hiddenInput, {
       target: { files: [file] },
     });
-    expect(storageSpy).toBeCalledWith(file.name, file, {
-      contentType: 'text/plain',
-      level: 'public',
-      progressCallback: expect.any(Function),
-      provider: undefined,
-      resumable: false,
-    });
 
     // Wait for the file to be uploaded
-    await waitFor(() => expect(onUploadStart).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(storageSpy).toBeCalledWith(file.name, file, {
+        contentType: 'text/plain',
+        level: 'public',
+        progressCallback: expect.any(Function),
+        provider: undefined,
+        resumable: false,
+      });
+      expect(onUploadStart).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('renders a warning if maxFileCount is zero', () => {

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
@@ -60,15 +60,14 @@ describe('useUploadFiles', () => {
       useUploadFiles({ ...props, files: [mockUploadingFile, mockQueuedFile] })
     );
 
-    expect(mockSetUploadingFile).toHaveBeenCalledTimes(1);
-    expect(mockSetUploadingFile).toHaveBeenCalledWith({
-      id: mockQueuedFile.id,
-    });
-    expect(mockSetUploadingFile).not.toHaveBeenCalledWith({
-      id: mockUploadingFile.id,
-    });
-
     await waitFor(() => {
+      expect(mockSetUploadingFile).toHaveBeenCalledTimes(1);
+      expect(mockSetUploadingFile).toHaveBeenCalledWith({
+        id: mockQueuedFile.id,
+      });
+      expect(mockSetUploadingFile).not.toHaveBeenCalledWith({
+        id: mockUploadingFile.id,
+      });
       expect(mockSetUploadSuccess).toHaveBeenCalledTimes(1);
       expect(mockSetUploadSuccess).toHaveBeenCalledWith({
         id: mockQueuedFile.id,
@@ -81,7 +80,7 @@ describe('useUploadFiles', () => {
     });
   });
 
-  it('should upload all resumable queued files', () => {
+  it('should upload all resumable queued files', async () => {
     (Storage.put as jest.Mock).mockResolvedValue(storageOutput);
     renderHook(() =>
       useUploadFiles({
@@ -90,14 +89,15 @@ describe('useUploadFiles', () => {
         files: [mockUploadingFile, mockQueuedFile],
       })
     );
-
-    expect(mockSetUploadingFile).toHaveBeenCalledTimes(1);
-    expect(mockSetUploadingFile).toHaveBeenCalledWith({
-      id: mockQueuedFile.id,
-      uploadTask: expect.any(Object),
-    });
-    expect(mockSetUploadingFile).not.toHaveBeenCalledWith({
-      id: mockUploadingFile.id,
+    await waitFor(() => {
+      expect(mockSetUploadingFile).toHaveBeenCalledTimes(1);
+      expect(mockSetUploadingFile).toHaveBeenCalledWith({
+        id: mockQueuedFile.id,
+        uploadTask: expect.any(Object),
+      });
+      expect(mockSetUploadingFile).not.toHaveBeenCalledWith({
+        id: mockUploadingFile.id,
+      });
     });
   });
 

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 
 import { Storage, UploadTask } from '@aws-amplify/storage';
 
-import { FileStatus, StorageFile } from '../../../types';
+import { FileStatus, StorageFile, StorageManagerProps } from '../../../types';
 import { useUploadFiles, UseUploadFilesProps } from '../useUploadFiles';
 import { waitFor } from '@testing-library/react';
 
@@ -33,6 +33,7 @@ const mockSetUploadingFile = jest.fn();
 const mockSetUploadProgress = jest.fn();
 const mockSetUploadSuccess = jest.fn();
 const mockOnUploadError = jest.fn();
+const mockOnUploadStart = jest.fn();
 const props: Omit<UseUploadFilesProps, 'files'> = {
   accessLevel: 'public',
   maxFileCount: 2,
@@ -40,6 +41,7 @@ const props: Omit<UseUploadFilesProps, 'files'> = {
   setUploadProgress: mockSetUploadProgress,
   setUploadSuccess: mockSetUploadSuccess,
   onUploadError: mockOnUploadError,
+  onUploadStart: mockOnUploadStart,
 };
 
 const storageOutput: UploadTask = {
@@ -121,5 +123,59 @@ describe('useUploadFiles', () => {
       expect(mockOnUploadError).toHaveBeenCalledTimes(1);
       expect(mockOnUploadError).toHaveBeenCalledWith(mockError, { key: 'key' });
     });
+  });
+
+  it('should start upload after processFile', async () => {
+    (Storage.put as jest.Mock).mockResolvedValue(storageOutput);
+    const processFile: StorageManagerProps['processFile'] = ({ file }) => {
+      return {
+        file,
+        key: 'test.png',
+      };
+    };
+    renderHook(() =>
+      useUploadFiles({
+        ...props,
+        isResumable: true,
+        processFile,
+        files: [mockQueuedFile],
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockOnUploadStart).toHaveBeenCalledWith({
+        key: 'test.png',
+      });
+    });
+  });
+
+  it('should start upload after processFile promise resolves', async () => {
+    (Storage.put as jest.Mock).mockResolvedValue(storageOutput);
+    const processFile: StorageManagerProps['processFile'] = ({ file }) => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({ file, key: 'test.png' });
+        }, 100);
+      });
+    };
+    renderHook(() =>
+      useUploadFiles({
+        ...props,
+        isResumable: true,
+        processFile,
+        files: [mockQueuedFile],
+      })
+    );
+
+    await waitFor(
+      () => {
+        expect(mockOnUploadStart).toHaveBeenCalledWith({
+          key: 'test.png',
+        });
+      },
+      {
+        timeout: 200,
+      }
+    );
   });
 });

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/resolveFile.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/resolveFile.ts
@@ -1,10 +1,9 @@
 import { isFunction } from '@aws-amplify/ui';
-import { StorageManagerProps } from '../../types';
+import { ProcessFileParams, StorageManagerProps } from '../../types';
 
-interface ProcessFileParams extends Pick<StorageManagerProps, 'processFile'> {
-  file: File;
-  key: string;
-}
+interface ResolveFileParams
+  extends Pick<StorageManagerProps, 'processFile'>,
+    ProcessFileParams {}
 
 /**
  * Utility function that takes the processFile prop, along with a file a key
@@ -15,7 +14,7 @@ export const resolveFile = ({
   processFile,
   file,
   key,
-}: ProcessFileParams): Promise<Pick<ProcessFileParams, 'file' | 'key'>> => {
+}: ResolveFileParams): Promise<ProcessFileParams> => {
   return new Promise((resolve, reject) => {
     const result = isFunction(processFile)
       ? processFile({ file, key })
@@ -23,9 +22,7 @@ export const resolveFile = ({
     if (result instanceof Promise) {
       result.then(resolve).catch(reject);
     } else {
-      resolve({
-        ...result,
-      });
+      resolve(result);
     }
   });
 };

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/resolveFile.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/resolveFile.ts
@@ -1,0 +1,31 @@
+import { isFunction } from '@aws-amplify/ui';
+import { StorageManagerProps } from '../../types';
+
+interface ProcessFileParams extends Pick<StorageManagerProps, 'processFile'> {
+  file: File;
+  key: string;
+}
+
+/**
+ * Utility function that takes the processFile prop, along with a file a key
+ * and returns a Promise that resolves to { file, key, ..rest }
+ * regardless if processFile is defined and if it is sync or async
+ */
+export const resolveFile = ({
+  processFile,
+  file,
+  key,
+}: ProcessFileParams): Promise<Pick<ProcessFileParams, 'file' | 'key'>> => {
+  return new Promise((resolve, reject) => {
+    const result = isFunction(processFile)
+      ? processFile({ file, key })
+      : { file, key };
+    if (result instanceof Promise) {
+      result.then(resolve).catch(reject);
+    } else {
+      resolve({
+        ...result,
+      });
+    }
+  });
+};

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/useUploadFiles.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/useUploadFiles.ts
@@ -78,33 +78,21 @@ export function useUploadFiles({
         resolveFile({ processFile, file, key }).then(
           ({ file, key, ...rest }) => {
             onUploadStart?.({ key });
-            if (isResumable) {
-              const uploadTask = uploadFile({
-                ...rest,
-                file,
-                key: path + key,
-                isResumable: true,
-                level: accessLevel,
-                completeCallback: onComplete,
-                progressCallback: onProgress,
-                errorCallback: onError,
-                provider,
-              }) as unknown as UploadTask;
-              setUploadingFile({ id, uploadTask });
-            } else {
-              uploadFile({
-                ...rest,
-                file,
-                key: path + key,
-                isResumable: false,
-                level: accessLevel,
-                completeCallback: onComplete,
-                progressCallback: onProgress,
-                errorCallback: onError,
-                provider,
-              });
-              setUploadingFile({ id });
-            }
+            const uploadTask = uploadFile({
+              ...rest,
+              file,
+              key: path + key,
+              isResumable,
+              level: accessLevel,
+              completeCallback: onComplete,
+              progressCallback: onProgress,
+              errorCallback: onError,
+              provider,
+            }) as unknown as UploadTask;
+            setUploadingFile({
+              id,
+              uploadTask: isResumable ? uploadTask : undefined,
+            });
           }
         );
       }

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/useUploadFiles.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/useUploadFiles.ts
@@ -75,26 +75,23 @@ export function useUploadFiles({
       };
 
       if (file) {
-        resolveFile({ processFile, file, key }).then(
-          ({ file, key, ...rest }) => {
-            onUploadStart?.({ key });
-            const uploadTask = uploadFile({
-              ...rest,
-              file,
-              key: path + key,
-              isResumable,
-              level: accessLevel,
-              completeCallback: onComplete,
-              progressCallback: onProgress,
-              errorCallback: onError,
-              provider,
-            }) as unknown as UploadTask;
-            setUploadingFile({
-              id,
-              uploadTask: isResumable ? uploadTask : undefined,
-            });
-          }
-        );
+        resolveFile({ processFile, file, key }).then(({ key, ...rest }) => {
+          onUploadStart?.({ key });
+          const uploadTask = uploadFile({
+            ...rest,
+            isResumable,
+            provider,
+            key: path + key,
+            level: accessLevel,
+            completeCallback: onComplete,
+            progressCallback: onProgress,
+            errorCallback: onError,
+          }) as unknown as UploadTask;
+          setUploadingFile({
+            id,
+            uploadTask: isResumable ? uploadTask : undefined,
+          });
+        });
       }
     }
   }, [

--- a/packages/react-storage/src/components/StorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/types.ts
@@ -8,6 +8,7 @@ import {
   FilePickerProps,
 } from './ui';
 import { StorageManagerDisplayText } from './utils';
+import { has, isObject } from '@aws-amplify/ui';
 
 export enum FileStatus {
   QUEUED = 'queued',
@@ -32,11 +33,16 @@ export type StorageFiles = StorageFile[];
 
 export type DefaultFile = Pick<StorageFile, 'key'>;
 
-export type ProcessFileParams = Required<Pick<StorageFile, 'file' | 'key'>>;
+export type ProcessFileParams = Required<Pick<StorageFile, 'file' | 'key'>> &
+  Record<string, any>;
 
 export type ProcessFile = (
   params: ProcessFileParams
-) => ProcessFileParams & Record<string, any>;
+) => Promise<ProcessFileParams> | ProcessFileParams;
+
+export const isProcessedFile = (arg: unknown): arg is ProcessFileParams => {
+  return isObject(arg) && has(arg, 'file');
+};
 
 export interface StorageManagerProps {
   /**

--- a/packages/react-storage/src/components/StorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/types.ts
@@ -8,7 +8,6 @@ import {
   FilePickerProps,
 } from './ui';
 import { StorageManagerDisplayText } from './utils';
-import { has, isObject } from '@aws-amplify/ui';
 
 export enum FileStatus {
   QUEUED = 'queued',
@@ -39,10 +38,6 @@ export type ProcessFileParams = Required<Pick<StorageFile, 'file' | 'key'>> &
 export type ProcessFile = (
   params: ProcessFileParams
 ) => Promise<ProcessFileParams> | ProcessFileParams;
-
-export const isProcessedFile = (arg: unknown): arg is ProcessFileParams => {
-  return isObject(arg) && has(arg, 'file');
-};
 
 export interface StorageManagerProps {
   /**

--- a/packages/react-storage/src/components/StorageManager/utils/__tests__/uploadFile.test.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/__tests__/uploadFile.test.ts
@@ -18,7 +18,7 @@ describe('uploadfile', () => {
 
     uploadFile({
       file: imageFile,
-      fileName: imageFile.name,
+      key: imageFile.name,
       completeCallback,
       errorCallback,
       isResumable: true,
@@ -42,7 +42,7 @@ describe('uploadfile', () => {
     const progressCallback = () => '';
     uploadFile({
       file: imageFile,
-      fileName: imageFile.name,
+      key: imageFile.name,
       level: 'public',
       progressCallback: progressCallback,
       errorCallback: () => '',
@@ -63,7 +63,7 @@ describe('uploadfile', () => {
   it('calls uploadFile with contentType defined image type', () => {
     uploadFile({
       file: imageFile,
-      fileName: imageFile.name,
+      key: imageFile.name,
       level: 'public',
       progressCallback: () => '',
       errorCallback: () => '',
@@ -86,7 +86,7 @@ describe('uploadfile', () => {
 
     uploadFile({
       file: imageFileTypeUndefined,
-      fileName: imageFileTypeUndefined.name,
+      key: imageFileTypeUndefined.name,
       level: 'public',
       progressCallback: () => '',
       errorCallback: () => '',
@@ -109,7 +109,7 @@ describe('uploadfile', () => {
   it('passes metadata to Storage.put', () => {
     uploadFile({
       file: imageFile,
-      fileName: imageFile.name,
+      key: imageFile.name,
       level: 'public',
       progressCallback: () => '',
       errorCallback: () => '',

--- a/packages/react-storage/src/components/StorageManager/utils/uploadFile.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/uploadFile.ts
@@ -1,9 +1,9 @@
 import { Storage } from 'aws-amplify';
 import type { StorageAccessLevel, UploadTask } from '@aws-amplify/storage';
 
-type UploadFileProps = {
+export type UploadFileProps = {
   file: File;
-  fileName: string;
+  key: string;
   level: StorageAccessLevel;
   isResumable?: boolean;
   progressCallback: (progress: { loaded: number; total: number }) => void;
@@ -16,7 +16,7 @@ type UploadFile = Promise<void> | UploadTask;
 
 export function uploadFile({
   file,
-  fileName,
+  key,
   level = 'private',
   progressCallback,
   errorCallback,
@@ -27,7 +27,7 @@ export function uploadFile({
 }: UploadFileProps): UploadFile {
   const contentType = file.type || 'binary/octet-stream';
   if (isResumable === true) {
-    return Storage.put(fileName, file, {
+    return Storage.put(key, file, {
       level,
       resumable: true, // Ensures correct typing for resumable behavior
       progressCallback,
@@ -45,7 +45,7 @@ export function uploadFile({
       ...rest,
     });
   } else {
-    return Storage.put(fileName, file, {
+    return Storage.put(key, file, {
       level,
       resumable: false,
       progressCallback,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Allowing the `processFile` prop to return a Promise or immediately returning. This allows for doing things like reading the file before upload. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
