### PR TITLE
Placeholder start color end color props

### DIFF
--- a/packages/react/src/primitives/types/placeholder.ts
+++ b/packages/react/src/primitives/types/placeholder.ts
@@ -1,5 +1,8 @@
+import { Property } from 'csstype';
 import { Sizes } from './base';
 import { ViewProps } from './view';
+
+import type { ColorKeys } from './theme';
 
 export type PlaceholderSizes = Sizes;
 
@@ -17,4 +20,16 @@ export interface PlaceholderProps extends ViewProps {
    * Controls the display size of placeholder
    */
   size?: PlaceholderSizes;
+
+  /**
+   * @description
+   * Controls the start color of placeholder
+   */
+  startColor?: ColorKeys<Property.BackgroundColor>;
+
+  /**
+   * @description
+   * Controls the end color of placeholder
+   */
+  endColor?: ColorKeys<Property.BackgroundColor>;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

1.Added startColor and endColor in the placeholder component
2.Set the startColor and endColor type as Colorkeys<Property.BackgroundColor>


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
