### PR TITLE
fix(ui-react): use guaranteed value for BreadCrumbs key

### DIFF
--- a/.changeset/modern-melons-doubt.md
+++ b/.changeset/modern-melons-doubt.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(ui-react): use guaranteed value for BreadCrumbs key

--- a/docs/src/pages/[platform]/components/breadcrumbs/examples/BreadcrumbsStyleExample.tsx
+++ b/docs/src/pages/[platform]/components/breadcrumbs/examples/BreadcrumbsStyleExample.tsx
@@ -22,8 +22,8 @@ export default function BreadcrumbsStyleExample() {
       borderRadius="medium"
       padding="medium"
     >
-      {breadcrumbs.map(({ href, text, isCurrent }) => (
-        <Breadcrumbs.Item key={href}>
+      {breadcrumbs.map(({ href, text, isCurrent }, idx) => (
+        <Breadcrumbs.Item key={`${href}${idx}`}>
           <Breadcrumbs.Link
             fontWeight="bold"
             textDecoration="underline"

--- a/packages/react/src/primitives/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react/src/primitives/Breadcrumbs/Breadcrumbs.tsx
@@ -28,7 +28,7 @@ const BreadcrumbsPrimitive: Primitive<BreadcrumbsProps, 'nav'> = (
       {items?.map(({ href, label }, idx) => {
         const isCurrent = items.length - 1 === idx;
         return (
-          <BreadcrumbItem key={href}>
+          <BreadcrumbItem key={`${href}${idx}`}>
             <BreadcrumbLink href={href} isCurrent={isCurrent}>
               {label}
             </BreadcrumbLink>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fix subtle issue with `key` used in `BreadCrumbs`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
