### PR TITLE
feat(A.Next): add machine context

### DIFF
--- a/packages/react-core-auth/src/components/Authenticator/Machine/MachineContext.tsx
+++ b/packages/react-core-auth/src/components/Authenticator/Machine/MachineContext.tsx
@@ -1,0 +1,53 @@
+import React, { useCallback } from 'react';
+import { useInterpret, useSelector } from '@xstate/react';
+import {
+  AuthenticatorMachineOptions,
+  AuthMachineState,
+  getNextServiceFacade,
+  createAuthenticatorMachine,
+} from '@aws-amplify/ui';
+
+import { MachineContextType, UseMachineSelector, UseMachine } from './types';
+import { defaultComparator, getComparator } from './utils';
+
+export const USE_MACHINE_ERROR =
+  '`useMachine` must be used inside an `Authenticator.Provider`.';
+
+const MachineContext = React.createContext<MachineContextType | null>(null);
+
+export function useMachine(selector?: UseMachineSelector): UseMachine {
+  const context = React.useContext(MachineContext);
+
+  if (!context) {
+    throw new Error(USE_MACHINE_ERROR);
+  }
+
+  const { service } = context;
+  const { send } = service;
+
+  const xstateSelector = useCallback(
+    (state: AuthMachineState) => getNextServiceFacade({ send, state }),
+    [send]
+  );
+
+  const comparator = selector ? getComparator(selector) : defaultComparator;
+  const facade = useSelector(service, xstateSelector, comparator);
+
+  return facade;
+}
+
+interface MachineProviderProps extends AuthenticatorMachineOptions {
+  children?: React.ReactNode;
+}
+
+export function MachineProvider({
+  children,
+  ...data
+}: MachineProviderProps): JSX.Element {
+  const service = useInterpret(() => createAuthenticatorMachine(data));
+  const value = React.useMemo(() => ({ service }), [service]);
+
+  return (
+    <MachineContext.Provider value={value}>{children}</MachineContext.Provider>
+  );
+}

--- a/packages/react-core-auth/src/components/Authenticator/Machine/__mocks__/useMachine.ts
+++ b/packages/react-core-auth/src/components/Authenticator/Machine/__mocks__/useMachine.ts
@@ -1,0 +1,36 @@
+import { NextAuthenticatorServiceFacade } from '@aws-amplify/ui';
+import { UseMachine } from '../types';
+
+const challengeName = 'CUSTOM_CHALLENGE';
+const codeDeliveryDetails = undefined;
+const errorMessage = 'error';
+const federatedProviders = undefined;
+const isPending = false;
+const resendCode = jest.fn();
+const route = 'idle';
+const setRoute = jest.fn();
+const skipVerification = jest.fn();
+const submitForm = jest.fn();
+const toFederatedSignIn = jest.fn();
+const totpSecretCode = undefined;
+const unverifiedContactMethods = {};
+
+export const mockMachineContext: NextAuthenticatorServiceFacade = {
+  challengeName,
+  codeDeliveryDetails,
+  errorMessage,
+  federatedProviders,
+  isPending,
+  loginMechanism: 'username',
+  resendCode,
+  route,
+  setRoute,
+  skipVerification,
+  submitForm,
+  toFederatedSignIn,
+  totpSecretCode,
+  unverifiedContactMethods,
+  username: 'Charles',
+};
+
+export const mockUseMachineOutput: UseMachine = mockMachineContext;

