### PR TITLE
fix(accessibility): add role=status to Button loading text span

### DIFF
--- a/.changeset/wild-singers-beg.md
+++ b/.changeset/wild-singers-beg.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+fix(accessibility): add role=status to Button loading text span

--- a/packages/react/src/components/AccountSettings/ChangePassword/__tests__/__snapshots__/ChangePassword.test.tsx.snap
+++ b/packages/react/src/components/AccountSettings/ChangePassword/__tests__/__snapshots__/ChangePassword.test.tsx.snap
@@ -48,6 +48,10 @@ exports[`ChangePassword renders as expected 1`] = `
               type="button"
             >
               <span
+                class="amplify-flex amplify-button__loader-wrapper"
+                role="status"
+              />
+              <span
                 aria-live="polite"
                 class="amplify-visually-hidden"
               >
@@ -112,6 +116,10 @@ exports[`ChangePassword renders as expected 1`] = `
               role="switch"
               type="button"
             >
+              <span
+                class="amplify-flex amplify-button__loader-wrapper"
+                role="status"
+              />
               <span
                 aria-live="polite"
                 class="amplify-visually-hidden"
@@ -178,6 +186,10 @@ exports[`ChangePassword renders as expected 1`] = `
               type="button"
             >
               <span
+                class="amplify-flex amplify-button__loader-wrapper"
+                role="status"
+              />
+              <span
                 aria-live="polite"
                 class="amplify-visually-hidden"
               >
@@ -210,6 +222,10 @@ exports[`ChangePassword renders as expected 1`] = `
         disabled=""
         type="submit"
       >
+        <span
+          class="amplify-flex amplify-button__loader-wrapper"
+          role="status"
+        />
         Update password
       </button>
     </div>
@@ -264,6 +280,10 @@ exports[`ChangePassword renders as expected with component overrides 1`] = `
               role="switch"
               type="button"
             >
+              <span
+                class="amplify-flex amplify-button__loader-wrapper"
+                role="status"
+              />
               <span
                 aria-live="polite"
                 class="amplify-visually-hidden"
@@ -330,6 +350,10 @@ exports[`ChangePassword renders as expected with component overrides 1`] = `
               type="button"
             >
               <span
+                class="amplify-flex amplify-button__loader-wrapper"
+                role="status"
+              />
+              <span
                 aria-live="polite"
                 class="amplify-visually-hidden"
               >
@@ -395,6 +419,10 @@ exports[`ChangePassword renders as expected with component overrides 1`] = `
               type="button"
             >
               <span
+                class="amplify-flex amplify-button__loader-wrapper"
+                role="status"
+              />
+              <span
                 aria-live="polite"
                 class="amplify-visually-hidden"
               >
@@ -427,6 +455,10 @@ exports[`ChangePassword renders as expected with component overrides 1`] = `
         disabled=""
         type="submit"
       >
+        <span
+          class="amplify-flex amplify-button__loader-wrapper"
+          role="status"
+        />
         Custom Submit Button
       </button>
     </div>

--- a/packages/react/src/components/AccountSettings/DeleteUser/__tests__/__snapshots__/DeleteUser.test.tsx.snap
+++ b/packages/react/src/components/AccountSettings/DeleteUser/__tests__/__snapshots__/DeleteUser.test.tsx.snap
@@ -12,6 +12,10 @@ exports[`DeleteUser renders as expected 1`] = `
       data-variation="warning"
       type="button"
     >
+      <span
+        class="amplify-flex amplify-button__loader-wrapper"
+        role="status"
+      />
       Delete Account
     </button>
   </div>
@@ -29,6 +33,10 @@ exports[`DeleteUser renders as expected with components overrides 1`] = `
       data-fullwidth="false"
       type="button"
     >
+      <span
+        class="amplify-flex amplify-button__loader-wrapper"
+        role="status"
+      />
       Custom Delete Button
     </button>
   </div>

