### PR TITLE
fix(docs): card demo setVariations prop error in dev

### DIFF
--- a/docs/src/pages/[platform]/components/card/demo.tsx
+++ b/docs/src/pages/[platform]/components/card/demo.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import {
   Card,
-  Text,
   View,
-  Image,
-  Badge,
-  Button,
-  Flex,
-  Divider,
-  Heading,
   SelectField,
   CardProps,
   useTheme,
@@ -60,7 +53,7 @@ export const CardDemo = () => {
         backgroundColor={tokens.colors.background.secondary}
         padding={tokens.space.medium}
       >
-        <Card {...props}>{`I'm a card!`}</Card>
+        <Card variation={variation}>{`I'm a card!`}</Card>
       </View>
     </Demo>
   );


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Minor fix for an error that only shows when running `yarn docs dev` on the Card docs page that I noticed when checking out a different PR. Not present on built docs site.  Remove some unused imports.

```React does not recognize the setVariation prop on a DOM element``` 

<img width="800" alt="React does not recognize the setVariation prop on a DOM element" src="https://github.com/aws-amplify/amplify-ui/assets/376920/82e60c2b-3435-4228-9fcf-f419ab5434ae">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
