### PR TITLE
chore: import maplibre styles

### DIFF
--- a/.changeset/unlucky-hotels-watch.md
+++ b/.changeset/unlucky-hotels-watch.md
@@ -1,6 +1,5 @@
 ---
 "@aws-amplify/ui-react-geo": patch
-"@aws-amplify/ui-react": patch
 ---
 
 chore: import maplibre styles

--- a/.changeset/unlucky-hotels-watch.md
+++ b/.changeset/unlucky-hotels-watch.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react-geo": patch
+"@aws-amplify/ui-react": patch
+---
+
+chore: import maplibre styles

--- a/packages/react-geo/src/styles.css
+++ b/packages/react-geo/src/styles.css
@@ -1,1 +1,4 @@
 @import '../../ui/dist/styles.css';
+@import '@maplibre/maplibre-gl-geocoder/dist/maplibre-gl-geocoder.css';
+@import 'maplibre-gl-js-amplify/dist/public/amplify-geocoder.css';
+@import 'maplibre-gl/dist/maplibre-gl.css';

--- a/packages/react-geo/src/styles.css
+++ b/packages/react-geo/src/styles.css
@@ -1,4 +1,4 @@
-@import '../../ui/dist/styles.css';
 @import '@maplibre/maplibre-gl-geocoder/dist/maplibre-gl-geocoder.css';
-@import 'maplibre-gl-js-amplify/dist/public/amplify-geocoder.css';
 @import 'maplibre-gl/dist/maplibre-gl.css';
+@import 'maplibre-gl-js-amplify/dist/public/amplify-geocoder.css';
+@import '../../ui/dist/styles.css';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Importing missing maplibre styles in `ui-react-geo` package.
We need the same ones in ui-react-geo as we have in ui-react: https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/src/styles.css
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Description of how you validated changes
- Tested MapView and LocationSearch components in sample app with these imports.
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
