### PR TITLE
fix(docs): update maplibre urls

### DIFF
--- a/docs/src/pages/[platform]/connected-components/geo/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/geo/react.mdx
@@ -29,7 +29,7 @@ There's a known issue for users of Create React App v4 where the default prod `b
 The `MapView` component adds an interactive map to your application.
 
 `MapView` is fully integrated with the open source library [react-map-gl](https://visgl.github.io/react-map-gl/) v7
-while using [maplibre-gl-js](https://maplibre.org/maplibre-gl-js-docs/api/) as the map tile source. `MapView` is
+while using [maplibre-gl-js](https://maplibre.org/maplibre-gl-js/docs/API/) as the map tile source. `MapView` is
 used as a replacement to `react-map-gl`'s [default map](https://visgl.github.io/react-map-gl/docs/api-reference/map)
 and supports the same functionality.
 
@@ -80,7 +80,7 @@ state to be handled by the component._
 
 ### Animation and Native Map Methods
 
-You may want to access the [native maplibre-gl map object](https://maplibre.org/maplibre-gl-js-docs/api/map/) from within the component that renders `<MapView>` (to animate a viewport transition with `flyTo`, for example). To accomplish this, you can pass your own ref to `<MapView>` using [React's `useRef` hook](https://legacy.reactjs.org/docs/hooks-reference.html#useref) which will contain the `map` object:
+You may want to access the [native maplibre-gl map object](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/) from within the component that renders `<MapView>` (to animate a viewport transition with `flyTo`, for example). To accomplish this, you can pass your own ref to `<MapView>` using [React's `useRef` hook](https://legacy.reactjs.org/docs/hooks-reference.html#useref) which will contain the `map` object:
 
 <Fragment platforms={['react']}>
   {({ platform }) => import(`./fragments/map-ref.${platform}.mdx`)}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Maplibre changed their docs urls from maplibre.org/maplibre-gl-js-docs/api/ to maplibre.org/maplibre-gl-js/docs/API/

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
