### PR TITLE
fix(react-native): add spacing between Radio icon and label

### DIFF
--- a/.changeset/clever-eagles-design.md
+++ b/.changeset/clever-eagles-design.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-native": patch
+---
+
+fix(react-native): add spacing between Radio icon and label

--- a/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/__snapshots__/VerifyUser.spec.tsx.snap
+++ b/packages/react-native/src/Authenticator/Defaults/VerifyUser/__tests__/__snapshots__/VerifyUser.spec.tsx.snap
@@ -102,6 +102,7 @@ Array [
                 "borderRadius": 999,
                 "borderWidth": 2,
                 "justifyContent": "center",
+                "margin": 4,
               },
               Object {
                 "height": 20,
@@ -168,6 +169,7 @@ Array [
                 "borderRadius": 999,
                 "borderWidth": 2,
                 "justifyContent": "center",
+                "margin": 4,
               },
               Object {
                 "height": 20,
@@ -410,6 +412,7 @@ Array [
                 "borderRadius": 999,
                 "borderWidth": 2,
                 "justifyContent": "center",
+                "margin": 4,
               },
               Object {
                 "height": 20,
@@ -476,6 +479,7 @@ Array [
                 "borderRadius": 999,
                 "borderWidth": 2,
                 "justifyContent": "center",
+                "margin": 4,
               },
               Object {
                 "height": 20,

--- a/packages/react-native/src/primitives/Radio/__tests__/__snapshots__/Radio.spec.tsx.snap
+++ b/packages/react-native/src/primitives/Radio/__tests__/__snapshots__/Radio.spec.tsx.snap
@@ -37,6 +37,7 @@ exports[`Radio applies theme and custom styles 1`] = `
           "borderRadius": 999,
           "borderWidth": 2,
           "justifyContent": "center",
+          "margin": 4,
         },
         Object {
           "height": 20,
@@ -108,6 +109,7 @@ exports[`Radio renders as expected when disabled 1`] = `
           "borderRadius": 999,
           "borderWidth": 2,
           "justifyContent": "center",
+          "margin": 4,
         },
         Object {
           "height": 20,
@@ -174,6 +176,7 @@ exports[`Radio renders as expected when passing a number to the size prop 1`] = 
           "borderRadius": 999,
           "borderWidth": 2,
           "justifyContent": "center",
+          "margin": 4,
         },
         Object {
           "height": 40,
@@ -257,6 +260,7 @@ exports[`Radio renders as expected when selected is false 1`] = `
           "borderRadius": 999,
           "borderWidth": 2,
           "justifyContent": "center",
+          "margin": 4,
         },
         Object {
           "height": 20,
@@ -323,6 +327,7 @@ exports[`Radio renders as expected when selected is true 1`] = `
           "borderRadius": 999,
           "borderWidth": 2,
           "justifyContent": "center",
+          "margin": 4,
         },
         Object {
           "height": 20,
@@ -406,6 +411,7 @@ exports[`Radio renders as expected when size is large 1`] = `
           "borderRadius": 999,
           "borderWidth": 2,
           "justifyContent": "center",
+          "margin": 4,
         },
         Object {
           "height": 24,
@@ -489,6 +495,7 @@ exports[`Radio renders as expected when size is medium 1`] = `
           "borderRadius": 999,
           "borderWidth": 2,
           "justifyContent": "center",
+          "margin": 4,
         },
         Object {
           "height": 20,
@@ -572,6 +579,7 @@ exports[`Radio renders as expected when size is small 1`] = `
           "borderRadius": 999,
           "borderWidth": 2,
           "justifyContent": "center",
+          "margin": 4,
         },
         Object {
           "height": 16,
@@ -655,6 +663,7 @@ exports[`Radio renders as expected with accessibilityRole 1`] = `
           "borderRadius": 999,
           "borderWidth": 2,
           "justifyContent": "center",
+          "margin": 4,
         },
         Object {
           "height": 20,

--- a/packages/react-native/src/primitives/Radio/styles.ts
+++ b/packages/react-native/src/primitives/Radio/styles.ts
@@ -9,7 +9,7 @@ const ROUNDED_BORDER_RADIUS = 999;
 export const getThemedStyles = (theme: StrictTheme): Required<RadioStyles> => {
   const {
     components,
-    tokens: { colors, fontSizes, opacities, borderWidths },
+    tokens: { colors, fontSizes, opacities, borderWidths, space },
   } = theme;
 
   return StyleSheet.create({
@@ -31,6 +31,7 @@ export const getThemedStyles = (theme: StrictTheme): Required<RadioStyles> => {
       borderRadius: ROUNDED_BORDER_RADIUS,
       borderWidth: borderWidths.medium,
       justifyContent: 'center',
+      margin: space.xxs,
       ...components?.radio?.radioContainer,
     },
     radioDot: {

--- a/packages/react-native/src/primitives/RadioGroup/__tests__/__snapshots__/RadioGroup.spec.tsx.snap
+++ b/packages/react-native/src/primitives/RadioGroup/__tests__/__snapshots__/RadioGroup.spec.tsx.snap
@@ -54,6 +54,7 @@ exports[`RadioGroup renders as expected when direction is horizontal 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -134,6 +135,7 @@ exports[`RadioGroup renders as expected when direction is horizontal 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -197,6 +199,7 @@ exports[`RadioGroup renders as expected when direction is horizontal 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -261,6 +264,7 @@ exports[`RadioGroup renders as expected when direction is horizontal 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -348,6 +352,7 @@ exports[`RadioGroup renders as expected when direction is vertical 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -428,6 +433,7 @@ exports[`RadioGroup renders as expected when direction is vertical 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -491,6 +497,7 @@ exports[`RadioGroup renders as expected when direction is vertical 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -555,6 +562,7 @@ exports[`RadioGroup renders as expected when direction is vertical 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -642,6 +650,7 @@ exports[`RadioGroup renders as expected when size is large 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 24,
@@ -722,6 +731,7 @@ exports[`RadioGroup renders as expected when size is large 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 24,
@@ -785,6 +795,7 @@ exports[`RadioGroup renders as expected when size is large 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 24,
@@ -849,6 +860,7 @@ exports[`RadioGroup renders as expected when size is large 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 24,
@@ -936,6 +948,7 @@ exports[`RadioGroup renders as expected when size is medium 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -1016,6 +1029,7 @@ exports[`RadioGroup renders as expected when size is medium 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -1079,6 +1093,7 @@ exports[`RadioGroup renders as expected when size is medium 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -1143,6 +1158,7 @@ exports[`RadioGroup renders as expected when size is medium 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -1230,6 +1246,7 @@ exports[`RadioGroup renders as expected when size is small 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 16,
@@ -1310,6 +1327,7 @@ exports[`RadioGroup renders as expected when size is small 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 16,
@@ -1373,6 +1391,7 @@ exports[`RadioGroup renders as expected when size is small 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 16,
@@ -1437,6 +1456,7 @@ exports[`RadioGroup renders as expected when size is small 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 16,
@@ -1524,6 +1544,7 @@ exports[`RadioGroup renders default RadioGroup as expected 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -1604,6 +1625,7 @@ exports[`RadioGroup renders default RadioGroup as expected 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -1667,6 +1689,7 @@ exports[`RadioGroup renders default RadioGroup as expected 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,
@@ -1731,6 +1754,7 @@ exports[`RadioGroup renders default RadioGroup as expected 1`] = `
               "borderRadius": 999,
               "borderWidth": 2,
               "justifyContent": "center",
+              "margin": 4,
             },
             Object {
               "height": 20,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add `margin` to `Radio` "dot" icon container

**Screenshots**

**Before:**

![Simulator Screenshot - iPhone 13 - 2023-06-15 at 08 41 48](https://github.com/aws-amplify/amplify-ui/assets/15002885/a9b298e6-a8de-4c54-96f4-41a8c3156081)

**After:**

![Simulator Screenshot - iPhone 13 - 2023-06-15 at 08 47 58](https://github.com/aws-amplify/amplify-ui/assets/15002885/9669c778-401c-41e9-8c76-e33705c2f0b0)

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
