### PR TITLE
fix(liveness): catch websocket connection errors

### DIFF
--- a/.changeset/polite-ants-wonder.md
+++ b/.changeset/polite-ants-wonder.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+fix(liveness): catch websocket connection errors

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/index.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/index.ts
@@ -1189,8 +1189,8 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
 );
 
 const responseStreamActor = async (callback: StreamActorCallback) => {
-  const stream = await responseStream;
   try {
+    const stream = await responseStream;
     for await (const event of stream) {
       if (isServerSesssionInformationEvent(event)) {
         callback({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Previously errors when establishing connection were uncaught by the xstate machine and would just print to the logs
- After putting the one line into the try catch errors are now caught and handled correctly. This should stop the endless `connecting...` errors

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
