### PR TITLE
Remove dev preview callout for Android Authenticator

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/DeveloperPreview.tsx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/DeveloperPreview.tsx
@@ -5,10 +5,9 @@ export const DeveloperPreview = () => {
   const {
     query: { platform = 'react' },
   } = useRouter();
-  if (platform !== 'react-native' && platform !== 'android') return null;
+  if (platform !== 'react-native') return null;
 
-  const devPlatformName =
-    platform === 'react-native' ? 'React Native' : 'Android';
+  const devPlatformName = 'React Native';
 
   return (
     <Alert variation="info" heading="Developer Preview">

--- a/docs/src/pages/[platform]/connected-components/authenticator/quick-start-install.android.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/quick-start-install.android.mdx
@@ -14,6 +14,6 @@ Add the following dependency to your **app**'s `build.gradle` file and click "Sy
 ```groovy
 dependencies {    
     // Authenticator dependency
-    implementation 'com.amplifyframework.ui:authenticator:1.0.0-dev-preview.0'
+    implementation 'com.amplifyframework.ui:authenticator:1.0.0'
 }
 ```


### PR DESCRIPTION
#### Description of changes

- Remove the dev-preview callout for Android Authenticator.
- Update the dependency version to 1.0.0

#### Issue #, if available

N/A

#### Description of how you validated changes

Run locally

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
