### PR TITLE
fix(ui-react): update ButtonGroup to respect child props and allow optional children

### DIFF
--- a/.changeset/mean-vans-attend.md
+++ b/.changeset/mean-vans-attend.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(ui-react): update ButtonGroup to respect child props and allow optional children

--- a/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
@@ -12,7 +12,14 @@ import { ComponentClassNames } from '../shared/constants';
 import { Flex } from '../Flex';
 
 const ButtonGroupPrimitive: Primitive<ButtonGroupProps, 'div'> = (
-  { className, children, role = 'group', size, variation, ...rest },
+  {
+    className,
+    children,
+    role = 'group',
+    size: _size,
+    variation: _variation,
+    ...rest
+  },
   ref
 ) => (
   <Flex
@@ -23,6 +30,7 @@ const ButtonGroupPrimitive: Primitive<ButtonGroupProps, 'div'> = (
   >
     {React.Children.map(children, (child) => {
       if (React.isValidElement<ButtonProps>(child)) {
+        const { size = _size, variation = _variation } = child.props;
         return React.cloneElement(child, { size, variation });
       }
       return child;

--- a/packages/react/src/primitives/ButtonGroup/__tests__/ButtonGroup.test.tsx
+++ b/packages/react/src/primitives/ButtonGroup/__tests__/ButtonGroup.test.tsx
@@ -10,35 +10,37 @@ import {
   expectFlexContainerStyleProps,
 } from '../../Flex/__tests__/Flex.test';
 
-describe('ButtonGroup:', () => {
-  const getButtonGroup = (
-    props: Partial<PrimitiveProps<ButtonGroupProps, 'div'>>
-  ) => {
-    return (
-      <ButtonGroup {...props}>
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-        <Button>Button 3</Button>
-      </ButtonGroup>
-    );
-  };
+const ButtonGroupWithChildren = React.forwardRef<
+  HTMLDivElement,
+  ButtonGroupProps
+>((props, ref) => {
+  return (
+    <ButtonGroup {...props} ref={ref}>
+      <Button>Button 1</Button>
+      <Button>Button 2</Button>
+      <Button>Button 3</Button>
+    </ButtonGroup>
+  );
+});
+
+describe('ButtonGroup', () => {
   it('should render classname and custom classname', async () => {
     const className = 'class-test';
-    render(getButtonGroup({ className }));
+    render(<ButtonGroupWithChildren className={className} />);
 
     const buttonGroup = await screen.findByRole('group');
     expect(buttonGroup).toHaveClass(ComponentClassNames.ButtonGroup, className);
   });
 
   it('should render all flex style props', async () => {
-    render(getButtonGroup(testFlexProps));
+    render(<ButtonGroupWithChildren {...testFlexProps} />);
     const buttonGroup = await screen.findByRole('group');
     expectFlexContainerStyleProps(buttonGroup);
   });
 
   it('should set size for each child button correctly', async () => {
     const size = 'large';
-    render(getButtonGroup({ size }));
+    render(<ButtonGroupWithChildren size={size} />);
 
     const buttons = await screen.findAllByRole('button');
     expect(buttons[0]).toHaveAttribute('data-size', size);
@@ -46,9 +48,9 @@ describe('ButtonGroup:', () => {
     expect(buttons[2]).toHaveAttribute('data-size', size);
   });
 
-  it('should set variation for each child button correctly', async () => {
+  it('sets variation for each child button correctly', async () => {
     const variation = 'primary';
-    render(getButtonGroup({ variation }));
+    render(<ButtonGroupWithChildren variation={variation} />);
 
     const buttons = await screen.findAllByRole('button');
     expect(buttons[0]).toHaveAttribute('data-variation', variation);
@@ -56,9 +58,34 @@ describe('ButtonGroup:', () => {
     expect(buttons[2]).toHaveAttribute('data-variation', variation);
   });
 
+  it('respects child button size and variation props', async () => {
+    const size = 'large';
+    const variation = 'primary';
+    render(
+      <ButtonGroup size={size} variation={variation}>
+        <Button size="small">Button 1</Button>
+        <Button>Button 2</Button>
+        <Button variation="link">Button 3</Button>
+      </ButtonGroup>
+    );
+    const [first, second, third] = await screen.findAllByRole('button');
+
+    // override size prop
+    expect(first).toHaveAttribute('data-size', 'small');
+    expect(first).toHaveAttribute('data-variation', variation);
+
+    // inherit parent props
+    expect(second).toHaveAttribute('data-size', size);
+    expect(second).toHaveAttribute('data-variation', variation);
+
+    // override size prop
+    expect(second).toHaveAttribute('data-size', size);
+    expect(third).toHaveAttribute('data-variation', 'link');
+  });
+
   it('should forward ref to DOM element', async () => {
     const ref = React.createRef<HTMLDivElement>();
-    render(getButtonGroup({ ref }));
+    render(<ButtonGroupWithChildren ref={ref} />);
 
     await screen.findAllByRole('group');
     expect(ref.current?.nodeName).toBe('DIV');

--- a/packages/react/src/primitives/types/buttonGroup.ts
+++ b/packages/react/src/primitives/types/buttonGroup.ts
@@ -12,7 +12,7 @@ export interface BaseButtonGroupProps
     BaseStyleProps,
     BaseFlexProps,
     Pick<BaseButtonProps, 'size' | 'variation'> {
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 export type ButtonGroupProps<Element extends ElementType = 'div'> =


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Prevent `ButtonGroup` child element cloning from ignoring child `props`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
