### PR TITLE
fix(ui-react-native): Fix RN Authenticator not trimming values before validation

### DIFF
--- a/.changeset/unlucky-teachers-kneel.md
+++ b/.changeset/unlucky-teachers-kneel.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react-native': patch
+---
+
+fix(ui-react-native): Fix RN Authenticator not trimming values before validation.

--- a/packages/react-native/src/Authenticator/hooks/useFieldValues/__tests__/utils.spec.ts
+++ b/packages/react-native/src/Authenticator/hooks/useFieldValues/__tests__/utils.spec.ts
@@ -234,6 +234,15 @@ describe('runFieldValidation', () => {
     expect(result).toEqual([]);
   });
 
+  it('should trim values when validating', () => {
+    const value = ' test@example.com ';
+    const stateValidations = {};
+
+    const result = runFieldValidation(field, value, stateValidations);
+
+    expect(result).toEqual([]);
+  });
+
   it('should return an array with the required field error when value is missing', () => {
     const value = undefined;
     const stateValidations = {};

--- a/packages/react-native/src/Authenticator/hooks/useFieldValues/utils.ts
+++ b/packages/react-native/src/Authenticator/hooks/useFieldValues/utils.ts
@@ -202,7 +202,7 @@ export const runFieldValidation = (
     fieldErrors.push(getRequiredFieldText());
   }
   if (field.type === 'email') {
-    if (!isValidEmail(value)) {
+    if (!isValidEmail(value?.trim())) {
       fieldErrors.push(getInvalidEmailText());
     }
   }


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This change fixes an issue where the RN Authenticator shows validation errors for email fields with leading or trailing spaces on blur/change validations.


https://github.com/aws-amplify/amplify-ui/assets/68251134/8a8c1bcf-d3c9-4a79-9480-642e9649e4db



#### Issue #, if available


Fixes: https://github.com/aws-amplify/amplify-ui/issues/4336

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