--- a/packages/react-core-auth/src/components/Authenticator/Machine/__tests__/MachineContext.spec.tsx
+++ b/packages/react-core-auth/src/components/Authenticator/Machine/__tests__/MachineContext.spec.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { NextAuthenticatorServiceFacade } from '@aws-amplify/ui';
+import * as UIModule from '@aws-amplify/ui';
+
+import * as utils from '../utils';
+
+import {
+  MachineProvider,
+  useMachine,
+  USE_MACHINE_ERROR,
+} from '../MachineContext';
+
+const mockServiceFacade: NextAuthenticatorServiceFacade = {
+  challengeName: undefined,
+  codeDeliveryDetails: undefined,
+  errorMessage: undefined,
+  federatedProviders: undefined,
+  loginMechanism: 'username',
+  isPending: false,
+  route: 'idle',
+  unverifiedContactMethods: { email: 'test#example.com' },
+  totpSecretCode: undefined,
+  resendCode: jest.fn(),
+  setRoute: jest.fn(),
+  submitForm: jest.fn(),
+  toFederatedSignIn: jest.fn(),
+  skipVerification: jest.fn(),
+  username: undefined,
+};
+
+const getNextServiceFacadeSpy = jest
+  .spyOn(UIModule, 'getNextServiceFacade')
+  .mockReturnValue(mockServiceFacade);
+
+// test setup
+jest.mock('@xstate/react', () => ({
+  ...jest.requireActual('@xstate/react'),
+  useSelector: jest.fn((_, selector: () => NextAuthenticatorServiceFacade) =>
+    selector()
+  ),
+}));
+
+// mock `aws-amplify` to prevent logging auth errors during test runs
+jest.mock('aws-amplify');
+
+jest.mock('../utils');
+const getComparatorSpy = jest.spyOn(utils, 'getComparator');
+
+const Wrapper = ({ children }: { children?: React.ReactNode }) => (
+  <MachineProvider>{children}</MachineProvider>
+);
+
+describe('useMachine', () => {
+  beforeEach(() => {
+    getComparatorSpy.mockClear();
+    getNextServiceFacadeSpy.mockClear();
+  });
+
+  it('throws an error when used outside an MachineProvider', () => {
+    const { result } = renderHook(useMachine);
+
+    expect(result.error?.message).toBe(USE_MACHINE_ERROR);
+  });
+
+  it('returns the expected values', () => {
+    const { result } = renderHook(useMachine, {
+      wrapper: Wrapper,
+    });
+
+    expect(getNextServiceFacadeSpy).toHaveBeenCalled();
+
+    expect(result.current).toMatchSnapshot();
+  });
+
+  it('calls getComparator with the selector argument', () => {
+    const mockSelector = jest.fn();
+
+    renderHook(() => useMachine(mockSelector), { wrapper: Wrapper });
+
+    expect(getComparatorSpy).toHaveBeenLastCalledWith(mockSelector);
+  });
+
+  it('does not call getComparator when no selector argument passed', () => {
+    renderHook(useMachine, { wrapper: Wrapper });
+
+    expect(getComparatorSpy).not.toBeCalled();
+  });
+});

