### PR TITLE
Remove variable.css from font import

### DIFF
--- a/docs/src/pages/[platform]/getting-started/installation/fonts.web.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/fonts.web.mdx
@@ -39,7 +39,7 @@ You can also install it as an NPM dependency:
 Then import the variable font in your application:
 
 ```javascript
-import '@fontsource/inter/variable.css';
+import '@fontsource/inter';
 ```
 
 Check out [Fontsource](https://fontsource.org/) for more information and documentation on this library.


### PR DESCRIPTION
#### Description of changes

Removed /variable.css so the import statement look like 
`import '@fontsource/inter';`
 because using variable.css leads to the following error:
`error: Module not found: Error: Can't resolve '@fontsource/inter/variable.css' in ....`

#### Description of how you validated changes

Its the recommended way of importing a font, see https://fontsource.org/fonts/inter/install
Error above is gone, Fonts are available
