### PR TITLE
fix: remove mjs support for new categorical packages

### DIFF
--- a/packages/react-core-notifications/package.json
+++ b/packages/react-core-notifications/package.json
@@ -2,11 +2,11 @@
   "name": "@aws-amplify/ui-react-core-notifications",
   "version": "1.0.0",
   "main": "dist/index.js",
-  "module": "dist/esm/index.mjs",
+  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.mjs",
+      "import": "./dist/esm/index.js",
       "require": "./dist/index.js"
     },
     "./package.json": "./package.json"
@@ -31,7 +31,7 @@
     "lint": "yarn typecheck && eslint src --ext .js,.ts,.tsx",
     "prebuild": "rimraf dist",
     "test": "jest",
-    "test:ci": "yarn test && yarn check:esm",
+    "test:ci": "yarn test",
     "test:watch": "yarn test --watch",
     "typecheck": "tsc --noEmit"
   },
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@aws-amplify/eslint-config-amplify-ui": "0.0.0",
+    "@rollup/plugin-commonjs": "^22.0.1",
     "@rollup/plugin-typescript": "^8.3.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",

--- a/packages/react-core-notifications/rollup.config.js
+++ b/packages/react-core-notifications/rollup.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from 'rollup';
+import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import { terser } from 'rollup-plugin-terser';
 import externals from 'rollup-plugin-node-externals';
@@ -17,6 +18,7 @@ const config = defineConfig([
       format: 'cjs',
     },
     plugins: [
+      commonjs(),
       externals({ include: /^@aws-amplify/ }),
       typescript({ declarationDir: 'dist/types', sourceMap, tsconfig }),
       terser(),
@@ -33,6 +35,7 @@ const config = defineConfig([
       preserveModulesRoot: 'src',
     },
     plugins: [
+      commonjs(),
       externals({ include: /^@aws-amplify/ }),
       typescript({
         outDir: 'dist/esm',

--- a/packages/react-geo/package.json
+++ b/packages/react-geo/package.json
@@ -2,11 +2,11 @@
   "name": "@aws-amplify/ui-react-geo",
   "version": "1.0.0",
   "main": "dist/index.js",
-  "module": "dist/esm/index.mjs",
+  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.mjs",
+      "import": "./dist/esm/index.js",
       "require": "./dist/index.js"
     },
     "./styles.css": "./dist/styles.css"
@@ -35,7 +35,7 @@
     "prebuild": "rimraf dist",
     "size": "yarn size-limit",
     "test": "jest",
-    "test:ci": "yarn test && yarn check:esm",
+    "test:ci": "yarn test",
     "test:watch": "yarn test --watch",
     "typecheck": "tsc --noEmit"
   },
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@aws-amplify/eslint-config-amplify-ui": "0.0.0",
+    "@rollup/plugin-commonjs": "^22.0.1",
     "@rollup/plugin-typescript": "^8.3.1",
     "@size-limit/preset-big-lib": "^7.0.8",
     "@testing-library/jest-dom": "^5.14.1",
@@ -81,7 +82,7 @@
   "size-limit": [
     {
       "name": "Geo",
-      "path": "dist/esm/index.mjs",
+      "path": "dist/esm/index.js",
       "import": "{ MapView, LocationSearch }",
       "limit": "330 kB"
     }

--- a/packages/react-geo/rollup.config.js
+++ b/packages/react-geo/rollup.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from 'rollup';
+import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import { terser } from 'rollup-plugin-terser';
 import styles from 'rollup-plugin-styles';
@@ -18,6 +19,7 @@ const config = defineConfig([
       format: 'cjs',
     },
     plugins: [
+      commonjs(),
       externals({ include: /^@aws-amplify/ }),
       typescript({ declarationDir: 'dist/types', sourceMap, tsconfig }),
       terser(),
@@ -34,6 +36,7 @@ const config = defineConfig([
       preserveModulesRoot: 'src',
     },
     plugins: [
+      commonjs(),
       externals({ include: /^@aws-amplify/ }),
       typescript({
         outDir: 'dist/esm',

--- a/packages/react-notifications/package.json
+++ b/packages/react-notifications/package.json
@@ -2,11 +2,11 @@
   "name": "@aws-amplify/ui-react-notifications",
   "version": "1.0.0",
   "main": "dist/index.js",
-  "module": "dist/esm/index.mjs",
+  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.mjs",
+      "import": "./dist/esm/index.js",
       "require": "./dist/index.js"
     },
     "./styles.css": "./dist/styles.css"
@@ -35,7 +35,7 @@
     "prebuild": "rimraf dist",
     "size": "yarn size-limit",
     "test": "jest",
-    "test:ci": "yarn test && yarn check:esm",
+    "test:ci": "yarn test",
     "test:watch": "yarn test --watch",
     "typecheck": "tsc --noEmit"
   },
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@aws-amplify/eslint-config-amplify-ui": "0.0.0",
+    "@rollup/plugin-commonjs": "^22.0.1",
     "@rollup/plugin-typescript": "^8.3.1",
     "@size-limit/preset-big-lib": "^7.0.8",
     "@testing-library/jest-dom": "^5.14.1",
@@ -81,7 +82,7 @@
   "size-limit": [
     {
       "name": "InAppMessaging",
-      "path": "dist/esm/index.mjs",
+      "path": "dist/esm/index.js",
       "import": "{ InAppMessagingProvider, InAppMessageDisplay }",
       "limit": "110 kB"
     }

--- a/packages/react-notifications/rollup.config.js
+++ b/packages/react-notifications/rollup.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from 'rollup';
+import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import { terser } from 'rollup-plugin-terser';
 import styles from 'rollup-plugin-styles';
@@ -18,6 +19,7 @@ const config = defineConfig([
       format: 'cjs',
     },
     plugins: [
+      commonjs(),
       externals({ include: /^@aws-amplify/ }),
       typescript({ declarationDir: 'dist/types', sourceMap, tsconfig }),
       terser(),
@@ -34,6 +36,7 @@ const config = defineConfig([
       preserveModulesRoot: 'src',
     },
     plugins: [
+      commonjs(),
       externals({ include: /^@aws-amplify/ }),
       typescript({
         outDir: 'dist/esm',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Removes .mjs support from categorical packages
- reference PR - https://github.com/aws-amplify/amplify-ui/pull/3733

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
