### PR TITLE
fix(react): update 4.x version to use ^ version of aws-amplify

### DIFF
--- a/.changeset/giant-bugs-rush.md
+++ b/.changeset/giant-bugs-rush.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(react): update 4.x version to use ^ version of aws-amplify

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,7 +69,7 @@
     "tslib": "2.4.1"
   },
   "peerDependencies": {
-    "aws-amplify": ">= 5.0.1",
+    "aws-amplify": "^5.0.1",
     "react": ">= 16.14.0",
     "react-dom": ">= 16.14.0"
   },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Patching 4.x version to use ^ for `aws-amplify` peer dependency
- Version packages PR which released `ui-react-@4.6.4` - https://github.com/aws-amplify/amplify-ui/pull/3973
- Actual commit - https://github.com/aws-amplify/amplify-ui/commit/52ece83b6b54c8ec24bad33c3ceed8b74e70822a

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
