### PR TITLE
chore(ci): use absolute path to reference reusable-tagged-publish

### DIFF
--- a/.github/workflow-samples/tagged-release.yml
+++ b/.github/workflow-samples/tagged-release.yml
@@ -60,7 +60,7 @@ jobs:
       DOCSEARCH_DOCS_INDEX_NAME: ${{ secrets.DOCSEARCH_DOCS_INDEX_NAME }}
 
   publish:
-    uses: ./.github/workflows/reusable-tagged-publish.yml
+    uses: aws-amplify/amplify-ui/.github/workflows/reusable-tagged-publish.yml@main
     needs: e2e
     with:
       dist-tag: <TAG>

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -151,7 +151,7 @@ jobs:
 
   publish:
     needs: [e2e, guides]
-    uses: ./.github/workflows/reusable-tagged-publish.yml
+    uses: aws-amplify/amplify-ui/.github/workflows/reusable-tagged-publish.yml@main
     with:
       dist-tag: next
     secrets:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

References `reusable-tagged-publish` using absolute path instead of relative path for the sake of consistency.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Double checked the syntaax.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
