### PR TITLE
fix(docs): ratings demo values inputs

### DIFF
--- a/docs/src/pages/[platform]/components/rating/RatingPropControls.tsx
+++ b/docs/src/pages/[platform]/components/rating/RatingPropControls.tsx
@@ -55,7 +55,9 @@ export const RatingPropControls: RatingPropControlsInterface = ({
         value={value}
         placeholder="Set Value"
         type="number"
-        onChange={(event) => handleValueChange(event.target.value)}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          handleValueChange(event.target.value)
+        }
       />
 
       <TextField
@@ -63,7 +65,9 @@ export const RatingPropControls: RatingPropControlsInterface = ({
         value={maxValue}
         placeholder="Set Max Value"
         type="number"
-        onChange={(event) => handleMaxValueChange(event.target.value)}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          handleMaxValueChange(event.target.value)
+        }
       />
 
       <SelectField
@@ -87,14 +91,18 @@ export const RatingPropControls: RatingPropControlsInterface = ({
         label="fillColor"
         value={fillColor as string}
         placeholder="Set Fill Color"
-        onChange={(event) => setFillColor(event.target.value)}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          setFillColor(event.target.value)
+        }
       />
 
       <TextField
         label="emptyColor"
         value={emptyColor as string}
         placeholder="Set Empty Color"
-        onChange={(event) => setEmptyColor(event.target.value)}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          setEmptyColor(event.target.value)
+        }
       />
     </Flex>
   );

--- a/docs/src/pages/[platform]/components/rating/RatingPropControls.tsx
+++ b/docs/src/pages/[platform]/components/rating/RatingPropControls.tsx
@@ -32,22 +32,38 @@ export const RatingPropControls: RatingPropControlsInterface = ({
   setFillColor,
   setEmptyColor,
 }) => {
+  function handleValueChange(value: string) {
+    if (value === '') {
+      setValue(0);
+    } else if (parseFloat(value)) {
+      setValue(parseFloat(value));
+    }
+  }
+
+  function handleMaxValueChange(value: string) {
+    if (value === '') {
+      setMaxValue(0);
+    } else if (parseInt(value)) {
+      setMaxValue(parseInt(value));
+    }
+  }
+
   return (
     <Flex direction="column">
       <TextField
         label="value"
         value={value}
-        type="number"
         placeholder="Set Value"
-        onChange={(event) => setValue(event.target.value)}
+        type="number"
+        onChange={(event) => handleValueChange(event.target.value)}
       />
 
       <TextField
         label="maxValue"
         value={maxValue}
-        type="number"
         placeholder="Set Max Value"
-        onChange={(event) => setMaxValue(event.target.value)}
+        type="number"
+        onChange={(event) => handleMaxValueChange(event.target.value)}
       />
 
       <SelectField

--- a/docs/src/pages/[platform]/components/rating/RatingPropControls.tsx
+++ b/docs/src/pages/[platform]/components/rating/RatingPropControls.tsx
@@ -37,15 +37,17 @@ export const RatingPropControls: RatingPropControlsInterface = ({
       <TextField
         label="value"
         value={value}
+        type="number"
         placeholder="Set Value"
-        onChange={(event) => setValue(parseInt(event.target.value))}
+        onChange={(event) => setValue(event.target.value)}
       />
 
       <TextField
         label="maxValue"
         value={maxValue}
+        type="number"
         placeholder="Set Max Value"
-        onChange={(event) => setMaxValue(parseInt(event.target.value))}
+        onChange={(event) => setMaxValue(event.target.value)}
       />
 
       <SelectField


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Updates the Ratings demo inputs for value and maxValue to use number type input and removes the parseInt on the onChange. 

Unrelated, there is a small rendering bug in the Ratings element itself which causes a height discrepancy when you use a value less than 1 that I will open a issue for (verified here https://codesandbox.io/p/sandbox/ratings-height-bug-68rgd5?file=%2Fsrc%2FApp.tsx%3A8%2C40 and you can see it in the demo if you change the value to .5 there is a small shift)

**Before**
Hit backspace in the value and maxValue inputs to see current behavior on [Ratings demo](https://ui.docs.amplify.aws/react/components/rating)

**After**

https://github.com/aws-amplify/amplify-ui/assets/376920/84473d6f-10a2-40d2-b1ac-be348faa7684




Fixes https://github.com/aws-amplify/amplify-ui/issues/4090

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
