### PR TITLE
Revert "chore: use same version of @xstate/react across amplify-ui"

### DIFF
--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -19,6 +19,7 @@
     "@aws-amplify/ui-react-native": "*",
     "@react-native-async-storage/async-storage": "^1.17.5",
     "@react-native-community/netinfo": "^8.3.0",
+    "@xstate/react": "3.0.0",
     "amazon-cognito-identity-js": "^5.2.11",
     "react": "17.0.2",
     "react-native": "^0.68.1",

--- a/packages/react-liveness/package.json
+++ b/packages/react-liveness/package.json
@@ -57,7 +57,7 @@
     "@tensorflow/tfjs-backend-wasm": "3.11.0",
     "@tensorflow/tfjs-converter": "3.11.0",
     "@tensorflow/tfjs-core": "3.11.0",
-    "@xstate/react": "3.0.1",
+    "@xstate/react": "3.0.0",
     "classnames": "2.3.1",
     "nanoid": "3.1.31",
     "react-countdown-circle-timer": "^2.5.4",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,6 +54,7 @@
     "@radix-ui/react-dropdown-menu": "1.0.0",
     "@radix-ui/react-slider": "1.0.0",
     "@radix-ui/react-tabs": "1.0.0",
+    "@xstate/react": "3.0.0",
     "classnames": "2.3.1",
     "deepmerge": "4.2.2",
     "lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9622,6 +9622,14 @@
   dependencies:
     fast-safe-stringify "^2.0.7"
 
+"@xstate/react@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@xstate/react/-/react-3.0.0.tgz#888d9a6f128c70b632c18ad55f1f851f6ab092ba"
+  integrity sha512-KHSCfwtb8gZ7QH2luihvmKYI+0lcdHQOmGNRUxUEs4zVgaJCyd8csCEmwPsudpliLdUmyxX2pzUBojFkINpotw==
+  dependencies:
+    use-isomorphic-layout-effect "^1.0.0"
+    use-sync-external-store "^1.0.0"
+
 "@xstate/react@3.0.1":
   version "3.0.1"
   resolved "https://registry.npmjs.org/@xstate/react/-/react-3.0.1.tgz#937eeb5d5d61734ab756ca40146f84a6fe977095"


### PR DESCRIPTION
This led to e2e failures on ios and e2e react-native tests. Will unblock the CI first, and fix later.