### PR TITLE
Revert "chore(canary): pin aria-query deps temporarily"

### DIFF
--- a/canary/apps/react/cra-ts/package.json
+++ b/canary/apps/react/cra-ts/package.json
@@ -32,9 +32,6 @@
       "react-app/jest"
     ]
   },
-  "resolutions": {
-    "aria-query": "5.1.3"
-  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
The upstream issue has been fixed: https://github.com/A11yance/aria-query/issues/502