### PR TITLE
fix(liveness): add accessibility attributes to error modal

### DIFF
--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/FaceLivenessErrorModal.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/FaceLivenessErrorModal.tsx
@@ -69,7 +69,12 @@ const renderToastErrorModal = (props: {
     <>
       <Flex className={LivenessClassNames.ErrorModal}>
         <AlertIcon ariaHidden variation="error" />
-        <Text className={LivenessClassNames.ErrorModalHeading}>{heading}</Text>
+        <Text
+          className={LivenessClassNames.ErrorModalHeading}
+          id="timeout-error-heading"
+        >
+          {heading}
+        </Text>
       </Flex>
       {message}
     </>
@@ -116,7 +121,7 @@ export const FaceLivenessErrorModal: React.FC<FaceLivenessErrorModalProps> = (
 
   return (
     <Overlay className={LivenessClassNames.OpaqueOverlay}>
-      <Toast>
+      <Toast ariaLabelledBy="timeout-error-heading" role="dialog">
         {children}
         <Flex justifyContent="center">
           <Button variation="primary" type="button" onClick={onRetry}>

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/FaceLivenessErrorModal.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/FaceLivenessErrorModal.tsx
@@ -71,7 +71,7 @@ const renderToastErrorModal = (props: {
         <AlertIcon ariaHidden variation="error" />
         <Text
           className={LivenessClassNames.ErrorModalHeading}
-          id="timeout-error-heading"
+          id="error-heading"
         >
           {heading}
         </Text>
@@ -121,7 +121,7 @@ export const FaceLivenessErrorModal: React.FC<FaceLivenessErrorModalProps> = (
 
   return (
     <Overlay className={LivenessClassNames.OpaqueOverlay}>
-      <Toast ariaLabelledBy="timeout-error-heading" role="dialog">
+      <Toast ariaLabelledBy="error-heading" role="dialog">
         {children}
         <Flex justifyContent="center">
           <Button variation="primary" type="button" onClick={onRetry}>

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/__tests__/FaceLivenessErrorModal.test.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/__tests__/FaceLivenessErrorModal.test.tsx
@@ -26,12 +26,27 @@ describe('FaceLivenessErrorModal', () => {
         {renderErrorModal({ errorState })}
       </FaceLivenessErrorModal>
     );
-
-    expect(screen.getByText(serverHeaderText)).toBeInTheDocument();
-    expect(screen.getByText(serverMessageText)).toBeInTheDocument();
+    const timeoutModal = screen.getByRole('dialog');
+    expect(timeoutModal).toBeInTheDocument();
+    expect(timeoutModal).toHaveAttribute(
+      'aria-labelledby',
+      'timeout-error-heading'
+    );
   });
 
   it('should render the timeout message appropriately', () => {
+    const errorState = LivenessErrorState.TIMEOUT;
+    render(
+      <FaceLivenessErrorModal onRetry={() => {}}>
+        {renderErrorModal({ errorState })}
+      </FaceLivenessErrorModal>
+    );
+
+    expect(screen.getByText(timeoutHeaderText)).toBeInTheDocument();
+    expect(screen.getByText(timeoutMessageText)).toBeInTheDocument();
+  });
+
+  it('should render the timeout message with proper accessibility attributes', () => {
     const errorState = LivenessErrorState.TIMEOUT;
     render(
       <FaceLivenessErrorModal onRetry={() => {}}>

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/__tests__/FaceLivenessErrorModal.test.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/__tests__/FaceLivenessErrorModal.test.tsx
@@ -26,12 +26,9 @@ describe('FaceLivenessErrorModal', () => {
         {renderErrorModal({ errorState })}
       </FaceLivenessErrorModal>
     );
-    const timeoutModal = screen.getByRole('dialog');
-    expect(timeoutModal).toBeInTheDocument();
-    expect(timeoutModal).toHaveAttribute(
-      'aria-labelledby',
-      'timeout-error-heading'
-    );
+
+    expect(screen.getByText(serverHeaderText)).toBeInTheDocument();
+    expect(screen.getByText(serverMessageText)).toBeInTheDocument();
   });
 
   it('should render the timeout message appropriately', () => {
@@ -54,8 +51,9 @@ describe('FaceLivenessErrorModal', () => {
       </FaceLivenessErrorModal>
     );
 
-    expect(screen.getByText(timeoutHeaderText)).toBeInTheDocument();
-    expect(screen.getByText(timeoutMessageText)).toBeInTheDocument();
+    const timeoutModal = screen.getByRole('dialog');
+    expect(timeoutModal).toBeInTheDocument();
+    expect(timeoutModal).toHaveAttribute('aria-labelledby', 'error-heading');
   });
 
   it('should render the runtime error message appropriately', () => {

--- a/packages/react/__tests__/__snapshots__/exports.ts.snap
+++ b/packages/react/__tests__/__snapshots__/exports.ts.snap
@@ -126,6 +126,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -380,6 +383,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -670,6 +676,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -1018,6 +1027,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -1274,6 +1286,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -1528,6 +1543,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -1825,6 +1843,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -2096,6 +2117,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -2351,6 +2375,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -2687,6 +2714,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -2964,6 +2994,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -3222,6 +3255,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -3470,6 +3506,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -3723,6 +3762,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -3991,6 +4033,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -4283,6 +4328,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -4556,6 +4604,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -4835,6 +4886,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -5093,6 +5147,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -5341,6 +5398,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -5601,6 +5661,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -5870,6 +5933,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -6164,6 +6230,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -6412,6 +6481,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -6665,6 +6737,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -6939,6 +7014,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -7225,6 +7303,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -7516,6 +7597,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -7805,6 +7889,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -8088,6 +8175,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -8366,6 +8456,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -8902,6 +8995,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -9432,6 +9528,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -9683,6 +9782,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -9989,6 +10091,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -10325,6 +10430,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -10610,6 +10718,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -10864,6 +10975,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -11223,6 +11337,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -11540,6 +11657,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -11925,6 +12045,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -12285,6 +12408,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -12619,6 +12745,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -12878,6 +13007,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -13123,6 +13255,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -13372,6 +13507,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -13617,6 +13755,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -13866,6 +14007,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -14111,6 +14255,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -14361,6 +14508,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -14624,6 +14774,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -14956,6 +15109,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {
@@ -15305,6 +15461,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -15603,6 +15762,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -15883,6 +16045,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "ariaLabel": {
         "type": "string",
       },
+      "ariaLabelledBy": {
+        "type": "string",
+      },
       "ariaValuetext": {
         "type": "string",
       },
@@ -16128,6 +16293,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
         "type": "string",
       },
       "ariaLabel": {
+        "type": "string",
+      },
+      "ariaLabelledBy": {
         "type": "string",
       },
       "ariaValuetext": {

--- a/packages/react/src/primitives/View/View.tsx
+++ b/packages/react/src/primitives/View/View.tsx
@@ -14,6 +14,7 @@ const ViewPrimitive: Primitive<ViewProps, 'div'> = (
     children,
     testId,
     ariaLabel,
+    ariaLabelledBy,
     isDisabled,
     style,
     inert,
@@ -27,6 +28,7 @@ const ViewPrimitive: Primitive<ViewProps, 'div'> = (
     as,
     {
       'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
       'data-testid': testId,
       disabled: isDisabled,
       ref,

--- a/packages/react/src/primitives/types/base.ts
+++ b/packages/react/src/primitives/types/base.ts
@@ -43,6 +43,12 @@ export interface AriaProps {
 
   /**
    * @description
+   * Identifies the element (or elements) that labels the element it is applied to.
+   */
+  ariaLabelledBy?: AriaAttributes['aria-labelledby'];
+
+  /**
+   * @description
    * Defines the human readable text alternative of `aria-valuenow` for a range widget
    */
   ariaValuetext?: AriaAttributes['aria-valuetext'];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Added `aria-labelledby` and `role` to the modal element
<img width="753" alt="Screenshot 2023-12-01 at 3 09 39 PM" src="https://github.com/aws-amplify/amplify-ui/assets/70536670/8906f542-01c3-4e12-bf2c-9a08a50f36e4">
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
