### PR TITLE
fix(angular): fix `unsafe-*` eslint rule errors

### DIFF
--- a/packages/angular/.eslintrc.js
+++ b/packages/angular/.eslintrc.js
@@ -22,9 +22,6 @@ module.exports = {
          */
         '@typescript-eslint/explicit-module-boundary-types': 'warn',
         '@typescript-eslint/member-ordering': 'warn',
-        '@typescript-eslint/no-unsafe-argument': 'warn',
-        '@typescript-eslint/no-unsafe-assignment': 'warn',
-        '@typescript-eslint/no-unsafe-member-access': 'warn',
 
         /*
          * `prefer-nullish-coalescing` requires `strictNullChecks` to be on.

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/verify-user/verify-user.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/verify-user/verify-user.component.html
@@ -19,9 +19,7 @@
         [value]="unverifiedContactMethod.key"
         [id]="labelId"
       />
-      <label [for]="labelId">{{
-        getLabelForAttr(unverifiedContactMethod.key)
-      }}</label>
+      <label [for]="labelId">{{ getLabel(unverifiedContactMethod.key) }}</label>
     </div>
 
     <button

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/verify-user/verify-user.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/verify-user/verify-user.component.ts
@@ -11,6 +11,7 @@ import {
   SignInState,
   translate,
   authenticatorTextUtil,
+  UnverifiedContactMethods,
 } from '@aws-amplify/ui';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import { getAttributeMap } from '../../../../common';
@@ -47,10 +48,10 @@ export class VerifyUserComponent implements OnInit {
     return this.authenticator.slotContext;
   }
 
-  getLabelForAttr(authAttr: string): string {
+  getLabel(attr: keyof UnverifiedContactMethods): string {
     const attributeMap = getAttributeMap();
-    const label = attributeMap[authAttr]?.label;
-    return translate<string>(label);
+    const { label } = attributeMap[attr];
+    return translate(label);
   }
 
   onInput(event: Event) {

--- a/packages/angular/projects/ui-angular/src/lib/services/__tests__/authenticator.service.test.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/__tests__/authenticator.service.test.ts
@@ -33,7 +33,9 @@ jest.spyOn(UIModule, 'getServiceFacade').mockReturnValue(mockFacade);
 // mock interpreted authservice
 jest
   .spyOn(XState, 'interpret')
-  .mockReturnValue(new MockAuthService() as unknown as XState.AnyInterpreter);
+  .mockReturnValue(
+    new MockAuthService() as unknown as ReturnType<typeof XState.interpret>
+  );
 
 describe('AuthenticatorService', () => {
   let authService: AuthenticatorService;
@@ -52,8 +54,7 @@ describe('AuthenticatorService', () => {
 
     expect(handler).toBeCalledTimes(1);
 
-    const facade = handler.mock.calls[0][0];
-    expect(facade).toEqual(mockFacade);
+    expect(handler).toHaveBeenCalledWith(mockFacade);
 
     unsubscribe();
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes the following eslint rule errors:
- @typescript-eslint/no-unsafe-argument
- @typescript-eslint/no-unsafe-assignment
- @typescript-eslint/no-unsafe-member-access

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

CI below

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