--- a/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignInButtons/__tests__/__snapshots__/FederatedSignInButton.test.tsx.snap
+++ b/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignInButtons/__tests__/__snapshots__/FederatedSignInButton.test.tsx.snap
@@ -9,6 +9,10 @@ exports[`FederatedSignInButton renders as expected with { provider: 'Facebook', 
     type="button"
   >
     <span
+      class="amplify-flex amplify-button__loader-wrapper"
+      role="status"
+    />
+    <span
       class="amplify-text"
     >
       Sign In with Facebook
@@ -25,6 +29,10 @@ exports[`FederatedSignInButton renders as expected with { provider: 'Google', te
     style="font-weight: var(--amplify-font-weights-normal); gap: 1rem;"
     type="button"
   >
+    <span
+      class="amplify-flex amplify-button__loader-wrapper"
+      role="status"
+    />
     <span
       class="amplify-text"
     >
@@ -43,6 +51,10 @@ exports[`FederatedSignInButton renders as expected with { provider: 'LoginWithAm
     type="button"
   >
     <span
+      class="amplify-flex amplify-button__loader-wrapper"
+      role="status"
+    />
+    <span
       class="amplify-text"
     >
       Sign In with Amazon
@@ -59,6 +71,10 @@ exports[`FederatedSignInButton renders as expected with { provider: 'SignInWithA
     style="font-weight: var(--amplify-font-weights-normal); gap: 1rem;"
     type="button"
   >
+    <span
+      class="amplify-flex amplify-button__loader-wrapper"
+      role="status"
+    />
     <span
       class="amplify-text"
     >

--- a/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/__snapshots__/UploadPreviewer.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/UploadPreviewer/__tests__/__snapshots__/UploadPreviewer.test.tsx.snap
@@ -28,6 +28,10 @@ exports[`UploadPreviewer renders as expected 1`] = `
           data-variation="link"
           type="button"
         >
+          <span
+            class="amplify-flex amplify-button__loader-wrapper"
+            role="status"
+          />
           Clear all
         </button>
         <button
@@ -37,6 +41,10 @@ exports[`UploadPreviewer renders as expected 1`] = `
           data-variation="primary"
           type="button"
         >
+          <span
+            class="amplify-flex amplify-button__loader-wrapper"
+            role="status"
+          />
           Upload 1 file
         </button>
       </div>

--- a/packages/react/src/components/Storage/FileUploader/UploadTracker/__tests__/__snapshots__/UploadTracker.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/UploadTracker/__tests__/__snapshots__/UploadTracker.test.tsx.snap
@@ -33,6 +33,10 @@ exports[`UploadTracker exists 1`] = `
         type="button"
       >
         <span
+          class="amplify-flex amplify-button__loader-wrapper"
+          role="status"
+        />
+        <span
           class="amplify-visually-hidden"
         >
           Edit file name 
@@ -68,6 +72,10 @@ exports[`UploadTracker exists 1`] = `
         data-size="small"
         type="button"
       >
+        <span
+          class="amplify-flex amplify-button__loader-wrapper"
+          role="status"
+        />
         <span
           class="amplify-visually-hidden"
         >

--- a/packages/react/src/components/Storage/FileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
+++ b/packages/react/src/components/Storage/FileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
@@ -34,6 +34,10 @@ exports[`File Uploader exists 1`] = `
       data-size="small"
       type="button"
     >
+      <span
+        class="amplify-flex amplify-button__loader-wrapper"
+        role="status"
+      />
       Browse files
     </button>
     <span

--- a/packages/react/src/primitives/Button/Button.tsx
+++ b/packages/react/src/primitives/Button/Button.tsx
@@ -55,14 +55,19 @@ const ButtonPrimitive: Primitive<ButtonProps, 'button'> = (
       type={type}
       {...rest}
     >
-      {isLoading ? (
-        <Flex as="span" className={ComponentClassNames.ButtonLoaderWrapper} role="status">
-          <Loader size={size} />
-          {loadingText ? loadingText : null}
-        </Flex>
-      ) : (
-        children
-      )}
+      <Flex
+        as="span"
+        className={ComponentClassNames.ButtonLoaderWrapper}
+        role="status"
+      >
+        {isLoading && (
+          <>
+            <Loader size={size} />
+            {loadingText ? loadingText : null}
+          </>
+        )}
+      </Flex>
+      {!isLoading && children}
     </View>
   );
 };

--- a/packages/react/src/primitives/Button/Button.tsx
+++ b/packages/react/src/primitives/Button/Button.tsx
@@ -56,7 +56,7 @@ const ButtonPrimitive: Primitive<ButtonProps, 'button'> = (
       {...rest}
     >
       {isLoading ? (
-        <Flex as="span" className={ComponentClassNames.ButtonLoaderWrapper}>
+        <Flex as="span" className={ComponentClassNames.ButtonLoaderWrapper} role="status">
           <Loader size={size} />
           {loadingText ? loadingText : null}
         </Flex>

--- a/packages/react/src/primitives/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/primitives/Button/__tests__/Button.test.tsx
@@ -127,7 +127,7 @@ describe('Button test suite', () => {
 
     await screen.findByRole('button');
     expect(ref.current?.nodeName).toBe('BUTTON');
-    expect(ref.current?.innerHTML).toBe(buttonText);
+    expect(ref.current?.innerHTML).toContain(buttonText);
   });
 
   it('should set size and variation props correctly', async () => {

--- a/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/react/src/primitives/Pagination/__tests__/Pagination.test.tsx
@@ -37,7 +37,7 @@ describe('Pagination component:', () => {
     const lastPage = await screen.findByLabelText(
       `${ComponentText.PaginationItem.pageLabel} ${totalPages}`
     );
-    expect(lastPage.childNodes.length).toBe(1);
+    expect(lastPage.childNodes.length).toBe(2);
     expect(lastPage).toHaveTextContent('5');
   });
 
@@ -76,14 +76,14 @@ describe('Pagination component:', () => {
       ComponentText.PaginationItem.previousLabel
     );
     expect(previous.nodeName).toBe('BUTTON');
-    expect(previous.childNodes.length).toBe(1);
+    expect(previous.childNodes.length).toBe(2);
     expect(previous).toBeDisabled();
 
     const next = await screen.findByLabelText(
       ComponentText.PaginationItem.nextLabel
     );
     expect(next.nodeName).toBe('BUTTON');
-    expect(next.childNodes.length).toBe(1);
+    expect(next.childNodes.length).toBe(2);
     expect(next).not.toBeDisabled();
   });
 
@@ -102,13 +102,13 @@ describe('Pagination component:', () => {
     const previous = await screen.findByLabelText(
       ComponentText.PaginationItem.previousLabel
     );
-    expect(previous.childNodes.length).toBe(1);
+    expect(previous.childNodes.length).toBe(2);
     expect(previous).not.toBeDisabled();
 
     const next = await screen.findByLabelText(
       ComponentText.PaginationItem.nextLabel
     );
-    expect(next.childNodes.length).toBe(1);
+    expect(next.childNodes.length).toBe(2);
     expect(next).toBeDisabled();
   });
 
@@ -118,13 +118,13 @@ describe('Pagination component:', () => {
     const previous = await screen.findByLabelText(
       ComponentText.PaginationItem.previousLabel
     );
-    expect(previous.childNodes.length).toBe(1);
+    expect(previous.childNodes.length).toBe(2);
     expect(previous).not.toBeDisabled();
 
     const next = await screen.findByLabelText(
       ComponentText.PaginationItem.nextLabel
     );
-    expect(next.childNodes.length).toBe(1);
+    expect(next.childNodes.length).toBe(2);
     expect(next).not.toBeDisabled();
   });
 
@@ -143,13 +143,13 @@ describe('Pagination component:', () => {
     const previous = await screen.findByLabelText(
       ComponentText.PaginationItem.previousLabel
     );
-    expect(previous.childNodes.length).toBe(1);
+    expect(previous.childNodes.length).toBe(2);
     expect(previous).not.toBeDisabled();
 
     const next = await screen.findByLabelText(
       ComponentText.PaginationItem.nextLabel
     );
-    expect(next.childNodes.length).toBe(1);
+    expect(next.childNodes.length).toBe(2);
     expect(next).not.toBeDisabled();
   });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Loading text is being announced by screen reader when using Mac VoiceOver, but not when using JAWS or NVDA. I moved the span wrapping the spinner and loading text to be rendered regardless of the button's loading state. The spinner and the loading text still only render based on isLoading. Also added role="status" to that span to trigger announcing the text change via screen readers.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
