### PR TITLE
fix(build-system-tests): pin angular cli to 16 to unblock tests

### DIFF
--- a/.github/workflows/build-system-test.yml
+++ b/.github/workflows/build-system-test.yml
@@ -72,7 +72,7 @@ jobs:
           - framework: angular
             framework-version: latest
             build-tool: angular-cli
-            build-tool-version: latest
+            build-tool-version: 16
             pkg-manager: npm
             language: ts
             node-version: 18


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Our build system test for Angular is failing due to the recent Angular CLI 17 release. This updates the test to use the previous version 16 until our library supports 17.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
