### PR TITLE
fix(react): omit ReactNode from Collection children prop

### DIFF
--- a/.changeset/wild-rocks-invent.md
+++ b/.changeset/wild-rocks-invent.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(react): omit ReactNode from Collection children prop

--- a/docs/tests/__snapshots__/props-table.test.ts.snap
+++ b/docs/tests/__snapshots__/props-table.test.ts.snap
@@ -1716,13 +1716,6 @@ exports[`Props Table 1`] = `
                         \\"category\\": \\"BaseComponentProps\\",
                         \\"isOptional\\": true
                     },
-                    \\"children\\": {
-                        \\"name\\": \\"children\\",
-                        \\"type\\": \\"React.ReactNode\\",
-                        \\"description\\": \\"Children to be rendered inside the component The component to be repeated\\\\nSame interface as Array.prototype.map\\",
-                        \\"category\\": \\"BaseComponentProps\\",
-                        \\"isOptional\\": false
-                    },
                     \\"className\\": {
                         \\"name\\": \\"className\\",
                         \\"type\\": \\"string | undefined\\",
@@ -1818,6 +1811,13 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"items\\",
                         \\"type\\": \\"Item[]\\",
                         \\"description\\": \\"The items from a data source that will be mapped by the Collection component\\",
+                        \\"category\\": \\"CollectionBaseProps\\",
+                        \\"isOptional\\": false
+                    },
+                    \\"children\\": {
+                        \\"name\\": \\"children\\",
+                        \\"type\\": \\"(item: Item, index: number) => JSX.Element\\",
+                        \\"description\\": \\"The component to be repeated\\\\nSame interface as Array.prototype.map\\",
                         \\"category\\": \\"CollectionBaseProps\\",
                         \\"isOptional\\": false
                     }

--- a/packages/react/__tests__/__snapshots__/exports.ts.snap
+++ b/packages/react/__tests__/__snapshots__/exports.ts.snap
@@ -2156,9 +2156,6 @@ Object {
       "boxShadow": Object {
         "type": "string",
       },
-      "children": Object {
-        "type": "string",
-      },
       "className": Object {
         "type": "string",
       },

--- a/packages/react/src/primitives/types/collection.ts
+++ b/packages/react/src/primitives/types/collection.ts
@@ -75,7 +75,7 @@ export interface CollectionBaseProps<Item> {
   children: (item: Item, index: number) => JSX.Element;
 }
 
-// Omit `children` prop of `BaseFlexProps` and  `BaseGridProps` to prevent `CollectionProps[`children']`
+// Omit `children` prop of `BaseFlexProps` and `BaseGridProps` to prevent `CollectionProps[`children']`
 // from resolving to a type union of `React.ReactNode & (item: Item, index: number) => JSX.Element`
 export type ListCollectionProps<Item> = Omit<BaseFlexProps, 'children'> &
   CollectionBaseProps<Item>;

--- a/packages/react/src/primitives/types/collection.ts
+++ b/packages/react/src/primitives/types/collection.ts
@@ -75,10 +75,11 @@ export interface CollectionBaseProps<Item> {
   children: (item: Item, index: number) => JSX.Element;
 }
 
-// @TODO Add TableCollectionProps
-export type ListCollectionProps<Item> = BaseFlexProps &
+// Omit `children` prop of `BaseFlexProps` and  `BaseGridProps` to prevent `CollectionProps[`children']`
+// from resolving to a type union of `React.ReactNode & (item: Item, index: number) => JSX.Element`
+export type ListCollectionProps<Item> = Omit<BaseFlexProps, 'children'> &
   CollectionBaseProps<Item>;
-export type GridCollectionProps<Item> = BaseGridProps &
+export type GridCollectionProps<Item> = Omit<BaseGridProps, 'children'> &
   CollectionBaseProps<Item>;
 
 export type BaseCollectionProps<


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Prevent `CollectionProp['children']` from resolving to unsatisfiable type union

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-ui/issues/4098
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested in sample app

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
