### PR TITLE
refactor(vue): refactor reset-password and force-new-password components

### DIFF
--- a/packages/vue/jest.config.cjs
+++ b/packages/vue/jest.config.cjs
@@ -13,10 +13,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 51,
-      functions: 64,
-      lines: 76,
-      statements: 75,
+      branches: 62,
+      functions: 81,
+      lines: 87,
+      statements: 87,
     },
   },
   testEnvironment: 'jsdom',

--- a/packages/vue/src/components/__tests__/__snapshots__/confirm-reset-password.spec.ts.snap
+++ b/packages/vue/src/components/__tests__/__snapshots__/confirm-reset-password.spec.ts.snap
@@ -1,0 +1,283 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfirmResetPassword renders as expected 1`] = `
+<div>
+  
+  <div>
+    
+    
+    <form
+      data-amplify-authenticator-confirmresetpassword=""
+      data-amplify-form=""
+    >
+      
+      
+      <fieldset
+        class="amplify-flex amplify-authenticator__column"
+        data-amplify-fieldset=""
+      >
+        
+        
+        <h3
+          class="amplify-heading amplify-heading--3"
+          data-amplify-heading=""
+        >
+          Reset Password
+        </h3>
+        
+        <div
+          class="amplify-flex amplify-authenticator__column"
+        >
+          
+          
+          
+          <!-- password input -->
+          
+          <!-- textfield input -->
+          <div
+            class="amplify-flex amplify-field amplify-textfield amplify-phonenumberfield amplify-authenticator__column"
+          >
+            
+            <label
+              class="amplify-label"
+              data-amplify-label=""
+              for="amplify-field-99999"
+            >
+              
+              Code *
+              
+            </label>
+            <div
+              class="amplify-flex amplify-field-group"
+            >
+              
+              <div
+                class="amplify-field-group__outer-start"
+              >
+                
+                
+              </div>
+              <div
+                class="amplify-field-group__field-wrapper"
+              >
+                
+                <!--Phone input-->
+                <input
+                  aria-invalid="false"
+                  autocomplete=""
+                  class="amplify-input amplify-field-group__control"
+                  data-amplify-input=""
+                  id="amplify-field-99999"
+                  name="confirmation_code"
+                  placeholder="Code"
+                  required=""
+                  type="number"
+                />
+                
+              </div>
+              
+            </div>
+            
+          </div>
+          
+          <!-- Validation error, if any -->
+          <!--v-if-->
+          
+          
+          <!-- password input -->
+          <div
+            class="amplify-flex amplify-field amplify-textfield amplify-passwordfield amplify-authenticator__column"
+          >
+            
+            <label
+              class="amplify-label"
+              data-amplify-label=""
+              for="amplify-field-99999"
+            >
+              
+              New Password
+              
+            </label>
+            <div
+              class="amplify-flex amplify-field-group"
+            >
+              
+              <div
+                class="amplify-field-group__field-wrapper"
+              >
+                
+                <input
+                  aria-invalid="false"
+                  autocomplete="new-password"
+                  class="amplify-input amplify-field-group__control"
+                  data-amplify-input=""
+                  data-amplify-password="true"
+                  id="amplify-field-99999"
+                  modelvalue=""
+                  name="password"
+                  placeholder="New Password"
+                  required=""
+                  type="password"
+                />
+                
+              </div>
+              <div
+                class="amplify-field-group__outer-end"
+              >
+                
+                <button
+                  aria-checked="false"
+                  aria-label="Show password"
+                  class="amplify-button amplify-field-group__control amplify-field__show-password"
+                  data-fullwidth="false"
+                  role="switch"
+                  type="button"
+                >
+                  <svg
+                    class="amplify-icon"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                    />
+                  </svg>
+                </button>
+                
+              </div>
+              
+            </div>
+            
+          </div>
+          <!-- Validation error, if any -->
+          <!--v-if-->
+          
+          
+          <!-- password input -->
+          <div
+            class="amplify-flex amplify-field amplify-textfield amplify-passwordfield amplify-authenticator__column"
+          >
+            
+            <label
+              class="amplify-label"
+              data-amplify-label=""
+              for="amplify-field-99999"
+            >
+              
+              Confirm Password
+              
+            </label>
+            <div
+              class="amplify-flex amplify-field-group"
+            >
+              
+              <div
+                class="amplify-field-group__field-wrapper"
+              >
+                
+                <input
+                  aria-invalid="false"
+                  autocomplete="new-password"
+                  class="amplify-input amplify-field-group__control"
+                  data-amplify-input=""
+                  data-amplify-password="true"
+                  id="amplify-field-99999"
+                  modelvalue=""
+                  name="confirm_password"
+                  placeholder="Confirm Password"
+                  required=""
+                  type="password"
+                />
+                
+              </div>
+              <div
+                class="amplify-field-group__outer-end"
+              >
+                
+                <button
+                  aria-checked="false"
+                  aria-label="Show password"
+                  class="amplify-button amplify-field-group__control amplify-field__show-password"
+                  data-fullwidth="false"
+                  role="switch"
+                  type="button"
+                >
+                  <svg
+                    class="amplify-icon"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                    />
+                  </svg>
+                </button>
+                
+              </div>
+              
+            </div>
+            
+          </div>
+          <!-- Validation error, if any -->
+          <!--v-if-->
+          
+          
+          
+        </div>
+        
+        <footer
+          class="amplify-flex amplify-authenticator__column"
+        >
+          
+          <!--v-if-->
+          
+          <button
+            class="amplify-button amplify-button--primary amplify-field-group__control amplify-authenticator__font"
+            data-amplify-button=""
+            data-disabled="false"
+            data-fullwidth="false"
+            data-loading="false"
+            data-variation="primary"
+            fullwidth="false"
+            type="submit"
+          >
+            
+            Submit
+            
+          </button>
+          
+          
+          <button
+            class="amplify-button amplify-button--link amplify-button--small amplify-field-group__control amplify-authenticator__font"
+            data-amplify-button=""
+            data-disabled="false"
+            data-fullwidth="false"
+            data-loading="false"
+            data-size="small"
+            data-variation="link"
+            fullwidth="false"
+            type="button"
+          >
+            
+            Resend Code
+            
+          </button>
+          
+          
+          
+          
+        </footer>
+        
+        
+      </fieldset>
+      
+      
+    </form>
+    
+    
+  </div>
+  
+</div>
+`;

--- a/packages/vue/src/components/__tests__/__snapshots__/force-new-password.spec.ts.snap
+++ b/packages/vue/src/components/__tests__/__snapshots__/force-new-password.spec.ts.snap
@@ -1,0 +1,286 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfirmResetPassword renders as expected 1`] = `
+<div>
+  
+  <div>
+    
+    
+    <form
+      data-amplify-authenticator-forcenewpassword=""
+      data-amplify-form=""
+    >
+      
+      
+      <fieldset
+        class="amplify-flex amplify-authenticator__column"
+        data-amplify-fieldset=""
+      >
+        
+        
+        <h3
+          class="amplify-heading amplify-heading--3"
+          data-amplify-heading=""
+        >
+          Change Password
+        </h3>
+        
+        <div
+          class="amplify-flex amplify-authenticator__column"
+        >
+          
+          
+          
+          
+          <!-- password input -->
+          <div
+            class="amplify-flex amplify-field amplify-textfield amplify-passwordfield amplify-authenticator__column"
+          >
+            
+            <label
+              class="amplify-label"
+              data-amplify-label=""
+              for="amplify-field-99999"
+            >
+              
+              Password
+              
+            </label>
+            <div
+              class="amplify-flex amplify-field-group"
+            >
+              
+              <div
+                class="amplify-field-group__field-wrapper"
+              >
+                
+                <input
+                  aria-invalid="false"
+                  autocomplete="new-password"
+                  class="amplify-input amplify-field-group__control"
+                  data-amplify-input=""
+                  data-amplify-password="true"
+                  id="amplify-field-99999"
+                  modelvalue=""
+                  name="password"
+                  placeholder="Enter your Password"
+                  required=""
+                  type="password"
+                />
+                
+              </div>
+              <div
+                class="amplify-field-group__outer-end"
+              >
+                
+                <button
+                  aria-checked="false"
+                  aria-label="Show password"
+                  class="amplify-button amplify-field-group__control amplify-field__show-password"
+                  data-fullwidth="false"
+                  role="switch"
+                  type="button"
+                >
+                  <svg
+                    class="amplify-icon"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                    />
+                  </svg>
+                </button>
+                
+              </div>
+              
+            </div>
+            
+          </div>
+          <!-- Validation error, if any -->
+          <!--v-if-->
+          
+          
+          <!-- password input -->
+          <div
+            class="amplify-flex amplify-field amplify-textfield amplify-passwordfield amplify-authenticator__column"
+          >
+            
+            <label
+              class="amplify-label"
+              data-amplify-label=""
+              for="amplify-field-99999"
+            >
+              
+              Confirm Password
+              
+            </label>
+            <div
+              class="amplify-flex amplify-field-group"
+            >
+              
+              <div
+                class="amplify-field-group__field-wrapper"
+              >
+                
+                <input
+                  aria-invalid="false"
+                  autocomplete="new-password"
+                  class="amplify-input amplify-field-group__control"
+                  data-amplify-input=""
+                  data-amplify-password="true"
+                  id="amplify-field-99999"
+                  modelvalue=""
+                  name="confirm_password"
+                  placeholder="Please confirm your Password"
+                  required=""
+                  type="password"
+                />
+                
+              </div>
+              <div
+                class="amplify-field-group__outer-end"
+              >
+                
+                <button
+                  aria-checked="false"
+                  aria-label="Show password"
+                  class="amplify-button amplify-field-group__control amplify-field__show-password"
+                  data-fullwidth="false"
+                  role="switch"
+                  type="button"
+                >
+                  <svg
+                    class="amplify-icon"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                    />
+                  </svg>
+                </button>
+                
+              </div>
+              
+            </div>
+            
+          </div>
+          <!-- Validation error, if any -->
+          <!--v-if-->
+          
+          
+          <!-- password input -->
+          
+          <!-- textfield input -->
+          <div
+            class="amplify-flex amplify-field amplify-textfield amplify-phonenumberfield amplify-authenticator__column"
+          >
+            
+            <label
+              class="amplify-label"
+              data-amplify-label=""
+              for="amplify-field-99999"
+            >
+              
+              Preferred Username
+              
+            </label>
+            <div
+              class="amplify-flex amplify-field-group"
+            >
+              
+              <div
+                class="amplify-field-group__outer-start"
+              >
+                
+                
+              </div>
+              <div
+                class="amplify-field-group__field-wrapper"
+              >
+                
+                <!--Phone input-->
+                <input
+                  aria-invalid="false"
+                  autocomplete=""
+                  class="amplify-input amplify-field-group__control"
+                  data-amplify-input=""
+                  id="amplify-field-99999"
+                  name="preferred_username"
+                  placeholder="Enter your Preferred Username"
+                  required=""
+                  type="text"
+                />
+                
+              </div>
+              
+            </div>
+            
+          </div>
+          
+          <!-- Validation error, if any -->
+          <!--v-if-->
+          
+          
+          
+          
+        </div>
+        
+        <footer
+          class="amplify-flex amplify-authenticator__column"
+        >
+          
+          <!--v-if-->
+          
+          <button
+            class="amplify-button amplify-button--primary amplify-field-group__control amplify-authenticator__font"
+            data-amplify-button=""
+            data-disabled="false"
+            data-fullwidth="false"
+            data-loading="false"
+            data-variation="primary"
+            fullwidth="false"
+            style="font-weight: normal;"
+          >
+            
+            Change Password
+            
+          </button>
+          
+          
+          <button
+            class="amplify-button amplify-button--link amplify-button--small amplify-field-group__control amplify-authenticator__font"
+            data-amplify-button=""
+            data-disabled="false"
+            data-fullwidth="false"
+            data-loading="false"
+            data-size="small"
+            data-variation="link"
+            fullwidth="false"
+            style="font-weight: normal;"
+            type="button"
+          >
+            
+            Back to Sign In
+            
+          </button>
+          
+          
+          
+          
+        </footer>
+        
+        
+      </fieldset>
+      
+      
+    </form>
+    
+    
+  </div>
+  
+</div>
+`;

