### PR TITLE
Revert "fix: Pin webpack version to unblock react canaries (#3909)"

### DIFF
--- a/canary/apps/react/cra-ts/package.json
+++ b/canary/apps/react/cra-ts/package.json
@@ -44,9 +44,6 @@
       "last 1 safari version"
     ]
   },
-  "resolutions": {
-    "webpack": "5.82.1"
-  },
   "devDependencies": {
     "@size-limit/preset-app": "^7.0.8",
     "customize-cra": "^1.0.0",

--- a/canary/apps/react/cra/package.json
+++ b/canary/apps/react/cra/package.json
@@ -33,9 +33,6 @@
       "last 1 safari version"
     ]
   },
-  "resolutions": {
-    "webpack": "5.82.1"
-  },
   "devDependencies": {
     "@size-limit/preset-app": "^7.0.8",
     "customize-cra": "^1.0.0",


### PR DESCRIPTION
This reverts commit 9ecbe7e8e0be902cd59940d8020b35b94b0748c7.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Reverting the change to pin Webpack to older version, the fix is released in patch 5.83.1.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/3911

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran yarn install && yarn build for cra canary apps

```
yarn run v1.22.19
$ react-app-rewired build
Creating an optimized production build...
Compiled successfully.
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
