### PR TITLE
chore(react): Use displayText for Account Settings

### DIFF
--- a/docs/src/pages/[platform]/connected-components/account-settings/change-password/props.ts
+++ b/docs/src/pages/[platform]/connected-components/account-settings/change-password/props.ts
@@ -20,6 +20,11 @@ export const CHANGE_PASSWORD = [
     description: 'Submit button',
     type: `ChangePasswordComponents`,
   },
+  {
+    name: `displayText?`,
+    description: 'Text to override in the component',
+    type: `Partial<ChangePasswordDisplayText>`,
+  },
 ];
 
 export const OVERRIDES = [

--- a/docs/src/pages/[platform]/connected-components/account-settings/change-password/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/account-settings/change-password/react.mdx
@@ -327,7 +327,7 @@ function App() {
 
 ### Text and labels
 
-All text in the `ChangePassword` component is customizable with the displayText prop. 
+All text in the `ChangePassword` component is customizable with the `displayText` prop. 
 
 
 <Example>
@@ -335,7 +335,6 @@ All text in the `ChangePassword` component is customizable with the displayText 
 
 ```jsx
 import { AccountSettings } from '@aws-amplify/ui-react';
-
 
 function App() {
   return (
@@ -347,7 +346,6 @@ function App() {
         updatePasswordText: 'Update your password',
       }}  
     />
-     
   );
 }
 ```

--- a/docs/src/pages/[platform]/connected-components/account-settings/change-password/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/account-settings/change-password/react.mdx
@@ -324,6 +324,37 @@ function App() {
   </ExpanderItem>
 </Expander>
 
+
+### Text and labels
+
+All text in the `ChangePassword` component is customizable with the displayText prop. 
+
+
+<Example>
+  <ExampleCode>
+
+```jsx
+import { AccountSettings } from '@aws-amplify/ui-react';
+
+
+function App() {
+  return (
+    <AccountSettings.ChangePassword 
+      displayText={{
+        currentPasswordLabel: 'Enter current password',
+        newPasswordLabel: 'Enter new password',
+        confirmPasswordLabel: 'Confirm your password',
+        updatePasswordText: 'Update your password',
+      }}  
+    />
+     
+  );
+}
+```
+
+  </ExampleCode>
+</Example>
+
 ### Theming
 
 `ChangePassword` component is built upon our robust [Amplify UI theming system](../../theming). To get started, add a theme object and set the appropriate [design tokens](../../theming#design-tokens). You can then pass that `theme` to the `ThemeProvider` so the changes can take affect.

--- a/docs/src/pages/[platform]/connected-components/account-settings/delete-user/props.ts
+++ b/docs/src/pages/[platform]/connected-components/account-settings/delete-user/props.ts
@@ -20,6 +20,11 @@ export const DELETE_USER = [
     description: 'Custom components override',
     type: `DeleteUserComponents`,
   },
+  {
+    name: `displayText?`,
+    description: 'Text to override in the component',
+    type: `Partial<DeleteUserDisplayText>`,
+  },
 ];
 
 export const OVERRIDES = [
@@ -63,7 +68,8 @@ export const WARNING = [
   },
   {
     name: `onConfirm`,
-    description: 'Callback function triggered when user confirms account deletion',
+    description:
+      'Callback function triggered when user confirms account deletion',
     type: `() => void`,
   },
   {

--- a/docs/src/pages/[platform]/connected-components/account-settings/delete-user/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/account-settings/delete-user/react.mdx
@@ -241,6 +241,37 @@ The following example overrides the warning component to require users to type "
   </ExpanderItem>
 </Expander>
 
+### Text and labels
+
+All text in the `DeleteUser` component is customizable with the displayText prop. 
+
+
+<Example>
+  <ExampleCode>
+
+```jsx
+import { AccountSettings } from '@aws-amplify/ui-react';
+
+
+function App() {
+  return (
+    <AccountSettings.DeleteUser 
+      displayText={{
+        deleteAccountText: 'Delete the account',
+        cancelText: 'Cancel',
+        deleteMyAccountText: 'Delete account',
+        warningText: 'Are you sure you want to delete your account? You will lose access and all data.'
+      }}  
+    />
+     
+  );
+}
+```
+
+  </ExampleCode>
+</Example>
+
+
 ### Theming
 
 `DeleteUser` component is built upon our robust [Amplify UI theming system](../../theming). To get started, add a theme object and set the appropriate [design tokens](../../theming#design-tokens). You can then pass that `theme` to the `ThemeProvider` so the changes can take affect.

--- a/docs/src/pages/[platform]/connected-components/account-settings/delete-user/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/account-settings/delete-user/react.mdx
@@ -243,7 +243,7 @@ The following example overrides the warning component to require users to type "
 
 ### Text and labels
 
-All text in the `DeleteUser` component is customizable with the displayText prop. 
+All text in the `DeleteUser` component is customizable with the `displayText` prop. 
 
 
 <Example>
@@ -251,7 +251,6 @@ All text in the `DeleteUser` component is customizable with the displayText prop
 
 ```jsx
 import { AccountSettings } from '@aws-amplify/ui-react';
-
 
 function App() {
   return (
@@ -263,7 +262,6 @@ function App() {
         warningText: 'Are you sure you want to delete your account? You will lose access and all data.'
       }}  
     />
-     
   );
 }
 ```

--- a/packages/e2e/features/ui/components/account-settings/delete-user.feature
+++ b/packages/e2e/features/ui/components/account-settings/delete-user.feature
@@ -14,7 +14,7 @@ Feature: Delete User
     Then I see "Hello"
     Then I see "Delete Account:"
     Then I click the "Delete Account" button
-    Then I see "Deleting your account is not reversable. You will lose access to your account and all data associated with it."
+    Then I see "Deleting your account is not reversible. You will lose access to your account and all data associated with it."
     Then I click the "Delete my account" button
     Then I see "Sign in"
 
@@ -27,7 +27,7 @@ Feature: Delete User
     Then I see "Hello"
     Then I see "Delete Account:"
     Then I click the "Delete Account" button
-    Then I see "Deleting your account is not reversable. You will lose access to your account and all data associated with it."
+    Then I see "Deleting your account is not reversible. You will lose access to your account and all data associated with it."
     Then I click the "Cancel" button
     Then I click the "Sign Out" button
     Then I see "Sign in"
@@ -41,7 +41,7 @@ Feature: Delete User
     Then I see "Hello"
     Then I see "Delete Account:"
     Then I click the "Delete Account" button
-    Then I see "Deleting your account is not reversable. You will lose access to your account and all data associated with it."
+    Then I see "Deleting your account is not reversible. You will lose access to your account and all data associated with it."
     Then I click the "Delete my account" button
     Then I see 'Error deleting user'
     Then I click the "Sign Out" button

--- a/packages/react/src/components/AccountSettings/ChangePassword/ChangePassword.tsx
+++ b/packages/react/src/components/AccountSettings/ChangePassword/ChangePassword.tsx
@@ -8,7 +8,6 @@ import {
   getDefaultConfirmPasswordValidators,
   getDefaultPasswordValidators,
   runFieldValidators,
-  translate,
 } from '@aws-amplify/ui';
 
 import { useAuth } from '../../../internal';
@@ -17,6 +16,7 @@ import { ComponentClassName } from '../constants';
 import { FormValues, BlurredFields, ValidationError } from '../types';
 import { ChangePasswordProps, ValidateParams } from './types';
 import DEFAULTS from './defaults';
+import { defaultChangePasswordDisplayText } from '../utils';
 
 const logger = new Logger('ChangePassword');
 
@@ -39,10 +39,11 @@ const getIsDisabled = (
 };
 
 function ChangePassword({
-  onSuccess,
-  onError,
-  validators,
   components,
+  displayText: overrideDisplayText,
+  onError,
+  onSuccess,
+  validators,
 }: ChangePasswordProps): JSX.Element | null {
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const [formValues, setFormValues] = React.useState<FormValues>({});
@@ -114,11 +115,16 @@ function ChangePassword({
   );
 
   /* Translations */
-  // TODO: add AccountSettingsTextUtil to collect these strings
-  const currentPasswordLabel = translate('Current Password');
-  const newPasswordLabel = translate('New Password');
-  const confirmPasswordLabel = translate('Confirm Password');
-  const updatePasswordText = translate('Update password');
+  const displayText = {
+    ...defaultChangePasswordDisplayText,
+    ...overrideDisplayText,
+  };
+  const {
+    confirmPasswordLabel,
+    currentPasswordLabel,
+    newPasswordLabel,
+    updatePasswordText,
+  } = displayText;
 
   /* Subcomponents */
   const {

--- a/packages/react/src/components/AccountSettings/ChangePassword/__tests__/ChangePassword.test.tsx
+++ b/packages/react/src/components/AccountSettings/ChangePassword/__tests__/ChangePassword.test.tsx
@@ -7,6 +7,15 @@ import ChangePassword from '../ChangePassword';
 import { Button } from '../../../../primitives';
 import { ChangePasswordComponents } from '../types';
 import { ComponentClassName } from '../../constants';
+import { defaultChangePasswordDisplayText } from '../../utils';
+import AccountSettings from '../../AccountSettings';
+
+const {
+  confirmPasswordLabel,
+  currentPasswordLabel,
+  newPasswordLabel,
+  updatePasswordText,
+} = defaultChangePasswordDisplayText;
 
 const components: ChangePasswordComponents = {
   CurrentPasswordField: (props) => (
@@ -70,10 +79,10 @@ describe('ChangePassword', () => {
     const onSuccess = jest.fn();
     render(<ChangePassword onSuccess={onSuccess} />);
 
-    const currentPassword = await screen.findByLabelText('Current Password');
-    const newPassword = await screen.findByLabelText('New Password');
+    const currentPassword = await screen.findByLabelText(currentPasswordLabel);
+    const newPassword = await screen.findByLabelText(newPasswordLabel);
     const submitButton = await screen.findByRole('button', {
-      name: 'Update password',
+      name: updatePasswordText,
     });
 
     fireEvent.input(currentPassword, {
@@ -100,7 +109,7 @@ describe('ChangePassword', () => {
     render(<ChangePassword onSuccess={onSuccess} />);
 
     const submitButton = await screen.findByRole('button', {
-      name: 'Update password',
+      name: updatePasswordText,
     });
     fireEvent.submit(submitButton);
 
@@ -116,7 +125,7 @@ describe('ChangePassword', () => {
     render(<ChangePassword onError={onError} />);
 
     const submitButton = await screen.findByRole('button', {
-      name: 'Update password',
+      name: updatePasswordText,
     });
 
     fireEvent.submit(submitButton);
@@ -132,7 +141,7 @@ describe('ChangePassword', () => {
     render(<ChangePassword onError={onError} />);
 
     const submitButton = await screen.findByRole('button', {
-      name: 'Update password',
+      name: updatePasswordText,
     });
 
     fireEvent.submit(submitButton);
@@ -144,7 +153,7 @@ describe('ChangePassword', () => {
     render(<ChangePassword />);
 
     const submitButton = await screen.findByRole('button', {
-      name: 'Update password',
+      name: updatePasswordText,
     });
 
     expect(submitButton).toHaveAttribute('disabled');
@@ -153,11 +162,11 @@ describe('ChangePassword', () => {
   it('enables submit button once formValues are valid', async () => {
     render(<ChangePassword />);
 
-    const currentPassword = await screen.findByLabelText('Current Password');
-    const newPassword = await screen.findByLabelText('New Password');
-    const confirmPassword = await screen.findByLabelText('Confirm Password');
+    const currentPassword = await screen.findByLabelText(currentPasswordLabel);
+    const newPassword = await screen.findByLabelText(newPasswordLabel);
+    const confirmPassword = await screen.findByLabelText(confirmPasswordLabel);
     const submitButton = await screen.findByRole('button', {
-      name: 'Update password',
+      name: updatePasswordText,
     });
 
     fireEvent.input(currentPassword, {
@@ -179,9 +188,9 @@ describe('ChangePassword', () => {
   it('displays new password validation error message', async () => {
     render(<ChangePassword />);
 
-    const newPassword = await screen.findByLabelText('New Password');
+    const newPassword = await screen.findByLabelText(newPasswordLabel);
     const submitButton = await screen.findByRole('button', {
-      name: 'Update password',
+      name: updatePasswordText,
     });
 
     fireEvent.input(newPassword, {
@@ -203,10 +212,10 @@ describe('ChangePassword', () => {
   it('displays confirm password validation error message', async () => {
     render(<ChangePassword />);
 
-    const newPassword = await screen.findByLabelText('New Password');
-    const confirmPassword = await screen.findByLabelText('Confirm Password');
+    const newPassword = await screen.findByLabelText(newPasswordLabel);
+    const confirmPassword = await screen.findByLabelText(confirmPasswordLabel);
     const submitButton = await screen.findByRole('button', {
-      name: 'Update password',
+      name: updatePasswordText,
     });
 
     fireEvent.input(newPassword, {
@@ -243,9 +252,9 @@ describe('ChangePassword', () => {
     };
     render(<ChangePassword validators={[minLength, hasSpecialChar]} />);
 
-    const newPassword = await screen.findByLabelText('New Password');
+    const newPassword = await screen.findByLabelText(newPasswordLabel);
     const submitButton = await screen.findByRole('button', {
-      name: 'Update password',
+      name: updatePasswordText,
     });
 
     fireEvent.input(newPassword, {
@@ -330,5 +339,16 @@ describe('ChangePassword', () => {
       currentPassword: 'oldpassword',
       newPassword: 'newpassword',
     });
+  });
+  it('renders as expected with override display text', () => {
+    const newPasswordLabelOverride = 'Custom new password label';
+    const displayTextOverride = {
+      newPasswordLabel: newPasswordLabelOverride,
+    };
+    const { getByText, queryByText } = render(
+      <AccountSettings.ChangePassword displayText={displayTextOverride} />
+    );
+    expect(getByText(newPasswordLabelOverride)).toBeVisible();
+    expect(queryByText(newPasswordLabel)).toBe(null);
   });
 });

--- a/packages/react/src/components/AccountSettings/ChangePassword/types.ts
+++ b/packages/react/src/components/AccountSettings/ChangePassword/types.ts
@@ -1,10 +1,12 @@
 import { InputEventType, ValidatorOptions } from '@aws-amplify/ui';
+
 import {
   SubmitButtonComponent,
   ErrorMessageComponent,
   PasswordFieldComponent,
   FormValues,
 } from '../types';
+import { ChangePasswordDisplayText } from '../utils';
 
 export interface ChangePasswordComponents {
   ConfirmPasswordField?: PasswordFieldComponent;
@@ -28,4 +30,6 @@ export interface ChangePasswordProps {
   validators?: ValidatorOptions[];
   /** custom component overrides */
   components?: ChangePasswordComponents;
+  /** overrides default display text */
+  displayText?: Partial<ChangePasswordDisplayText>;
 }

--- a/packages/react/src/components/AccountSettings/DeleteUser/DeleteUser.tsx
+++ b/packages/react/src/components/AccountSettings/DeleteUser/DeleteUser.tsx
@@ -1,26 +1,32 @@
 import React from 'react';
 
-import { deleteUser, translate, getLogger } from '@aws-amplify/ui';
+import { deleteUser, getLogger } from '@aws-amplify/ui';
 
 import { useAuth } from '../../../internal';
 import { Flex } from '../../../primitives';
 import { ComponentClassName } from '../constants';
 import DEFAULTS from './defaults';
 import { DeleteUserProps, DeleteUserState } from './types';
+import { defaultDeleteUserDisplayText } from '../utils';
 
 const logger = getLogger('Auth');
 
 function DeleteUser({
   components,
-  onSuccess,
-  onError,
+  displayText: overrideDisplayText,
   handleDelete,
+  onError,
+  onSuccess,
 }: DeleteUserProps): JSX.Element | null {
   const [state, setState] = React.useState<DeleteUserState>('IDLE');
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
 
   // translations
-  const deleteAccountText = translate('Delete Account');
+  const displayText = {
+    ...defaultDeleteUserDisplayText,
+    ...overrideDisplayText,
+  };
+  const { deleteAccountText } = displayText;
 
   const { user, isLoading } = useAuth();
 

--- a/packages/react/src/components/AccountSettings/DeleteUser/__tests__/DeleteUser.test.tsx
+++ b/packages/react/src/components/AccountSettings/DeleteUser/__tests__/DeleteUser.test.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  findByText,
-  queryByText,
-} from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 import * as UIModule from '@aws-amplify/ui';
 

--- a/packages/react/src/components/AccountSettings/DeleteUser/__tests__/DeleteUser.test.tsx
+++ b/packages/react/src/components/AccountSettings/DeleteUser/__tests__/DeleteUser.test.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  findByText,
+  queryByText,
+} from '@testing-library/react';
 
 import * as UIModule from '@aws-amplify/ui';
 
@@ -13,6 +20,7 @@ import {
 import { ComponentClassName } from '../../constants';
 import { DeleteUserComponents, WarningViewProps } from '../types';
 import DeleteUser from '../DeleteUser';
+import { defaultDeleteUserDisplayText } from '../../utils';
 
 jest.mock('../../../../internal', () => ({
   useAuth: () => ({
@@ -22,6 +30,9 @@ jest.mock('../../../../internal', () => ({
 }));
 
 const deleteUserSpy = jest.spyOn(UIModule, 'deleteUser');
+
+const { cancelText, deleteAccountText, deleteMyAccountText } =
+  defaultDeleteUserDisplayText;
 
 function CustomWarningView({ onCancel, onConfirm }: WarningViewProps) {
   return (
@@ -78,13 +89,13 @@ describe('DeleteUser', () => {
     render(<DeleteUser onSuccess={onSuccess} />);
 
     const deleteAccountButton = await screen.findByRole('button', {
-      name: 'Delete Account',
+      name: deleteAccountText,
     });
 
     fireEvent.click(deleteAccountButton);
 
     const confirmDeleteButton = await screen.findByRole('button', {
-      name: 'Delete my account',
+      name: deleteMyAccountText,
     });
 
     fireEvent.click(confirmDeleteButton);
@@ -99,13 +110,13 @@ describe('DeleteUser', () => {
     render(<DeleteUser onSuccess={onSuccess} />);
 
     const deleteAccountButton = await screen.findByRole('button', {
-      name: 'Delete Account',
+      name: deleteAccountText,
     });
 
     fireEvent.click(deleteAccountButton);
 
     const confirmDeleteButton = await screen.findByRole('button', {
-      name: 'Delete my account',
+      name: deleteMyAccountText,
     });
 
     fireEvent.click(confirmDeleteButton);
@@ -122,13 +133,13 @@ describe('DeleteUser', () => {
     render(<DeleteUser onError={onError} />);
 
     const deleteAccountButton = await screen.findByRole('button', {
-      name: 'Delete Account',
+      name: deleteAccountText,
     });
 
     fireEvent.click(deleteAccountButton);
 
     const confirmDeleteButton = await screen.findByRole('button', {
-      name: 'Delete my account',
+      name: deleteMyAccountText,
     });
 
     fireEvent.click(confirmDeleteButton);
@@ -143,21 +154,21 @@ describe('DeleteUser', () => {
     render(<DeleteUser />);
 
     const deleteAccountButton = await screen.findByRole('button', {
-      name: 'Delete Account',
+      name: deleteAccountText,
     });
     fireEvent.click(deleteAccountButton);
 
     // warning window now should be visible
-    await screen.findByText('Delete my account');
+    await screen.findByText(deleteMyAccountText);
 
     const cancelButton = await screen.findByRole('button', {
-      name: 'Cancel',
+      name: cancelText,
     });
     fireEvent.click(cancelButton);
 
     // warning window should be gone now
     await waitFor(() =>
-      expect(screen.queryByText('Delete my account')).not.toBeInTheDocument()
+      expect(screen.queryByText(deleteMyAccountText)).not.toBeInTheDocument()
     );
   });
 
@@ -168,13 +179,13 @@ describe('DeleteUser', () => {
     render(<DeleteUser onError={onError} />);
 
     const deleteAccountButton = await screen.findByRole('button', {
-      name: 'Delete Account',
+      name: deleteAccountText,
     });
 
     fireEvent.click(deleteAccountButton);
 
     const confirmDeleteButton = await screen.findByRole('button', {
-      name: 'Delete my account',
+      name: deleteMyAccountText,
     });
 
     fireEvent.click(confirmDeleteButton);
@@ -262,5 +273,17 @@ describe('DeleteUser', () => {
     await screen.findByText('Mock Error');
 
     expect(await screen.findByText('Custom Error Message')).toBeDefined();
+  });
+
+  it('renders as expected with override display text', () => {
+    const deleteAccountTextOverride = 'Custom delete account label';
+    const displayTextOverride = {
+      deleteAccountText: deleteAccountTextOverride,
+    };
+    const { getByText, queryByText } = render(
+      <DeleteUser displayText={displayTextOverride} />
+    );
+    expect(getByText(deleteAccountTextOverride)).toBeVisible();
+    expect(queryByText(deleteAccountText)).toBe(null);
   });
 });

--- a/packages/react/src/components/AccountSettings/DeleteUser/defaults.tsx
+++ b/packages/react/src/components/AccountSettings/DeleteUser/defaults.tsx
@@ -1,23 +1,27 @@
 import React from 'react';
-import { translate } from '@aws-amplify/ui';
 
 import { Button, Card, Flex, Text } from '../../../primitives';
 import { ButtonComponent } from '../types';
 import { DefaultErrorMessage } from '../shared/Defaults';
-import { DeleteUserComponents, WarningViewComponent } from './types';
+import {
+  DeleteUserComponents,
+  WarningViewComponent,
+  WarningViewProps,
+} from './types';
+import { defaultDeleteUserDisplayText } from '../utils';
 
 const DefaultWarningView: WarningViewComponent = ({
+  displayText: overrideDisplayText,
+  isDisabled,
   onCancel,
   onConfirm,
-  isDisabled,
-}) => {
+}: WarningViewProps) => {
   // translations
-  // TODO: consolodiate translations to accountSettingsTextUtil
-  const warningText = translate(
-    'Deleting your account is not reversable. You will lose access to your account and all data associated with it.'
-  );
-  const cancelText = translate('Cancel');
-  const deleteMyAccountText = translate('Delete my account');
+  const displayText = {
+    ...defaultDeleteUserDisplayText,
+    ...overrideDisplayText,
+  };
+  const { cancelText, deleteMyAccountText, warningText } = displayText;
 
   return (
     <Card>

--- a/packages/react/src/components/AccountSettings/DeleteUser/types.ts
+++ b/packages/react/src/components/AccountSettings/DeleteUser/types.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import { AmplifyUser } from '@aws-amplify/ui';
 
 import { ButtonComponent, ErrorMessageComponent } from '../types';
+import { DeleteUserDisplayText } from '../utils';
 
 export interface WarningViewProps {
   /** called when end user cancels account deletion */
@@ -11,6 +12,8 @@ export interface WarningViewProps {
   onConfirm: () => void;
   /** whether account deletion is in progress */
   isDisabled: boolean;
+  /** overrides default display text */
+  displayText?: Partial<DeleteUserDisplayText>;
 }
 
 export type WarningViewComponent<Props = {}> = React.ComponentType<
@@ -42,4 +45,7 @@ export interface DeleteUserProps {
 
   /** custom component overrides */
   components?: DeleteUserComponents;
+
+  /** overrides default display text*/
+  displayText?: Partial<DeleteUserDisplayText>;
 }

--- a/packages/react/src/components/AccountSettings/utils/displayText.ts
+++ b/packages/react/src/components/AccountSettings/utils/displayText.ts
@@ -1,0 +1,18 @@
+export const defaultChangePasswordDisplayText = {
+  currentPasswordLabel: 'Current Password',
+  newPasswordLabel: 'New Password',
+  confirmPasswordLabel: 'Confirm Password',
+  updatePasswordText: 'Update password',
+};
+
+export type ChangePasswordDisplayText = typeof defaultChangePasswordDisplayText;
+
+export const defaultDeleteUserDisplayText = {
+  deleteAccountText: 'Delete Account',
+  warningText:
+    'Deleting your account is not reversible. You will lose access to your account and all data associated with it.',
+  cancelText: 'Cancel',
+  deleteMyAccountText: 'Delete my account',
+};
+
+export type DeleteUserDisplayText = typeof defaultDeleteUserDisplayText;

--- a/packages/react/src/components/AccountSettings/utils/index.ts
+++ b/packages/react/src/components/AccountSettings/utils/index.ts
@@ -1,0 +1,6 @@
+export {
+  defaultChangePasswordDisplayText,
+  defaultDeleteUserDisplayText,
+  ChangePasswordDisplayText,
+  DeleteUserDisplayText,
+} from './displayText';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

* Replace i18n module with displayText for Account Settings components.
* Add unit tests for text overrides.
* Add docs sections for each component.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
