### PR TITLE
chore: fix prettier css formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
   "files.insertFinalNewline": true,
   "prettier.requireConfig": true,
   "typescript.tsdk": "node_modules/typescript/lib",
+  "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/docs/src/styles/docs/_variables.scss
+++ b/docs/src/styles/docs/_variables.scss
@@ -5,5 +5,5 @@ $breakpoint-xl: 1280px;
 $breakpoint-xxl: 1536px;
 
 $font-code: 'Source Code Pro', 'Fira Code', 'Fira Mono', ui-monospace,
-SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
-monospace;
+  SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+  monospace;

--- a/docs/src/styles/docs/algolia.scss
+++ b/docs/src/styles/docs/algolia.scss
@@ -87,11 +87,11 @@
   .DocSearch-Logo svg {
     color: var(--amplify-colors-font-tertiary);
   }
-  
+
   .DocSearch-MagnifierLabel {
     color: var(--amplify-colors-font-disabled);
   }
-  
+
   .DocSearch-Hit {
     border-radius: var(--amplify-radii-small);
     padding-block-end: var(--amplify-space-small);

--- a/docs/src/styles/docs/code.scss
+++ b/docs/src/styles/docs/code.scss
@@ -3,11 +3,10 @@
  * Based on Atom's One Light theme: https://github.com/atom/atom/tree/master/packages/one-light-syntax
  */
 
-
 .docs-home code.prism-code {
   font-size: inherit;
 }
- 
+
 code[class*='language-'],
 pre[class*='language-'] {
   background: var(--amplify-colors-background-secondary);
@@ -121,20 +120,20 @@ section > pre[class*='language-'] {
   & .token.selector {
     color: var(--amplify-colors-purple-80);
   }
-  
+
   & .token.property {
     color: var(--amplify-colors-teal-80);
   }
-  
+
   & .token.function,
   & .token.url > .token.function {
     color: var(--amplify-colors-teal-80);
   }
-  
+
   & .token.url > .token.string.url {
     color: var(--amplify-colors-green-80);
   }
-  
+
   & .token.important,
   & .token.atrule .token.rule {
     color: var(--amplify-colors-pink-80);
@@ -386,7 +385,6 @@ pre > code.diff-highlight .token.token.inserted:not(.prefix) *::selection {
 .token.entity {
   color: var(--amplify-colors-font-secondary);
 }
-
 
 .token.class-name {
   color: var(--amplify-colors-pink-80);

--- a/docs/src/styles/docs/component.scss
+++ b/docs/src/styles/docs/component.scss
@@ -5,7 +5,8 @@
   cursor: pointer;
   color: var(--amplify-colors-font-secondary);
   padding: var(--amplify-space-large);
-  border: var(--amplify-border-widths-small) solid var(--amplify-colors-border-secondary);
+  border: var(--amplify-border-widths-small) solid
+    var(--amplify-colors-border-secondary);
   box-shadow: none;
 }
 

--- a/docs/src/styles/docs/framework-chooser.scss
+++ b/docs/src/styles/docs/framework-chooser.scss
@@ -7,7 +7,7 @@
   justify-content: flex-start;
   border-color: var(--amplify-colors-border-secondary);
   gap: var(--amplify-space-xs);
-  
+
   &.current {
     background-color: var(--amplify-components-button-hover-background-color);
     border-color: var(--amplify-components-button-active-border-color);

--- a/docs/src/styles/docs/home.scss
+++ b/docs/src/styles/docs/home.scss
@@ -1,31 +1,35 @@
 @import './variables';
 
 @mixin window-buttons {
-  content:'';
+  content: '';
   position: absolute;
   top: 50%;
   left: 0;
   width: 4rem;
   height: 0.75rem;
   transform: translateY(-50%);
-  background-image: radial-gradient(circle closest-side at 6px, #E26964 90%, #FFFFFF00),
-  radial-gradient(circle closest-side at 24px, #F7CE51 90%, #FFFFFF00),
-  radial-gradient(circle closest-side at 42px, #92D148 90%, #FFFFFF00);
+  background-image: radial-gradient(
+      circle closest-side at 6px,
+      #e26964 90%,
+      #ffffff00
+    ),
+    radial-gradient(circle closest-side at 24px, #f7ce51 90%, #ffffff00),
+    radial-gradient(circle closest-side at 42px, #92d148 90%, #ffffff00);
 }
 
 .docs-home-section {
   position: relative;
   overflow: hidden;
   padding: var(--amplify-space-large);
-  
+
   @media (min-width: $breakpoint-medium) {
     padding: var(--amplify-space-xxl);
   }
-  
+
   @media (min-width: $breakpoint-large) {
     padding: var(--amplify-space-xxxl);
   }
-  
+
   & > * + * {
     margin-top: var(--amplify-space-large);
   }
@@ -35,13 +39,13 @@
   max-width: 100rem;
   gap: var(--amplify-space-xl);
   margin: var(--amplify-space-large) auto;
-  
+
   &--thin {
     max-width: 60rem;
     gap: var(--amplify-space-xl);
     margin: var(--amplify-space-large) auto;
   }
-  
+
   @media (min-width: $breakpoint-medium) {
     gap: var(--amplify-space-xxl);
     &--thin {
@@ -58,14 +62,12 @@
   text-align: center;
   align-items: center;
 
-  
   @media (max-width: $breakpoint-small) {
     & > svg {
       display: none;
     }
   }
 }
-
 
 .docs-home-text {
   font-size: var(--amplify-font-sizes-large);
@@ -90,10 +92,10 @@
       max-width: 40vw;
     }
   }
-  
+
   .install-code__content {
     background-color: var(--amplify-colors-background-primary);
-    
+
     @media (min-width: $breakpoint-medium) {
       font-size: var(--amplify-font-sizes-large);
     }
@@ -110,10 +112,16 @@
           &::after {
             content: '';
             position: absolute;
-            bottom: calc(-1 * var(--amplify-space-xs)); left: 0; right: 0;
+            bottom: calc(-1 * var(--amplify-space-xs));
+            left: 0;
+            right: 0;
             height: var(--amplify-space-xs);
             background-color: var(--amplify-colors-brand-secondary-60);
-            background-image: linear-gradient(90deg, var(--amplify-colors-brand-secondary-40) 0%, var(--amplify-colors-brand-primary-40) 100%);
+            background-image: linear-gradient(
+              90deg,
+              var(--amplify-colors-brand-secondary-40) 0%,
+              var(--amplify-colors-brand-primary-40) 100%
+            );
             transform: skewX(-15deg);
           }
         }
@@ -128,19 +136,27 @@
 
 .docs-hero {
   background-image: url('/svg/grid.svg'),
-    linear-gradient(0deg, hsla(var(--docs-gradient-color-hsl), 1) 0%, hsla(var(--docs-gradient-color-hsl), 0) 35%),
-    linear-gradient(180deg, hsla(var(--docs-gradient-color-hsl), 1) 0%, hsla(var(--docs-gradient-color-hsl), 0) 35%);
+    linear-gradient(
+      0deg,
+      hsla(var(--docs-gradient-color-hsl), 1) 0%,
+      hsla(var(--docs-gradient-color-hsl), 0) 35%
+    ),
+    linear-gradient(
+      180deg,
+      hsla(var(--docs-gradient-color-hsl), 1) 0%,
+      hsla(var(--docs-gradient-color-hsl), 0) 35%
+    );
   background-color: var(--docs-callout-bg);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
   padding: var(--amplify-space-large);
-  
+
   @media (min-width: $breakpoint-medium) {
     padding: var(--amplify-space-xl);
   }
-  
+
   @media (min-width: $breakpoint-large) {
     padding: var(--amplify-space-xxl);
   }
@@ -148,13 +164,29 @@
 
 .docs-grid-bg {
   background-image: url('/svg/grid.svg'),
-    linear-gradient(0deg, hsla(var(--docs-gradient-color-hsl), 1) 0%, hsla(var(--docs-gradient-color-hsl), 0) 35%),
-    linear-gradient(180deg, hsla(var(--docs-gradient-color-hsl), 1) 0%, hsla(var(--docs-gradient-color-hsl), 0) 35%);
+    linear-gradient(
+      0deg,
+      hsla(var(--docs-gradient-color-hsl), 1) 0%,
+      hsla(var(--docs-gradient-color-hsl), 0) 35%
+    ),
+    linear-gradient(
+      180deg,
+      hsla(var(--docs-gradient-color-hsl), 1) 0%,
+      hsla(var(--docs-gradient-color-hsl), 0) 35%
+    );
 }
 
 .docs-gradient-bg {
-  background-image: linear-gradient(0deg, hsla(var(--docs-gradient-color-hsl), 1) 0%, hsla(var(--docs-gradient-color-hsl), 0) 30%),
-  linear-gradient(180deg, hsla(var(--docs-gradient-color-hsl), 1) 0%, hsla(var(--docs-gradient-color-hsl), 0) 30%),
+  background-image: linear-gradient(
+      0deg,
+      hsla(var(--docs-gradient-color-hsl), 1) 0%,
+      hsla(var(--docs-gradient-color-hsl), 0) 30%
+    ),
+    linear-gradient(
+      180deg,
+      hsla(var(--docs-gradient-color-hsl), 1) 0%,
+      hsla(var(--docs-gradient-color-hsl), 0) 30%
+    ),
     linear-gradient(
       86deg,
       var(--amplify-colors-brand-primary-10) 12%,
@@ -165,45 +197,75 @@
       var(--amplify-colors-green-10) 24%,
       rgba(255, 255, 255, 0) 44%
     ),
-    linear-gradient(57deg, var(--amplify-colors-pink-10) 24%, rgba(255, 255, 255, 0) 37%),
+    linear-gradient(
+      57deg,
+      var(--amplify-colors-pink-10) 24%,
+      rgba(255, 255, 255, 0) 37%
+    ),
     radial-gradient(
       circle at 170% 64%,
       rgba(255, 255, 255, 0) 83%,
       var(--amplify-colors-brand-secondary-10) 100%
     ),
-    linear-gradient(175deg, hsla(var(--docs-gradient-color-hsl), 0) 0%, var(--amplify-colors-brand-secondary-10) 54%);
+    linear-gradient(
+      175deg,
+      hsla(var(--docs-gradient-color-hsl), 0) 0%,
+      var(--amplify-colors-brand-secondary-10) 54%
+    );
 }
 
 .docs-burst-bg {
   position: relative;
   z-index: 1;
-  
+
   &::before {
     content: '';
     z-index: -1;
     pointer-events: none;
     position: absolute;
-    top: 0; right: 0; bottom: 0; left: 0;
-    background-image: linear-gradient(0deg, hsla(var(--docs-gradient-color-hsl), 1) 0%, hsla(var(--docs-gradient-color-hsl), 0) 40%),
-      linear-gradient(180deg, hsla(var(--docs-gradient-color-hsl), 1) 0%, hsla(var(--docs-gradient-color-hsl), 0) 40%),
-      radial-gradient(circle at 0% 50%, var(--amplify-colors-pink-40), hsla(var(--docs-gradient-color-hsl), 0) 25%),
-      radial-gradient(circle at 85% 30%, var(--amplify-colors-purple-40), hsla(var(--docs-gradient-color-hsl), 0) 50%),
-      radial-gradient(circle at 35% 70%, var(--amplify-colors-teal-40), hsla(var(--docs-gradient-color-hsl), 0) 50%);
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-image: linear-gradient(
+        0deg,
+        hsla(var(--docs-gradient-color-hsl), 1) 0%,
+        hsla(var(--docs-gradient-color-hsl), 0) 40%
+      ),
+      linear-gradient(
+        180deg,
+        hsla(var(--docs-gradient-color-hsl), 1) 0%,
+        hsla(var(--docs-gradient-color-hsl), 0) 40%
+      ),
+      radial-gradient(
+        circle at 0% 50%,
+        var(--amplify-colors-pink-40),
+        hsla(var(--docs-gradient-color-hsl), 0) 25%
+      ),
+      radial-gradient(
+        circle at 85% 30%,
+        var(--amplify-colors-purple-40),
+        hsla(var(--docs-gradient-color-hsl), 0) 50%
+      ),
+      radial-gradient(
+        circle at 35% 70%,
+        var(--amplify-colors-teal-40),
+        hsla(var(--docs-gradient-color-hsl), 0) 50%
+      );
     opacity: 0.25;
   }
 }
-
 
 .with-lines {
   counter-reset: code-lines;
   margin: 0;
   padding: 0;
-  
+
   & .token-line {
     counter-increment: code-lines;
     position: relative;
     padding-left: 3rem;
-    
+
     &::before {
       position: absolute;
       left: 0;
@@ -211,7 +273,7 @@
       text-align: right;
       color: var(--amplify-colors-font-tertiary);
       opacity: 0.75;
-      content: counter(code-lines) " ";
+      content: counter(code-lines) ' ';
     }
   }
 }
@@ -222,13 +284,13 @@ pre.with-lines,
   margin: 0;
   padding: 0;
   padding-left: 3rem !important;
-  
+
   & .token-line {
     counter-increment: code-lines;
     position: relative;
     padding-left: 3rem;
     padding-left: 0;
-    
+
     &::before {
       position: absolute;
       left: -3rem;
@@ -236,7 +298,7 @@ pre.with-lines,
       text-align: right;
       color: var(--amplify-colors-font-tertiary);
       opacity: 0.75;
-      content: counter(code-lines) " ";
+      content: counter(code-lines) ' ';
     }
   }
 }
@@ -245,10 +307,11 @@ pre.with-lines,
   position: relative;
   background-color: var(--amplify-colors-background-secondary);
   border-radius: var(--amplify-radii-small);
-  border: var(--amplify-border-widths-small) solid var(--amplify-colors-border-primary);
+  border: var(--amplify-border-widths-small) solid
+    var(--amplify-colors-border-primary);
   box-shadow: var(--amplify-shadows-large);
   font-size: var(--amplify-font-sizes-medium);
-  
+
   &__header {
     position: relative;
     text-align: center;
@@ -274,7 +337,7 @@ pre.scrollable.prism-code {
   position: relative;
   width: 100%;
   height: 100%;
-  
+
   &.prism-code {
     margin: 0;
     padding: 0;
@@ -283,7 +346,7 @@ pre.scrollable.prism-code {
 
 .docs-home-figma {
   position: relative;
-  
+
   &__logo {
     position: absolute;
     top: 0;
@@ -292,7 +355,7 @@ pre.scrollable.prism-code {
     height: 10rem;
     opacity: 0.75;
   }
-  
+
   &__code,
   &__studio {
     border-radius: var(--amplify-radii-small);
@@ -306,18 +369,18 @@ pre.scrollable.prism-code {
       right: -5rem;
     }
   }
-  
+
   &__studio {
     padding-top: var(--amplify-space-medium);
     top: 0;
   }
-  
+
   &__code {
     bottom: -2rem;
   }
-  
+
   &__data {
-    outline: 2px dashed #1ABCFE;
+    outline: 2px dashed #1abcfe;
     position: relative;
     counter-increment: figma-data;
     &::before {
@@ -329,17 +392,17 @@ pre.scrollable.prism-code {
       line-height: 1.5rem;
       border-radius: 1.5rem;
       font-size: var(--amplify-font-sizes-small);
-      background-color: #1ABCFE;
+      background-color: #1abcfe;
       text-align: center;
       color: white;
       font-weight: var(--amplify-font-weights-bold);
     }
   }
-  
+
   &__node {
     position: relative;
     margin-top: 2rem;
-    border: 2px solid #1ABCFE;
+    border: 2px solid #1abcfe;
     padding: var(--amplify-space-medium);
     min-width: 20rem;
     max-width: 30rem;
@@ -347,43 +410,43 @@ pre.scrollable.prism-code {
       left: -2rem;
     }
   }
-  
+
   &__node-label {
     position: absolute;
     top: -2rem;
     left: 0;
     line-height: 1;
-    color: #1ABCFE;
-  
+    color: #1abcfe;
+
     & > .amplify-icon {
       margin-inline-end: var(--amplify-space-xs);
     }
   }
-  
+
   &__node-handles {
     position: absolute;
-    top: -.25rem;
-    left: -.25rem;
-    right: -.25rem;
-    
+    top: -0.25rem;
+    left: -0.25rem;
+    right: -0.25rem;
+
     &::before,
     &::after {
       content: '';
       position: absolute;
       width: 0.5rem;
       height: 0.5rem;
-      outline: 2px solid #1ABCFE;
+      outline: 2px solid #1abcfe;
       background: var(--amplify-colors-background-primary);
     }
-    
+
     &::after {
       right: 0;
       left: auto;
     }
-    
+
     &:nth-child(2) {
       top: auto;
-      bottom: .25rem;
+      bottom: 0.25rem;
     }
   }
 }
@@ -394,7 +457,8 @@ pre.scrollable.prism-code {
   }
   @media (min-width: $breakpoint-small) {
     position: relative;
-    border: var(--amplify-border-widths-small) solid var(--amplify-colors-border-primary);
+    border: var(--amplify-border-widths-small) solid
+      var(--amplify-colors-border-primary);
     box-shadow: var(--amplify-shadows-large);
     border-radius: var(--amplify-radii-small);
     background-color: var(--amplify-colors-background-primary);
@@ -417,7 +481,6 @@ pre.scrollable.prism-code {
       border-radius: var(--amplify-radii-xl);
       text-align: center;
       color: var(--amplify-colors-font-disabled);
-
     }
     &__page {
       padding: var(--amplify-space-large);
@@ -425,26 +488,25 @@ pre.scrollable.prism-code {
   }
 }
 
-
 .docs-home-coming-soon {
   opacity: 0.25;
   pointer-events: none;
 }
 
-
 .docs-home-editor {
   display: flex;
   flex-direction: row;
-  border: var(--amplify-border-widths-small) solid var(--amplify-colors-border-secondary);
+  border: var(--amplify-border-widths-small) solid
+    var(--amplify-colors-border-secondary);
   box-shadow: var(--amplify-shadows-medium);
   border-radius: var(--amplify-radii-small);
-  
+
   &__code-panel,
   &__preview-panel {
     flex: 1;
     padding: var(--amplify-space-medium);
   }
-  
+
   &__code-panel {
     border-start-start-radius: var(--amplify-radii-small);
     border-end-start-radius: var(--amplify-radii-small);
@@ -452,9 +514,10 @@ pre.scrollable.prism-code {
     overflow: auto;
     font-size: var(--amplify-font-sizes-medium);
     background-color: var(--amplify-colors-background-primary);
-    border-right: var(--amplify-border-widths-small) solid var(--amplify-colors-border-secondary);
+    border-right: var(--amplify-border-widths-small) solid
+      var(--amplify-colors-border-secondary);
   }
-  
+
   &__preview-panel {
     border-start-end-radius: var(--amplify-radii-small);
     border-end-end-radius: var(--amplify-radii-small);

--- a/docs/src/styles/docs/install-code.scss
+++ b/docs/src/styles/docs/install-code.scss
@@ -12,7 +12,7 @@
   padding: 0;
   overflow-x: auto;
   white-space: nowrap;
-  
+
   &::before {
     content: '$';
     color: var(--amplify-colors-brand-secondary-40);

--- a/docs/src/styles/docs/responsiveTable.scss
+++ b/docs/src/styles/docs/responsiveTable.scss
@@ -4,26 +4,30 @@ $breakpoint-tableBreak: $breakpoint-large;
 
 .docs-grid-bordered {
   border: solid var(--amplify-colors-border-tertiary);
-  border-width: var(--amplify-border-widths-small) 0 0 var(--amplify-border-widths-small);
+  border-width: var(--amplify-border-widths-small) 0 0
+    var(--amplify-border-widths-small);
   li {
     list-style: none;
     padding: var(--amplify-space-small);
     font-size: var(--amplify-font-sizes-small);
     border: solid var(--amplify-colors-border-tertiary);
-    border-width: 0 var(--amplify-border-widths-small) var(--amplify-border-widths-small) 0;
+    border-width: 0 var(--amplify-border-widths-small)
+      var(--amplify-border-widths-small) 0;
   }
 }
 
 .docs-responsiveTable {
   --labelWidth: 6rem;
   line-height: var(--amplify-line-heights-small);
-  pre, code {
+  pre,
+  code {
     margin: 0;
     padding: 0;
     background: none;
     white-space: normal;
   }
-  td, th {
+  td,
+  th {
     &:first-child {
       border-left: none;
     }
@@ -31,8 +35,9 @@ $breakpoint-tableBreak: $breakpoint-large;
       border-right: none;
     }
   }
-  &:not([data-highlightonhover=true]) {
-    td, th {
+  &:not([data-highlightonhover='true']) {
+    td,
+    th {
       &:first-child {
         padding-left: 0;
       }
@@ -43,13 +48,16 @@ $breakpoint-tableBreak: $breakpoint-large;
   }
   @media (max-width: $breakpoint-tableBreak) {
     display: block;
-    pre, code {
+    pre,
+    code {
       max-width: 100%;
     }
-    tr, th, tbody {
+    tr,
+    th,
+    tbody {
       display: block;
     }
-    &[data-highlightonhover=true] {
+    &[data-highlightonhover='true'] {
       .amplify-table__row:not(.amplify-table__head *):hover {
         background-color: transparent;
       }
@@ -58,26 +66,29 @@ $breakpoint-tableBreak: $breakpoint-large;
       /* We can't `display: none` a thead or SR won't recognize it */
       height: 0;
       overflow: hidden;
-      tr, th {
+      tr,
+      th {
         height: 0;
         margin: 0;
         overflow: hidden;
         border: none;
       }
     }
-    td, th  {
+    td,
+    th {
       padding: 0;
       display: flex;
       align-items: stretch;
       &:not(:last-child) {
-        border-bottom: var(--amplify-border-widths-small) solid var(--amplify-colors-border-tertiary);
+        border-bottom: var(--amplify-border-widths-small) solid
+          var(--amplify-colors-border-tertiary);
       }
     }
     tr {
-      border: var(--amplify-border-widths-small) solid var(--amplify-colors-border-secondary);
+      border: var(--amplify-border-widths-small) solid
+        var(--amplify-colors-border-secondary);
       margin-block-end: var(--amplify-space-small);
     }
-
   }
 }
 
@@ -97,7 +108,7 @@ $breakpoint-tableBreak: $breakpoint-large;
 }
 
 .docs-responsiveTable__value {
-  td:first-child &  {
+  td:first-child & {
     font-weight: var(--amplify-font-weights-bold);
   }
   @media (max-width: $breakpoint-tableBreak) {
@@ -108,6 +119,3 @@ $breakpoint-tableBreak: $breakpoint-large;
     padding: var(--amplify-space-xxs);
   }
 }
-
-
-

--- a/docs/src/styles/docs/tokenList.scss
+++ b/docs/src/styles/docs/tokenList.scss
@@ -49,7 +49,9 @@
   }
 }
 
-.docs-tokenItem--fontWeights, .docs-tokenItem--fontSizes, .docs-tokenItem--lineHeights {
+.docs-tokenItem--fontWeights,
+.docs-tokenItem--fontSizes,
+.docs-tokenItem--lineHeights {
   grid-template-columns: auto 1fr;
   .docs-fontBlock {
     grid-area: 1 / 1 / 4 / 1;
@@ -63,7 +65,8 @@
   }
 }
 
-.docs-tokenItem--space, .docs-tokenItem--borderWidths {
+.docs-tokenItem--space,
+.docs-tokenItem--borderWidths {
   grid-template-columns: 100px auto;
   @media (min-width: $breakpoint-medium) {
     grid-template-columns: 140px 100px 1fr auto;
@@ -75,7 +78,6 @@
     grid-template-columns: 140px 100px 280px auto;
   }
 }
-
 
 .docs-tokenItem--radii {
   grid-template-columns: auto;
@@ -105,7 +107,6 @@
   }
 }
 
-
 .docs-colorBlock {
   width: var(--swatch-size);
   height: var(--swatch-size);
@@ -114,7 +115,8 @@
   border-radius: 100%;
 }
 
-.docs-spaceBlock, .docs-borderBlock {
+.docs-spaceBlock,
+.docs-borderBlock {
   grid-area: 1 / 1 / 4 / 1;
   align-self: center;
   min-width: 100%;
@@ -135,16 +137,24 @@
 .docs-radiusBlock {
   svg {
     background-size: 1rem 1rem;
-    background-image:
-      linear-gradient(to right, var(--amplify-colors-neutral-20) 1px, transparent 1px),
-      linear-gradient(to bottom, var(--amplify-colors-neutral-20) 1px, transparent 1px);
+    background-image: linear-gradient(
+        to right,
+        var(--amplify-colors-neutral-20) 1px,
+        transparent 1px
+      ),
+      linear-gradient(
+        to bottom,
+        var(--amplify-colors-neutral-20) 1px,
+        transparent 1px
+      );
   }
 }
 .docs-radiusBlock-border {
   transform: translate(-100%, 0);
 }
 
-.docs-tokenItem-meta, .docs-tokenItem-path {
+.docs-tokenItem-meta,
+.docs-tokenItem-path {
   font-family: $font-code;
   font-size: var(--amplify-font-sizes-small);
 }

--- a/packages/ui/src/theme/css/component/button.scss
+++ b/packages/ui/src/theme/css/component/button.scss
@@ -203,10 +203,12 @@
       color: var(--amplify-components-button-link-active-color);
     }
   }
-  
+
   &--destructive {
     border-width: var(--amplify-components-button-destructive-border-width);
-    background-color: var(--amplify-components-button-destructive-background-color);
+    background-color: var(
+      --amplify-components-button-destructive-background-color
+    );
     border-color: var(--amplify-components-button-destructive-border-color);
     color: var(--amplify-components-button-destructive-color);
 
@@ -214,7 +216,9 @@
       background-color: var(
         --amplify-components-button-destructive-hover-background-color
       );
-      border-color: var(--amplify-components-button-destructive-hover-border-color);
+      border-color: var(
+        --amplify-components-button-destructive-hover-border-color
+      );
       color: var(--amplify-components-button-destructive-hover-color);
     }
 
@@ -222,7 +226,9 @@
       background-color: var(
         --amplify-components-button-destructive-focus-background-color
       );
-      border-color: var(--amplify-components-button-destructive-focus-border-color);
+      border-color: var(
+        --amplify-components-button-destructive-focus-border-color
+      );
       color: var(--amplify-components-button-destructive-focus-color);
       box-shadow: var(--amplify-components-button-destructive-focus-box-shadow);
     }
@@ -256,7 +262,7 @@
       --amplify-components-button-destructive-loading-color
     );
   }
-  
+
   &--warning {
     background-color: var(--amplify-components-button-warning-background-color);
     border-color: var(--amplify-components-button-warning-border-color);
@@ -305,7 +311,9 @@
       background-color: var(
         --amplify-components-button-warning-active-background-color
       );
-      border-color: var(--amplify-components-button-warning-active-border-color);
+      border-color: var(
+        --amplify-components-button-warning-active-border-color
+      );
       color: var(--amplify-components-button-warning-active-color);
     }
   }

--- a/packages/ui/src/theme/css/component/field.scss
+++ b/packages/ui/src/theme/css/component/field.scss
@@ -2,7 +2,7 @@
   font-size: var(--amplify-components-field-font-size);
   gap: var(--amplify-components-field-gap);
   flex-direction: var(--amplify-components-field-flex-direction);
-  
+
   &--small {
     font-size: var(--amplify-components-field-small-font-size);
     gap: var(--amplify-components-field-small-gap);

--- a/packages/ui/src/theme/css/component/switchField.scss
+++ b/packages/ui/src/theme/css/component/switchField.scss
@@ -54,7 +54,9 @@
     box-shadow: var(--amplify-components-switchfield-focused-shadow);
   }
   &--error {
-    background-color: var(--amplify-components-switchfield-track-error-background-color);
+    background-color: var(
+      --amplify-components-switchfield-track-error-background-color
+    );
   }
 }
 

--- a/packages/ui/src/theme/css/component/toggleButtonGroup.scss
+++ b/packages/ui/src/theme/css/component/toggleButtonGroup.scss
@@ -11,9 +11,11 @@
     &.amplify-togglebutton--pressed {
       z-index: 2;
     }
-    
+
     &:not(:first-of-type) {
-      margin-inline-start: calc(-1 * var(--amplify-components-button-border-width));
+      margin-inline-start: calc(
+        -1 * var(--amplify-components-button-border-width)
+      );
       border-start-start-radius: 0;
       border-end-start-radius: 0;
       // required for Safari 14 and below
@@ -23,7 +25,7 @@
         border-bottom-left-radius: 0;
       }
     }
-    
+
     &:not(:last-of-type) {
       border-start-end-radius: 0;
       border-end-end-radius: 0;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Sets prettier as the default formatter in vscode settings for css.

In the recent Button PR I opened, some of the variable names are quite long and the default formatting was adding extra spaces to custom css properties, like `var(  --variable )` instead of `var(--variable)` which breaks the css. I tested this change in my Button branch and it fixes the broken variables.

I went through and re-saved all of the css/scss files I could find so there are some formatting changes in some of the files.

Can smoke test here: https://fixprettiercss.dvmvffzts1tcu.amplifyapp.com/

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
