### PR TITLE
chore(liveness): increase ws connection timeout to 10s, default was 2s

### DIFF
--- a/.changeset/big-oranges-hang.md
+++ b/.changeset/big-oranges-hang.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+chore(liveness): increase ws connection timeout to 10s, default was 2s

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
@@ -10,6 +10,7 @@ import {
   RekognitionStreamingClientConfig,
   StartFaceLivenessSessionCommand,
 } from '@aws-sdk/client-rekognitionstreaming';
+import { WebSocketFetchHandler } from '@aws-sdk/middleware-websocket';
 import { VideoRecorder } from './videoRecorder';
 
 export interface StartLivenessStreamInput {
@@ -117,6 +118,7 @@ export class LivenessStreamProvider extends AmazonAIInterpretPredictionsProvider
       credentials,
       region: this.region,
       customUserAgent: getAmplifyUserAgent(),
+      requestHandler: new WebSocketFetchHandler({ connectionTimeout: 10_000 }),
     };
 
     if (ENDPOINT) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Original WS connection timeout was 2s
- On slower connections we would see the connection timing out and retrying 3 additional times
- Tested with Slow 3G throttle profile on chrome which adds 2s of latency to each request

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
