### PR TITLE
fix(storage): fixing drop handler for file extensions

### DIFF
--- a/.changeset/dull-cheetahs-deliver.md
+++ b/.changeset/dull-cheetahs-deliver.md
@@ -1,0 +1,8 @@
+---
+"@aws-amplify/ui-react-storage": patch
+"@aws-amplify/ui-react": patch
+---
+
+fix(storage): fixing drop handler for file extensions
+
+Previously, adding a file extension for an `acceptedFileTypes` when a customer would drop a file it would show as rejected even if it was a valid file type. This fixes that issue. 

--- a/examples/next/pages/ui/components/storage/storage-manager/accept-file-extension/aws-exports.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/accept-file-extension/aws-exports.js
@@ -1,0 +1,2 @@
+import awsExports from '@environments/storage/file-uploader/src/aws-exports';
+export default awsExports;

--- a/examples/next/pages/ui/components/storage/storage-manager/accept-file-extension/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/accept-file-extension/index.page.tsx
@@ -1,0 +1,19 @@
+import { Amplify } from 'aws-amplify';
+import { StorageManager } from '@aws-amplify/ui-react-storage';
+import '@aws-amplify/ui-react/styles.css';
+import awsExports from './aws-exports';
+Amplify.configure(awsExports);
+
+export function StorageManagerExample() {
+  return (
+    <>
+      <StorageManager
+        acceptedFileTypes={['.png']}
+        accessLevel="public"
+        maxFileCount={1}
+        showThumbnails
+      />
+    </>
+  );
+}
+export default StorageManagerExample;

--- a/packages/react/src/primitives/DropZone/__tests__/filterAllowedFiles.test.ts
+++ b/packages/react/src/primitives/DropZone/__tests__/filterAllowedFiles.test.ts
@@ -1,0 +1,32 @@
+import { filterAllowedFiles } from '../filterAllowedFiles';
+
+describe('filterAllowFiles', () => {
+  const droppedFiles = [
+    new File([], 'test.jpg', { type: 'image/jpg' }),
+    new File([], 'test.png', { type: 'image/png' }),
+  ];
+
+  it('should work with * MIME types', () => {
+    const { acceptedFiles, rejectedFiles } = filterAllowedFiles(droppedFiles, [
+      'image/*',
+    ]);
+    expect(rejectedFiles).toHaveLength(0);
+    expect(acceptedFiles).toHaveLength(2);
+  });
+
+  it('should work with extension types', () => {
+    const { acceptedFiles, rejectedFiles } = filterAllowedFiles(droppedFiles, [
+      '.png',
+    ]);
+    expect(rejectedFiles).toHaveLength(1);
+    expect(acceptedFiles).toHaveLength(1);
+  });
+
+  it('should work with *', () => {
+    const { acceptedFiles, rejectedFiles } = filterAllowedFiles(droppedFiles, [
+      '*',
+    ]);
+    expect(rejectedFiles).toHaveLength(0);
+    expect(acceptedFiles).toHaveLength(2);
+  });
+});

--- a/packages/react/src/primitives/DropZone/filterAllowedFiles.ts
+++ b/packages/react/src/primitives/DropZone/filterAllowedFiles.ts
@@ -1,0 +1,50 @@
+// Drag event file shape is different than the drop event fileshape
+type DragFile =
+  | {
+      kind: string;
+      type: string;
+      name?: string;
+    }
+  | File;
+
+export function filterAllowedFiles<FileType extends DragFile = DragFile>(
+  files: FileType[],
+  acceptedFileTypes: string[]
+): { acceptedFiles: FileType[]; rejectedFiles: FileType[] } {
+  // Allow any files if acceptedFileTypes is undefined, empty array, or contains '*'
+  if (
+    !acceptedFileTypes ||
+    acceptedFileTypes.length === 0 ||
+    acceptedFileTypes.includes('*')
+  ) {
+    return { acceptedFiles: files, rejectedFiles: [] };
+  }
+  const acceptedFiles: FileType[] = [];
+  const rejectedFiles: FileType[] = [];
+
+  function filterFile(file: DragFile) {
+    const { type = '', name = '' } = file;
+    const mimeType = type.toLowerCase();
+    const baseMimeType = mimeType.split('/')[0];
+
+    return acceptedFileTypes.some((type) => {
+      const validType = type.trim().toLowerCase();
+      // if the accepted file type is a file extension
+      // it will start with '.', check against the file name
+      if (validType.charAt(0) === '.') {
+        return name.toLowerCase().endsWith(validType);
+      }
+      // This is something like a image/* mime type
+      if (validType.endsWith('/*')) {
+        return baseMimeType === validType.split('/')[0];
+      }
+      return mimeType === validType;
+    });
+  }
+
+  files.forEach((file) => {
+    (filterFile(file) ? acceptedFiles : rejectedFiles).push(file);
+  });
+
+  return { acceptedFiles, rejectedFiles };
+}

