### PR TITLE
fix(authenticator): exclude empty phone_number values from sign up submit

### DIFF
--- a/.changeset/eleven-beers-marry.md
+++ b/.changeset/eleven-beers-marry.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(authenticator): exclude empty phone_number values from sign up submit

--- a/packages/ui/src/machines/authenticator/__tests__/utils.test.ts
+++ b/packages/ui/src/machines/authenticator/__tests__/utils.test.ts
@@ -13,12 +13,25 @@ describe('getUserAttributes', () => {
 
   it('does not returns the phone_number attribute when undefined', () => {
     const formValues = {
-      email: 'example#example.com',
+      email: 'example@example.com',
+      country_code: '+1',
       phone_number: undefined,
     };
     const output = getUserAttributes(formValues);
 
-    const expected = { email: 'example#example.com' };
+    const expected = { email: 'example@example.com' };
+    expect(output).toStrictEqual(expected);
+  });
+
+  it('returns an undefined value phone_number attribute when phone_number is an empty string', () => {
+    const formValues = {
+      email: 'example@example.com',
+      country_code: '+1',
+      phone_number: '',
+    };
+    const output = getUserAttributes(formValues);
+
+    const expected = { email: 'example@example.com' };
     expect(output).toStrictEqual(expected);
   });
 });
@@ -31,7 +44,7 @@ describe('getSignUpInput', () => {
       phone_number: '8002428976',
       password: 'a_password',
       confirm_password: 'a_password',
-      email: 'example#example.com',
+      email: 'example@example.com',
       country_code: '+26',
     };
 
@@ -41,7 +54,7 @@ describe('getSignUpInput', () => {
       options: {
         autoSignIn: true,
         userAttributes: {
-          email: 'example#example.com',
+          email: 'example@example.com',
           phone_number: '+268002428976',
         },
       },
@@ -58,7 +71,7 @@ describe('getUsernameSignUp', () => {
       phone_number: '8002428976',
       password: 'a_password',
       confirm_password: 'a_password',
-      email: 'example#example.com',
+      email: 'example@example.com',
       country_code: '+26',
     };
 

--- a/packages/ui/src/machines/authenticator/actors/signUp.ts
+++ b/packages/ui/src/machines/authenticator/actors/signUp.ts
@@ -293,14 +293,14 @@ export function signUpActor({ services }: SignUpMachineOptions) {
         async federatedSignIn(_, { data }) {
           return signInWithRedirect(data);
         },
-        async handleSignUp(context, _event) {
+        async handleSignUp(context) {
           const { formValues, loginMechanisms, username } = context;
           const loginMechanism = loginMechanisms[0];
           const input = getSignUpInput(username, formValues, loginMechanism);
 
           return services.handleSignUp(input);
         },
-        async validateSignUp(context, _event) {
+        async validateSignUp(context) {
           // This needs to exist in the machine to reference new `services`
 
           return runValidators(

--- a/packages/ui/src/machines/authenticator/utils.ts
+++ b/packages/ui/src/machines/authenticator/utils.ts
@@ -7,6 +7,7 @@ import { isString } from '../../utils';
 
 // default `autoSignIn` flag is `true`
 const DEFAULT_AUTO_SIGN_IN = true;
+const EMPTY_STRING = '';
 
 export const sanitizePhoneNumber = (dialCode: string, phoneNumber: string) =>
   `${dialCode}${phoneNumber}`.replace(/[^A-Z0-9+]/gi, '');
@@ -49,7 +50,7 @@ export const getUserAttributes = (
   );
 
   // only include `phone_number` attribute in `userAttributes` if it has a value
-  if (isString(phone_number)) {
+  if (isString(phone_number) && phone_number !== EMPTY_STRING) {
     const { country_code } = formValues;
     return {
       ...userAttributes,


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Prevent empty string values for `phone_number` from being included in `SignUpInput`
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://github.com/aws-amplify/amplify-ui/issues/4794
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual test and unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
