### PR TITLE
fix (docs): limit app router alert to react platform

### DIFF
--- a/docs/src/components/AppDirectoryAlert.tsx
+++ b/docs/src/components/AppDirectoryAlert.tsx
@@ -1,6 +1,6 @@
 import { Alert, Link, Text } from '@aws-amplify/ui-react';
 
-export const AppDirectoryAlert = () => (
+const AppDirectoryAlert = () => (
   <Alert variation="info" role="none">
     <Text>
       Next.js 13.4+ introduces{' '}
@@ -28,3 +28,4 @@ export const AppDirectoryAlert = () => (
     </Text>
   </Alert>
 );
+export default AppDirectoryAlert;

--- a/docs/src/pages/[platform]/connected-components/account-settings/account-settings.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/account-settings/account-settings.react.mdx
@@ -3,6 +3,7 @@ import { AppDirectoryAlert } from '@/components/AppDirectoryAlert';
 
 import { InstallScripts } from '@/components/InstallScripts';
 import { DeveloperPreview } from './DeveloperPreview';
+import { Fragment } from '@/components/Fragment';
 
 <DeveloperPreview />
 
@@ -14,7 +15,10 @@ Account Settings components are a set of standalone components that add [user ma
 
 ## Quick Start
 
-<AppDirectoryAlert />
+<Fragment platforms={['react']}>
+  {({ platform }) => import('@/components/AppDirectoryAlert')}
+</Fragment>
+
 
 ### Step 1. Configure Backend
 

--- a/docs/src/pages/[platform]/connected-components/authenticator/index.page.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/index.page.mdx
@@ -31,7 +31,9 @@ export async function getStaticProps() {
 
 ## Quick start
 
-<AppDirectoryAlert />
+<Fragment platforms={['react']}>
+  {({ platform }) => import('@/components/AppDirectoryAlert')}
+</Fragment>
 
 ### Step 1. Configure backend
 

--- a/docs/src/pages/[platform]/connected-components/geo/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/geo/react.mdx
@@ -11,7 +11,9 @@ Amplify UI Geo is powered by
 
 ### Quick Start
 
-<AppDirectoryAlert />
+<Fragment platforms={['react']}>
+  {({ platform }) => import('@/components/AppDirectoryAlert')}
+</Fragment>
 
 <Alert variation="info" heading="Create React App setup">
 There's a known issue for users of Create React App v4 where the default prod `browserslist` configuration causes build errors when building for production. See the [Create React App Troubleshooting Guide](/getting-started/troubleshooting#create-react-app) to configure Create React App for use with the MapView UI component.

--- a/docs/src/pages/[platform]/connected-components/in-app-messaging/index.page.mdx
+++ b/docs/src/pages/[platform]/connected-components/in-app-messaging/index.page.mdx
@@ -39,7 +39,9 @@ In-App Messaging allows you to better engage users with contextually appropriate
 
 ## Getting Started
 
-<AppDirectoryAlert />
+<Fragment platforms={['react']}>
+  {({ platform }) => import('@/components/AppDirectoryAlert')}
+</Fragment>
 
 Integration with your application can be done with the `InAppMessagingProvider` and `InAppMessageDisplay` components directly, 
 or wrap your app in `withInAppMessaging` (a [React Higher-Order Component](https://legacy.reactjs.org/docs/higher-order-components.html)):

--- a/docs/src/pages/[platform]/connected-components/liveness/quick-start-add.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/liveness/quick-start-add.react.mdx
@@ -15,7 +15,9 @@ import { InstallScripts } from '@/components/InstallScripts';
 
 ### Step 3. Initialize Amplify
 
-<AppDirectoryAlert />
+<Fragment platforms={['react']}>
+  {({ platform }) => import('@/components/AppDirectoryAlert')}
+</Fragment>
 
 ```jsx
 import React from 'react';

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
@@ -5,6 +5,7 @@ import { AppDirectoryAlert } from '@/components/AppDirectoryAlert';
 import { ComponentStyleDisplay } from '@/components/ComponentStyleDisplay';
 import ReactPropsTable from '@/components/propsTable/ReactPropsTable';
 import { Example, ExampleCode } from '@/components/Example';
+import { Fragment } from '@/components/Fragment';
 import { InstallScripts } from '@/components/InstallScripts';
 import { STORAGE_MANAGER, FILE_PICKER, DROPZONE_PROPS, DISPLAY_TEXT } from './props';
 import {
@@ -28,7 +29,9 @@ import {
   Did you follow the [quick start instructions](/connected-components/storage#quick-start) to set up the storage and auth services?
 </Alert>
 
-<AppDirectoryAlert />
+<Fragment platforms={['react']}>
+  {({ platform }) => import('@/components/AppDirectoryAlert')}
+</Fragment>
 
 To use the StorageManager component import it into your React application with the included styles. 
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fix issue where the Next App Directory alert was showing on all platforms.

![CleanShot 2023-05-23 at 17 16 33](https://github.com/aws-amplify/amplify-ui/assets/6165315/a333d5d3-859b-414c-94e9-df15e7c18360)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually smoke tested each connected component page

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
