### PR TITLE
chore(ui): remove deprecated scrollview css

### DIFF
--- a/packages/ui/src/theme/css/component/scrollView.scss
+++ b/packages/ui/src/theme/css/component/scrollView.scss
@@ -1,14 +1,4 @@
 .amplify-scrollview {
   display: block;
   overflow: auto;
-  // @TODO: Deprecated - Remove in 3.0
-  &--horizontal {
-    overflow-x: scroll;
-    overflow-y: initial;
-  }
-  // @TODO: Deprecated - Remove in 3.0
-  &--vertical {
-    overflow-x: initial;
-    overflow-y: scroll;
-  }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Remove deprecated scrollview css from a couple versions back. I did a search for usage of `.amplify-scrollview--horizontal` and `.amplify-scrollview--vertical` and couldn't find any.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
