### PR TITLE
chore: update federated auth enums for v6

### DIFF
--- a/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignInButtons/__tests__/__snapshots__/FederatedSignInButton.test.tsx.snap
+++ b/packages/react/src/components/Authenticator/FederatedSignIn/FederatedSignInButtons/__tests__/__snapshots__/FederatedSignInButton.test.tsx.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FederatedSignInButton renders as expected with { provider: 'Amazon', text: 'Sign In with Amazon' } provider 1`] = `
+<div>
+  <button
+    class="amplify-button amplify-field-group__control federated-sign-in-button"
+    style="font-weight: var(--amplify-font-weights-normal); gap: 1rem;"
+    type="button"
+  >
+    <span
+      class="amplify-text"
+    >
+      Sign In with Amazon
+    </span>
+  </button>
+</div>
+`;
+
+exports[`FederatedSignInButton renders as expected with { provider: 'Apple', text: 'Sign In with Apple' } provider 1`] = `
+<div>
+  <button
+    class="amplify-button amplify-field-group__control federated-sign-in-button"
+    style="font-weight: var(--amplify-font-weights-normal); gap: 1rem;"
+    type="button"
+  >
+    <span
+      class="amplify-text"
+    >
+      Sign In with Apple
+    </span>
+  </button>
+</div>
+`;
+
 exports[`FederatedSignInButton renders as expected with { provider: 'Facebook', text: 'Sign In with Facebook' } provider 1`] = `
 <div>
   <button
@@ -27,38 +59,6 @@ exports[`FederatedSignInButton renders as expected with { provider: 'Google', te
       class="amplify-text"
     >
       Sign In with Google
-    </span>
-  </button>
-</div>
-`;
-
-exports[`FederatedSignInButton renders as expected with { provider: 'LoginWithAmazon', text: 'Sign In with Amazon' } provider 1`] = `
-<div>
-  <button
-    class="amplify-button amplify-field-group__control federated-sign-in-button"
-    style="font-weight: var(--amplify-font-weights-normal); gap: 1rem;"
-    type="button"
-  >
-    <span
-      class="amplify-text"
-    >
-      Sign In with Amazon
-    </span>
-  </button>
-</div>
-`;
-
-exports[`FederatedSignInButton renders as expected with { provider: 'SignInWithApple', text: 'Sign In with Apple' } provider 1`] = `
-<div>
-  <button
-    class="amplify-button amplify-field-group__control federated-sign-in-button"
-    style="font-weight: var(--amplify-font-weights-normal); gap: 1rem;"
-    type="button"
-  >
-    <span
-      class="amplify-text"
-    >
-      Sign In with Apple
     </span>
   </button>
 </div>

--- a/packages/ui/src/types/authenticator/user.ts
+++ b/packages/ui/src/types/authenticator/user.ts
@@ -16,8 +16,8 @@ export type ContactMethod = 'Email' | 'Phone Number';
 
 /** Federated IDPs that Authenticator supports */
 export enum FederatedIdentityProviders {
-  Apple = 'SignInWithApple',
-  Amazon = 'LoginWithAmazon',
+  Apple = 'Apple',
+  Amazon = 'Amazon',
   Facebook = 'Facebook',
   Google = 'Google',
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Updates the federated auth enum to match the strings expected by js v6

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Was able to use Login with Amazon after updating the enums.


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
