### PR TITLE
ci: set up ci to run unit, e2e and publish to next-release tag

### DIFF
--- a/.github/workflows/publish-next-release.yml
+++ b/.github/workflows/publish-next-release.yml
@@ -1,0 +1,104 @@
+# Description: This workflow runs unit + e2e tests, then publishes UI packages
+#              to `@next-release` NPM tag.
+#
+# Triggered by: merge to `next-release/main`
+
+name: Test and Publish / next-release
+
+on:
+  push:
+    branches: [angular-major-release/main]
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+jobs:
+  setup-cache:
+    uses: ./.github/workflows/reusable-setup-cache.yml
+    with:
+      commit: ${{ github.sha }}
+      repository: ${{ github.repository }}
+
+  unit:
+    uses: ./.github/workflows/reusable-unit.yml
+    needs: setup-cache
+    with:
+      commit: ${{ github.sha }}
+      repository: ${{ github.repository }}
+
+  e2e:
+    uses: ./.github/workflows/reusable-e2e.yml
+    needs: unit
+    with:
+      commit: ${{ github.sha }}
+      repository: ${{ github.repository }}
+    secrets:
+      AUTH_E2E_ROLE_ARN: ${{ secrets.AUTH_E2E_ROLE_ARN }}
+      DATASTORE_E2E_ROLE_ARN: ${{ secrets.DATASTORE_E2E_ROLE_ARN }}
+      GEO_E2E_ROLE_ARN: ${{ secrets.GEO_E2E_ROLE_ARN }}
+      STORAGE_E2E_ROLE_ARN: ${{ secrets.STORAGE_E2E_ROLE_ARN }}
+      LIVENESS_E2E_ROLE_ARN: ${{ secrets.LIVENESS_E2E_ROLE_ARN }}
+      IN_APP_MESSAGING_E2E_ROLE_ARN: ${{ secrets.IN_APP_MESSAGING_E2E_ROLE_ARN }}
+      DOMAIN: ${{ secrets.DOMAIN }}
+      PHONE_NUMBER: ${{ secrets.PHONE_NUMBER }}
+      USERNAME: ${{ secrets.USERNAME }}
+      NEW_PASSWORD: ${{ secrets.NEW_PASSWORD }}
+      VALID_PASSWORD: ${{ secrets.VALID_PASSWORD }}
+      SITE_URL: ${{ secrets.SITE_URL }}
+      DOCSEARCH_DOCS_APP_ID: ${{ secrets.DOCSEARCH_DOCS_APP_ID }}
+      DOCSEARCH_DOCS_API_KEY: ${{ secrets.DOCSEARCH_DOCS_API_KEY }}
+      DOCSEARCH_DOCS_INDEX_NAME: ${{ secrets.DOCSEARCH_DOCS_INDEX_NAME }}
+
+  publish:
+    needs: [e2e]
+    uses: ./.github/workflows/reusable-tagged-publish.yml
+    with:
+      dist-tag: next-release
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  build-test:
+    needs: publish
+    runs-on: ubuntu-latest
+    environment: ci
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+      - name: Setup Node.js 16
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0 https://github.com/actions/setup-node/commit/64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version: 16
+          cache: 'yarn'
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+      - name: Add Amplify CLI
+        run: yarn global add @aws-amplify/cli
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: ${{ secrets.AUTH_E2E_ROLE_ARN }}
+      # Amplify CLI does not support headless pull with temporary credentials
+      # when useProfile is false.
+      # See: https://github.com/aws-amplify/amplify-cli/issues/11009.
+      - name: Create temp AWS profile
+        run: |
+          aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID && \
+          aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY && \
+          aws configure set aws_session_token $AWS_SESSION_TOKEN && \
+          aws configure set default.region $AWS_REGION
+      - name: Pull down AWS environments
+        run: yarn pull
+        working-directory: ./canary
+      - name: Delete AWS Profile
+        run: rm -rf ~/.aws
+      - name: Setup canary apps against @next-release
+        run: yarn setup:next-release
+        working-directory: ./canary
+      - name: Run yarn install on each sample app
+        run: yarn install
+        working-directory: ./canary
+      - name: Run yarn build on each sample app
+        run: yarn build
+        working-directory: ./canary

--- a/.github/workflows/test-angular-major-release-prs.yml
+++ b/.github/workflows/test-angular-major-release-prs.yml
@@ -5,7 +5,7 @@
 #   (2) On every commit to the PR
 #   (3) Adding run-tests label to the PR
 
-name: Test / Internal PRs
+name: Test / Internal PRs on angular-major-release/main
 
 concurrency:
   group: test-internal-prs-${{ github.event.pull_request.id }}
@@ -13,7 +13,7 @@ concurrency:
 
 on:
   pull_request:
-    branches: [main]
+    branches: [angular-major-release/main]
     types: [opened, synchronize, labeled]
 
 jobs:
@@ -98,7 +98,7 @@ jobs:
 
   setup-cache:
     needs: setup
-    uses: aws-amplify/amplify-ui/.github/workflows/reusable-setup-cache.yml@main
+    uses: ./.github/workflows/reusable-setup-cache.yml
     with:
       commit: ${{ github.event.pull_request.head.sha }}
       repository: ${{ github.repository }}
@@ -130,14 +130,14 @@ jobs:
         run: yarn license
 
   unit:
-    uses: aws-amplify/amplify-ui/.github/workflows/reusable-unit.yml@main
+    uses: ./.github/workflows/reusable-unit.yml
     needs: setup-cache
     with:
       commit: ${{ github.event.pull_request.head.sha }}
       repository: ${{ github.repository }}
 
   e2e:
-    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@main
+    uses: ./.github/workflows/reusable-e2e.yml
     needs: unit
     with:
       commit: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Set up ci to run unit, e2e and publish to `next-release` tag
- This will be reverted before we merge `angular-major-release/main` to `main`.


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
