### PR TITLE
fix: check for existing PR before creating liveness sync pr

### DIFF
--- a/.github/workflows/liveness-branch-sync.yml
+++ b/.github/workflows/liveness-branch-sync.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
       - name: Create sync pull request
-        run: gh pr create -B liveness-release -H main --title 'Sync branch main to liveness-release' --body 'Created by Github action'
+        run: gh pr edit -B liveness-release || gh pr create -B liveness-release -H main --title 'Sync branch main to liveness-release' --body 'Created by Github action'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/liveness-branch-sync.yml
+++ b/.github/workflows/liveness-branch-sync.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
       - name: Create sync pull request
-        run:
+        run: |
           length=$(gh pr list -B liveness-release -H main -s open --json title --jq "length")
           if [[ "$length" -eq 0 ]]; then
-          gh pr create -B liveness-release -H main --title 'Sync branch main to liveness-release' --body 'Created by Github action'
+            gh pr create -B liveness-release -H main --title 'Sync branch main to liveness-release' --body 'Created by Github action'
           else
-          echo "Sync PR already open, skipping."
+            echo "Sync PR already open, skipping."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/liveness-branch-sync.yml
+++ b/.github/workflows/liveness-branch-sync.yml
@@ -15,6 +15,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
       - name: Create sync pull request
-        run: length=$(gh pr list -B liveness-release -H main -s open --json title --jq "length"); if [[ "$length" -gt 0 ]]; then echo "PR already exists"; true; else false; fi|| gh pr create -B liveness-release -H main --title 'Sync branch main to liveness-release' --body 'Created by Github action'
+        run:
+          length=$(gh pr list -B liveness-release -H main -s open --json title --jq "length")
+          if [[ "$length" -eq 0 ]]; then
+          gh pr create -B liveness-release -H main --title 'Sync branch main to liveness-release' --body 'Created by Github action'
+          else
+          echo "Sync PR already open, skipping."
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/liveness-branch-sync.yml
+++ b/.github/workflows/liveness-branch-sync.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
       - name: Create sync pull request
-        run: gh pr edit -B liveness-release || gh pr create -B liveness-release -H main --title 'Sync branch main to liveness-release' --body 'Created by Github action'
+        run: length=$(gh pr list -B liveness-release -H main -s open --json title --jq "length"); if [[ "$length" -gt 0 ]]; then echo "PR already exists"; true; else false; fi|| gh pr create -B liveness-release -H main --title 'Sync branch main to liveness-release' --body 'Created by Github action'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Added `gh pr edit` command before `gh pr create` command to see if a PR exists
- Example of running the command when a PR exists
```
❯ gh pr edit -B liveness-release || gh pr create -B liveness-release -H main --title 'Sync branch main to liveness-release' --body 'Created by Github action'
https://github.com/aws-amplify/amplify-ui/pull/3887
```
- Example of running the command when a PR does not exist
```
❯ gh pr edit -B liveness-release || gh pr create -B liveness-release -H main --title 'Sync branch main to liveness-release' --body 'Created by Github action'
no pull requests found for branch "main"
Warning: 2 uncommitted changes

Creating pull request for main into liveness-release in aws-amplify/amplify-ui

https://github.com/aws-amplify/amplify-ui/pull/3888
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
