### PR TITLE
chore(ci): Fix check changed packages to run on PR

### DIFF
--- a/.github/actions/changed-packages/action.yml
+++ b/.github/actions/changed-packages/action.yml
@@ -1,9 +1,9 @@
 # Example usage in `./workflows/reusable-e2e.yml`
 name: Check Changed Packages
-description: 'Checks whether any files in the specified packages were changed in the current commit'
+description: 'Checks whether any files in the specified packages were changed in the current PR'
 inputs:
-  commit:
-    description: 'Commit to check files against'
+  pr-branch:
+    description: 'PR to check files against'
     required: true
   packages:
     description: 'List of packages to check for changes, separated by new line'
@@ -19,20 +19,22 @@ runs:
       id: check-changed-packages
       shell: bash
       env:
-        COMMIT_HASH: ${{ inputs.commit }}
+        PR_BRANCH: ${{ inputs.pr-branch }}
         PACKAGES: ${{ inputs.packages }}
       run: |
-        # stores the names of changed packages
-        changed_packages=()
-        changed_files=$(git diff-tree --no-commit-id --name-only -r $COMMIT_HASH)
-
         # concatenate input package names with pipe
         # input is on multiple lines so need :a;N;$!ba; to allow sed to read entire stream at once
         package_names=$(echo "$PACKAGES" | sed ':a;N;$!ba;s/\n/|/g')
 
-        # check if any of the modified files belongs to the specified input packages
-        if echo "$changed_files" | grep -Eq "^($package_names)/"; then
-          echo "has-changed-packages=true" >> $GITHUB_OUTPUT
-        else
-          echo "has-changed-packages=false" >> $GITHUB_OUTPUT
-        fi
+        changed_packages=false
+        for COMMIT_HASH in $(git rev-list origin/main..origin/$PR_BRANCH); do
+          changed_files=$(git diff-tree --no-commit-id --name-only -r $COMMIT_HASH)
+
+          # check if any of the modified files belongs to the specified input packages
+          if echo "$changed_files" | grep -Eq "^($package_names)/"; then
+            echo "has-changed-packages=true" >> $GITHUB_OUTPUT
+            exit 
+          fi
+        done
+
+        echo "has-changed-packages=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -36,6 +36,7 @@ jobs:
     needs: unit
     with:
       commit: ${{ github.sha }}
+      pr_branch: 'main'
       repository: ${{ github.repository }}
       skip-changed-packages-check: 'true' # always run e2e tests for native platform on main
     secrets:

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -9,6 +9,10 @@ on:
         # commit to run tests against
         required: true
         type: string
+      pr-branch:
+        # branch to check changed files against
+        required: true
+        type: string
       repository:
         # repository to run tests against (possibly a fork of amplify-ui)
         required: true
@@ -327,9 +331,9 @@ jobs:
       - name: Checkout Amplify UI
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
         with:
-          ref: ${{ inputs.commit }}
+          ref: ${{ inputs.pr-branch }}
           repository: ${{ inputs.repository }}
-          fetch-depth: 2
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Determine if there were changes to react-native packages
@@ -337,7 +341,7 @@ jobs:
         id: has-rn-changed-packages
         uses: ./.github/actions/changed-packages
         with:
-          commit: ${{ inputs.commit }}
+          pr-branch: ${{ inputs.pr-branch }}
           packages: |
             packages/react-native
             packages/react-core

--- a/.github/workflows/test-fork-prs.yml
+++ b/.github/workflows/test-fork-prs.yml
@@ -240,6 +240,7 @@ jobs:
       contents: read # This is required for actions/checkout
     with:
       commit: ${{ needs.setup.outputs.commit_id }}
+      pr-branch: ${{ github.event.workflow_run.head_branch }}
       repository: ${{ github.repository }}
     secrets:
       AUTH_E2E_ROLE_ARN: ${{ secrets.AUTH_E2E_ROLE_ARN }}

--- a/.github/workflows/test-internal-prs.yml
+++ b/.github/workflows/test-internal-prs.yml
@@ -137,7 +137,7 @@ jobs:
       repository: ${{ github.repository }}
 
   e2e:
-    uses: ./.github/workflows/reusable-e2e.yml # CHANGE TO BE REVERTED
+    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@main
     needs: unit
     with:
       commit: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test-internal-prs.yml
+++ b/.github/workflows/test-internal-prs.yml
@@ -137,10 +137,11 @@ jobs:
       repository: ${{ github.repository }}
 
   e2e:
-    uses: aws-amplify/amplify-ui/.github/workflows/reusable-e2e.yml@main
+    uses: ./.github/workflows/reusable-e2e.yml # CHANGE TO BE REVERTED
     needs: unit
     with:
       commit: ${{ github.event.pull_request.head.sha }}
+      pr-branch: ${{ github.event.pull_request.head.ref }}
       repository: ${{ github.event.pull_request.head.repo.full_name }}
     permissions:
       id-token: write # This is required for requesting the JWT


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change updates the `check-changed-packages` workflow step to look at all the commits on a PR and not just the latest commit when determining whether to run RN e2e tests.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Tested on fork: https://github.com/ioanabrooks/amplify-ui/pull/27
CI: https://github.com/aws-amplify/amplify-ui/actions/runs/5325809488/jobs/9647306466?pr=4133

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
