### PR TITLE
fix(react): fix CollectionProps and BaseCollectionProps

### DIFF
--- a/docs/tests/__snapshots__/props-table.test.ts.snap
+++ b/docs/tests/__snapshots__/props-table.test.ts.snap
@@ -1818,7 +1818,7 @@ exports[`Props Table 1`] = `
                         \\"name\\": \\"children\\",
                         \\"type\\": \\"(item: Item, index: number) => JSX.Element\\",
                         \\"description\\": \\"The component to be repeated\\\\nSame interface as Array.prototype.map\\",
-                        \\"category\\": \\"CollectionBaseProps\\",
+                        \\"category\\": \\"CollectionChildren\\",
                         \\"isOptional\\": false
                     }
                 }

--- a/packages/react/src/primitives/types/collection.ts
+++ b/packages/react/src/primitives/types/collection.ts
@@ -83,29 +83,26 @@ export type GridCollectionProps<Item> = BaseGridProps &
   CollectionBaseProps<Item>;
 
 /**
- * Omits `React.ReactNode` as children to prevent intersection type of
- * `{ children: React.ReactNode & (item: Item, index: number) => JSX.Element; }
+ * Omits `React.ReactNode` as children to prevent intersection type for `children` of
+ * `React.ReactNode & (item: Item, index: number) => JSX.Element`
  * and replaces with `CollectionChildren`
  */
-type ReassignChildren<T, Item> = Omit<T, 'children'> & CollectionChildren<Item>;
+type ReplaceChildren<T, Item> = Omit<T, 'children'> & CollectionChildren<Item>;
 
 // Note: `BaseCollectionProps` is used directly as the expected props interface of `Collection`
 export type BaseCollectionProps<
   Item,
   Element extends ElementType
-> = ReassignChildren<
-  PrimitivePropsWithAs<CollectionWrapperProps, Element> &
-    (
-      | ({ type: 'list' } & ListCollectionProps<Item>)
-      | ({ type: 'grid' } & GridCollectionProps<Item>)
-    ),
-  Item
->;
+> = PrimitivePropsWithAs<CollectionWrapperProps, Element> &
+  (
+    | ReplaceChildren<{ type: 'list' } & ListCollectionProps<Item>, Item>
+    | ReplaceChildren<{ type: 'grid' } & GridCollectionProps<Item>, Item>
+  );
 
 export type CollectionProps<
   Item,
   Element extends ElementType = 'div'
-> = ReassignChildren<
+> = ReplaceChildren<
   PrimitiveProps<
     BaseCollectionProps<Item, Element> & { children: React.ReactNode },
     Element


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update `children` omission  for `CollectionProps` and extend to `BaseCollectionProps`
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
