### PR TITLE
chore(e2e): increase timeouts, bump Detox, update macos runner

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -348,7 +348,7 @@ jobs:
   e2e-ios:
     needs: check-changed-packages
     if: ${{ inputs.skip-changed-packages-check == 'true' || needs.check-changed-packages.outputs.has-changed-packages == 'true' }}
-    runs-on: macos-13
+    runs-on: macos-12
     environment: ci
     env:
       NODE_ENV: test

--- a/packages/e2e/.detoxrc.json
+++ b/packages/e2e/.detoxrc.json
@@ -42,7 +42,7 @@
     "simulator": {
       "type": "ios.simulator",
       "device": {
-        "type": "iPhone 14"
+        "type": "iPhone 13"
       }
     },
     "emulator": {

--- a/packages/e2e/detox/init.ts
+++ b/packages/e2e/detox/init.ts
@@ -15,9 +15,9 @@ dotenv.config();
 
 // Cucumber has default timeout of 5000, not enough for Detox async operations
 // https://wix.github.io/Detox/docs/guide/cucumber-js-integration
-// anything lower than 400000 (6min) has caused flakiness in CI, especially for initial bundling
+// anything lower than 500000 (8min) has caused flakiness in CI, especially for initial bundling
 // TODO: review when more powerful mac-os runtimes are available in github workflows
-setDefaultTimeout(400000);
+setDefaultTimeout(500000);
 
 BeforeAll(async () => {
   await init({

--- a/packages/e2e/features/ui/components/authenticator/confirm-sign-up.feature
+++ b/packages/e2e/features/ui/components/authenticator/confirm-sign-up.feature
@@ -19,7 +19,7 @@ Feature: Confirm Sign Up
     Then I see "Enter this code:"
     Then I see "It will take several minutes to arrive."
 
-  @react-native
+  @todo-react-native
   Scenario: Confirm new password page has correct translations
     When I type a new "email"
     And I type my password

--- a/packages/e2e/features/ui/components/authenticator/verify-user.feature
+++ b/packages/e2e/features/ui/components/authenticator/verify-user.feature
@@ -3,6 +3,8 @@ Feature: Verify User
   If end user tries to sign in with unverified account, Authenticator will
   redirect them to account verification screen.
 
+  Note: tests are skipped for React Native, need separate app for verify-user so we don't mock sign-in
+   
   Background:
     Given I'm running the example "/ui/components/authenticator/sign-in-with-email"
     And I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.GetUserAttributeVerificationCode" } }' with fixture "verify-user-email"
@@ -49,7 +51,7 @@ Feature: Verify User
     Then I see "Sign out"
     And I click the "Sign out" button
 
-  @todo-angular @todo-react @todo-vue @todo-react-native 
+  @todo-angular @todo-react @todo-vue @todo-react-native
   Scenario: Redirect to "Confirm Verify" page and verify custom header and footer 
     When I type my "email" with status "UNVERIFIED"
     And I type my password

--- a/packages/e2e/features/ui/components/authenticator/verify-user.feature
+++ b/packages/e2e/features/ui/components/authenticator/verify-user.feature
@@ -19,7 +19,7 @@ Feature: Verify User
     Then "New Label" field does not have class "amplify-visually-hidden"
     Then I see placeholder "Enter your Confirmation Code:"
 
-  @react-nativee
+  @todo-react-native
   Scenario: Redirect to "Confirm Verify" page and replace label
     When I type my "email" with status "UNVERIFIED"
     And I type my password
@@ -30,7 +30,7 @@ Feature: Verify User
     And I click the "Skip" button
     And I click the "Sign out" button
 
-  @angular @react @vue @react-nativee
+  @angular @react @vue @todo-react-native
   Scenario: Redirect to "Verify" page and verify custom header and footer text
     When I type my "email" with status "UNVERIFIED"
     And I type my password
@@ -40,7 +40,7 @@ Feature: Verify User
     And I click the "Skip" button
     And I click the "Sign out" button
 
-  @angular @react @vue @react-nativee
+  @angular @react @vue @todo-react-native
   Scenario: Skip verify account
     When I type my "email" with status "UNVERIFIED"
     And I type my password
@@ -49,7 +49,7 @@ Feature: Verify User
     Then I see "Sign out"
     And I click the "Sign out" button
 
-  @todo-angular @todo-react @todo-vue @todo-react-native
+  @todo-angular @todo-react @todo-vue @todo-react-native 
   Scenario: Redirect to "Confirm Verify" page and verify custom header and footer 
     When I type my "email" with status "UNVERIFIED"
     And I type my password

--- a/yarn.lock
+++ b/yarn.lock
@@ -14942,19 +14942,19 @@ detect-port@^1.3.0:
     debug "4"
 
 detox@^20.6.0:
-  version "20.6.0"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-20.6.0.tgz#9aef5d7d17c5a0e8a96592570a510881ac59c249"
-  integrity sha512-89YxptnkvyQazN2I8EDRkH8tWqiOvqsGXZCZwUKP5lsulBSTJka7SS5Fd8AnQGUd5vPs+tTqO+zb0FgCRcV/Tg==
+  version "20.11.2"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-20.11.2.tgz#7628ad7909b343069e164fbada428ac12464eb67"
+  integrity sha512-UuaIO0DzXnmrcEswVvsrP1AboEyUuJbcO+GAg3/I3aZNqIPS2hSu2jhHnIiQVj0QI2DGuCaw0y8QMTCG2KqE3Q==
   dependencies:
     ajv "^8.6.3"
     bunyan "^1.8.12"
     bunyan-debug-stream "^3.1.0"
     caf "^15.0.1"
-    chalk "^2.4.2"
+    chalk "^4.0.0"
     child-process-promise "^2.2.0"
     execa "^5.1.1"
-    find-up "^4.1.0"
-    fs-extra "^4.0.2"
+    find-up "^5.0.0"
+    fs-extra "^11.0.0"
     funpermaproxy "^1.1.0"
     glob "^8.0.3"
     ini "^1.3.4"
@@ -14962,7 +14962,7 @@ detox@^20.6.0:
     lodash "^4.17.11"
     multi-sort-stream "^1.0.3"
     multipipe "^4.0.0"
-    node-ipc "^9.2.1"
+    node-ipc "9.2.1"
     proper-lockfile "^3.0.2"
     resolve-from "^5.0.0"
     sanitize-filename "^1.6.1"
@@ -14977,8 +14977,8 @@ detox@^20.6.0:
     trace-event-lib "^1.3.1"
     which "^1.3.1"
     ws "^7.0.0"
-    yargs "^16.0.3"
-    yargs-parser "^20.2.9"
+    yargs "^17.0.0"
+    yargs-parser "^21.0.0"
     yargs-unparser "^2.0.0"
 
 devtools-protocol@0.0.1107588:
@@ -17417,14 +17417,14 @@ fs-extra@^10.0.0, fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
-  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+fs-extra@^11.0.0:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
   dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^5.0.0:
   version "5.0.0"
@@ -23610,7 +23610,7 @@ node-int64@^0.4.0:
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-ipc@^9.2.1:
+node-ipc@9.2.1:
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/node-ipc/-/node-ipc-9.2.1.tgz#b32f66115f9d6ce841dc4ec2009d6a733f98bb6b"
   integrity sha512-mJzaM6O3xHf9VT8BULvJSbdVbmHUKRNOH7zDDkCrA1/T+CVjq2WVIDfLt0azZRXpgArJtl3rtmEozrbXPZ9GaQ==
@@ -31463,7 +31463,7 @@ yaml@2.2.1, yaml@2.2.2, yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2, yaml@^2.1.1, ya
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
   integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
 
-yargs-parser@20.x, yargs-parser@^20.2.2, yargs-parser@^20.2.9:
+yargs-parser@20.x, yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
@@ -31534,7 +31534,7 @@ yargs@^15.1.0, yargs@^15.3.1, yargs@^15.4.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^16.0.3, yargs@^16.1.1, yargs@^16.2.0:
+yargs@^16.1.1, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
@@ -31547,7 +31547,7 @@ yargs@^16.0.3, yargs@^16.1.1, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.2.1, yargs@^17.3.1:
+yargs@^17.0.0, yargs@^17.2.1, yargs@^17.3.1:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This change:
* updates the timeout for app initialization to help address tests failures, both iOS and Android are timing out recently:
 https://github.com/aws-amplify/amplify-ui/actions/runs/5729414515/job/15531648865
 https://github.com/aws-amplify/amplify-ui/actions/runs/5729414515/job/15531649133

* refreshes yarn.lock file to update Detox version to latest.

* switches runner for ios tests to previous version (macos-12), the tests failures started happening with updated runners: https://github.com/actions/runner-images/issues/8027

* temporarily skip `Confirm new password page has correct translations` has been consistently failing in CI for both platforms, loses connection to Metro.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
