### PR TITLE
chore(docs): Updating docs to reflect TOTP support in Authenticator for Swift

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/configuration/index.page.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/configuration/index.page.mdx
@@ -115,3 +115,7 @@ with the exception of `address`, `gender`, `locale`, `picture`, `updated_at`, an
 <Fragment useCommonWebContent platforms={['web', 'react-native', 'swift']}>
   {({ platform }) => import(`./hidesignup.${platform}.mdx`)}
 </Fragment>
+
+<Fragment useCommonWebContent platforms={['swift']}>
+  {({ platform }) => import(`./totpIssuer.${platform}.mdx`)}
+</Fragment>

--- a/docs/src/pages/[platform]/connected-components/authenticator/configuration/totpIssuer.swift.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/configuration/totpIssuer.swift.mdx
@@ -1,0 +1,11 @@
+## TOTP Issuer
+
+The TOTP issuer is the name that will be shown in TOTP applications preceding the account name. In most cases, this should be the name of your app. For example, if your app is called "My App", your user will see "My App" - "username" in their TOTP app. This can be customized by adding the `totpOptions` argument to the Authenticator component with a value for `issuer`. 
+
+Note: Unless changed, the default issuer is the application name retrieved from the project configuration. The key for this value is `CFBundleDisplayName` on iOS found in `info.plist`.
+
+```swift
+Authenticator(totpOptions: .init(issuer: "My App")) { _ in
+    Text("Signed In Content")
+}
+```

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.full-ui-customization.swift.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.full-ui-customization.swift.mdx
@@ -56,3 +56,30 @@ struct CustomSignInView: View {
 }
 
 ```
+
+### TOTP Setup
+
+You can also customize the TOTP setup experience. We make available arguments in the `ContinueSignInWithTOTPSetupView` i.e. `qrCodeContent` and `copyKeyContent` that can help you provide custom content for the TOTP Setup Experience. In the example below, examine how you could customize the setup screen.
+
+```swift
+Authenticator(
+    continueSignInWithTOTPSetupContent: { state in
+        ContinueSignInWithTOTPSetupView(
+            state: state,
+
+            // Example of how a customer can pass a custom QR code
+            qrCodeContent: { state in
+                // Your custom QR Code implementation goes here
+
+            },
+            copyKeyContent: { state in
+                // YOUR custom implementation goes here
+            }
+        )
+    },
+    content: { state in
+        Text("Signed In Content")
+    }
+)
+
+```


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

The PR aims to update docs to add details of TOTP  in Authenticator for Swift. The changes updates the following 2 things:
* How a customer can pass in a configuration to udpate the issuer. 
* How a customer can customize the TOTP Setup Experience. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
