### PR TITLE
fix(docs): plain link styles

### DIFF
--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -79,7 +79,7 @@ body {
   line-height: 1.5;
 }
 
-a {
+a:not([class]) {
   color: var(--amplify-components-link-color);
 
   &:hover,

--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -79,6 +79,9 @@ body {
   line-height: 1.5;
 }
 
+/* 
+  Target all plain links, typically those generated in markdown in documentation
+  that don't have special classes or our primitive classes */
 a:not([class]) {
   color: var(--amplify-components-link-color);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Our styles for links on the docs site are overriding our updated Button primitive styles which broke our home page "Get started building" Button hover style.

Updated our link override styles on docs site to only target links with no classes (so basically links that are generated in markdown or plain <a></a> links used in documentation)


**After**

![CleanShot 2023-08-18 at 11 43 16](https://github.com/aws-amplify/amplify-ui/assets/376920/f96a8ce5-79ed-4284-9cc4-1c3d945c128d)


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
