### PR TITLE
 fix(Docs): Clicking on Size on Ratings docs takes you to select dropdown instead of Size section #4096 

### DIFF
--- a/docs/src/pages/[platform]/components/rating/RatingPropControls.tsx
+++ b/docs/src/pages/[platform]/components/rating/RatingPropControls.tsx
@@ -72,7 +72,6 @@ export const RatingPropControls: RatingPropControlsInterface = ({
 
       <SelectField
         name="size"
-        id="size"
         label="size"
         value={size}
         onChange={(event) =>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- the size option in right hand navigation was taking  user to size drop down instead of 'Size section' [here](https://ui.docs.amplify.aws/react/components/rating#size).
- It was caused by `id='root'` property of that dropdown.
- removed the `id=root` that fixed the issue


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #4096 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
build and ran the docs in localhost

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
