### PR TITLE
fix(liveness): add a11y tags to match indicator bar

### DIFF
--- a/.changeset/chilled-donkeys-decide.md
+++ b/.changeset/chilled-donkeys-decide.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+fix(liveness): add a11y tags to match indicator bar

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/MatchIndicator.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/MatchIndicator.tsx
@@ -34,6 +34,11 @@ export const MatchIndicator: React.FC<MatchIndicatorProps> = ({
       <div
         className={`${LivenessClassNames.MatchIndicator}__bar`}
         style={percentageStyles}
+        aria-live="polite"
+        role="progressbar"
+        aria-label="MatchIndicator"
+        aria-valuenow={percentage}
+        aria-valuetext={`${percentage}% face fit`}
       ></div>
     </div>
   );

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/MatchIndicator.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/MatchIndicator.tsx
@@ -34,7 +34,6 @@ export const MatchIndicator: React.FC<MatchIndicatorProps> = ({
       <div
         className={`${LivenessClassNames.MatchIndicator}__bar`}
         style={percentageStyles}
-        aria-live="polite"
         role="progressbar"
         aria-label="MatchIndicator"
         aria-valuenow={percentage}

--- a/packages/ui/src/theme/css/component/liveness.scss
+++ b/packages/ui/src/theme/css/component/liveness.scss
@@ -209,7 +209,7 @@
   content: '';
   width: 100%;
   height: 100%;
-  background: var(--amplify-colors-primary-40);
+  background: var(--amplify-colors-primary-80);
   left: -100%;
   transform: translate(var(--percentage), 0);
   transition: var(--amplify-liveness-match-indicator-transition);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- Updated color to match 300 : 1 ratio and added aria tags

<img width="398" alt="Screenshot 2023-12-01 at 11 06 36 AM" src="https://github.com/aws-amplify/amplify-ui/assets/68032955/ac7b3350-f4c7-4377-b1a8-58b8673fbbd5">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
