### PR TITLE
fix(docs): fix missing focus styles for some links

### DIFF
--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -89,14 +89,15 @@ a:not([class]) {
   &:focus {
     color: var(--amplify-components-link-hover-color);
   }
+  &:active {
+    color: var(--amplify-components-link-active-color);
+  }
+}
 
+a {
   &:focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px var(--amplify-colors-border-focus);
-  }
-
-  &:active {
-    color: var(--amplify-components-link-active-color);
   }
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fix the focus styles I broke in https://github.com/aws-amplify/amplify-ui/pull/4362 😣 

A few of our special link classes do not have a focus style defined and were relying on the previous base focus-visible style that was broadly applied via `a {}` (like the cards on the home page). I went through and checked other pages and link types (plain links, special links with classes like in the sidebar/ToC, `<Link>` elements, etc)

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
