### PR TITLE
chore: remove ThemeAlert from primitives pages

### DIFF
--- a/docs/src/components/ThemeExample.mdx
+++ b/docs/src/components/ThemeExample.mdx
@@ -1,6 +1,5 @@
 import { Link, Flex, View } from '@aws-amplify/ui-react';
 import { Fragment } from '@/components/Fragment';
-import { ThemeAlert } from '@/components/ThemeAlert';
 import { GITHUB_REPO_FILE } from '@/data/links';
 import { DesignTokenIcon } from '@/components/Icons';
 

--- a/docs/src/components/ThemeExample.mdx
+++ b/docs/src/components/ThemeExample.mdx
@@ -1,5 +1,4 @@
 import { Link, Flex, View } from '@aws-amplify/ui-react';
-import { Fragment } from '@/components/Fragment';
 import { GITHUB_REPO_FILE } from '@/data/links';
 import { DesignTokenIcon } from '@/components/Icons';
 

--- a/docs/src/components/ThemeExample.mdx
+++ b/docs/src/components/ThemeExample.mdx
@@ -6,8 +6,6 @@ import { DesignTokenIcon } from '@/components/Icons';
 
 ### Theme
 
-<ThemeAlert />
-
 You can customize the appearance of all {props.component} components in your application with a [Theme](/theming).
 
 <Link

--- a/docs/src/pages/[platform]/theming/getting-started.react.mdx
+++ b/docs/src/pages/[platform]/theming/getting-started.react.mdx
@@ -1,7 +1,5 @@
 import { Tabs, TabItem } from '@aws-amplify/ui-react';
-import { ThemeAlert } from '@/components/ThemeAlert';
 
-<ThemeAlert />
 Step 1: Wrap your App with `ThemeProvider`
 
 ```jsx


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This PR removes the "AmplifyProvider was renamed" message from most pages except for the ThemeProvider page itself. Leaving it there allows people to still search for AmplifyProvider via Google and find a result.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
