### PR TITLE
chore(ui-vue): Clean up unused css

### DIFF
--- a/.changeset/fuzzy-worms-wait.md
+++ b/.changeset/fuzzy-worms-wait.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-vue': patch
+---
+
+Fixes an issue where warnings related to unused css would appear while building with nuxt.

--- a/packages/vue/src/components/primitives/styles.css
+++ b/packages/vue/src/components/primitives/styles.css
@@ -10,22 +10,5 @@ html {
 }
 
 [data-amplify-spacer] {
-  @apply flex-1;
-}
-
-[data-amplify-lostcode] {
-  @apply flex flex-col items-start;
-}
-
-[data-amplify-select] {
-  @apply block w-full  rounded shadow-sm;
-  border-width: 1px;
-  padding: 0.5rem 0.75rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  width: 97%;
-}
-
-[data-amplify-alias-label] {
-  @apply flex flex-col;
+  flex: 1;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes an issue where warnings related to unused css that has `@apply` directive appear while building with nuxt.

Also experienced in CI while building our mega-app with nuxt: https://github.com/aws-amplify/amplify-ui/actions/runs/6329587438/job/17190179520

```
[warn] warnings when minifying css:
Warning: G] Expected ";" but found "}" [css-syntax-error]

    <stdin>:1:278009:
      1 │ ...ta-amplify-spacer]{@apply flex-1}[data-amplify-lostcode]{@apply ...
        │                                    ^
        ╵                                    ;


Warning: G] Expected ";" but found "}" [css-syntax-error]

    <stdin>:1:278066:
      1 │ ...@apply flex flex-col items-start}[data-amplify-select]{@apply bl...
        │                                    ^
        ╵                                    ;


Warning: G] Expected ";" but found "}" [css-syntax-error]

    <stdin>:1:278256:
      1 │ ...lias-label]{@apply flex flex-col}.amplify-authenticator__font{fo...
        │                                    ^
        ╵                                    ;

```
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fixes: https://github.com/aws-amplify/amplify-ui/issues/4484

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Tested locally by building vue mega app with nuxt.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
