### PR TITLE
fix(authenticator): persist totp secret code between actors

### DIFF
--- a/examples/react-native/src/App/App.tsx
+++ b/examples/react-native/src/App/App.tsx
@@ -54,6 +54,9 @@ const DarkModeExample = React.lazy(
 /**
  * `Authenticator` e2e Apps
  */
+const SignInTotpMfa = React.lazy(
+  () => import('../ui/components/authenticator/sign-in-totp-mfa/Example')
+);
 const SignInWithEmail = React.lazy(
   () => import('../ui/components/authenticator/sign-in-with-email/Example')
 );
@@ -114,6 +117,8 @@ export const ExampleComponent = () => {
 
     // Detox-Cucumber e2e tests
     // below apps are not meant to be run as example apps, they are part of integration testing in CI
+    case 'ui/components/authenticator/sign-in-totp-mfa':
+      return <SignInTotpMfa />;
     case '/ui/components/authenticator/sign-in-with-email':
       return <SignInWithEmail />;
     case '/ui/components/authenticator/sign-in-with-username':

--- a/examples/react-native/src/ui/components/authenticator/sign-in-totp-mfa/Example.tsx
+++ b/examples/react-native/src/ui/components/authenticator/sign-in-totp-mfa/Example.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { Authenticator } from '@aws-amplify/ui-react-native';
+import { Amplify } from 'aws-amplify';
+import { parseAWSExports } from '@aws-amplify/core/internals/utils';
+
+import { SignOutButton } from '../SignOutButton';
+import awsconfig from './aws-exports';
+
+const config = parseAWSExports(awsconfig);
+if (!config.Auth) {
+  throw new Error('Auth config not found');
+}
+// mock server endpoint for Detox e2es
+config.Auth.Cognito.userPoolEndpoint = 'http://127.0.0.1:9091/';
+Amplify.configure(config);
+
+function App() {
+  return (
+    <Authenticator.Provider>
+      <Authenticator initialState="signUp">
+        <View style={style.container}>
+          <SignOutButton />
+        </View>
+      </Authenticator>
+    </Authenticator.Provider>
+  );
+}
+
+const style = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});
+
+export default App;

--- a/examples/react-native/src/ui/components/authenticator/sign-in-totp-mfa/aws-exports.js
+++ b/examples/react-native/src/ui/components/authenticator/sign-in-totp-mfa/aws-exports.js
@@ -1,0 +1,2 @@
+import awsExports from '@aws-amplify/ui-environments/auth/auth-with-totp-mfa/src/aws-exports';
+export default awsExports;

--- a/packages/ui/src/machines/authenticator/actors/signUp.ts
+++ b/packages/ui/src/machines/authenticator/actors/signUp.ts
@@ -67,7 +67,6 @@ const handleAutoSignInResponse = {
       actions: 'setNextSignInStep',
       target: '#signUpActor.fetchUserAttributes',
     },
-    // @todo-migration handle continue sign in with setuptotp here
     {
       cond: 'shouldConfirmSignInWithNewPassword',
       actions: 'setNextSignInStep',
@@ -85,10 +84,9 @@ const handleAutoSignInResponse = {
     },
     {
       actions: [
+        'setNextSignInStep',
         'setChallengeName',
         'setMissingAttributes',
-        'setNextSignInStep',
-        // @todo-migration doesn't seem to being handled correctly from auto sign in
         'setTotpSecretCode',
       ],
       target: '#signUpActor.resolved',

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -27,16 +27,15 @@ export type AuthenticatorMachineOptions = AuthContext['config'] & {
 };
 
 const getActorContext = (context: AuthContext, defaultStep?: InitialStep) => ({
-  codeDeliveryDetails: context.actorDoneData?.codeDeliveryDetails,
-  remoteError: context.actorDoneData?.remoteError,
+  ...context.actorDoneData,
   step: context.actorDoneData?.step ?? defaultStep,
-  username: context.actorDoneData?.username,
-  unverifiedUserAttributes: context.actorDoneData?.unverifiedUserAttributes,
 
+  // initialize empty objects on actor start
   formValues: {},
   touched: {},
   validationError: {},
 
+  // values included on `context.config` that should be available in actors
   formFields: context.config?.formFields,
   loginMechanisms: context.config?.loginMechanisms,
   passwordSettings: context.config?.passwordSettings,
@@ -341,6 +340,7 @@ export function createAuthenticatorMachine(
               remoteError: event.data.remoteError,
               username: event.data.username,
               step: event.data.step,
+              totpSecretCode: event.data.totpSecretCode,
               unverifiedUserAttributes: event.data.unverifiedUserAttributes,
             };
           },

--- a/packages/ui/src/machines/authenticator/types.ts
+++ b/packages/ui/src/machines/authenticator/types.ts
@@ -109,6 +109,7 @@ export interface ActorDoneData {
   missingAttributes?: string[];
   remoteError?: string;
   step: Step;
+  totpSecretCode?: string;
   username?: string;
   unverifiedUserAttributes?: UnverifiedUserAttributes;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Pass all values of `actorDoneData` to actors on spawn
- add `totpSecretCode` to `ActorDoneData`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
