### PR TITLE
ci: run reusable workflows in categorical-packages/main branch

### DIFF
--- a/.github/workflows/test-internal-prs.yml
+++ b/.github/workflows/test-internal-prs.yml
@@ -130,14 +130,14 @@ jobs:
         run: yarn license
 
   unit:
-    uses: ./.github/workflows/reusable-unit.yml
+    uses: aws-amplify/amplify-ui/.github/workflows/reusable-unit.yml@categorical-packages/main
     needs: setup-cache
     with:
       commit: ${{ github.event.pull_request.head.sha }}
       repository: ${{ github.repository }}
 
   e2e:
-    uses: ./.github/workflows/reusable-e2e.yml
+    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@categorical-packages/main
     needs: unit
     with:
       commit: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test-internal-prs.yml
+++ b/.github/workflows/test-internal-prs.yml
@@ -5,7 +5,7 @@
 #   (2) On every commit to the PR
 #   (3) Adding run-tests label to the PR
 
-name: Test / Internal PRs
+name: Test / Internal PRs to categorical-packages/main
 
 concurrency:
   group: test-internal-prs-${{ github.event.pull_request.id }}
@@ -13,7 +13,7 @@ concurrency:
 
 on:
   pull_request:
-    branches: [main]
+    branches: [categorical-packages/main]
     types: [opened, synchronize, labeled]
 
 jobs:
@@ -130,14 +130,14 @@ jobs:
         run: yarn license
 
   unit:
-    uses: aws-amplify/amplify-ui/.github/workflows/reusable-unit.yml@main
+    uses: ./.github/workflows/reusable-unit.yml
     needs: setup-cache
     with:
       commit: ${{ github.event.pull_request.head.sha }}
       repository: ${{ github.repository }}
 
   e2e:
-    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@main
+    uses: ./.github/workflows/reusable-e2e.yml
     needs: unit
     with:
       commit: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update `test-internal-prs` workflow to use local `reusable-*` workflows to run workflows on each PR to `categorical-packages/main` instead of having POC PRs.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
