### PR TITLE
fix(primitives): fix border color token for SwitchField thumb

### DIFF
--- a/.changeset/hip-llamas-cover.md
+++ b/.changeset/hip-llamas-cover.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+fix(primitives): fix border color token for SwitchField thumb

--- a/docs/src/pages/[platform]/components/switchfield/examples/SwitchFieldThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/switchfield/examples/SwitchFieldThemeExample.tsx
@@ -6,15 +6,15 @@ const theme: Theme = {
     components: {
       switchfield: {
         thumb: {
-          backgroundColor: { value: '{colors.green.40}' },
-          borderColor: { value: '{colors.border.tertiary}' },
+          backgroundColor: { value: '{colors.background.primary}' },
+          borderColor: { value: '{colors.border.primary}' },
           transition: {
             duration: { value: '{time.long}' },
           },
         },
 
         track: {
-          backgroundColor: { value: '{colors.neutral.60}' },
+          backgroundColor: { value: '{colors.background.tertiary}' },
           checked: {
             backgroundColor: { value: '{colors.brand.secondary.60}' },
           },

--- a/docs/tests/__snapshots__/cssvars-table.test.ts.snap
+++ b/docs/tests/__snapshots__/cssvars-table.test.ts.snap
@@ -3720,11 +3720,19 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         \\"variable\\": \\"--amplify-components-switchfield-thumb-border-color\\",
-        \\"value\\": \\"var(--amplify-colors-border-tertiary)\\"
+        \\"value\\": \\"transparent\\"
     },
     {
         \\"variable\\": \\"--amplify-components-switchfield-thumb-border-radius\\",
         \\"value\\": \\"var(--amplify-radii-xxxl)\\"
+    },
+    {
+        \\"variable\\": \\"--amplify-components-switchfield-thumb-border-style\\",
+        \\"value\\": \\"solid\\"
+    },
+    {
+        \\"variable\\": \\"--amplify-components-switchfield-thumb-border-width\\",
+        \\"value\\": \\"var(--amplify-border-widths-small)\\"
     },
     {
         \\"variable\\": \\"--amplify-components-switchfield-thumb-checked-transform\\",

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -826,7 +826,9 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-switchfield-small-font-size: var(--amplify-font-sizes-small);
         --amplify-components-switchfield-label-padding: var(--amplify-space-xs);
         --amplify-components-switchfield-thumb-background-color: var(--amplify-colors-background-primary);
-        --amplify-components-switchfield-thumb-border-color: var(--amplify-colors-border-tertiary);
+        --amplify-components-switchfield-thumb-border-color: transparent;
+        --amplify-components-switchfield-thumb-border-width: var(--amplify-border-widths-small);
+        --amplify-components-switchfield-thumb-border-style: solid;
         --amplify-components-switchfield-thumb-border-radius: var(--amplify-radii-xxxl);
         --amplify-components-switchfield-thumb-checked-transform: var(--amplify-transforms-slide-x-medium);
         --amplify-components-switchfield-thumb-transition-duration: var(--amplify-time-medium);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -860,7 +860,9 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-switchfield-small-font-size: var(--amplify-font-sizes-small);
         --amplify-components-switchfield-label-padding: var(--amplify-space-xs);
         --amplify-components-switchfield-thumb-background-color: var(--amplify-colors-background-primary);
-        --amplify-components-switchfield-thumb-border-color: var(--amplify-colors-border-tertiary);
+        --amplify-components-switchfield-thumb-border-color: transparent;
+        --amplify-components-switchfield-thumb-border-width: var(--amplify-border-widths-small);
+        --amplify-components-switchfield-thumb-border-style: solid;
         --amplify-components-switchfield-thumb-border-radius: var(--amplify-radii-xxxl);
         --amplify-components-switchfield-thumb-checked-transform: var(--amplify-transforms-slide-x-medium);
         --amplify-components-switchfield-thumb-transition-duration: var(--amplify-time-medium);

--- a/packages/ui/src/theme/css/component/switchField.scss
+++ b/packages/ui/src/theme/css/component/switchField.scss
@@ -1,6 +1,8 @@
 .amplify-switchfield {
   display: inline-block;
   font-size: var(--amplify-components-switchfield-font-size);
+  cursor: pointer;
+  
   &--small {
     font-size: var(--amplify-components-switchfield-small-font-size);
   }
@@ -68,6 +70,8 @@
   border-radius: var(--amplify-components-switchfield-thumb-border-radius);
   width: var(--amplify-components-switchfield-thumb-width);
   height: var(--amplify-components-switchfield-thumb-width);
+  border-width: var(--amplify-components-switchfield-thumb-border-width);
+  border-style: var(--amplify-components-switchfield-thumb-border-style);
   border-color: var(--amplify-components-switchfield-thumb-border-color);
   overflow-wrap: break-word;
   &--checked {

--- a/packages/ui/src/theme/tokens/components/switchField.ts
+++ b/packages/ui/src/theme/tokens/components/switchField.ts
@@ -18,7 +18,12 @@ export type SwitchFieldTokens<OutputType extends OutputVariantKey> =
     small?: SwitchFieldSizeTokens<OutputType>;
     label?: DesignTokenProperties<'padding', OutputType>;
     thumb?: DesignTokenProperties<
-      'backgroundColor' | 'borderColor' | 'borderRadius' | 'width',
+      | 'backgroundColor'
+      | 'borderColor'
+      | 'borderStyle'
+      | 'borderWidth'
+      | 'borderRadius'
+      | 'width',
       OutputType
     > & {
       checked?: DesignTokenProperties<'transform', OutputType>;
@@ -67,7 +72,9 @@ export const switchfield: Required<SwitchFieldTokens<'default'>> = {
 
   thumb: {
     backgroundColor: { value: '{colors.background.primary.value}' },
-    borderColor: { value: '{colors.border.tertiary.value}' },
+    borderColor: { value: 'transparent' },
+    borderWidth: { value: '{borderWidths.small.value}' },
+    borderStyle: { value: 'solid' },
     borderRadius: { value: '{radii.xxxl.value}' },
     checked: {
       transform: { value: '{transforms.slideX.medium.value}' },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

We exposed a `borderColor` token for the thumb of the SwitchField, but because we weren't setting borderWidth or borderStyle, that token wasn't doing anything. Also added the pointer cursor so it looks interactive on hover. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
