### PR TITLE
fix(react-native): skip cognito hosted ui for social providers

### DIFF
--- a/examples/react-native/ios/ReactNative/AppDelegate.mm
+++ b/examples/react-native/ios/ReactNative/AppDelegate.mm
@@ -1,6 +1,7 @@
 #import "AppDelegate.h"
 
 #import <React/RCTBundleURLProvider.h>
+#import <React/RCTLinkingManager.h>
 
 @implementation AppDelegate
 
@@ -21,6 +22,13 @@
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
+}
+
+- (BOOL)application:(UIApplication *)application
+   openURL:(NSURL *)url
+   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  return [RCTLinkingManager application:application openURL:url options:options];
 }
 
 /// This method controls whether the `concurrentRoot`feature of React18 is turned on or off.

--- a/examples/react-native/ios/ReactNative/AppDelegate.mm
+++ b/examples/react-native/ios/ReactNative/AppDelegate.mm
@@ -1,7 +1,6 @@
 #import "AppDelegate.h"
 
 #import <React/RCTBundleURLProvider.h>
-#import <React/RCTLinkingManager.h>
 
 @implementation AppDelegate
 
@@ -22,13 +21,6 @@
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
-}
-
-- (BOOL)application:(UIApplication *)application
-   openURL:(NSURL *)url
-   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
-{
-  return [RCTLinkingManager application:application openURL:url options:options];
 }
 
 /// This method controls whether the `concurrentRoot`feature of React18 is turned on or off.

--- a/packages/react-native/src/Authenticator/common/FederatedProviderButtons/FederatedProviderButtons.tsx
+++ b/packages/react-native/src/Authenticator/common/FederatedProviderButtons/FederatedProviderButtons.tsx
@@ -1,7 +1,11 @@
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
 
-import { SocialProvider, authenticatorTextUtil } from '@aws-amplify/ui';
+import {
+  SocialProvider,
+  authenticatorTextUtil,
+  capitalize,
+} from '@aws-amplify/ui';
 
 import { Divider } from '../../../primitives';
 import { useTheme } from '../../../theme';
@@ -29,7 +33,7 @@ export default function FederatedProviderButtons({
         const providerIconSource = icons[`${provider}Logo`];
 
         const handlePress = () => {
-          toFederatedSignIn({ provider });
+          toFederatedSignIn({ provider: capitalize(provider) });
         };
 
         return (


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

`Auth.signInWithRedirect({ provider })` expects the provider to have a capitalized name. In the React authenticator we have a silly switch statement. This is just a temporary fix. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

![CleanShot 2023-11-08 at 23 12 52](https://github.com/aws-amplify/amplify-ui/assets/321279/339c5077-9b25-4d6e-9698-4c0696c71458)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
