### PR TITLE
fix(ui): add event callbacks to defaultAuthHubHandler

### DIFF
--- a/examples/next/pages/ui/components/authenticator/use-authenticator-auth-status/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/use-authenticator-auth-status/index.page.tsx
@@ -1,0 +1,51 @@
+import { Amplify, Auth } from 'aws-amplify';
+
+import {
+  Button,
+  Flex,
+  Text,
+  TextField,
+  PasswordField,
+  useAuthenticator,
+} from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+import awsExports from './aws-exports';
+import React from 'react';
+Amplify.configure(awsExports);
+
+export default function App() {
+  const { authStatus } = useAuthenticator();
+
+  const isAuthenticated = authStatus === 'authenticated';
+
+  return (
+    <Flex
+      as="form"
+      direction="column"
+      onSubmit={(e: any) => {
+        e.preventDefault();
+
+        Auth.signIn(Object.fromEntries(new FormData(e.target)) as any);
+      }}
+    >
+      <Text>{authStatus}</Text>
+      {isAuthenticated ? null : (
+        <>
+          <TextField label="Username" id="username" name="username" />
+          <PasswordField label="Password" id="password" name="password" />
+        </>
+      )}
+      <Button
+        onClick={() => {
+          if (isAuthenticated) {
+            Auth.signOut();
+          }
+        }}
+        type={isAuthenticated ? 'button' : 'submit'}
+      >
+        {isAuthenticated ? 'Sign Out' : 'Sign In'}
+      </Button>
+    </Flex>
+  );
+}

--- a/packages/e2e/features/ui/components/authenticator/use-authenticator-auth-status.feature
+++ b/packages/e2e/features/ui/components/authenticator/use-authenticator-auth-status.feature
@@ -1,0 +1,20 @@
+Feature: Verify Auth Status on Sign In and Sign Out
+
+  Background:
+    Given I'm running the example "/ui/components/authenticator/use-authenticator-auth-status"
+
+  @react
+  Scenario: Sign in with confirmed credentials, reload, sign out, and reload
+    Then I see "configuring" 
+    When I type my "username" with status "CONFIRMED"
+    And I type my password
+    And I click the "Sign In" button
+    Then I see "authenticated"
+    Then I see "Sign out"
+    When I reload the page
+    Then I see "authenticated"
+    Then I see "Sign Out"
+    And I click the "Sign Out" button
+    Then I see "unauthenticated"
+    When I reload the page
+    Then I see "configuring"

--- a/packages/react-core/src/Authenticator/context/AuthenticatorContext.tsx
+++ b/packages/react-core/src/Authenticator/context/AuthenticatorContext.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { AuthInterpreter } from '@aws-amplify/ui';
+import { AuthInterpreter, AuthStatus } from '@aws-amplify/ui';
 
 /**
  * Authenticator React.Context type
@@ -12,5 +12,6 @@ type AuthenticatorContextType = { service: AuthInterpreter };
  *
  * https://xstate.js.org/docs/recipes/react.html#context-provider
  */
-export const AuthenticatorContext =
-  React.createContext<AuthenticatorContextType | null>(null);
+export const AuthenticatorContext = React.createContext<
+  (AuthenticatorContextType & { authStatus: AuthStatus }) | null
+>(null);