--- a/packages/react-core-auth/src/components/Authenticator/Machine/__tests__/__snapshots__/MachineContext.spec.tsx.snap
+++ b/packages/react-core-auth/src/components/Authenticator/Machine/__tests__/__snapshots__/MachineContext.spec.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useMachine returns the expected values 1`] = `
+Object {
+  "challengeName": undefined,
+  "codeDeliveryDetails": undefined,
+  "errorMessage": undefined,
+  "federatedProviders": undefined,
+  "isPending": false,
+  "loginMechanism": "username",
+  "resendCode": [MockFunction],
+  "route": "idle",
+  "setRoute": [MockFunction],
+  "skipVerification": [MockFunction],
+  "submitForm": [MockFunction],
+  "toFederatedSignIn": [MockFunction],
+  "totpSecretCode": undefined,
+  "unverifiedContactMethods": Object {
+    "email": "test#example.com",
+  },
+  "username": undefined,
+}
+`;

--- a/packages/react-core-auth/src/components/Authenticator/Machine/__tests__/utils.spec.tsx
+++ b/packages/react-core-auth/src/components/Authenticator/Machine/__tests__/utils.spec.tsx
@@ -1,0 +1,60 @@
+import {
+  areSelectorDepsEqual,
+  defaultComparator,
+  getComparator,
+} from '../utils';
+
+describe('areSelectorDepsEqual', () => {
+  it('returns false when dep arrays have different lengths', () => {
+    const output = areSelectorDepsEqual([0, {}], [0]);
+
+    expect(output).toBe(false);
+  });
+
+  it('returns false when comparing an empty array and an empty object', () => {
+    const output = areSelectorDepsEqual([{}], [[]]);
+
+    expect(output).toBe(false);
+  });
+
+  it('returns false when dep arrays have similar object values', () => {
+    const output = areSelectorDepsEqual([0, { id: 4 }], [0, { id: 4 }]);
+
+    expect(output).toBe(false);
+  });
+
+  it('returns false when nested object values are different', () => {
+    const output = areSelectorDepsEqual(
+      [0, { options: {} }],
+      [0, { options: {} }]
+    );
+
+    expect(output).toBe(false);
+  });
+
+  it('returns true when arrays are equal length and have same deps', () => {
+    const output = areSelectorDepsEqual([{}, 0], [{}, 0]);
+
+    expect(output).toBe(true);
+  });
+});
+
+describe('getComparator', () => {
+  it('returns a comparator that compares arrays', () => {
+    const comparator = getComparator(({ route }) => [route]);
+
+    expect(comparator).toEqual(expect.any(Function));
+
+    expect(
+      comparator({ route: 'transition' }, { route: 'confirmSignIn' })
+    ).toBe(false);
+
+    expect(comparator({ route: 'idle' }, { route: 'idle' })).toBe(true);
+  });
+});
+
+describe('defaultComparator', () => {
+  it('returns false', () => {
+    expect(defaultComparator()).toBe(false);
+  });
+});

--- a/packages/react-core-auth/src/components/Authenticator/Machine/index.ts
+++ b/packages/react-core-auth/src/components/Authenticator/Machine/index.ts
@@ -1,0 +1,6 @@
+export { MachineProvider, useMachine } from './MachineContext';
+export {
+  AuthenticatorRouteComponentKey,
+  UseMachine,
+  UseMachineSelector,
+} from './types';

--- a/packages/react-core-auth/src/components/Authenticator/Machine/types.ts
+++ b/packages/react-core-auth/src/components/Authenticator/Machine/types.ts
@@ -1,0 +1,45 @@
+import {
+  AuthInterpreter,
+  NextAuthenticatorServiceFacade,
+} from '@aws-amplify/ui';
+
+/**
+ * state machine context interface
+ */
+type ServiceFacadeKey = keyof NextAuthenticatorServiceFacade;
+
+export interface MachineContextType {
+  service: AuthInterpreter;
+}
+
+/**
+ * Inspired from https://xstate.js.org/docs/packages/xstate-react/#useselector-actor-selector-compare-getsnapshot.
+ *
+ * Selector accepts current facade values and returns an array of
+ * desired value(s) that should trigger re-render.
+ */
+export type UseMachineSelector = (
+  context: Partial<NextAuthenticatorServiceFacade>
+) => NextAuthenticatorServiceFacade[ServiceFacadeKey][];
+
+export interface UseMachine extends NextAuthenticatorServiceFacade {}
+
+export type Comparator = (
+  currentMachineContext: Partial<NextAuthenticatorServiceFacade>,
+  nextMachineContext: Partial<NextAuthenticatorServiceFacade>
+) => boolean;
+
+export type AuthenticatorRouteComponentKey =
+  | 'confirmResetPassword'
+  | 'confirmSignIn'
+  | 'confirmSignUp'
+  | 'confirmVerifyUser'
+  | 'forceNewPassword'
+  | 'resetPassword'
+  | 'setupTOTP'
+  | 'signIn'
+  | 'signUp'
+  | 'verifyUser';
+
+export type AuthenticatorRouteComponentName =
+  Capitalize<AuthenticatorRouteComponentKey>;

--- a/packages/react-core-auth/src/components/Authenticator/Machine/utils.ts
+++ b/packages/react-core-auth/src/components/Authenticator/Machine/utils.ts
@@ -1,0 +1,40 @@
+import { areEmptyArrays, areEmptyObjects } from '@aws-amplify/ui';
+
+import { Comparator, UseMachineSelector } from './types';
+
+export const defaultComparator = (): false => false;
+
+/**
+ * Does an ordering and shallow comparison of each array value,
+ * plus a value equality check for empty objects and arrays.
+ */
+export function areSelectorDepsEqual<T>(
+  currentDeps: T[],
+  nextDeps: T[]
+): boolean {
+  if (currentDeps.length !== nextDeps.length) {
+    return false;
+  }
+  return currentDeps.every((currentDep, index) => {
+    const nextDep = nextDeps[index];
+
+    if (
+      areEmptyArrays(currentDep, nextDep) ||
+      areEmptyObjects(currentDep, nextDep)
+    ) {
+      return true;
+    }
+
+    return currentDep === nextDep;
+  });
+}
+
+export const getComparator =
+  (selector: UseMachineSelector): Comparator =>
+  (currentFacade, nextFacade) => {
+    const currentSelectorDeps = selector(currentFacade);
+    const nextSelectorDeps = selector(nextFacade);
+
+    // Shallow compare the array values
+    return areSelectorDepsEqual(currentSelectorDeps, nextSelectorDeps);
+  };

--- a/packages/react-core-auth/src/exported.ts
+++ b/packages/react-core-auth/src/exported.ts
@@ -1,0 +1,2 @@
+// temp file until there are actual exports
+export const exported = '';

--- a/packages/react-core-auth/src/index.ts
+++ b/packages/react-core-auth/src/index.ts
@@ -1,1 +1,1 @@
-export const exported = '';
+export { exported } from './exported';

--- a/packages/ui/src/helpers/authenticator/__tests__/facade.test.ts
+++ b/packages/ui/src/helpers/authenticator/__tests__/facade.test.ts
@@ -4,6 +4,7 @@ import {
   getSendEventAliases,
   getServiceContextFacade,
   getServiceFacade,
+  getNextServiceFacade,
 } from '../facade';
 import { AmplifyUser, AuthEvent, AuthMachineState } from '../../../types';
 
@@ -235,6 +236,26 @@ describe('getServiceFacade', () => {
     expect(serviceFacade).toHaveProperty('authStatus');
     expect(serviceFacade).toHaveProperty('route');
     expect(serviceFacade).toHaveProperty('user');
+    expect(serviceFacade).toHaveProperty('route');
+  });
+});
+
+describe('getNextServiceFacade', () => {
+  const send = jest.fn();
+  const state = {
+    value: 'idle',
+    context: {},
+    hasTag: () => false,
+    matches: () => false,
+  } as unknown as AuthMachineState;
+
+  it('returns expected methods and properties', () => {
+    const serviceFacade = getNextServiceFacade({ send, state });
+
+    expect(serviceFacade).not.toHaveProperty('authStatus');
+    expect(serviceFacade).toHaveProperty('route');
+    expect(serviceFacade).not.toHaveProperty('user');
+    expect(serviceFacade).toHaveProperty('username');
     expect(serviceFacade).toHaveProperty('route');
   });
 });

--- a/packages/ui/src/helpers/authenticator/constants.ts
+++ b/packages/ui/src/helpers/authenticator/constants.ts
@@ -2,7 +2,11 @@
  * This file contains helpers related to forms and input attributes.
  */
 
-import { DefaultFormFieldOptions } from '../../types';
+import {
+  AuthEventTypes,
+  DefaultFormFieldOptions,
+  NavigableRoute,
+} from '../../types';
 import { countryDialCodes } from '../../i18n';
 
 export const defaultFormFieldOptions: DefaultFormFieldOptions = {
@@ -136,3 +140,12 @@ export const ALLOWED_SPECIAL_CHARACTERS = [
  */
 export const emailRegex =
   /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+/**
++ * map navigable route keys to auth event names
++ */
+export const NAVIGABLE_ROUTE_EVENT: Record<NavigableRoute, AuthEventTypes> = {
+  resetPassword: 'RESET_PASSWORD',
+  signIn: 'SIGN_IN',
+  signUp: 'SIGN_UP',
+};

--- a/packages/ui/src/helpers/authenticator/facade.ts
+++ b/packages/ui/src/helpers/authenticator/facade.ts
@@ -8,18 +8,24 @@ import { Sender } from 'xstate';
 
 import {
   ActorContextWithForms,
+  AmplifyUser,
   AuthEvent,
   AuthEventData,
   AuthEventTypes,
   AuthMachineState,
+  ChallengeName,
   CodeDeliveryDetails,
-  AmplifyUser,
-  ValidationError,
+  FederatedProvider,
+  LoginMechanism,
+  NavigableRoute,
   SocialProvider,
   UnverifiedContactMethods,
+  ValidationError,
 } from '../../types';
 
 import { getActorContext, getActorState } from './actor';
+import { NAVIGABLE_ROUTE_EVENT } from './constants';
+import { getRoute } from './utils';
 
 export type AuthenticatorRoute =
   | 'authenticated'
@@ -77,6 +83,34 @@ export interface AuthenticatorServiceFacade
   extends AuthenticatorSendEventAliases,
     AuthenticatorServiceContextFacade {}
 
+interface NextAuthenticatorServiceContextFacade {
+  challengeName: ChallengeName | undefined;
+  codeDeliveryDetails: CodeDeliveryDetails | undefined;
+  errorMessage: string | undefined;
+  federatedProviders: FederatedProvider[] | undefined;
+  loginMechanism: LoginMechanism | undefined;
+  isPending: boolean;
+  route: AuthenticatorRoute;
+  totpSecretCode: string | undefined;
+  username: string | undefined;
+  unverifiedContactMethods: UnverifiedContactMethods | undefined;
+}
+
+type NextSendEventAlias =
+  | 'resendCode'
+  | 'submitForm'
+  | 'toFederatedSignIn'
+  | 'skipVerification';
+
+interface NextAuthenticatorSendEventAliases
+  extends Pick<AuthenticatorSendEventAliases, NextSendEventAlias> {
+  setRoute: (route: NavigableRoute) => void;
+}
+
+export interface NextAuthenticatorServiceFacade
+  extends NextAuthenticatorSendEventAliases,
+    NextAuthenticatorServiceContextFacade {}
+
 /**
  * Creates public facing auth helpers that abstracts out xstate implementation
  * detail. Each framework implementation can export these helpers so that
@@ -116,6 +150,22 @@ export const getSendEventAliases = (
   };
 };
 
+const getNextSendEventAliases = (
+  send: Sender<AuthEvent>
+): NextAuthenticatorSendEventAliases => {
+  const { toFederatedSignIn, submitForm, resendCode, skipVerification } =
+    getSendEventAliases(send);
+  return {
+    resendCode,
+    // manual "route" navigation
+    setRoute: (route: NavigableRoute) =>
+      send({ type: NAVIGABLE_ROUTE_EVENT[route] }),
+    skipVerification,
+    submitForm,
+    toFederatedSignIn,
+  };
+};
+
 export const getServiceContextFacade = (
   state: AuthMachineState
 ): AuthenticatorServiceContextFacade => {
@@ -140,54 +190,7 @@ export const getServiceContextFacade = (
   const actorState = getActorState(state);
   const isPending = state.hasTag('pending') || actorState?.hasTag('pending');
 
-  // Any additional idle states added beyond (idle, setup) should be updated inside the authStatus below as well
-  const route = (() => {
-    switch (true) {
-      case state.matches('idle'):
-        return 'idle';
-      case state.matches('setup'):
-        return 'setup';
-      case state.matches('signOut'):
-        return 'signOut';
-      case state.matches('authenticated'):
-        return 'authenticated';
-      case actorState?.matches('confirmSignUp'):
-        return 'confirmSignUp';
-      case actorState?.matches('confirmSignIn'):
-        return 'confirmSignIn';
-      case actorState?.matches('setupTOTP.edit'):
-      case actorState?.matches('setupTOTP.submit'):
-        return 'setupTOTP';
-      case actorState?.matches('signIn'):
-        return 'signIn';
-      case actorState?.matches('signUp'):
-        return 'signUp';
-      case actorState?.matches('forceNewPassword'):
-        return 'forceNewPassword';
-      case actorState?.matches('resetPassword'):
-        return 'resetPassword';
-      case actorState?.matches('confirmResetPassword'):
-        return 'confirmResetPassword';
-      case actorState?.matches('verifyUser'):
-        return 'verifyUser';
-      case actorState?.matches('confirmVerifyUser'):
-        return 'confirmVerifyUser';
-      case actorState?.matches('setupTOTP.getTotpSecretCode'):
-      case state.matches('signIn.runActor'):
-        /**
-         * This route is needed for autoSignIn to capture both the
-         * autoSignIn.pending and the resolved states when the
-         * signIn actor is running.
-         */
-        return 'transition';
-      default:
-        console.debug(
-          'Cannot infer `route` from Authenticator state:',
-          state.value
-        );
-        return null;
-    }
-  })();
+  const route = getRoute(state, actorState);
 
   // Auth status represents the current state of the auth flow
   // The `configuring` state is used to indicate when the xState machine is loading
@@ -218,6 +221,45 @@ export const getServiceContextFacade = (
   };
 };
 
+export const getNextServiceContextFacade = (
+  state: AuthMachineState
+): NextAuthenticatorServiceContextFacade => {
+  const actorContext = (getActorContext(state) ?? {}) as ActorContextWithForms;
+  const {
+    codeDeliveryDetails,
+    remoteError: errorMessage,
+    unverifiedContactMethods,
+    totpSecretCode,
+  } = actorContext;
+
+  const { socialProviders: federatedProviders, loginMechanisms } =
+    state.context?.config ?? {};
+
+  const loginMechanism = loginMechanisms?.[0];
+
+  // check for user in actorContext prior to state context. actorContext is more "up to date",
+  // but is not available on all states
+  const user = actorContext?.user ?? state.context?.user;
+  const { challengeName, username } = user ?? {};
+  const actorState = getActorState(state);
+  const isPending = state.hasTag('pending') || actorState?.hasTag('pending');
+
+  const route = getRoute(state, actorState);
+
+  return {
+    challengeName,
+    codeDeliveryDetails,
+    errorMessage,
+    federatedProviders,
+    isPending,
+    loginMechanism,
+    route,
+    totpSecretCode,
+    unverifiedContactMethods,
+    username,
+  };
+};
+
 export const getServiceFacade = ({
   send,
   state,
@@ -233,3 +275,14 @@ export const getServiceFacade = ({
     ...serviceContext,
   };
 };
+
+export const getNextServiceFacade = ({
+  send,
+  state,
+}: {
+  send: Sender<AuthEvent>;
+  state: AuthMachineState;
+}): NextAuthenticatorServiceFacade => ({
+  ...getNextSendEventAliases(send),
+  ...getNextServiceContextFacade(state),
+});

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -7,7 +7,7 @@ import {
   AmplifyUser,
   AuthFormFields,
 } from '../../types';
-import { isObject } from '../../utils';
+import { isEmptyObject } from '../../utils';
 
 import { stopActor } from './actions';
 import { resetPasswordActor, signInActor, signOutActor } from './actors';
@@ -377,7 +377,7 @@ export function createAuthenticatorMachine(
         stopResetPasswordActor: stopActor('resetPasswordActor'),
         stopSignOutActor: stopActor('signOutActor'),
         configure: assign((_, event) => {
-          const { services: customServices, ...config } = isObject(
+          const { services: customServices, ...config } = !isEmptyObject(
             overrideConfigServices
           )
             ? overrideConfigServices

--- a/packages/ui/src/types/authenticator/attributes.ts
+++ b/packages/ui/src/types/authenticator/attributes.ts
@@ -45,6 +45,11 @@ export const LoginMechanismArray = [
   'phone_number',
 ] as const;
 
+/**
+ * Default supported federated sign sn providers
+ */
+export type FederatedProvider = 'amazon' | 'apple' | 'facebook' | 'google';
+
 /** Login mechanisms that can be used to sign in */
 export type LoginMechanism = typeof LoginMechanismArray[number];
 

--- a/packages/ui/src/types/authenticator/stateMachine/context.ts
+++ b/packages/ui/src/types/authenticator/stateMachine/context.ts
@@ -23,6 +23,21 @@ export interface ActorDoneData {
 }
 
 /**
+ * Authenticator routes that can be directly navigated to by user interaction.
+ */
+export type NavigableRoute = 'signIn' | 'signUp' | 'resetPassword';
+export type InitialRoute = 'signIn' | 'signUp' | 'resetPassword';
+
+/**
+ * Authenticator routes that have default links
+ */
+export type NavigationRoute =
+  | 'resetPassword'
+  | 'setupTOTP'
+  | 'signIn'
+  | 'signUp';
+
+/**
  * Context interface for the top-level machine
  */
 export interface AuthContext {

--- a/packages/ui/src/types/authenticator/user.ts
+++ b/packages/ui/src/types/authenticator/user.ts
@@ -2,6 +2,7 @@ import { ChallengeName, CognitoUser } from 'amazon-cognito-identity-js';
 
 /** Known challenge names */
 export type AuthChallengeName = ChallengeName;
+export { ChallengeName };
 
 /** Contact destinations that we can send user confirmation code to */
 export type ContactMethod = 'Email' | 'Phone Number';

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -130,7 +130,7 @@ export function areEmptyArrays<T>(...values: T[]): boolean {
  * @param {unknown} value The value to check
  * @returns {boolean} Returns `true` if `value` is empty, `false` otherwise
  */
-function isEmptyObject<T>(value: T): boolean {
+export function isEmptyObject<T>(value: T): boolean {
   return isObject(value) && isEmpty(value);
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add `MachineProvider` and `useMachine` and state machine utils for `A.Next`:
- `MachineProvider` and `useMachine` correspond to existing `AuthenticatorProvider` and `useAuthenticator` with only required functionality
- add `overrideServices` to `createAuthenticatorMachine` to allow `A.Next` to bypass extraneous configuration updates

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual tests, some unit tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
