### PR TITLE
fix: Pin webpack version to unblock react canaries

### DIFF
--- a/canary/apps/react/cra-ts/package.json
+++ b/canary/apps/react/cra-ts/package.json
@@ -44,6 +44,9 @@
       "last 1 safari version"
     ]
   },
+  "resolutions": {
+    "webpack": "5.82.1"
+  },
   "devDependencies": {
     "@size-limit/preset-app": "^7.0.8",
     "customize-cra": "^1.0.0",

--- a/canary/apps/react/cra/package.json
+++ b/canary/apps/react/cra/package.json
@@ -33,6 +33,9 @@
       "last 1 safari version"
     ]
   },
+  "resolutions": {
+    "webpack": "5.82.1"
+  },
   "devDependencies": {
     "@size-limit/preset-app": "^7.0.8",
     "customize-cra": "^1.0.0",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Build and Runtime canaries are failing for react CRA and CRA-ts

```
$ react-app-rewired build
Creating an optimized production build...
Failed to compile.

HookWebpackError: Cannot read properties of undefined (reading 'e')
-- inner error --
TypeError: Cannot read properties of undefined (reading 'e')
Generated code for /home/runner/work/amplify-ui/amplify-ui/canary/apps/react/cra-ts/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[5].use[1]!/home/runner/work/amplify-ui/amplify-ui/canary/apps/react/cra-ts/node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[5].use[2]!/home/runner/work/amplify-ui/amplify-ui/canary/apps/react/cra-ts/node_modules/source-map-loader/dist/cjs.js!/home/runner/work/amplify-ui/amplify-ui/canary/apps/react/cra-ts/node_modules/@aws-amplify/ui-react/dist/styles.css
```

Webpack released a new version around the time that matches the failures: https://www.npmjs.com/package/webpack?activeTab=readme

Pinning webpack to previous release to unblock canaries.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran `yarn build` locally 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
