### PR TITLE
chore(docs): clean up TextAreaField demos

### DIFF
--- a/docs/src/pages/[platform]/components/textareafield/TextAreaFieldPropControls.tsx
+++ b/docs/src/pages/[platform]/components/textareafield/TextAreaFieldPropControls.tsx
@@ -8,12 +8,6 @@ import {
 } from '@aws-amplify/ui-react';
 
 export interface TextAreaFieldControlsProps extends BaseTextAreaFieldProps {
-  setAutoComplete: (
-    value: React.SetStateAction<BaseTextAreaFieldProps['autoComplete']>
-  ) => void;
-  setDefaultValue: (
-    value: React.SetStateAction<BaseTextAreaFieldProps['defaultValue']>
-  ) => void;
   setDescriptiveText: (
     value: React.SetStateAction<BaseTextAreaFieldProps['descriptiveText']>
   ) => void;
@@ -29,17 +23,11 @@ export interface TextAreaFieldControlsProps extends BaseTextAreaFieldProps {
   setIsReadOnly: (
     value: React.SetStateAction<BaseTextAreaFieldProps['isReadOnly']>
   ) => void;
-  setIsRequired: (
-    value: React.SetStateAction<BaseTextAreaFieldProps['isRequired']>
-  ) => void;
   setLabel: (
     value: React.SetStateAction<BaseTextAreaFieldProps['label']>
   ) => void;
   setLabelHidden: (
     value: React.SetStateAction<BaseTextAreaFieldProps['labelHidden']>
-  ) => void;
-  setMaxLength: (
-    value: React.SetStateAction<BaseTextAreaFieldProps['maxLength']>
   ) => void;
   setName: (
     value: React.SetStateAction<BaseTextAreaFieldProps['name']>
@@ -53,9 +41,6 @@ export interface TextAreaFieldControlsProps extends BaseTextAreaFieldProps {
   setRows: (
     value: React.SetStateAction<BaseTextAreaFieldProps['rows']>
   ) => void;
-  setValue: (
-    value: React.SetStateAction<BaseTextAreaFieldProps['value']>
-  ) => void;
   setVariation: (
     value: React.SetStateAction<BaseTextAreaFieldProps['variation']>
   ) => void;
@@ -66,61 +51,33 @@ interface TextAreaFieldControlsInterface {
 }
 
 export const TextAreaFieldPropControls: TextAreaFieldControlsInterface = ({
-  autoComplete,
-  defaultValue,
   descriptiveText,
   errorMessage,
   hasError,
   isDisabled,
   isReadOnly,
-  isRequired,
   label,
   labelHidden,
-  maxLength,
   name,
   placeholder,
   rows,
-  setAutoComplete,
-  setDefaultValue,
   setDescriptiveText,
   setErrorMessage,
   setHasError,
   setIsDisabled,
   setIsReadOnly,
-  setIsRequired,
   setLabel,
   setLabelHidden,
-  setMaxLength,
   setName,
   setPlaceholder,
   setRows,
   setSize,
-  setValue,
   setVariation,
   size,
-  value,
   variation,
 }) => {
   return (
     <Flex direction="column">
-      <TextField
-        placeholder="Set autocomplete"
-        name="autocomplete"
-        value={autoComplete}
-        onChange={(event: any) => {
-          setAutoComplete(event.target.value);
-        }}
-        label="autocomplete"
-      />
-      <TextField
-        placeholder="Set default value"
-        name="defaultValue"
-        value={defaultValue}
-        onChange={(event: any) => {
-          setDefaultValue(event.target.value);
-        }}
-        label="defaultValue"
-      />
       <TextField
         placeholder="Set label"
         name="label"
@@ -158,15 +115,6 @@ export const TextAreaFieldPropControls: TextAreaFieldControlsInterface = ({
         label="rows"
       />
       <TextField
-        placeholder="Set maxLength"
-        name="maxLength"
-        value={maxLength}
-        onChange={(event: any) => {
-          setMaxLength(event.target.value);
-        }}
-        label="maxLength"
-      />
-      <TextField
         placeholder="Set descriptive text"
         name="descriptiveText"
         value={descriptiveText.toString()}
@@ -183,15 +131,6 @@ export const TextAreaFieldPropControls: TextAreaFieldControlsInterface = ({
           setErrorMessage(event.target.value);
         }}
         label="errorMessage"
-      />
-      <TextField
-        placeholder="Set value"
-        name="value"
-        value={value}
-        onChange={(event: any) => {
-          setValue(event.target.value);
-        }}
-        label="value"
       />
       <Flex wrap="wrap">
         <SwitchField
@@ -227,14 +166,6 @@ export const TextAreaFieldPropControls: TextAreaFieldControlsInterface = ({
             setIsReadOnly(!isReadOnly);
           }}
           label="isReadOnly"
-        />
-        <SwitchField
-          checked={isRequired}
-          name="isRequired"
-          onChange={() => {
-            setIsRequired(!isRequired);
-          }}
-          label="isRequired"
         />
       </Flex>
 

--- a/docs/src/pages/[platform]/components/textareafield/demo.tsx
+++ b/docs/src/pages/[platform]/components/textareafield/demo.tsx
@@ -68,7 +68,7 @@ export const TextAreaFieldDemo = () => {
   placeholder="${placeholder}"` +
     (rows
       ? `
-  rows="${rows}"`
+  rows={${rows}}`
       : '') +
     (size
       ? `

--- a/docs/src/pages/[platform]/components/textareafield/demo.tsx
+++ b/docs/src/pages/[platform]/components/textareafield/demo.tsx
@@ -1,124 +1,69 @@
 import * as React from 'react';
 
-import {
-  TextAreaField,
-  Flex,
-  FlexContainerStyleProps,
-  BaseTextAreaFieldProps,
-} from '@aws-amplify/ui-react';
+import { TextAreaField, BaseTextAreaFieldProps } from '@aws-amplify/ui-react';
 
 import { Demo } from '@/components/Demo';
 import { useTextAreaFieldProps } from './useTextAreaFieldProps';
-import { GetFieldControls } from '../shared/GetFieldControls';
-import { useFlexContainerStyleProps } from '../shared/useFlexContainerStyleProps';
 import { TextAreaFieldPropControls } from './TextAreaFieldPropControls';
 
 export const TextAreaFieldDemo = () => {
-  const flexStyleProps = useFlexContainerStyleProps({
-    alignItems: '',
-    alignContent: '',
-    direction: 'column',
-    gap: '',
-    justifyContent: '',
-    wrap: 'nowrap',
-  });
   const textFieldProps = useTextAreaFieldProps({
-    autoComplete: 'off',
-    defaultValue: null,
     descriptiveText: 'Enter a valid last name',
     errorMessage: '',
     hasError: false,
     isDisabled: false,
-    isReadOnly: false,
-    isRequired: false,
     label: 'Last name',
     labelHidden: false,
     name: 'last_name',
     placeholder: 'Baggins',
     rows: 3,
-    maxLength: null,
-    size: 'small',
-    value: null,
+    size: null,
     variation: null,
   });
-  const FlexPropControls = GetFieldControls({
-    typeName: 'Flex',
-    fields: flexStyleProps,
-  });
-
-  const [
-    [alignItems],
-    [alignContent],
-    [direction],
-    [gap],
-    [justifyContent],
-    [wrap],
-  ] = flexStyleProps;
 
   const {
-    autoComplete,
-    defaultValue,
     hasError,
     label,
     descriptiveText,
     errorMessage,
     isDisabled,
     isReadOnly,
-    isRequired,
     labelHidden,
     placeholder,
     size,
     rows,
-    maxLength,
-    value,
     name,
     variation,
   } = textFieldProps;
 
   const code =
     `<TextAreaField` +
-    (alignContent
+    (descriptiveText
       ? `
-  alignContent={${alignContent}}`
+  descriptiveText="${descriptiveText}"`
       : '') +
-    (alignItems
-      ? `
-    alignItems={${alignItems}}`
-      : '') +
-    `
-  autoComplete="${autoComplete}"
-  descriptiveText="${descriptiveText}"` +
-    (defaultValue
-      ? `
-  defaultValue="${defaultValue}"`
-      : '') +
-    `
-  direction="${direction}"` +
     (errorMessage
       ? `
   errorMessage="${errorMessage}"`
       : '') +
-    (gap
+    (hasError
       ? `
-  gap="${gap}"`
+  hasError={${hasError}}`
       : '') +
-    `
-  hasError={${hasError}}
-  isDisabled={${isDisabled}}
-  isReadOnly={${isReadOnly}}
-  isRequired={${isRequired}}` +
-    (justifyContent
+    (isDisabled
       ? `
-  justifyContent={${justifyContent}}`
+  isDisabled={${isDisabled}}`
+      : '') +
+    (isReadOnly
+      ? `
+  isReadOnly={${isReadOnly}}`
+      : '') +
+    (labelHidden
+      ? `
+  labelHidden={${labelHidden}}`
       : '') +
     `
   label="${label}"
-  labelHidden={${labelHidden}} ` +
-    (maxLength
-      ? `
-  maxLength="${maxLength}"`
-      : '') +
-    `
   name="${name}"
   placeholder="${placeholder}"` +
     (rows
@@ -129,84 +74,32 @@ export const TextAreaFieldDemo = () => {
       ? `
   size="${size}"`
       : '') +
-    (value
-      ? `
-  value="${value}"`
-      : '') +
     (variation
       ? `
   variation="${variation}"`
       : '') +
-    `
-  wrap="${wrap}"
-  onChange={(e) => console.info(e.currentTarget.value)}
-  onInput={(e) => console.info('input fired:', e.currentTarget.value)}
-  onCopy={(e) => console.info('onCopy fired:', e.currentTarget.value)}
-  onCut={(e) => console.info('onCut fired:', e.currentTarget.value)}
-  onPaste={(e) => console.info('onPaste fired:', e.currentTarget.value)}
-  onSelect={(e) =>
-    console.info(
-      'onSelect fired:',
-      e.currentTarget.value.substring(
-        e.currentTarget.selectionStart,
-        e.currentTarget.selectionEnd
-      )
-    )
-  }
-/>`;
+    `/>`;
 
   return (
     <Demo
       code={code}
-      propControls={
-        <Flex direction="column">
-          <TextAreaFieldPropControls {...textFieldProps} />
-          {FlexPropControls}
-        </Flex>
-      }
+      propControls={<TextAreaFieldPropControls {...textFieldProps} />}
     >
       <TextAreaField
-        alignContent={alignContent as FlexContainerStyleProps['alignContent']}
-        alignItems={alignItems as FlexContainerStyleProps['alignItems']}
-        autoComplete={autoComplete as BaseTextAreaFieldProps['autoComplete']}
         descriptiveText={
           descriptiveText as BaseTextAreaFieldProps['descriptiveText']
         }
-        defaultValue={defaultValue as BaseTextAreaFieldProps['defaultValue']}
-        direction={direction as FlexContainerStyleProps['direction']}
         errorMessage={errorMessage as BaseTextAreaFieldProps['errorMessage']}
-        gap={gap as FlexContainerStyleProps['gap']}
         hasError={hasError as unknown as boolean}
         isDisabled={isDisabled as unknown as boolean}
         isReadOnly={isReadOnly as unknown as boolean}
-        isRequired={isRequired as unknown as boolean}
-        justifyContent={
-          justifyContent as FlexContainerStyleProps['justifyContent']
-        }
         label={label as BaseTextAreaFieldProps['label']}
         labelHidden={labelHidden as unknown as boolean}
-        maxLength={maxLength as BaseTextAreaFieldProps['maxLength']}
         name={name as BaseTextAreaFieldProps['name']}
         placeholder={placeholder as BaseTextAreaFieldProps['placeholder']}
         rows={rows as BaseTextAreaFieldProps['rows']}
         size={size as BaseTextAreaFieldProps['size']}
-        value={value as BaseTextAreaFieldProps['value']}
         variation={variation as BaseTextAreaFieldProps['variation']}
-        wrap={wrap as FlexContainerStyleProps['wrap']}
-        onChange={(e) => console.info(e.currentTarget.value)}
-        onInput={(e) => console.info('input fired:', e.currentTarget.value)}
-        onCopy={(e) => console.info('onCopy fired:', e.currentTarget.value)}
-        onCut={(e) => console.info('onCut fired:', e.currentTarget.value)}
-        onPaste={(e) => console.info('onPaste fired:', e.currentTarget.value)}
-        onSelect={(e) =>
-          console.info(
-            'onSelect fired:',
-            e.currentTarget.value.substring(
-              e.currentTarget.selectionStart,
-              e.currentTarget.selectionEnd
-            )
-          )
-        }
       />
     </Demo>
   );

--- a/docs/src/pages/[platform]/components/textareafield/useTextAreaFieldProps.tsx
+++ b/docs/src/pages/[platform]/components/textareafield/useTextAreaFieldProps.tsx
@@ -5,14 +5,6 @@ import { BaseTextAreaFieldProps } from '@aws-amplify/ui-react';
 export const useTextAreaFieldProps = (
   initialValues: BaseTextAreaFieldProps
 ) => {
-  const [autoComplete, setAutoComplete] = React.useState<
-    BaseTextAreaFieldProps['autoComplete']
-  >(initialValues.autoComplete);
-
-  const [defaultValue, setDefaultValue] = React.useState<
-    BaseTextAreaFieldProps['defaultValue']
-  >(initialValues.defaultValue);
-
   const [hasError, setHasError] = React.useState<
     BaseTextAreaFieldProps['hasError']
   >(initialValues.hasError);
@@ -37,10 +29,6 @@ export const useTextAreaFieldProps = (
     BaseTextAreaFieldProps['isReadOnly']
   >(initialValues.isReadOnly);
 
-  const [isRequired, setIsRequired] = React.useState<
-    BaseTextAreaFieldProps['isRequired']
-  >(initialValues.isRequired);
-
   const [labelHidden, setLabelHidden] = React.useState<
     BaseTextAreaFieldProps['labelHidden']
   >(initialValues.labelHidden);
@@ -48,10 +36,6 @@ export const useTextAreaFieldProps = (
   const [placeholder, setPlaceholder] = React.useState<
     BaseTextAreaFieldProps['placeholder']
   >(initialValues.placeholder);
-
-  const [maxLength, setMaxLength] = React.useState<
-    BaseTextAreaFieldProps['maxLength']
-  >(initialValues.maxLength);
 
   const [name, setName] = React.useState<BaseTextAreaFieldProps['name']>(
     initialValues.name
@@ -65,31 +49,21 @@ export const useTextAreaFieldProps = (
     initialValues.size
   );
 
-  const [value, setValue] = React.useState<BaseTextAreaFieldProps['value']>(
-    initialValues.value
-  );
-
   const [variation, setVariation] = React.useState<
     BaseTextAreaFieldProps['variation']
   >(initialValues.variation);
 
   return {
-    autoComplete,
-    defaultValue,
     descriptiveText,
     errorMessage,
     hasError,
     isDisabled,
     isReadOnly,
-    isRequired,
     label,
     labelHidden,
-    maxLength,
     name,
     placeholder,
     rows,
-    setAutoComplete,
-    setDefaultValue,
     setDescriptiveText,
     setErrorMessage,
     setHasError,
@@ -98,15 +72,12 @@ export const useTextAreaFieldProps = (
     setIsRequired,
     setLabel,
     setLabelHidden,
-    setMaxLength,
     setName,
     setPlaceholder,
     setRows,
     setSize,
-    setValue,
     setVariation,
     size,
-    value,
     variation,
   };
 };

--- a/docs/src/pages/[platform]/components/textareafield/useTextAreaFieldProps.tsx
+++ b/docs/src/pages/[platform]/components/textareafield/useTextAreaFieldProps.tsx
@@ -69,7 +69,6 @@ export const useTextAreaFieldProps = (
     setHasError,
     setIsDisabled,
     setIsReadOnly,
-    setIsRequired,
     setLabel,
     setLabelHidden,
     setName,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

The TextAreaField demo had a lot of verbose props that are documented elsewhere or aren't really useful in the demo. Removed a bunch of those so that the demo code is more copy/paste-able and doesn't show false/empty props.

**Before**
<img width="400" src="https://github.com/aws-amplify/amplify-ui/assets/376920/af5e0b61-3c04-45ec-927a-a53242e0c99a" alt=""/>

**After**
<img width="400" src="https://github.com/aws-amplify/amplify-ui/assets/376920/bd1cebe6-8b93-413a-b733-5df3efd50912" alt=""/>

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