--- a/packages/vue/src/components/__tests__/__snapshots__/reset-password.spec.ts.snap
+++ b/packages/vue/src/components/__tests__/__snapshots__/reset-password.spec.ts.snap
@@ -1,0 +1,140 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResetPassword renders as expected 1`] = `
+<div>
+  
+  
+  <form
+    data-amplify-authenticator-resetpassword=""
+    data-amplify-form=""
+  >
+    
+    <div
+      class="amplify-flex amplify-authenticator__column"
+    >
+      
+      
+      <h3
+        class="amplify-heading amplify-heading--3"
+        data-amplify-heading=""
+      >
+        Reset Password
+      </h3>
+      
+      
+      <fieldset
+        class="amplify-flex amplify-authenticator__column"
+        data-amplify-fieldset=""
+      >
+        
+        
+        
+        <!-- password input -->
+        
+        <!-- textfield input -->
+        <div
+          class="amplify-flex amplify-field amplify-textfield amplify-phonenumberfield amplify-authenticator__column"
+        >
+          
+          <label
+            class="amplify-label"
+            data-amplify-label=""
+            for="amplify-field-99999"
+          >
+            
+            Email
+            
+          </label>
+          <div
+            class="amplify-flex amplify-field-group"
+          >
+            
+            <div
+              class="amplify-field-group__outer-start"
+            >
+              
+              
+            </div>
+            <div
+              class="amplify-field-group__field-wrapper"
+            >
+              
+              <!--Phone input-->
+              <input
+                aria-invalid="false"
+                autocomplete=""
+                class="amplify-input amplify-field-group__control"
+                data-amplify-input=""
+                id="amplify-field-99999"
+                name="email"
+                placeholder="Enter your Email"
+                required=""
+                type="email"
+              />
+              
+            </div>
+            
+          </div>
+          
+        </div>
+        
+        <!-- Validation error, if any -->
+        <!--v-if-->
+        
+        
+        
+      </fieldset>
+      
+      
+      <footer
+        class="amplify-flex amplify-authenticator__column"
+      >
+        
+        <!--v-if-->
+        
+        <button
+          class="amplify-button amplify-button--primary amplify-field-group__control amplify-authenticator__font"
+          data-amplify-button=""
+          data-disabled="false"
+          data-fullwidth="false"
+          data-loading="false"
+          data-variation="primary"
+          fullwidth="false"
+          type="submit"
+        >
+          
+          Send code
+          
+        </button>
+        
+        
+        <button
+          class="amplify-button amplify-button--link amplify-button--small amplify-field-group__control amplify-authenticator__font"
+          data-amplify-button=""
+          data-disabled="false"
+          data-fullwidth="false"
+          data-loading="false"
+          data-size="small"
+          data-variation="link"
+          fullwidth="false"
+          style="font-weight: normal;"
+          type="button"
+        >
+          
+          Back to Sign In
+          
+        </button>
+        
+        
+        
+        
+      </footer>
+      
+      
+    </div>
+    
+  </form>
+  
+  
+</div>
+`;

--- a/packages/vue/src/components/__tests__/confirm-reset-password.spec.ts
+++ b/packages/vue/src/components/__tests__/confirm-reset-password.spec.ts
@@ -166,7 +166,7 @@ describe('ConfirmResetPassword', () => {
     expect(resendCodeSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('disables the submit button if confirmation is pending', async () => {
+  it('disables the submit button if password reset is pending', async () => {
     useAuthenticatorSpy.mockReturnValue(
       reactive({ ...mockServiceFacade, isPending: true })
     );

--- a/packages/vue/src/components/__tests__/confirm-reset-password.spec.ts
+++ b/packages/vue/src/components/__tests__/confirm-reset-password.spec.ts
@@ -1,0 +1,182 @@
+import { reactive, Ref, ref } from 'vue';
+import { fireEvent, render, screen } from '@testing-library/vue';
+
+import * as UIModule from '@aws-amplify/ui';
+import { AuthInterpreter, AuthMachineState } from '@aws-amplify/ui';
+
+import { components } from '../../../global-spec';
+import * as UseAuthComposables from '../../composables/useAuth';
+import { baseMockServiceFacade } from '../../composables/__mock__/useAuthenticatorMock';
+import { UseAuthenticator } from '../../types';
+import ConfirmResetPassword from '../confirm-reset-password.vue';
+
+jest.spyOn(UseAuthComposables, 'useAuth').mockReturnValue({
+  authStatus: ref('unauthenticated'),
+  send: jest.fn(),
+  service: undefined as unknown as AuthInterpreter,
+  state: ref(undefined) as unknown as Ref<AuthMachineState>,
+});
+
+const updateBlurSpy = jest.fn();
+const updateFormSpy = jest.fn();
+const submitFormSpy = jest.fn();
+const resendCodeSpy = jest.fn();
+
+const mockServiceFacade: UseAuthenticator = {
+  ...baseMockServiceFacade,
+  route: 'confirmResetPassword',
+  updateBlur: updateBlurSpy,
+  updateForm: updateFormSpy,
+  submitForm: submitFormSpy,
+  resendCode: resendCodeSpy,
+};
+
+const useAuthenticatorSpy = jest
+  .spyOn(UseAuthComposables, 'useAuthenticator')
+  .mockReturnValue(reactive(mockServiceFacade));
+
+jest.spyOn(UIModule, 'getActorContext').mockReturnValue({
+  country_code: '+1',
+});
+
+jest.spyOn(UIModule, 'getSortedFormFields').mockReturnValue([
+  [
+    'confirmation_code',
+    {
+      label: 'Code *',
+      placeholder: 'Code',
+      type: 'number',
+    },
+  ],
+  [
+    'password',
+    {
+      label: 'New Password',
+      placeholder: 'New Password',
+      type: 'password',
+    },
+  ],
+  [
+    'confirm_password',
+    {
+      label: 'Confirm Password',
+      placeholder: 'Confirm Password',
+      type: 'password',
+    },
+  ],
+]);
+
+const codeInputPrams = { name: 'confirmation_code', value: '123456' };
+const newPasswordInputParams = {
+  name: 'password',
+  value: 'verysecurepassword',
+};
+const confirmPasswordInputParams = {
+  name: 'confirm_password',
+  value: 'verysecurepassword',
+};
+
+describe('ConfirmResetPassword', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders as expected', () => {
+    // mock random value so that snapshots are consistent
+    const mathRandomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.1);
+
+    const { container } = render(ConfirmResetPassword, {
+      global: { components },
+    });
+    expect(container).toMatchSnapshot();
+
+    mathRandomSpy.mockRestore();
+  });
+
+  it('handles change events as expected', async () => {
+    render(ConfirmResetPassword, {
+      global: { components },
+    });
+
+    const codeField = await screen.findByLabelText('Code *');
+    const newPasswordField = await screen.findByLabelText('New Password');
+    const confirmPasswordField = await screen.findByLabelText(
+      'Confirm Password'
+    );
+
+    await fireEvent.input(codeField, { target: codeInputPrams });
+    expect(updateFormSpy).toHaveBeenCalledWith(codeInputPrams);
+
+    await fireEvent.input(newPasswordField, { target: newPasswordInputParams });
+    expect(updateFormSpy).toHaveBeenCalledWith(newPasswordInputParams);
+
+    await fireEvent.input(confirmPasswordField, {
+      target: confirmPasswordInputParams,
+    });
+    expect(updateFormSpy).toHaveBeenCalledWith(confirmPasswordInputParams);
+  });
+
+  it('handles blur events as expected', async () => {
+    render(ConfirmResetPassword, {
+      global: { components },
+    });
+
+    const codeField = await screen.findByLabelText('Code *');
+    const newPasswordField = await screen.findByLabelText('New Password');
+    const confirmPasswordField = await screen.findByLabelText(
+      'Confirm Password'
+    );
+
+    await fireEvent.blur(codeField);
+    expect(updateBlurSpy).toHaveBeenCalledWith({ name: 'confirmation_code' });
+
+    await fireEvent.blur(newPasswordField);
+    expect(updateBlurSpy).toHaveBeenCalledWith({ name: 'password' });
+
+    await fireEvent.blur(confirmPasswordField);
+    expect(updateBlurSpy).toHaveBeenCalledWith({ name: 'confirm_password' });
+  });
+
+  it('handles submit events as expected', async () => {
+    render(ConfirmResetPassword, { global: { components } });
+
+    const submitButton = await screen.findByRole('button', {
+      name: 'Submit',
+    });
+
+    await fireEvent.click(submitButton);
+    expect(submitFormSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('displays error if present', async () => {
+    useAuthenticatorSpy.mockReturnValueOnce(
+      reactive({ ...mockServiceFacade, error: 'mockError' })
+    );
+    render(ConfirmResetPassword, { global: { components } });
+
+    expect(await screen.findByText('mockError')).toBeInTheDocument();
+  });
+
+  it('handles back to sign in button as expected', async () => {
+    render(ConfirmResetPassword, { global: { components } });
+
+    const resendCodeButton = await screen.findByRole('button', {
+      name: 'Resend Code',
+    });
+    await fireEvent.click(resendCodeButton);
+
+    expect(resendCodeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the submit button if confirmation is pending', async () => {
+    useAuthenticatorSpy.mockReturnValue(
+      reactive({ ...mockServiceFacade, isPending: true })
+    );
+    render(ConfirmResetPassword, { global: { components } });
+
+    const submitButton = await screen.findByRole('button', {
+      name: 'Submit',
+    });
+    expect(submitButton).toBeDisabled();
+  });
+});

--- a/packages/vue/src/components/__tests__/force-new-password.spec.ts
+++ b/packages/vue/src/components/__tests__/force-new-password.spec.ts
@@ -175,7 +175,7 @@ describe('ConfirmResetPassword', () => {
     expect(toSignInSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('disables the submit button if confirmation is pending', async () => {
+  it('disables the submit button if password change is pending', async () => {
     useAuthenticatorSpy.mockReturnValue(
       reactive({ ...mockServiceFacade, isPending: true })
     );

--- a/packages/vue/src/components/__tests__/force-new-password.spec.ts
+++ b/packages/vue/src/components/__tests__/force-new-password.spec.ts
@@ -8,7 +8,7 @@ import { components } from '../../../global-spec';
 import * as UseAuthComposables from '../../composables/useAuth';
 import { baseMockServiceFacade } from '../../composables/__mock__/useAuthenticatorMock';
 import { UseAuthenticator } from '../../types';
-import ConfirmResetPassword from '../confirm-reset-password.vue';
+import ForceNewPassword from '../force-new-password.vue';
 
 jest.spyOn(UseAuthComposables, 'useAuth').mockReturnValue({
   authStatus: ref('unauthenticated'),
@@ -20,7 +20,7 @@ jest.spyOn(UseAuthComposables, 'useAuth').mockReturnValue({
 const updateBlurSpy = jest.fn();
 const updateFormSpy = jest.fn();
 const submitFormSpy = jest.fn();
-const resendCodeSpy = jest.fn();
+const toSignInSpy = jest.fn();
 
 const mockServiceFacade: UseAuthenticator = {
   ...baseMockServiceFacade,
@@ -28,7 +28,7 @@ const mockServiceFacade: UseAuthenticator = {
   updateBlur: updateBlurSpy,
   updateForm: updateFormSpy,
   submitForm: submitFormSpy,
-  resendCode: resendCodeSpy,
+  toSignIn: toSignInSpy,
 };
 
 const useAuthenticatorSpy = jest
@@ -41,18 +41,10 @@ jest.spyOn(UIModule, 'getActorContext').mockReturnValue({
 
 jest.spyOn(UIModule, 'getSortedFormFields').mockReturnValue([
   [
-    'confirmation_code',
-    {
-      label: 'Code *',
-      placeholder: 'Code',
-      type: 'number',
-    },
-  ],
-  [
     'password',
     {
-      label: 'New Password',
-      placeholder: 'New Password',
+      label: 'Password',
+      placeholder: 'Enter your Password',
       type: 'password',
     },
   ],
@@ -60,19 +52,30 @@ jest.spyOn(UIModule, 'getSortedFormFields').mockReturnValue([
     'confirm_password',
     {
       label: 'Confirm Password',
-      placeholder: 'Confirm Password',
+      placeholder: 'Please confirm your Password',
       type: 'password',
+    },
+  ],
+  [
+    'preferred_username',
+    {
+      label: 'Preferred Username',
+      placeholder: 'Enter your Preferred Username',
+      type: 'text',
     },
   ],
 ]);
 
-const codeInputPrams = { name: 'confirmation_code', value: '123456' };
-const newPasswordInputParams = {
+const passwordInputParams = {
   name: 'password',
   value: 'verysecurepassword',
 };
 const confirmPasswordInputParams = {
   name: 'confirm_password',
+  value: 'verysecurepassword',
+};
+const preferredUsernameInputParams = {
+  name: 'preferred_username',
   value: 'verysecurepassword',
 };
 
@@ -85,7 +88,7 @@ describe('ConfirmResetPassword', () => {
     // mock random value so that snapshots are consistent
     const mathRandomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.1);
 
-    const { container } = render(ConfirmResetPassword, {
+    const { container } = render(ForceNewPassword, {
       global: { components },
     });
     expect(container).toMatchSnapshot();
@@ -94,52 +97,58 @@ describe('ConfirmResetPassword', () => {
   });
 
   it('handles change events as expected', async () => {
-    render(ConfirmResetPassword, { global: { components } });
+    render(ForceNewPassword, {
+      global: { components },
+    });
 
-    const codeField = await screen.findByLabelText('Code *');
-    const newPasswordField = await screen.findByLabelText('New Password');
+    const passwordField = await screen.findByLabelText('Password');
     const confirmPasswordField = await screen.findByLabelText(
       'Confirm Password'
     );
+    const preferredUsernameField = await screen.findByLabelText(
+      'Preferred Username'
+    );
 
-    await fireEvent.input(codeField, { target: codeInputPrams });
-    expect(updateFormSpy).toHaveBeenCalledWith(codeInputPrams);
-
-    await fireEvent.input(newPasswordField, { target: newPasswordInputParams });
-    expect(updateFormSpy).toHaveBeenCalledWith(newPasswordInputParams);
+    await fireEvent.input(passwordField, { target: passwordInputParams });
+    expect(updateFormSpy).toHaveBeenCalledWith(passwordInputParams);
 
     await fireEvent.input(confirmPasswordField, {
       target: confirmPasswordInputParams,
     });
     expect(updateFormSpy).toHaveBeenCalledWith(confirmPasswordInputParams);
+
+    await fireEvent.input(preferredUsernameField, {
+      target: preferredUsernameInputParams,
+    });
+    expect(updateFormSpy).toHaveBeenCalledWith(preferredUsernameInputParams);
   });
 
   it('handles blur events as expected', async () => {
-    render(ConfirmResetPassword, {
-      global: { components },
-    });
+    render(ForceNewPassword, { global: { components } });
 
-    const codeField = await screen.findByLabelText('Code *');
-    const newPasswordField = await screen.findByLabelText('New Password');
+    const passwordField = await screen.findByLabelText('Password');
     const confirmPasswordField = await screen.findByLabelText(
       'Confirm Password'
     );
+    const preferredUsernameField = await screen.findByLabelText(
+      'Preferred Username'
+    );
 
-    await fireEvent.blur(codeField);
-    expect(updateBlurSpy).toHaveBeenCalledWith({ name: 'confirmation_code' });
-
-    await fireEvent.blur(newPasswordField);
+    await fireEvent.blur(passwordField);
     expect(updateBlurSpy).toHaveBeenCalledWith({ name: 'password' });
 
     await fireEvent.blur(confirmPasswordField);
     expect(updateBlurSpy).toHaveBeenCalledWith({ name: 'confirm_password' });
+
+    await fireEvent.blur(preferredUsernameField);
+    expect(updateBlurSpy).toHaveBeenCalledWith({ name: 'preferred_username' });
   });
 
   it('handles submit events as expected', async () => {
-    render(ConfirmResetPassword, { global: { components } });
+    render(ForceNewPassword, { global: { components } });
 
     const submitButton = await screen.findByRole('button', {
-      name: 'Submit',
+      name: 'Change Password',
     });
 
     await fireEvent.click(submitButton);
@@ -150,30 +159,30 @@ describe('ConfirmResetPassword', () => {
     useAuthenticatorSpy.mockReturnValueOnce(
       reactive({ ...mockServiceFacade, error: 'mockError' })
     );
-    render(ConfirmResetPassword, { global: { components } });
+    render(ForceNewPassword, { global: { components } });
 
     expect(await screen.findByText('mockError')).toBeInTheDocument();
   });
 
-  it('handles resend code button as expected', async () => {
-    render(ConfirmResetPassword, { global: { components } });
+  it('handles back to sign in button as expected', async () => {
+    render(ForceNewPassword, { global: { components } });
 
-    const resendCodeButton = await screen.findByRole('button', {
-      name: 'Resend Code',
+    const backToSignInButton = await screen.findByRole('button', {
+      name: 'Back to Sign In',
     });
-    await fireEvent.click(resendCodeButton);
+    await fireEvent.click(backToSignInButton);
 
-    expect(resendCodeSpy).toHaveBeenCalledTimes(1);
+    expect(toSignInSpy).toHaveBeenCalledTimes(1);
   });
 
   it('disables the submit button if confirmation is pending', async () => {
     useAuthenticatorSpy.mockReturnValue(
       reactive({ ...mockServiceFacade, isPending: true })
     );
-    render(ConfirmResetPassword, { global: { components } });
+    render(ForceNewPassword, { global: { components } });
 
     const submitButton = await screen.findByRole('button', {
-      name: 'Submit',
+      name: 'Changing…',
     });
     expect(submitButton).toBeDisabled();
   });

--- a/packages/vue/src/components/__tests__/reset-password.spec.ts
+++ b/packages/vue/src/components/__tests__/reset-password.spec.ts
@@ -1,0 +1,122 @@
+import { reactive, Ref, ref } from 'vue';
+import { fireEvent, render, screen } from '@testing-library/vue';
+
+import * as UIModule from '@aws-amplify/ui';
+import { AuthInterpreter, AuthMachineState } from '@aws-amplify/ui';
+
+import { components } from '../../../global-spec';
+import * as UseAuthComposables from '../../composables/useAuth';
+import { baseMockServiceFacade } from '../../composables/__mock__/useAuthenticatorMock';
+import { UseAuthenticator } from '../../types';
+import ResetPassword from '../reset-password.vue';
+
+jest.spyOn(UseAuthComposables, 'useAuth').mockReturnValue({
+  authStatus: ref('unauthenticated'),
+  send: jest.fn(),
+  service: undefined as unknown as AuthInterpreter,
+  state: ref(undefined) as unknown as Ref<AuthMachineState>,
+});
+
+const updateFormSpy = jest.fn();
+const submitFormSpy = jest.fn();
+const toSignInSpy = jest.fn();
+
+const mockServiceFacade: UseAuthenticator = {
+  ...baseMockServiceFacade,
+  route: 'resetPassword',
+  updateForm: updateFormSpy,
+  submitForm: submitFormSpy,
+  toSignIn: toSignInSpy,
+};
+
+const useAuthenticatorSpy = jest
+  .spyOn(UseAuthComposables, 'useAuthenticator')
+  .mockReturnValue(reactive(mockServiceFacade));
+
+jest.spyOn(UIModule, 'getActorContext').mockReturnValue({
+  country_code: '+1',
+});
+
+jest.spyOn(UIModule, 'getSortedFormFields').mockReturnValue([
+  [
+    'email',
+    {
+      label: 'Email',
+      placeholder: 'Enter your Email',
+      type: 'email',
+    },
+  ],
+]);
+
+const emailInputParams = { name: 'email', value: 'user@example.com' };
+
+describe('ResetPassword', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders as expected', () => {
+    // mock random value so that snapshots are consistent
+    const mathRandomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.1);
+
+    const { container } = render(ResetPassword, { global: { components } });
+    expect(container).toMatchSnapshot();
+
+    mathRandomSpy.mockRestore();
+  });
+
+  it('handles change events as expected', async () => {
+    render(ResetPassword, { global: { components } });
+
+    const emailField = await screen.findByLabelText('Email');
+
+    await fireEvent.input(emailField, { target: emailInputParams });
+    expect(updateFormSpy).toHaveBeenCalledWith(emailInputParams);
+  });
+
+  it('handles submit events as expected', async () => {
+    render(ResetPassword, { global: { components } });
+
+    const emailField = await screen.findByLabelText('Email');
+    await fireEvent.input(emailField, { target: emailInputParams });
+
+    const submitButton = await screen.findByRole('button', {
+      name: 'Send code',
+    });
+
+    await fireEvent.click(submitButton);
+    expect(submitFormSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('displays error if present', async () => {
+    useAuthenticatorSpy.mockReturnValueOnce(
+      reactive({ ...mockServiceFacade, error: 'mockError' })
+    );
+    render(ResetPassword, { global: { components } });
+
+    expect(await screen.findByText('mockError')).toBeInTheDocument();
+  });
+
+  it('handles back to sign in button as expected', async () => {
+    render(ResetPassword, { global: { components } });
+
+    const backToSignInButton = await screen.findByRole('button', {
+      name: 'Back to Sign In',
+    });
+    await fireEvent.click(backToSignInButton);
+
+    expect(toSignInSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the submit button if confirmation is pending', async () => {
+    useAuthenticatorSpy.mockReturnValue(
+      reactive({ ...mockServiceFacade, isPending: true })
+    );
+    render(ResetPassword, { global: { components } });
+
+    const submitButton = await screen.findByRole('button', {
+      name: 'Send code',
+    });
+    expect(submitButton).toBeDisabled();
+  });
+});

--- a/packages/vue/src/components/force-new-password.vue
+++ b/packages/vue/src/components/force-new-password.vue
@@ -1,26 +1,25 @@
 <script setup lang="ts">
-import { computed, ComputedRef, useAttrs } from 'vue';
+import { computed, toRefs, useAttrs } from 'vue';
 import {
   authenticatorTextUtil,
-  getActorState,
-  SignInState,
   getFormDataFromEvent,
   translate,
 } from '@aws-amplify/ui';
 
-import { useAuth, useAuthenticator } from '../composables/useAuth';
+import { useAuthenticator } from '../composables/useAuth';
+import { UseAuthenticator } from '../types';
 
 import AuthenticatorForceNewPasswordFormFields from './authenticator-force-new-password-form-fields.vue';
 
-const attrs = useAttrs();
+/** @deprecated Component events are deprecated and not maintained. */
 const emit = defineEmits(['haveAccountClicked', 'forceNewPasswordSubmit']);
+const attrs = useAttrs();
 
-const { state, send } = useAuth();
+// `facade` is manually typed to `UseAuthenticator` for temporary type safety.
+const facade: UseAuthenticator = useAuthenticator();
 
-const props = useAuthenticator();
-const actorState = computed(() =>
-  getActorState(state.value)
-) as ComputedRef<SignInState>;
+const { submitForm, toSignIn, updateBlur, updateForm } = facade;
+const { error, isPending } = toRefs(facade);
 
 // Text Util
 const { getChangePasswordText, getChangingText, getBackToSignInText } =
@@ -33,16 +32,18 @@ const backSignInText = computed(() => getBackToSignInText());
 
 // Methods
 const onHaveAccountClicked = (): void => {
+  // TODO(BREAKING): remove unused emit
+  // istanbul ignore next
   if (attrs?.onHaveAccountClicked) {
     emit('haveAccountClicked');
   } else {
-    send({
-      type: 'SIGN_IN',
-    });
+    toSignIn();
   }
 };
 
 const onForceNewPasswordSubmit = (e: Event): void => {
+  // TODO(BREAKING): remove unused emit
+  // istanbul ignore next
   if (attrs?.onForceNewPasswordSubmit) {
     emit('forceNewPasswordSubmit', e);
   } else {
@@ -51,21 +52,17 @@ const onForceNewPasswordSubmit = (e: Event): void => {
 };
 
 const submit = (e: Event): void => {
-  props.submitForm(getFormDataFromEvent(e));
+  submitForm(getFormDataFromEvent(e));
 };
 
 const onInput = (e: Event): void => {
   const { name, value } = e.target as HTMLInputElement;
-  send({
-    type: 'CHANGE',
-    //@ts-ignore
-    data: { name, value },
-  });
+  updateForm({ name, value });
 };
 
 function onBlur(e: Event) {
   const { name } = e.target as HTMLInputElement;
-  props.updateBlur({ name });
+  updateBlur({ name });
 }
 </script>
 
@@ -80,7 +77,7 @@ function onBlur(e: Event) {
       >
         <base-field-set
           class="amplify-flex amplify-authenticator__column"
-          :disabled="actorState.matches('forceNewPassword.pending')"
+          :disabled="isPending"
         >
           <slot name="header">
             <base-heading :level="3" class="amplify-heading">
@@ -94,8 +91,8 @@ function onBlur(e: Event) {
           </base-wrapper>
 
           <base-footer class="amplify-flex amplify-authenticator__column">
-            <base-alert data-ui-error v-if="actorState.context.remoteError">
-              {{ translate(actorState.context.remoteError) }}
+            <base-alert data-ui-error v-if="error">
+              {{ translate(error) }}
             </base-alert>
             <amplify-button
               class="amplify-field-group__control amplify-authenticator__font"
@@ -103,13 +100,14 @@ function onBlur(e: Event) {
               :loading="false"
               :variation="'primary'"
               style="font-weight: normal"
-              :disabled="actorState.matches('signUp.submit')"
-              >{{
-                actorState.matches('forceNewPassword.pending')
+              :disabled="isPending"
+            >
+              {{
+                isPending
                   ? changingPasswordLabel + '&hellip;'
                   : changePasswordLabel
-              }}</amplify-button
-            >
+              }}
+            </amplify-button>
             <amplify-button
               class="amplify-field-group__control amplify-authenticator__font"
               :fullwidth="false"
@@ -119,8 +117,8 @@ function onBlur(e: Event) {
               type="button"
               @click.prevent="onHaveAccountClicked"
             >
-              {{ backSignInText }}</amplify-button
-            >
+              {{ backSignInText }}
+            </amplify-button>
             <slot
               name="footer"
               :onHaveAccountClicked="onHaveAccountClicked"

--- a/packages/vue/src/components/reset-password.vue
+++ b/packages/vue/src/components/reset-password.vue
@@ -8,12 +8,17 @@ import {
 import BaseFormFields from './primitives/base-form-fields.vue';
 
 import { useAuthenticator } from '../composables/useAuth';
+import { UseAuthenticator } from '../types';
 
 const attrs = useAttrs();
+/** @deprecated Component events are deprecated and not maintained. */
 const emit = defineEmits(['resetPasswordSubmit', 'backToSignInClicked']);
 
-const { send, submitForm } = useAuthenticator();
-const { error, isPending } = toRefs(useAuthenticator());
+// `facade` is manually typed to `UseAuthenticator` for temporary type safety.
+const facade: UseAuthenticator = useAuthenticator();
+
+const { submitForm, toSignIn, updateForm } = facade;
+const { error, isPending } = toRefs(facade);
 
 // Text Util
 const { getBackToSignInText, getResetYourPasswordText, getSendCodeText } =
@@ -26,32 +31,27 @@ const sendCodeText = computed(() => getSendCodeText());
 
 // Methods
 const onResetPasswordSubmit = (e: Event): void => {
+  // TODO(BREAKING): remove unused emit
+  // istanbul ignore next
   if (attrs?.onResetPasswordSubmit) {
     emit('resetPasswordSubmit', e);
   } else {
-    submit(e);
+    submitForm(getFormDataFromEvent(e));
   }
-};
-
-const submit = (e: Event): void => {
-  submitForm(getFormDataFromEvent(e));
 };
 
 const onInput = (e: Event): void => {
   const { name, value } = e.target as HTMLInputElement;
-  send({
-    type: 'CHANGE',
-    data: { name, value },
-  });
+  updateForm({ name, value });
 };
 
 const onBackToSignInClicked = (): void => {
+  // TODO(BREAKING): remove unused emit
+  // istanbul ignore next
   if (attrs?.onBackToSignInClicked) {
     emit('backToSignInClicked');
   } else {
-    send({
-      type: 'SIGN_IN',
-    });
+    toSignIn();
   }
 };
 </script>
@@ -87,8 +87,9 @@ const onBackToSignInClicked = (): void => {
             :variation="'primary'"
             type="submit"
             :disabled="isPending"
-            >{{ sendCodeText }}</amplify-button
           >
+            {{ sendCodeText }}
+          </amplify-button>
           <amplify-button
             class="amplify-field-group__control amplify-authenticator__font"
             :fullwidth="false"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Refactors `reset-password`, `confirm-reset-password`, and `force-new-password` components to use `useAuthenticator` instead of explicit state machine lookup.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Existing CI, wrote unit test, and did smoke tests:

<video src="https://github.com/aws-amplify/amplify-ui/assets/43682783/c8a41c03-03ed-4568-b1d2-ecdd5a21b000" /> | <video src="https://github.com/aws-amplify/amplify-ui/assets/43682783/b324d43c-d939-4621-be48-db1797ebff24" />
|---|---|

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
