### PR TITLE
breaking: remove old AmplifyProvider

### DIFF
--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -2,7 +2,33 @@ import { Alert,  Tabs, TabItem } from '@aws-amplify/ui-react';
 import { TerminalCommand } from '@/components/InstallScripts';
 
 ## `@aws-amplify/ui-react`
-### 4.x to 5.x
+
+### Migrate from 5.x to 6.x
+#### Installation
+Install the 6.x version of both `@aws-amplify/ui-react` and `aws-amplify`.
+
+<Tabs>
+<TabItem title="npm">
+<TerminalCommand command="npm install @aws-amplify/ui-react@6.x aws-amplify@6.x" />
+</TabItem>
+<TabItem title="yarn">
+<TerminalCommand command="yarn add @aws-amplify/ui-react@6.x aws-amplify@6.x" />
+</TabItem>
+</Tabs>
+
+#### Update and usage
+
+`@aws-amplify/ui-react@6.x` introduces the following breaking changes:
+
+#### 1. `@aws-amplify/ui-react@6.x` drops `AmplifyProvider`. `AmplifyProvider` was renamed to `ThemeProvider` in version 2.18.3 but kept for compatibility. No API changes other than export name. If still using `AmplifyProvider`, replace directly with `ThemeProvider`:
+```diff
+- import { AmplifyProvider } from '@aws-amplify/ui-react';
++ import { ThemeProvider } from '@aws-amplify/ui-react';
+- const App = ( <AmplifyProvider><App /></AmplifyProvider>);
++ const App = ( <ThemeProvider><App /></ThemeProvider>);
+```
+
+### Migrate from 4.x to 5.x
 #### Installation
 Install the 5.x version of the `@aws-amplify/ui-react` library.
 
@@ -109,7 +135,7 @@ import { Link as ReactRouterLink } from 'react-router-dom';
 
 #### 4. `@aws-amplify/ui-react@5.x` updates component types to include the underlying rendered HTML element's attributes and strictly types the `View` component.
 
-### 3.x to 4.x
+### Migrate from 3.x to 4.x
 #### Installation
 Install the 4.x version of the `@aws-amplify/ui-react` library and the 5.x version of the `aws-amplify` library.
 
@@ -216,7 +242,7 @@ We replaced following legacy Authenticator texts:
 
 If you were using `I18n` to translate those keys, please update your translations accordingly to match the new strings.
 
-### 2.x to 3.x
+### Migrate from 2.x to 3.x
 
 #### Installation
 Install the 3.x version of the `@aws-amplify/ui-react` library.
@@ -249,7 +275,7 @@ Note: We did not remove the [Icon](/react/components/icon) component, which allo
 
 This export has been removed and should no longer be used.
 
-### 1.x to 2.x
+### Migrate from 1.x to 2.x
 #### Installation
 
 Install the 2.x version of the `@aws-amplify/ui-react` library.