--- a/packages/react/src/primitives/DropZone/useDropZone.ts
+++ b/packages/react/src/primitives/DropZone/useDropZone.ts
@@ -24,14 +24,20 @@ function filterAllowedFiles<FileType extends DragFile = DragFile>(
   const acceptedFiles: FileType[] = [];
   const rejectedFiles: FileType[] = [];
 
-  function filterFile({ type = '' }) {
+  function filterFile(file) {
+    const { type = '', name = '' } = file;
     const mimeType = type.toLowerCase();
     const baseMimeType = mimeType.split('/')[0];
 
     return acceptedFileTypes.some((type) => {
       const validType = type.trim().toLowerCase();
+      // if the accepted file type is a file extension
+      // it will start with '.', check against the file name
+      if (validType.charAt(0) === '.') {
+        return name.toLowerCase().endsWith(validType)
+      }
+      // This is something like a image/* mime type
       if (validType.endsWith('/*')) {
-        // This is something like a image/* mime type
         return baseMimeType === validType.split('/')[0];
       }
       return mimeType === validType;

--- a/packages/react/src/primitives/DropZone/useDropZone.ts
+++ b/packages/react/src/primitives/DropZone/useDropZone.ts
@@ -1,55 +1,7 @@
 import { useState } from 'react';
 import { UseDropZoneProps, UseDropZoneReturn, DragState } from './types';
 import { isFunction } from '@aws-amplify/ui';
-
-type DragFile =
-  | {
-      kind: string;
-      type: string;
-    }
-  | File;
-
-function filterAllowedFiles<FileType extends DragFile = DragFile>(
-  files: FileType[],
-  acceptedFileTypes: string[]
-): { acceptedFiles: FileType[]; rejectedFiles: FileType[] } {
-  // Allow any files if acceptedFileTypes is undefined, empty array, or contains '*'
-  if (
-    !acceptedFileTypes ||
-    acceptedFileTypes.length === 0 ||
-    acceptedFileTypes.includes('*')
-  ) {
-    return { acceptedFiles: files, rejectedFiles: [] };
-  }
-  const acceptedFiles: FileType[] = [];
-  const rejectedFiles: FileType[] = [];
-
-  function filterFile(file) {
-    const { type = '', name = '' } = file;
-    const mimeType = type.toLowerCase();
-    const baseMimeType = mimeType.split('/')[0];
-
-    return acceptedFileTypes.some((type) => {
-      const validType = type.trim().toLowerCase();
-      // if the accepted file type is a file extension
-      // it will start with '.', check against the file name
-      if (validType.charAt(0) === '.') {
-        return name.toLowerCase().endsWith(validType)
-      }
-      // This is something like a image/* mime type
-      if (validType.endsWith('/*')) {
-        return baseMimeType === validType.split('/')[0];
-      }
-      return mimeType === validType;
-    });
-  }
-
-  files.forEach((file) => {
-    (filterFile(file) ? acceptedFiles : rejectedFiles).push(file);
-  });
-
-  return { acceptedFiles, rejectedFiles };
-}
+import { filterAllowedFiles } from './filterAllowedFiles';
 
 export function useDropZone({
   onDropComplete,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

StorageManager was not handling file extension file types for drag and drop properly. This fixes it. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

| Before | After |
| - | - |
| ![CleanShot 2023-11-06 at 16 28 49](https://github.com/aws-amplify/amplify-ui/assets/321279/f601cf99-85ea-4bdd-9d22-03072f0b6651) | ![CleanShot 2023-11-06 at 16 29 54](https://github.com/aws-amplify/amplify-ui/assets/321279/8ed6a900-c9c0-4e64-8c80-33a6bb8cb01f) | 




#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
