### PR TITLE
fix(docs): Update react-map-gl links

### DIFF
--- a/docs/src/pages/[platform]/connected-components/geo/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/geo/react.mdx
@@ -30,7 +30,7 @@ The `MapView` component adds an interactive map to your application.
 
 `MapView` is fully integrated with the open source library [react-map-gl](https://visgl.github.io/react-map-gl/) v7
 while using [maplibre-gl-js](https://maplibre.org/maplibre-gl-js-docs/api/) as the map tile source. `MapView` is
-used as a replacement to `react-map-gl`'s [default map](https://visgl.github.io/react-map-gl/docs/api-reference/map/)
+used as a replacement to `react-map-gl`'s [default map](https://visgl.github.io/react-map-gl/docs/api-reference/map)
 and supports the same functionality.
 
 You can import the `MapView` component with related styles and use it in your Amplify application without any
@@ -86,7 +86,7 @@ You may want to access the [native maplibre-gl map object](https://maplibre.org/
   {({ platform }) => import(`./fragments/map-ref.${platform}.mdx`)}
 </Fragment>
 
-If you want access to the `map` object in a child component of `<MapView>`, you can use the [useMap hook from react-map-gl](https://visgl.github.io/react-map-gl/docs/api-reference/use-map/) instead:
+If you want access to the `map` object in a child component of `<MapView>`, you can use the [useMap hook from react-map-gl](https://visgl.github.io/react-map-gl/docs/api-reference/use-map) instead:
 
 <Fragment platforms={['react']}>
   {({ platform }) => import(`./fragments/use-map.${platform}.mdx`)}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

`https://visgl.github.io/react-map-gl/docs/api-reference/map/` and `https://visgl.github.io/react-map-gl/docs/api-reference/use-map/` are returning 404 and failing CI, update links to remove the trailing `/`

```
❌ [RETURNING STATUS...] 404 for page #95 link #49 -- https://visgl.github.io/react-map-gl/docs/api-reference/map/ from A tag "default map" on  page ***/react/connected-components/geo
❌ [RETURNING STATUS...] 404 for page #95 link #57 -- https://visgl.github.io/react-map-gl/docs/api-reference/use-map/ from A tag "useMap hook from react-map-gl" on  page ***/react/connected-components/geo
```
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
