### PR TITLE
fix(ui): add backgroundColor token for default Button style

### DIFF
--- a/.changeset/chatty-terms-brake.md
+++ b/.changeset/chatty-terms-brake.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(ui): add backgroundColor token for default Button style

--- a/docs/__tests__/__snapshots__/cssvars-table.test.ts.snap
+++ b/docs/__tests__/__snapshots__/cssvars-table.test.ts.snap
@@ -927,6 +927,10 @@ exports[`CSS Variables Table 1`] = `
         \\"value\\": \\"var(--amplify-colors-font-active)\\"
     },
     {
+        \\"variable\\": \\"--amplify-components-button-background-color\\",
+        \\"value\\": \\"transparent\\"
+    },
+    {
         \\"variable\\": \\"--amplify-components-button-border-color\\",
         \\"value\\": \\"var(--amplify-components-fieldcontrol-border-color)\\"
     },

--- a/docs/src/pages/[platform]/components/button/examples/ButtonThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/button/examples/ButtonThemeExample.tsx
@@ -13,7 +13,9 @@ const theme: Theme = {
       button: {
         // this will affect the font weight of all button variants
         fontWeight: { value: '{fontWeights.extrabold}' },
-
+        backgroundColor: { value: '#f1fff5' },
+        borderColor: { value: '{colors.purple.80}' },
+        color: { value: '{colors.purple.100}' },
         outlined: {
           info: {
             borderColor: '{colors.purple.60}',
@@ -59,6 +61,7 @@ const theme: Theme = {
 export const ButtonThemeExample = () => (
   <ThemeProvider theme={theme} colorMode="light">
     <Flex direction="row">
+      <Button>Default</Button>
       <Button variation="primary">Primary</Button>
       <Button variation="primary" colorTheme="error">
         Primary error

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -132,6 +132,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-button-padding-block-end: var(--amplify-components-fieldcontrol-padding-block-end);
         --amplify-components-button-padding-inline-start: var(--amplify-components-fieldcontrol-padding-inline-start);
         --amplify-components-button-padding-inline-end: var(--amplify-components-fieldcontrol-padding-inline-end);
+        --amplify-components-button-background-color: transparent;
         --amplify-components-button-border-color: var(--amplify-components-fieldcontrol-border-color);
         --amplify-components-button-border-width: var(--amplify-components-fieldcontrol-border-width);
         --amplify-components-button-border-style: var(--amplify-components-fieldcontrol-border-style);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -166,6 +166,7 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-button-padding-block-end: var(--amplify-components-fieldcontrol-padding-block-end);
         --amplify-components-button-padding-inline-start: var(--amplify-components-fieldcontrol-padding-inline-start);
         --amplify-components-button-padding-inline-end: var(--amplify-components-fieldcontrol-padding-inline-end);
+        --amplify-components-button-background-color: transparent;
         --amplify-components-button-border-color: var(--amplify-components-fieldcontrol-border-color);
         --amplify-components-button-border-width: var(--amplify-components-fieldcontrol-border-width);
         --amplify-components-button-border-style: var(--amplify-components-fieldcontrol-border-style);

--- a/packages/ui/src/theme/css/component/button.scss
+++ b/packages/ui/src/theme/css/component/button.scss
@@ -3,7 +3,9 @@
  */
 .amplify-button {
   // Internal base properties that are updated per variation and color theme
-  --amplify-internal-button-background-color: transparent;
+  --amplify-internal-button-background-color: var(
+    --amplify-components-button-background-color
+  );
   --amplify-internal-button-border-color: var(
     --amplify-components-button-border-color
   );

--- a/packages/ui/src/theme/tokens/components/button.ts
+++ b/packages/ui/src/theme/tokens/components/button.ts
@@ -86,6 +86,7 @@ export type ButtonTokens<Output extends OutputVariantKey> =
     | 'paddingBlockEnd'
     | 'paddingInlineStart'
     | 'paddingInlineEnd'
+    | 'backgroundColor'
     | 'borderColor'
     | 'borderWidth'
     | 'borderStyle'
@@ -129,6 +130,7 @@ export const button: Required<ButtonTokens<'default'>> = {
   paddingInlineEnd: {
     value: '{components.fieldcontrol.paddingInlineEnd.value}',
   },
+  backgroundColor: { value: 'transparent' },
   borderColor: { value: '{components.fieldcontrol.borderColor.value}' },
   borderWidth: { value: '{components.fieldcontrol.borderWidth.value}' },
   borderStyle: { value: '{components.fieldcontrol.borderStyle.value}' },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Our default Button variation/colorTheme did not have a backgroundColor token set. This updates it to use a token set to `transparent` so that it can be themed just like the other Button variations/colorThemes.

Also updated the Button theming demo to show customizing some of the default Button tokens; now including backgroundColor. (first button on the left in below screenshot)

<img width="500" alt="Screenshot 2023-08-21 at 6 28 12 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/3906ec83-e04f-468b-8e60-90278039239d">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
