### PR TITLE
chore(liveness): add liveness version user agent to rekognition streaming api call

### DIFF
--- a/.changeset/angry-ligers-enjoy.md
+++ b/.changeset/angry-ligers-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+chore(liveness): add liveness version user agent to rekognition streaming api call

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
@@ -1,7 +1,4 @@
-import {
-  Credentials as AmplifyCredentials,
-  getAmplifyUserAgent,
-} from '@aws-amplify/core';
+import { Credentials as AmplifyCredentials } from '@aws-amplify/core';
 import { AmazonAIInterpretPredictionsProvider } from '@aws-amplify/predictions';
 import {
   ClientSessionInformationEvent,
@@ -118,7 +115,7 @@ export class LivenessStreamProvider extends AmazonAIInterpretPredictionsProvider
     const clientconfig: RekognitionStreamingClientConfig = {
       credentials,
       region: this.region,
-      customUserAgent: `${getAmplifyUserAgent()} ${getLivenessUserAgent()}`,
+      customUserAgent: `${getLivenessUserAgent()}`,
       requestHandler: new WebSocketFetchHandler({ connectionTimeout: 10_000 }),
     };
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
@@ -12,6 +12,7 @@ import {
 } from '@aws-sdk/client-rekognitionstreaming';
 import { WebSocketFetchHandler } from '@aws-sdk/middleware-websocket';
 import { VideoRecorder } from './videoRecorder';
+import { getLivenessUserAgent } from '../../utils/platform';
 
 export interface StartLivenessStreamInput {
   sessionId: string;
@@ -117,7 +118,7 @@ export class LivenessStreamProvider extends AmazonAIInterpretPredictionsProvider
     const clientconfig: RekognitionStreamingClientConfig = {
       credentials,
       region: this.region,
-      customUserAgent: getAmplifyUserAgent(),
+      customUserAgent: `${getAmplifyUserAgent()} ${getLivenessUserAgent()}`,
       requestHandler: new WebSocketFetchHandler({ connectionTimeout: 10_000 }),
     };
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
@@ -1,4 +1,7 @@
-import { Credentials as AmplifyCredentials } from '@aws-amplify/core';
+import {
+  Credentials as AmplifyCredentials,
+  getAmplifyUserAgent,
+} from '@aws-amplify/core';
 import { AmazonAIInterpretPredictionsProvider } from '@aws-amplify/predictions';
 import {
   ClientSessionInformationEvent,
@@ -115,7 +118,7 @@ export class LivenessStreamProvider extends AmazonAIInterpretPredictionsProvider
     const clientconfig: RekognitionStreamingClientConfig = {
       credentials,
       region: this.region,
-      customUserAgent: `${getLivenessUserAgent()}`,
+      customUserAgent: `${getAmplifyUserAgent()} ${getLivenessUserAgent}`,
       requestHandler: new WebSocketFetchHandler({ connectionTimeout: 10_000 }),
     };
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/utils/__tests__/platform.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/utils/__tests__/platform.test.ts
@@ -8,12 +8,4 @@ describe('getLivenessUserAgent', () => {
     expect(customUserAgent).toContain('ui-react-liveness');
     expect(customUserAgent).toContain(VERSION);
   });
-
-  it('should return a user agent string with custom content', () => {
-    const customUserAgent = getLivenessUserAgent('specialEnding');
-
-    expect(customUserAgent).toContain('ui-react-liveness');
-    expect(customUserAgent).toContain(VERSION);
-    expect(customUserAgent).toContain('specialEnding');
-  });
 });

--- a/packages/react-liveness/src/components/FaceLivenessDetector/utils/__tests__/platform.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/utils/__tests__/platform.test.ts
@@ -1,0 +1,19 @@
+import { VERSION } from '../../../../version';
+import { getLivenessUserAgent } from '../platform';
+
+describe('getLivenessUserAgent', () => {
+  it('should return a user agent string containing the current version', () => {
+    const customUserAgent = getLivenessUserAgent();
+
+    expect(customUserAgent).toContain('ui-react-liveness');
+    expect(customUserAgent).toContain(VERSION);
+  });
+
+  it('should return a user agent string with custom content', () => {
+    const customUserAgent = getLivenessUserAgent('specialEnding');
+
+    expect(customUserAgent).toContain('ui-react-liveness');
+    expect(customUserAgent).toContain(VERSION);
+    expect(customUserAgent).toContain('specialEnding');
+  });
+});

--- a/packages/react-liveness/src/components/FaceLivenessDetector/utils/platform.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/utils/platform.ts
@@ -1,0 +1,7 @@
+import { VERSION } from '../../../version';
+
+const BASE_USER_AGENT = `ui-react-liveness ${VERSION}`;
+
+export const getLivenessUserAgent = (content?: string): string => {
+  return `${BASE_USER_AGENT}${content ? content : ''}`;
+};

--- a/packages/react-liveness/src/components/FaceLivenessDetector/utils/platform.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/utils/platform.ts
@@ -1,7 +1,7 @@
 import { VERSION } from '../../../version';
 
-const BASE_USER_AGENT = `ui-react-liveness ${VERSION}`;
+const BASE_USER_AGENT = `ui-react-liveness/${VERSION}`;
 
-export const getLivenessUserAgent = (content?: string): string => {
-  return `${BASE_USER_AGENT}${content ? content : ''}`;
+export const getLivenessUserAgent = (): string => {
+  return BASE_USER_AGENT;
 };


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Updated custom user agent to include liveness package version
- New User agent - `aws-sdk-js/3.348.0 ua/2.0 os/macOS#10.15.7 lang/js md/browser#Chrome_114.0.0.0 api/rekognitionstreaming#3.348.0 aws-amplify/5.1.7-js-ui-react-liveness-1.0.2`
- Old user agent - `aws-sdk-js/3.309.0 os/Android/13 lang/js md/browser/Chrome_113.0.5672.132 api/rekognitionstreaming/3.309.0 aws-amplify/5.2.1_js`
- Seems like aws sdk converts spaces to dashes in custom user agent

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
