### PR TITLE
fix(docs): hide icons from accessibility tree

### DIFF
--- a/docs/src/components/Layout/Footer.tsx
+++ b/docs/src/components/Layout/Footer.tsx
@@ -23,7 +23,7 @@ export const Footer = () => {
           rel="noopener noreferrer"
           gap="xs"
         >
-          <GithubIcon ariaLabel="" />
+          <GithubIcon aria-hidden="true" />
           Contribute on GitHub
         </Button>
         <Button
@@ -33,7 +33,7 @@ export const Footer = () => {
           rel="noopener noreferrer"
           gap="xs"
         >
-          <DiscordIcon ariaLabel="" />
+          <DiscordIcon aria-hidden="true" />
           Discuss on Discord
         </Button>
       </Flex>

--- a/docs/src/components/Layout/Header.tsx
+++ b/docs/src/components/Layout/Header.tsx
@@ -76,7 +76,7 @@ export const Header = ({
               title="GitHub"
             >
               <VisuallyHidden>GitHub</VisuallyHidden>
-              <GithubIcon />
+              <GithubIcon aria-hidden="true" />
             </Button>
           </View>
         ) : null}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds `aria-hidden="true"` to a few unlabelled icons on the docs site. The related links these icons are used for already have accessible labels so the icons are safe to hide.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
