### PR TITLE
chore: set amplify dependencies to be ^ instead of >=

### DIFF
--- a/.changeset/grumpy-feet-raise.md
+++ b/.changeset/grumpy-feet-raise.md
@@ -1,0 +1,15 @@
+---
+"@aws-amplify/ui-react-core-notifications": patch
+"@aws-amplify/ui-react-core": patch
+"@aws-amplify/ui-react-geo": patch
+"@aws-amplify/ui-react-liveness": patch
+"@aws-amplify/ui-react-native": patch
+"@aws-amplify/ui-react-notifications": patch
+"@aws-amplify/ui-react-storage": patch
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-vue": patch
+"@aws-amplify/ui-angular": patch
+---
+
+chore: set amplify dependencies to be ^ instead of >=

--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "@angular/core": ">= 14.0.0",
-    "aws-amplify": ">= 5.0.1"
+    "aws-amplify": "^5.0.1"
   },
   "dependencies": {
     "@aws-amplify/ui": "5.6.9",

--- a/packages/react-core-notifications/package.json
+++ b/packages/react-core-notifications/package.json
@@ -40,7 +40,7 @@
     "@aws-amplify/ui-react-core": "2.1.28"
   },
   "peerDependencies": {
-    "aws-amplify": ">= 5.0.1",
+    "aws-amplify": "^5.0.1",
     "react": ">= 16.14.0"
   },
   "devDependencies": {

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -37,7 +37,7 @@
     "xstate": "^4.33.6"
   },
   "peerDependencies": {
-    "aws-amplify": ">= 5.0.1",
+    "aws-amplify": "^5.0.1",
     "react": ">= 16.14.0"
   },
   "devDependencies": {

--- a/packages/react-geo/package.json
+++ b/packages/react-geo/package.json
@@ -47,7 +47,7 @@
     "tslib": "2.4.1"
   },
   "peerDependencies": {
-    "aws-amplify": ">= 5.0.1",
+    "aws-amplify": "^5.0.1",
     "react": ">= 16.14.0",
     "react-dom": ">= 16.14.0"
   },

--- a/packages/react-liveness/package.json
+++ b/packages/react-liveness/package.json
@@ -43,7 +43,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "aws-amplify": ">= 5.0.1",
+    "aws-amplify": "^5.0.1",
     "react": ">= 16.14.0",
     "react-dom": ">= 16.14.0"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -45,7 +45,7 @@
     "@aws-amplify/ui-react-core-notifications": "1.0.5"
   },
   "peerDependencies": {
-    "aws-amplify": ">= 5.0.1",
+    "aws-amplify": "^5.0.1",
     "react": ">= 16.14.0",
     "react-native": ">= 0.63.4",
     "react-native-safe-area-context": ">= 4.2.5"

--- a/packages/react-notifications/package.json
+++ b/packages/react-notifications/package.json
@@ -47,7 +47,7 @@
     "tinycolor2": "1.4.2"
   },
   "peerDependencies": {
-    "aws-amplify": ">= 5.0.1",
+    "aws-amplify": "^5.0.1",
     "react": ">= 16.14.0",
     "react-dom": ">= 16.14.0"
   },

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -48,7 +48,7 @@
     "tslib": "2.4.1"
   },
   "peerDependencies": {
-    "aws-amplify": ">= 5.0.1",
+    "aws-amplify": "^5.0.1",
     "react": ">= 16.14.0",
     "react-dom": ">= 16.14.0"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,7 +63,7 @@
     "tslib": "2.4.1"
   },
   "peerDependencies": {
-    "aws-amplify": ">= 5.0.1",
+    "aws-amplify": "^5.0.1",
     "react": ">= 16.14.0",
     "react-dom": ">= 16.14.0"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -51,7 +51,7 @@
     "tslib": "2.4.1"
   },
   "peerDependencies": {
-    "aws-amplify": ">= 5.0.1",
+    "aws-amplify": "^5.0.1",
     "xstate": "^4.33.6"
   },
   "peerDependenciesMeta": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -78,6 +78,6 @@
     "vue-tsc": "~0.40.10"
   },
   "peerDependencies": {
-    "aws-amplify": ">= 5.0.1"
+    "aws-amplify": "^5.0.1"
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Ensure that when aws-amplify upgrades to 6.x we do not break our peerDeps for customers, set the aws-amplify dep in our packages to be ^ instead of >=

Screenshot showing no other packages in our package.json seem to have the >=

<img width="462" alt="Screenshot 2023-08-04 at 10 36 12 AM" src="https://github.com/aws-amplify/amplify-ui/assets/68032955/1a530e75-8ec5-43ae-8d5c-1b61210d4cdf">

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
