### PR TITLE
fix(ui): disabled styles for search field button

### DIFF
--- a/.changeset/sour-dogs-turn.md
+++ b/.changeset/sour-dogs-turn.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(ui): Fix disabled hover style for SearchField button

--- a/packages/ui/src/theme/css/component/searchField.scss
+++ b/packages/ui/src/theme/css/component/searchField.scss
@@ -14,15 +14,6 @@
       border-color: var(--amplify-components-button-active-border-color);
       color: var(--amplify-components-button-active-color);
     }
-    &:disabled {
-      background-color: var(
-        --amplify-components-searchfield-button-disabled-background-color
-      );
-      border-color: var(
-        --amplify-components-searchfield-button-disabled-border-color
-      );
-      color: var(--amplify-components-searchfield-button-disabled-color);
-    }
     &:focus {
       background-color: var(
         --amplify-components-searchfield-button-focus-background-color
@@ -40,6 +31,15 @@
         --amplify-components-searchfield-button-hover-border-color
       );
       color: var(--amplify-components-searchfield-button-hover-color);
+    }
+    &:disabled {
+      background-color: var(
+        --amplify-components-searchfield-button-disabled-background-color
+      );
+      border-color: var(
+        --amplify-components-searchfield-button-disabled-border-color
+      );
+      color: var(--amplify-components-searchfield-button-disabled-color);
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Re-orders the disabled styles to come after the other state styles for the search field button to fix the disabled hover state.

Fixes https://github.com/aws-amplify/amplify-ui/issues/4337

**Before**
![CleanShot 2023-08-14 at 10 48 51](https://github.com/aws-amplify/amplify-ui/assets/376920/a68ae309-ff9a-48f5-9de7-46559452a7a4)

**After**
![CleanShot 2023-08-14 at 10 47 49](https://github.com/aws-amplify/amplify-ui/assets/376920/0934a0e5-60a2-4880-acd6-73e0b1d51e52)


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
