### PR TITLE
fix: react-17-next-11-node-16-ts

### DIFF
--- a/.github/scripts/mega-app-create-app.sh
+++ b/.github/scripts/mega-app-create-app.sh
@@ -18,8 +18,8 @@ if [[ "$BUILD_TOOL" == 'cra' && "$LANGUAGE" == 'ts' ]]; then
 fi
 
 if [ "$BUILD_TOOL" == 'next' ]; then
-    echo "npx create-next-app ${MEGA_APP_NAME} --ts --no-src-dir --no-experimental-app --no-eslint"
-    npx create-next-app ${MEGA_APP_NAME} --ts --no-src-dir --no-experimental-app --no-eslint
+    echo "npx create-next-app ${MEGA_APP_NAME} --ts --no-src-dir --no-experimental-app --no-eslint --no-app"
+    npx create-next-app ${MEGA_APP_NAME} --ts --no-src-dir --no-experimental-app --no-eslint --no-app
 fi
 
 if [ "$BUILD_TOOL" == 'vite' ]; then


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**Issue**: Mega-app _react-17-next-11-node-16-ts_ started to fail since May 5. https://github.com/aws-amplify/amplify-ui/actions/runs/4887947902/jobs/8725120905?pr=3751
**Reason**: On May 4,  *create-next-app* released a change (https://github.com/vercel/next.js/pull/49111) to ask a interactive question on command line to for the App Router and set the default to `Yes`
**Fix**: This PR is to add a `--no-app` flag so that it'll create a `pages/` folder instead of a `app/` folder.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

POC PR: https://github.com/aws-amplify/amplify-ui/pull/3751/

[![PoC / Build System Test Canary](https://github.com/aws-amplify/amplify-ui/actions/workflows/poc-build-system-test.yml/badge.svg)](https://github.com/aws-amplify/amplify-ui/actions/workflows/poc-build-system-test.yml)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
