### PR TITLE
fix missing package.json update for angular cli 16 build system test

### DIFF
--- a/build-system-tests/package.json
+++ b/build-system-tests/package.json
@@ -29,7 +29,7 @@
     "react-latest-cra-latest-js": "npm run setup:react:cra -- -l js",
     "react-17-next-11-ts": "npm run setup:react:next -- -f 17 -b 11",
     "react-latest-vite-2-ts": "npm run setup:react:vite -- -b 2",
-    "angular-latest-angular-cli-latest-ts": "npm run setup:angular:cli",
+    "angular-latest-angular-cli-16-ts": "npm run setup:angular:cli -- -b 16",
     "angular-14-angular-cli-14-ts": "npm run setup:angular:cli -- -f 14 -b 14 -n angular-latest-angular-cli-v14-ts",
     "vue-3-vue-cli-latest-ts": "npm run setup:vue:cli -- -f 3 -P yarn",
     "vue-latest-vite-latest-ts": "npm run setup:vue:vite",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Updates the package.json script for angular CLI 16 in our build system test.

I updated the Github workflow, but the package.json also needs to be updated because it was now giving this error:
```
npm ERR! Missing script: "angular-latest-angular-cli-16-ts"
```



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
