### PR TITLE
chore(liveness): improve face match percentage performance

### DIFF
--- a/.changeset/calm-swans-divide.md
+++ b/.changeset/calm-swans-divide.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+chore(liveness): improve face match percentage performance

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -66,7 +66,7 @@ const centeredLoader = (
 /**
  * For now we want to memoize the HOC for MatchIndicator because to optimize renders
  * The LivenessCameraModule still needs to be optimized for re-renders and at that time
- * we shoudl be able to remove this memoization
+ * we should be able to remove this memoization
  */
 const MemoizedMatchIndicator = React.memo(MatchIndicator);
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -22,8 +22,8 @@ import {
   Hint,
   RecordingIcon,
   Overlay,
-  MatchIndicator,
   selectErrorState,
+  MemoizedMatchIndicator,
 } from '../shared';
 import { LivenessClassNames } from '../types/classNames';
 import {
@@ -251,7 +251,9 @@ export const LivenessCameraModule = (
             {isRecording &&
             !isFlashingFreshness &&
             showMatchIndicatorStates.includes(faceMatchState!) ? (
-              <MatchIndicator percentage={faceMatchPercentage!} />
+              <MemoizedMatchIndicator
+                percentage={Math.ceil(faceMatchPercentage!)}
+              />
             ) : null}
 
             {isNotRecording && (

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -246,7 +246,9 @@ export const LivenessCameraModule = (
             {/* 
               We only want to show the MatchIndicator when we're recording
               and when the face is in either the too far state, or the 
-              initial face identified state
+              initial face identified state. Using the MemoizedMatchIndicator here
+              so that even when this component re-renders the indicator is only
+              re-rendered if the percentage prop changes.
             */}
             {isRecording &&
             !isFlashingFreshness &&

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -63,6 +63,13 @@ const centeredLoader = (
   />
 );
 
+/**
+ * For now we want to memoize the HOC for MatchIndicator because to optimize renders
+ * The LivenessCameraModule still needs to be optimized for re-renders and at that time
+ * we shoudl be able to remove this memoization
+ */
+const MemoizedMatchIndicator = React.memo(MatchIndicator);
+
 export const LivenessCameraModule = (
   props: LivenessCameraModuleProps
 ): JSX.Element => {
@@ -154,10 +161,6 @@ export const LivenessCameraModule = (
     setIsCameraReady(true);
     setCountDownRunning(true);
   };
-
-  const memoizedMatchIndicator = React.useMemo(() => {
-    return <MatchIndicator percentage={Math.ceil(faceMatchPercentage!)} />;
-  }, [faceMatchPercentage]);
 
   if (isCheckingCamera) {
     return (
@@ -256,9 +259,11 @@ export const LivenessCameraModule = (
             */}
             {isRecording &&
             !isFlashingFreshness &&
-            showMatchIndicatorStates.includes(faceMatchState!)
-              ? memoizedMatchIndicator
-              : null}
+            showMatchIndicatorStates.includes(faceMatchState!) ? (
+              <MemoizedMatchIndicator
+                percentage={Math.ceil(faceMatchPercentage!)}
+              />
+            ) : null}
 
             {isNotRecording && (
               <View

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -23,7 +23,7 @@ import {
   RecordingIcon,
   Overlay,
   selectErrorState,
-  MemoizedMatchIndicator,
+  MatchIndicator,
 } from '../shared';
 import { LivenessClassNames } from '../types/classNames';
 import {
@@ -155,6 +155,10 @@ export const LivenessCameraModule = (
     setCountDownRunning(true);
   };
 
+  const memoizedMatchIndicator = React.useMemo(() => {
+    return <MatchIndicator percentage={Math.ceil(faceMatchPercentage!)} />;
+  }, [faceMatchPercentage]);
+
   if (isCheckingCamera) {
     return (
       <Flex height={videoHeight} width="100%" position="relative">
@@ -246,17 +250,15 @@ export const LivenessCameraModule = (
             {/* 
               We only want to show the MatchIndicator when we're recording
               and when the face is in either the too far state, or the 
-              initial face identified state. Using the MemoizedMatchIndicator here
+              initial face identified state. Using the a memoized MatchIndicator here
               so that even when this component re-renders the indicator is only
               re-rendered if the percentage prop changes.
             */}
             {isRecording &&
             !isFlashingFreshness &&
-            showMatchIndicatorStates.includes(faceMatchState!) ? (
-              <MemoizedMatchIndicator
-                percentage={Math.ceil(faceMatchPercentage!)}
-              />
-            ) : null}
+            showMatchIndicatorStates.includes(faceMatchState!)
+              ? memoizedMatchIndicator
+              : null}
 
             {isNotRecording && (
               <View

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/MatchIndicator.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/MatchIndicator.tsx
@@ -38,3 +38,5 @@ export const MatchIndicator: React.FC<MatchIndicatorProps> = ({
     </div>
   );
 };
+
+export const MemoizedMatchIndicator = React.memo(MatchIndicator);

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/MatchIndicator.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/MatchIndicator.tsx
@@ -38,5 +38,3 @@ export const MatchIndicator: React.FC<MatchIndicatorProps> = ({
     </div>
   );
 };
-
-export const MemoizedMatchIndicator = React.memo(MatchIndicator);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Previously in a single 7 second session the face match percentage bar would re-render up to 800 times
- Reduced re-renders by rounding face match percentage values up and memoizing the component
- Now renders are down ~80 renders in a 7 second session
- To further reduce renders we can perform fewer face detection calls to Blazeface, but having a higher number of calls helps increase accuracy of sessions as we get more granularity into face match position

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
