### PR TITLE
fix radio disabled label color and radioGroup legend theming

### DIFF
--- a/docs/__tests__/__snapshots__/cssvars-table.test.ts.snap
+++ b/docs/__tests__/__snapshots__/cssvars-table.test.ts.snap
@@ -4147,8 +4147,12 @@ exports[`CSS Variables Table 1`] = `
         \\"value\\": \\"var(--amplify-colors-font-disabled)\\"
     },
     {
-        \\"variable\\": \\"--amplify-components-radiogroup-label-color\\",
-        \\"value\\": \\"var(--amplify-components-field-label-color)\\"
+        \\"variable\\": \\"--amplify-components-radiogroup-legend-color\\",
+        \\"value\\": \\"var(--amplify-components-fieldset-legend-color)\\"
+    },
+    {
+        \\"variable\\": \\"--amplify-components-radiogroup-legend-font-weight\\",
+        \\"value\\": \\"var(--amplify-font-weights-normal)\\"
     },
     {
         \\"variable\\": \\"--amplify-components-radiogroup-radio-background-color\\",

--- a/docs/src/pages/[platform]/components/radiogroupfield/examples/RadioGroupFieldThemeExample.tsx
+++ b/docs/src/pages/[platform]/components/radiogroupfield/examples/RadioGroupFieldThemeExample.tsx
@@ -16,6 +16,10 @@ const theme = {
             color: { value: '{colors.blue.80}' },
           },
         },
+        legend: {
+          color: { value: '{colors.blue.80}' },
+          fontWeight: { value: '{fontWeights.bold}' },
+        },
       },
     },
   },

--- a/packages/react/src/primitives/Radio/Radio.tsx
+++ b/packages/react/src/primitives/Radio/Radio.tsx
@@ -74,8 +74,14 @@ export const RadioPrimitive: Primitive<RadioProps, 'input'> = (
       {children && (
         <Text
           as="span"
-          className={ComponentClassName.RadioLabel}
-          data-disabled={shouldBeDisabled}
+          className={classNames(
+            ComponentClassName.RadioLabel,
+            classNameModifierByFlag(
+              ComponentClassName.RadioLabel,
+              `disabled`,
+              shouldBeDisabled
+            )
+          )}
         >
           {children}
         </Text>

--- a/packages/ui/src/theme/__tests__/defaultTheme.test.ts
+++ b/packages/ui/src/theme/__tests__/defaultTheme.test.ts
@@ -934,7 +934,8 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-radiogroup-radio-background-color: var(--amplify-components-radio-button-background-color);
         --amplify-components-radiogroup-radio-checked-color: var(--amplify-components-radio-button-checked-color);
         --amplify-components-radiogroup-radio-label-color: var(--amplify-components-radio-label-color);
-        --amplify-components-radiogroup-label-color: var(--amplify-components-field-label-color);
+        --amplify-components-radiogroup-legend-color: var(--amplify-components-fieldset-legend-color);
+        --amplify-components-radiogroup-legend-font-weight: var(--amplify-font-weights-normal);
         --amplify-components-rating-large-size: var(--amplify-font-sizes-xxxl);
         --amplify-components-rating-default-size: var(--amplify-font-sizes-xl);
         --amplify-components-rating-small-size: var(--amplify-font-sizes-small);

--- a/packages/ui/src/theme/__tests__/overrides.test.ts
+++ b/packages/ui/src/theme/__tests__/overrides.test.ts
@@ -968,7 +968,8 @@ describe('@aws-amplify/ui', () => {
         --amplify-components-radiogroup-radio-background-color: var(--amplify-components-radio-button-background-color);
         --amplify-components-radiogroup-radio-checked-color: var(--amplify-components-radio-button-checked-color);
         --amplify-components-radiogroup-radio-label-color: var(--amplify-components-radio-label-color);
-        --amplify-components-radiogroup-label-color: var(--amplify-components-field-label-color);
+        --amplify-components-radiogroup-legend-color: var(--amplify-components-fieldset-legend-color);
+        --amplify-components-radiogroup-legend-font-weight: var(--amplify-font-weights-normal);
         --amplify-components-rating-large-size: var(--amplify-font-sizes-xxxl);
         --amplify-components-rating-default-size: var(--amplify-font-sizes-xl);
         --amplify-components-rating-small-size: var(--amplify-font-sizes-small);

--- a/packages/ui/src/theme/css/component/radio.scss
+++ b/packages/ui/src/theme/css/component/radio.scss
@@ -9,9 +9,7 @@
   position: relative;
   &--disabled {
     cursor: var(--amplify-components-radio-disabled-cursor);
-    color: var(--amplify-components-radio-label-disabled-color);
   }
-  --amplify-components-text-color: var(--amplify-components-radio-label-color);
 }
 
 .amplify-radio__button {
@@ -93,5 +91,8 @@
 }
 
 .amplify-radio__label {
-  color: inherit;
+  color: var(--amplify-components-radio-label-color);
+  &--disabled {
+    color: var(--amplify-components-radio-label-disabled-color);
+  }
 }

--- a/packages/ui/src/theme/css/component/radioGroupField.scss
+++ b/packages/ui/src/theme/css/component/radioGroupField.scss
@@ -2,9 +2,15 @@
   flex-direction: column;
   align-items: flex-start;
 
-  --amplify-components-field-label-color: var(
-    --amplify-components-radiogroup-label-color
+  // Legend styling
+  --amplify-components-fieldset-legend-color: var(
+    --amplify-components-radiogroup-legend-color
   );
+  --amplify-components-fieldset-legend-font-weight: var(
+    --amplify-components-radiogroup-legend-font-weight
+  );
+
+  // Radio + label styling
   --amplify-components-radio-button-border-width: var(
     --amplify-components-radiogroup-radio-border-width
   );

--- a/packages/ui/src/theme/tokens/components/radioGroup.ts
+++ b/packages/ui/src/theme/tokens/components/radioGroup.ts
@@ -8,7 +8,7 @@ export type RadioGroupTokens<Output extends OutputVariantKey> = {
     _checked?: DesignTokenProperties<'color', Output>;
     label?: DesignTokenProperties<'color', Output>;
   };
-  label?: DesignTokenProperties<'color', Output>;
+  legend?: DesignTokenProperties<'color' | 'fontWeight', Output>;
 };
 
 export const radiogroup: Required<RadioGroupTokens<'default'>> = {
@@ -23,7 +23,8 @@ export const radiogroup: Required<RadioGroupTokens<'default'>> = {
       color: { value: '{components.radio.label.color}' },
     },
   },
-  label: {
-    color: { value: '{components.field.label.color}' },
+  legend: {
+    color: { value: '{components.fieldset.legend.color}' },
+    fontWeight: { value: '{fontWeights.normal}' },
   },
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- Add disabled class to .amplify-radio__label so it can have proper disabled styling/theming
 - remove unneeded disabled attribute on label
- Add tokens for theming legend of RadioGroupField, remove old top level label tokens.
- Update theme example for RadioGroupField in docs
- snapshots

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
