### PR TITLE
fix(react): ShowPasswordButton should have aria-hidden icon

### DIFF
--- a/packages/react/src/components/AccountSettings/ChangePassword/__tests__/__snapshots__/ChangePassword.test.tsx.snap
+++ b/packages/react/src/components/AccountSettings/ChangePassword/__tests__/__snapshots__/ChangePassword.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`ChangePassword renders as expected 1`] = `
                 Password is hidden
               </span>
               <span
+                aria-hidden="true"
                 class="amplify-icon"
                 style="width: 1em; height: 1em;"
               >
@@ -119,6 +120,7 @@ exports[`ChangePassword renders as expected 1`] = `
                 Password is hidden
               </span>
               <span
+                aria-hidden="true"
                 class="amplify-icon"
                 style="width: 1em; height: 1em;"
               >
@@ -184,6 +186,7 @@ exports[`ChangePassword renders as expected 1`] = `
                 Password is hidden
               </span>
               <span
+                aria-hidden="true"
                 class="amplify-icon"
                 style="width: 1em; height: 1em;"
               >
@@ -271,6 +274,7 @@ exports[`ChangePassword renders as expected with component overrides 1`] = `
                 Password is hidden
               </span>
               <span
+                aria-hidden="true"
                 class="amplify-icon"
                 style="width: 1em; height: 1em;"
               >
@@ -336,6 +340,7 @@ exports[`ChangePassword renders as expected with component overrides 1`] = `
                 Password is hidden
               </span>
               <span
+                aria-hidden="true"
                 class="amplify-icon"
                 style="width: 1em; height: 1em;"
               >
@@ -401,6 +406,7 @@ exports[`ChangePassword renders as expected with component overrides 1`] = `
                 Password is hidden
               </span>
               <span
+                aria-hidden="true"
                 class="amplify-icon"
                 style="width: 1em; height: 1em;"
               >

--- a/packages/react/src/primitives/PasswordField/ShowPasswordButton.tsx
+++ b/packages/react/src/primitives/PasswordField/ShowPasswordButton.tsx
@@ -42,8 +42,8 @@ const ShowPasswordButtonPrimitive: Primitive<
 
   const icon =
     fieldType === 'password'
-      ? icons?.visibility ?? <IconVisibility />
-      : icons?.visibilityOff ?? <IconVisibilityOff />;
+      ? icons?.visibility ?? <IconVisibility aria-hidden="true" />
+      : icons?.visibilityOff ?? <IconVisibilityOff aria-hidden="true" />;
 
   return (
     <Button


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- Adds aria-hidden to the SVG icon in the ShowPassword button. The button already has an accessible label so the icon can be safely hidden.
- Updates relevant snapshots

**Before**
<img width="600" alt="Screenshot 2023-08-22 at 10 51 09 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/c8004883-58c3-4267-9c27-2237786e0ebb">

**After**
<img width="600" alt="Screenshot 2023-08-22 at 10 51 29 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/5280165a-badb-414d-983f-f9aea439643d">



#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-ui/issues/4190

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
