### PR TITLE
chore: publish next-release-unstable tag

### DIFF
--- a/.github/workflows/build-system-test.yml
+++ b/.github/workflows/build-system-test.yml
@@ -55,9 +55,9 @@ jobs:
             language: ts
             node-version: 20
           - framework: react
-            framework-version: 17
+            framework-version: 18
             build-tool: next
-            build-tool-version: 11
+            build-tool-version: 12
             pkg-manager: npm
             language: ts
             node-version: 20

--- a/.github/workflows/publish-next-release-unstable.yml
+++ b/.github/workflows/publish-next-release-unstable.yml
@@ -1,0 +1,73 @@
+# Description: This workflow runs unit + e2e tests, then publishes UI packages
+#              to `@next-release` NPM tag.
+#
+# Triggered by: merge to `next-release/main`
+
+name: Test and Publish / next-release-unstable
+
+on:
+  push:
+    branches: [next-release/main]
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+jobs:
+  setup-cache:
+    uses: aws-amplify/amplify-ui/.github/workflows/reusable-setup-cache.yml@next-release/main
+    with:
+      commit: ${{ github.sha }}
+      repository: ${{ github.repository }}
+
+  publish:
+    uses: ./.github/workflows/reusable-tagged-publish.yml
+    with:
+      dist-tag: next-release-unstable
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  build-test:
+    needs: publish
+    runs-on: ubuntu-latest
+    environment: ci
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+      - name: Setup Node.js 20
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0 https://github.com/actions/setup-node/commit/64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version: 20
+          cache: 'yarn'
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+      - name: Add Amplify CLI
+        run: yarn global add @aws-amplify/cli
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: ${{ secrets.AUTH_E2E_ROLE_ARN }}
+      # Amplify CLI does not support headless pull with temporary credentials
+      # when useProfile is false.
+      # See: https://github.com/aws-amplify/amplify-cli/issues/11009.
+      - name: Create temp AWS profile
+        run: |
+          aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID && \
+          aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY && \
+          aws configure set aws_session_token $AWS_SESSION_TOKEN && \
+          aws configure set default.region $AWS_REGION
+      - name: Pull down AWS environments
+        run: yarn pull
+        working-directory: ./canary
+      - name: Delete AWS Profile
+        run: rm -rf ~/.aws
+      - name: Setup canary apps against @next-release-unstable
+        run: yarn setup:next-release-unstable
+        working-directory: ./canary
+      - name: Run yarn install on each sample app
+        run: yarn install
+        working-directory: ./canary
+      - name: Run yarn build on each sample app
+        run: yarn build
+        working-directory: ./canary


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
1. Publishes a next-release-unstable tag we can use for the bug bash which will not wait for tests before publishing
2. Fixes the Web build system test for main as well (when we merge)
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
