### PR TITLE
fix(liveness): remove websocket error showing up after connection closes

### DIFF
--- a/.changeset/purple-beans-roll.md
+++ b/.changeset/purple-beans-roll.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+fix(liveness): remove websocket error showing up after connection closes

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/index.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/index.ts
@@ -1176,10 +1176,7 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
         await livenessStreamProvider!.dispatchStopVideoEvent();
       },
       async getLiveness(context) {
-        const { livenessStreamProvider } = context;
         const { onAnalysisComplete } = context.componentProps!;
-
-        livenessStreamProvider!.endStream();
 
         // Get liveness result
         await onAnalysisComplete();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Fixes issue - https://github.com/aws-amplify/amplify-ui/issues/4123
- Previously a websocket connection is already closed error would show up after successful liveness checks
- This was happening because when closing the input stream the aws sdk client would try to send another websocket event, but if we have already sent the `stopVideo` event then the server will have already closed the connection. Hence we no longer need to close the input stream ourselves since the server will have already closed the connection

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