@@ -323,7 +349,7 @@ The latest version of the `Authenticator` has a completely different set of CSS 
 Previous versions of `Authenticator` exposed a `onAuthUIStateChange` handler to detect Auth state changes. For similar functionality see [useAuthenticator](/react/connected-components/authenticator/advanced#access-auth-state).
 
 ## `@aws-amplify/ui-react-liveness`
-### 1.x to 2.x
+### Migrate from 1.x to 2.x
 #### Installation
 
 Install the 2.x version of the `@aws-amplify/ui-react-liveness` library.

--- a/packages/react/__tests__/__snapshots__/exports.ts.snap
+++ b/packages/react/__tests__/__snapshots__/exports.ts.snap
@@ -4,7 +4,6 @@ exports[`@aws-amplify/ui-react exports should match snapshot 1`] = `
 Array [
   "AccountSettings",
   "Alert",
-  "AmplifyProvider",
   "Authenticator",
   "Autocomplete",
   "Badge",

--- a/packages/react/src/components/ThemeProvider/ThemeContext.tsx
+++ b/packages/react/src/components/ThemeProvider/ThemeContext.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 
 import { createTheme, WebTheme } from '@aws-amplify/ui';
 
-export interface AmplifyContextType {
+export interface ThemeContextType {
   theme: WebTheme;
 }
 
-export const AmplifyContext = React.createContext<AmplifyContextType>({
+export const ThemeContext = React.createContext<ThemeContextType>({
   theme: createTheme(),
 });

--- a/packages/react/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/react/src/components/ThemeProvider/ThemeProvider.tsx
@@ -8,7 +8,7 @@ import {
   sanitizeNamespaceImport,
 } from '@aws-amplify/ui';
 
-import { AmplifyContext } from './AmplifyContext';
+import { ThemeContext } from './ThemeContext';
 
 // Radix packages don't support ESM in Node, in some scenarios(e.g. SSR)
 // We have to use namespace import and sanitize it to ensure the interoperablity between ESM and CJS
@@ -40,7 +40,10 @@ interface ThemeProviderProps {
   theme?: Theme | WebTheme;
 }
 
-export function AmplifyProvider({
+/**
+ * [📖 Docs](https://ui.docs.amplify.aws/react/theming)
+ */
+export function ThemeProvider({
   children,
   colorMode,
   direction = 'ltr',
@@ -53,7 +56,7 @@ export function AmplifyProvider({
   } = value;
 
   return (
-    <AmplifyContext.Provider value={value}>
+    <ThemeContext.Provider value={value}>
       <DirectionProvider dir={direction}>
         {/*
           The data attributes on here as well as the root element allow for nested
@@ -124,11 +127,6 @@ export function AmplifyProvider({
           />
         )}
       </DirectionProvider>
-    </AmplifyContext.Provider>
+    </ThemeContext.Provider>
   );
 }
-
-/**
- * [📖 Docs](https://ui.docs.amplify.aws/react/theming)
- */
-export const ThemeProvider = AmplifyProvider;

--- a/packages/react/src/components/ThemeProvider/__tests__/AmplifyContext.test.tsx
+++ b/packages/react/src/components/ThemeProvider/__tests__/AmplifyContext.test.tsx
@@ -1,26 +1,26 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-import { AmplifyContext } from '../AmplifyContext';
+import { ThemeContext } from '../ThemeContext';
 import { WebTheme } from '@aws-amplify/ui';
 
-describe('AmplifyContext', () => {
+describe('ThemeContext', () => {
   it('should provide default context values', () => {
-    let amplifyContext;
+    let context;
 
     const TestComponent = () => {
-      amplifyContext = React.useContext(AmplifyContext);
+      context = React.useContext(ThemeContext);
       return null;
     };
 
     render(<TestComponent />);
 
-    expect(amplifyContext.theme.name).toBe('default-theme');
-    expect(JSON.stringify(amplifyContext.theme.tokens)).toBeDefined();
+    expect(context.theme.name).toBe('default-theme');
+    expect(JSON.stringify(context.theme.tokens)).toBeDefined();
   });
 
   it('should provide context values from a provider', () => {
-    let amplifyContext;
+    let context;
 
     const customTheme = {
       name: 'custom',
@@ -33,17 +33,17 @@ describe('AmplifyContext', () => {
     };
 
     const TestComponent = () => {
-      amplifyContext = React.useContext(AmplifyContext);
+      context = React.useContext(ThemeContext);
       return null;
     };
 
     render(
-      <AmplifyContext.Provider value={customContextValues}>
+      <ThemeContext.Provider value={customContextValues}>
         <TestComponent />
-      </AmplifyContext.Provider>
+      </ThemeContext.Provider>
     );
 
-    expect(amplifyContext.theme.name).toBe('custom');
-    expect(JSON.stringify(amplifyContext.theme.tokens)).toBe('{}');
+    expect(context.theme.name).toBe('custom');
+    expect(JSON.stringify(context.theme.tokens)).toBe('{}');
   });
 });

--- a/packages/react/src/components/ThemeProvider/index.ts
+++ b/packages/react/src/components/ThemeProvider/index.ts
@@ -1,6 +1,1 @@
-export {
-  ColorMode,
-  Direction,
-  AmplifyProvider,
-  ThemeProvider,
-} from './ThemeProvider';
+export { ColorMode, Direction, ThemeProvider } from './ThemeProvider';

--- a/packages/react/src/hooks/__tests__/useTheme.test.tsx
+++ b/packages/react/src/hooks/__tests__/useTheme.test.tsx
@@ -1,6 +1,6 @@
 import { createTheme, WebTheme } from '@aws-amplify/ui';
 import { renderHook } from '@testing-library/react-hooks';
-import { AmplifyProvider } from '../../components/ThemeProvider';
+import { ThemeProvider } from '../../components/ThemeProvider';
 import { useTheme } from '../useTheme';
 import * as React from 'react';
 
@@ -21,7 +21,7 @@ describe('useTheme', () => {
 
     const { result } = renderHook(() => useTheme(), {
       wrapper: ({ children }) => (
-        <AmplifyProvider theme={customTheme}>{children}</AmplifyProvider>
+        <ThemeProvider theme={customTheme}>{children}</ThemeProvider>
       ),
     });
 
@@ -48,7 +48,7 @@ describe('useTheme', () => {
 
     const { result } = renderHook(() => useTheme(), {
       wrapper: ({ children }) => (
-        <AmplifyProvider theme={extendedTheme}>{children}</AmplifyProvider>
+        <ThemeProvider theme={extendedTheme}>{children}</ThemeProvider>
       ),
     });
 
@@ -57,7 +57,7 @@ describe('useTheme', () => {
 
   it('should return a default theme if not provided through context', () => {
     const { result } = renderHook(() => useTheme(), {
-      wrapper: ({ children }) => <AmplifyProvider>{children}</AmplifyProvider>,
+      wrapper: ({ children }) => <ThemeProvider>{children}</ThemeProvider>,
     });
 
     expect(serializeTheme(result.current)).toBe(serializeTheme(createTheme()));

--- a/packages/react/src/hooks/useTheme.ts
+++ b/packages/react/src/hooks/useTheme.ts
@@ -2,17 +2,17 @@ import * as React from 'react';
 
 import { createTheme, WebTheme } from '@aws-amplify/ui';
 import {
-  AmplifyContext,
-  AmplifyContextType,
-} from '../components/ThemeProvider/AmplifyContext';
+  ThemeContext,
+  ThemeContextType,
+} from '../components/ThemeProvider/ThemeContext';
 
 /**
  * Get current Theme object value from Amplify context.
  * Returns a default theme if context is not available
  */
 export const getThemeFromContext = (
-  context: AmplifyContextType
-): AmplifyContextType['theme'] => {
+  context: ThemeContextType
+): ThemeContextType['theme'] => {
   if (typeof context === 'undefined' || typeof context.theme === 'undefined') {
     return createTheme();
   }
@@ -24,6 +24,6 @@ export const getThemeFromContext = (
  * [📖 Docs](https://ui.docs.amplify.aws/react/theming)
  */
 export const useTheme = (): WebTheme => {
-  const context = React.useContext(AmplifyContext);
+  const context = React.useContext(ThemeContext);
   return getThemeFromContext(context);
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This PR removes AmplifyProvider which was renamed to ThemeProvider in v2. It has been documented as ThemeProvider for 3 releases, so it's time to clean it up.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
* Ran Unit and Integration tests
* Ran Docs and validated that custom themes are rendering

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
