### PR TITLE
chore: Increase time to wait to check build system tests

### DIFF
--- a/build-system-tests/scripts/checkReactNativeLog.ts
+++ b/build-system-tests/scripts/checkReactNativeLog.ts
@@ -135,7 +135,7 @@ const checkReactNativeLog = async (): Promise<void> => {
   process.chdir(`mega-apps/${megaAppName}`);
 
   // Wait for the logging messages to be ready. The number is based on real experiments in Github Actions.
-  let timeToWait = platform === 'android' ? 500 : 300;
+  const timeToWait = 500;
 
   log('info', `Sleep for '${timeToWait}' seconds...`);
   await sleep(timeToWait);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Increase timeout for checking logs for build system tests on ios, to mitigate several transient failures.

Example: https://github.com/aws-amplify/amplify-ui/actions/runs/6321587860/job/17165846938

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
