### PR TITLE
React/expose files ref storage manager

### DIFF
--- a/.changeset/cyan-teachers-obey.md
+++ b/.changeset/cyan-teachers-obey.md
@@ -1,0 +1,18 @@
+---
+'@aws-amplify/ui-react-storage': minor
+---
+
+What changed:
+
+- Added exposed filesRef for the Storage Manager component.
+- This allows for clearing of the files list from a separate component where the Storage Manager component is being used.
+
+Why was the change made:
+
+- There was no easy way to clear the list of files without unmounting the component.
+- This capability is important when using Storage Manager inside a form. After submit, clear all entries including uploaded files.
+
+How should a customer update their code:
+
+- No changes are required by the customer since the added prop is optional in the Storage Manager component.
+- If customers want to take advantage of this change, they can create a files ref and include it in the Storage Manager component, then made calls to clearFiles from the ref.

--- a/packages/react-storage/src/components/StorageManager/StorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/StorageManager.tsx
@@ -38,6 +38,7 @@ function StorageManager({
   components,
   provider,
   path,
+  filesRef,
 }: StorageManagerProps): JSX.Element {
   if (!acceptedFileTypes || !accessLevel || !maxFileCount) {
     logger.warn(
@@ -75,6 +76,7 @@ function StorageManager({
 
   const {
     addFiles,
+    clearFiles,
     files,
     removeUpload,
     setUploadingFile,
@@ -83,6 +85,14 @@ function StorageManager({
     setUploadSuccess,
     setUploadResumed,
   } = useStorageManager(defaultFiles);
+
+  React.useImperativeHandle(filesRef, () => {
+    return {
+      clearFiles: () => {
+        clearFiles();
+      },
+    };
+  });
 
   const dropZoneProps = useDropZone({
     onChange: (event: React.DragEvent<HTMLDivElement>) => {

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/actions.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/actions.ts
@@ -18,6 +18,12 @@ export const addFilesAction = ({
   };
 };
 
+export const clearFilesAction = (): Action => {
+  return {
+    type: StorageManagerActionTypes.CLEAR_FILES,
+  };
+};
+
 export const setUploadingFileAction = ({
   id,
   uploadTask,

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/reducer.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/reducer.ts
@@ -34,6 +34,12 @@ export function storageManagerStateReducer(
         files: newFiles,
       };
     }
+    case StorageManagerActionTypes.CLEAR_FILES: {
+      return {
+        ...state,
+        files: [],
+      };
+    }
     case StorageManagerActionTypes.SET_STATUS_UPLOADING: {
       const { id, uploadTask } = action;
       const { files } = state;

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/types.ts
@@ -7,6 +7,7 @@ export interface UseStorageManagerState {
 
 export enum StorageManagerActionTypes {
   ADD_FILES = 'ADD_FILES',
+  CLEAR_FILES = 'CLEAR_FILES',
   SET_STATUS = 'SET_STATUS',
   SET_STATUS_UPLOADING = 'SET_STATUS_UPLOADING',
   SET_UPLOAD_PROGRESS = 'SET_UPLOAD_PROGRESS',
@@ -20,6 +21,9 @@ export type Action =
       type: StorageManagerActionTypes.ADD_FILES;
       files: File[];
       getFileErrorMessage: GetFileErrorMessage;
+    }
+  | {
+      type: StorageManagerActionTypes.CLEAR_FILES;
     }
   | {
       type: StorageManagerActionTypes.SET_STATUS;

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/useStorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/useStorageManager.tsx
@@ -7,6 +7,7 @@ import { Action, GetFileErrorMessage, UseStorageManagerState } from './types';
 import { storageManagerStateReducer } from './reducer';
 import {
   addFilesAction,
+  clearFilesAction,
   removeUploadAction,
   setUploadingFileAction,
   setUploadProgressAction,
@@ -19,6 +20,7 @@ export interface UseStorageManager {
     files: File[];
     getFileErrorMessage: GetFileErrorMessage;
   }) => void;
+  clearFiles: () => void;
   setUploadingFile: (params: { id: string; uploadTask?: UploadTask }) => void;
   setUploadProgress: (params: { id: string; progress: number }) => void;
   setUploadSuccess: (params: { id: string }) => void;
@@ -55,6 +57,10 @@ export function useStorageManager(
     getFileErrorMessage,
   }) => {
     dispatch(addFilesAction({ files, getFileErrorMessage }));
+  };
+
+  const clearFiles: UseStorageManager['clearFiles'] = () => {
+    dispatch(clearFilesAction());
   };
 
   const setUploadingFile: UseStorageManager['setUploadingFile'] = ({
@@ -95,6 +101,7 @@ export function useStorageManager(
     setUploadSuccess,
     setUploadingFile,
     addFiles,
+    clearFiles,
     files,
   };
 }

--- a/packages/react-storage/src/components/StorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/types.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import type { StorageAccessLevel, UploadTask } from '@aws-amplify/storage';
 
 import {
@@ -38,6 +40,10 @@ export type ProcessFileParams = Required<Pick<StorageFile, 'file' | 'key'>> &
 export type ProcessFile = (
   params: ProcessFileParams
 ) => Promise<ProcessFileParams> | ProcessFileParams;
+
+export interface FilesRefType {
+  clearFiles: () => void;
+}
 
 export interface StorageManagerProps {
   /**
@@ -116,4 +122,9 @@ export interface StorageManagerProps {
    * s3 for each file.
    */
   path?: string;
+
+  /**
+   * Ref for interfacing with selected files
+   */
+  filesRef?: React.Ref<FilesRefType>;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- Storage Manager component now has a `filesRef` prop that can be used to clear files currently managed in the components state.
- Following the existing code path for updates to the files state, I added a `clearFilesAction`, a case in the reducer to handle the action, and associated interface changes.
- In the `StorageManager` component, I expose the `clearFiles` function using the `useImperitiveHandle` React hook which will allow components that have passed a ref to the `StorageManager` component to clear the files.

#### Issue #3856 

#### Doc Change Pull Request #3870 

#### Description of how you validated changes

I created my own example using the existing framework in the repository. I added a storage component and a button to clear form values (including the Storage Manager files). I created a `files` ref using the `useRef` React component. I passed this to the `StorageManager` component and was able to call `files.current.clearValues()` when the reset button was clicked. This worked as expected.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [X] PR description included
- [X] Relevant documentation is changed or added (and PR referenced)
- [X] `yarn test` passes and tests are updated/added
- [X] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