--- a/packages/react-core/src/Authenticator/context/AuthenticatorProvider.tsx
+++ b/packages/react-core/src/Authenticator/context/AuthenticatorProvider.tsx
@@ -25,6 +25,10 @@ export default function AuthenticatorProvider({
 }: {
   children: ReactNode;
 }): JSX.Element {
+  // `authStatus` is exposed by `useAuthenticator` but should not be derived directly from the
+  // state machine as the machne only updates on `Authenticator` initiated events, which
+  // leads to scenarios where the state machine `authStatus` gets "stuck". For exmample,
+  // if a user was to sign in using `Auth.signIn` directly rather than using `Authenticator`
   const [authStatus, setAuthStatus] = React.useState<AuthStatus>('configuring');
 
   React.useEffect(() => {

--- a/packages/react-core/src/Authenticator/context/AuthenticatorProvider.tsx
+++ b/packages/react-core/src/Authenticator/context/AuthenticatorProvider.tsx
@@ -1,15 +1,43 @@
 import React, { ReactNode, useContext, useEffect, useMemo } from 'react';
 import { useInterpret } from '@xstate/react';
 
-import { createAuthenticatorMachine, listenToAuthHub } from '@aws-amplify/ui';
+import {
+  AuthStatus,
+  AuthMachineHubHandler,
+  createAuthenticatorMachine,
+  defaultAuthHubHandler,
+  listenToAuthHub,
+} from '@aws-amplify/ui';
 
 import { AuthenticatorContext } from './AuthenticatorContext';
+import { Auth } from 'aws-amplify';
+
+type Options = Parameters<AuthMachineHubHandler>[2];
+
+const createHubHandler =
+  (options: Options): AuthMachineHubHandler =>
+  async (data, service) => {
+    await defaultAuthHubHandler(data, service, options);
+  };
 
 export default function AuthenticatorProvider({
   children,
 }: {
   children: ReactNode;
 }): JSX.Element {
+  const [authStatus, setAuthStatus] = React.useState<AuthStatus>('configuring');
+
+  React.useEffect(() => {
+    Auth.currentAuthenticatedUser()
+      .then((user: { username?: string }) => {
+        if (user?.username) {
+          setAuthStatus('authenticated');
+        }
+      })
+      // prevent `Auth.currentAuthenticatedUser` from logging an error if `user` is `undefined`
+      .catch(() => null);
+  }, []);
+
   /**
    * Based on use cases, developer might already have added another Provider
    * outside Authenticator. In that case, we sync the two providers by just
@@ -21,14 +49,24 @@ export default function AuthenticatorProvider({
   const service = useInterpret(createAuthenticatorMachine);
 
   const value = useMemo(
-    () => (!parentProviderVal ? { service } : parentProviderVal),
-    [parentProviderVal, service]
+    () => (!parentProviderVal ? { authStatus, service } : parentProviderVal),
+    [authStatus, parentProviderVal, service]
   );
 
   const { service: activeService } = value;
 
   useEffect(() => {
-    const unsubscribe = listenToAuthHub(activeService);
+    const onSignIn = () => {
+      setAuthStatus('authenticated');
+    };
+    const onSignOut = () => {
+      setAuthStatus('unauthenticated');
+    };
+
+    const unsubscribe = listenToAuthHub(
+      activeService,
+      createHubHandler({ onSignIn, onSignOut })
+    );
     return unsubscribe;
   }, [activeService]);
 

--- a/packages/react-core/src/Authenticator/context/__tests__/AuthenticatorProvider.test.tsx
+++ b/packages/react-core/src/Authenticator/context/__tests__/AuthenticatorProvider.test.tsx
@@ -1,19 +1,34 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { Hub } from 'aws-amplify';
+import { Auth, Hub } from 'aws-amplify';
+import * as UIModule from '@aws-amplify/ui';
 
+import { useAuthenticator } from '../..';
 import { AuthenticatorProvider } from '..';
 
 // mock `aws-amplify` to prevent logging auth errors during test runs
 jest.mock('aws-amplify');
 
 const hubListenSpy = jest.spyOn(Hub, 'listen');
+const currentAuthenticatedUserSpy = jest
+  .spyOn(Auth, 'currentAuthenticatedUser')
+  .mockResolvedValue(undefined);
+const listenToAuthHubSpy = jest.spyOn(UIModule, 'listenToAuthHub');
 
 function TestComponent(): JSX.Element | null {
   return null;
 }
 
+function AuthStatusComponent(): JSX.Element | null {
+  const { authStatus } = useAuthenticator();
+  return <>{authStatus}</>;
+}
+
 describe('AuthenticatorProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('listens to Auth Hub events on init', () => {
     render(
       <AuthenticatorProvider>
@@ -27,5 +42,52 @@ describe('AuthenticatorProvider', () => {
       expect.any(Function),
       'authenticator-hub-handler'
     );
+  });
+
+  it('unsubscribes from listening on onmount', () => {
+    const unsubscribe = jest.fn();
+    listenToAuthHubSpy.mockReturnValue(unsubscribe);
+    const { unmount } = render(
+      <AuthenticatorProvider>
+        <TestComponent />
+      </AuthenticatorProvider>
+    );
+
+    unmount();
+
+    expect(unsubscribe).toBeCalledTimes(1);
+  });
+
+  it('returns the expected value of auth status on init when a user is not signed in', () => {
+    const { queryByText } = render(
+      <AuthenticatorProvider>
+        <AuthStatusComponent />
+      </AuthenticatorProvider>
+    );
+
+    expect(currentAuthenticatedUserSpy).toBeCalledTimes(2);
+    expect(queryByText('configuring')).toBeDefined();
+  });
+
+  it('returns the expected value of auth status on init when a user is signed in', () => {
+    currentAuthenticatedUserSpy.mockResolvedValueOnce({ username: 'username' });
+    const { queryByText } = render(
+      <AuthenticatorProvider>
+        <AuthStatusComponent />
+      </AuthenticatorProvider>
+    );
+
+    expect(queryByText('authenticated')).toBeDefined();
+  });
+
+  it('returns the expected value of auth status when a user signs out', () => {
+    currentAuthenticatedUserSpy.mockResolvedValueOnce({ username: 'username' });
+    const { queryByText } = render(
+      <AuthenticatorProvider>
+        <AuthStatusComponent />
+      </AuthenticatorProvider>
+    );
+
+    expect(queryByText('authenticated')).toBeDefined();
   });
 });

--- a/packages/react-core/src/Authenticator/context/__tests__/AuthenticatorProvider.test.tsx
+++ b/packages/react-core/src/Authenticator/context/__tests__/AuthenticatorProvider.test.tsx
@@ -79,15 +79,4 @@ describe('AuthenticatorProvider', () => {
 
     expect(queryByText('authenticated')).toBeDefined();
   });
-
-  it('returns the expected value of auth status when a user signs out', () => {
-    currentAuthenticatedUserSpy.mockResolvedValueOnce({ username: 'username' });
-    const { queryByText } = render(
-      <AuthenticatorProvider>
-        <AuthStatusComponent />
-      </AuthenticatorProvider>
-    );
-
-    expect(queryByText('authenticated')).toBeDefined();
-  });
 });

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticator/__tests__/__snapshots__/useAuthenticator.spec.tsx.snap
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticator/__tests__/__snapshots__/useAuthenticator.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`useAuthenticator returns the expected values 1`] = `
 Object {
   "QRFields": null,
-  "authStatus": "authenticated",
+  "authStatus": "configuring",
   "codeDeliveryDetails": Object {},
   "error": undefined,
   "fields": undefined,

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticator/__tests__/useAuthenticator.spec.tsx
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticator/__tests__/useAuthenticator.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
+import { Auth } from 'aws-amplify';
 import { AuthenticatorServiceFacade } from '@aws-amplify/ui';
 import * as UIModule from '@aws-amplify/ui';
 
@@ -58,6 +59,10 @@ const Wrapper = ({ children }: { children?: React.ReactNode }) => (
 );
 
 describe('useAuthenticator', () => {
+  beforeAll(() => {
+    jest.spyOn(Auth, 'currentAuthenticatedUser').mockResolvedValue(undefined);
+  });
+
   beforeEach(() => {
     getComparatorSpy.mockClear();
     getServiceFacadeSpy.mockClear();

--- a/packages/react-core/src/Authenticator/hooks/useAuthenticator/useAuthenticator.ts
+++ b/packages/react-core/src/Authenticator/hooks/useAuthenticator/useAuthenticator.ts
@@ -36,6 +36,9 @@ export default function useAuthenticator(
 
   const comparator = selector ? getComparator(selector) : defaultComparator;
 
+  // the purpose of `context.authStatus`is to intentionally override `facade.authStatus`. `facade.authStatus` does
+  // not update on external sign in events (for example when a user is not using the `Authenticator`).
+  const { authStatus } = context;
   const facade = useSelector(service, xstateSelector, comparator);
 
   const { route, totpSecretCode, unverifiedContactMethods, user, ...rest } =
@@ -57,6 +60,7 @@ export default function useAuthenticator(
 
   return {
     ...rest,
+    authStatus,
     route,
     totpSecretCode,
     unverifiedContactMethods,

--- a/packages/ui/src/helpers/authenticator/__tests__/defaultAuthHubHandler.test.ts
+++ b/packages/ui/src/helpers/authenticator/__tests__/defaultAuthHubHandler.test.ts
@@ -29,10 +29,15 @@ const unauthenticatedStateMachine = {
 const authSendSpy = jest.spyOn(authenticatedStateMachine, 'send');
 const unauthSendSpy = jest.spyOn(unauthenticatedStateMachine, 'send');
 
+const onSignIn = jest.fn();
+const onSignOut = jest.fn();
+
 describe('defaultAuthHubHandler', () => {
   beforeEach(() => {
     authSendSpy.mockClear();
     unauthSendSpy.mockClear();
+    onSignIn.mockClear();
+    onSignOut.mockClear();
   });
 
   it('responds to token refresh event when state is authenticated', async () => {
@@ -108,4 +113,18 @@ describe('defaultAuthHubHandler', () => {
       type: 'AUTO_SIGN_IN_FAILURE',
     });
   });
+
+  it.each(['signIn', 'signOut'])(
+    'calls the %s event handler as expected',
+    async (event) => {
+      const handler = event === 'signIn' ? onSignIn : onSignOut;
+      const handlerKey = event === 'signIn' ? 'onSignIn' : 'onSignOut';
+      await defaultAuthHubHandler(
+        { payload: { event } } as unknown as HubCapsule,
+        authenticatedStateMachine,
+        { [handlerKey]: handler }
+      );
+      expect(handler).toHaveBeenCalledTimes(1);
+    }
+  );
 });

--- a/packages/ui/src/helpers/authenticator/facade.ts
+++ b/packages/ui/src/helpers/authenticator/facade.ts
@@ -39,7 +39,7 @@ export type AuthenticatorRoute =
   | 'verifyUser';
 
 type AuthenticatorValidationErrors = ValidationError;
-type AuthStatus = 'configuring' | 'authenticated' | 'unauthenticated';
+export type AuthStatus = 'configuring' | 'authenticated' | 'unauthenticated';
 
 interface AuthenticatorServiceContextFacade {
   authStatus: AuthStatus;

--- a/packages/ui/src/types/authenticator/stateMachine/authMachine.ts
+++ b/packages/ui/src/types/authenticator/stateMachine/authMachine.ts
@@ -31,5 +31,6 @@ export type AuthMachineSend = AuthInterpreter['send'];
  */
 export type AuthMachineHubHandler = (
   data: HubCapsule,
-  service: AuthInterpreter
+  service: AuthInterpreter,
+  options?: { onSignIn?: () => void; onSignOut?: () => void }
 ) => Promise<void>;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add event handler callbacks to `defaultAuthHubHandler`
- initialize `authStatus` based on the result of `Auth.currentAuthenticatedUser` in `AuthenticatorProvider`
- pass `onSignIn` and `onSignOut` handlers to `defaultAuthHubHandler` to update `authStatus` value returned by `useAuthenticator`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

fixes https://github.com/aws-amplify/amplify-ui/issues/1977
fixes https://github.com/aws-amplify/amplify-ui/issues/2634
fixes https://github.com/aws-amplify/amplify-ui/issues/3729
related https://github.com/aws-amplify/amplify-ui/issues/3509

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- manual testing
- added e2e test
- added unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
