### PR TITLE
chore: update focus ring indicators

### DIFF
--- a/.changeset/poor-jeans-lie.md
+++ b/.changeset/poor-jeans-lie.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(ui): update/normalize focus indicator across primitives to improve accessibility.
+
+In some instances, the focus indicator ring has been updated from 1px to 2px and/or the color of the focus indicator ring has been changed to have at least a 3:1 contrast ratio in the area of contrast.

--- a/docs/__tests__/__snapshots__/cssvars-table.test.ts.snap
+++ b/docs/__tests__/__snapshots__/cssvars-table.test.ts.snap
@@ -2456,7 +2456,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-checkbox-button-error-focus-border-color",
-        "value": "var(--amplify-colors-transparent)"
+        "value": "var(--amplify-colors-border-error)"
     },
     {
         "variable": "--amplify-components-checkbox-button-error-focus-box-shadow",
@@ -2464,7 +2464,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-checkbox-button-focus-border-color",
-        "value": "var(--amplify-colors-transparent)"
+        "value": "var(--amplify-colors-border-focus)"
     },
     {
         "variable": "--amplify-components-checkbox-button-focus-box-shadow",

--- a/docs/__tests__/__snapshots__/cssvars-table.test.ts.snap
+++ b/docs/__tests__/__snapshots__/cssvars-table.test.ts.snap
@@ -1284,7 +1284,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-link-error-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-red-100)"
+        "value": "var(--amplify-components-fieldcontrol-error-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-link-error-focus-color",
@@ -1364,7 +1364,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-link-info-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-blue-100)"
+        "value": "var(--amplify-components-fieldcontrol-info-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-link-info-focus-color",
@@ -1428,7 +1428,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-link-overlay-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-overlay-90)"
+        "value": "var(--amplify-components-fieldcontrol-overlay-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-link-overlay-focus-color",
@@ -1480,7 +1480,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-link-success-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-green-100)"
+        "value": "var(--amplify-components-fieldcontrol-success-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-link-success-focus-color",
@@ -1532,7 +1532,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-link-warning-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-orange-100)"
+        "value": "var(--amplify-components-fieldcontrol-warning-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-link-warning-focus-color",
@@ -1644,7 +1644,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-outlined-error-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-red-100)"
+        "value": "var(--amplify-components-fieldcontrol-error-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-outlined-error-focus-color",
@@ -1696,7 +1696,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-outlined-info-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-blue-100)"
+        "value": "var(--amplify-components-fieldcontrol-info-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-outlined-info-focus-color",
@@ -1748,7 +1748,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-outlined-overlay-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-overlay-90)"
+        "value": "var(--amplify-components-fieldcontrol-overlay-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-outlined-overlay-focus-color",
@@ -1800,7 +1800,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-outlined-success-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-green-100)"
+        "value": "var(--amplify-components-fieldcontrol-success-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-outlined-success-focus-color",
@@ -1852,7 +1852,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-outlined-warning-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-orange-100)"
+        "value": "var(--amplify-components-fieldcontrol-warning-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-outlined-warning-focus-color",
@@ -1964,7 +1964,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-primary-error-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-red-100)"
+        "value": "var(--amplify-components-fieldcontrol-error-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-primary-error-focus-color",
@@ -2044,7 +2044,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-primary-info-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-blue-100)"
+        "value": "var(--amplify-components-fieldcontrol-info-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-primary-info-focus-color",
@@ -2108,7 +2108,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-primary-overlay-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-overlay-90)"
+        "value": "var(--amplify-components-fieldcontrol-overlay-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-primary-overlay-focus-color",
@@ -2160,7 +2160,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-primary-success-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-green-100)"
+        "value": "var(--amplify-components-fieldcontrol-success-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-primary-success-focus-color",
@@ -2212,7 +2212,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-button-primary-warning-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-orange-100)"
+        "value": "var(--amplify-components-fieldcontrol-overlay-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-button-primary-warning-focus-color",
@@ -2460,7 +2460,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-checkbox-button-error-focus-box-shadow",
-        "value": "0px 0px 0px 2px var(--amplify-colors-border-error)"
+        "value": "var(--amplify-components-fieldcontrol-error-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-checkbox-button-focus-border-color",
@@ -2468,7 +2468,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-checkbox-button-focus-box-shadow",
-        "value": "0px 0px 0px 2px var(--amplify-colors-border-focus)"
+        "value": "var(--amplify-components-fieldcontrol-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-checkbox-button-focus-outline-color",
@@ -2936,7 +2936,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-fieldcontrol-error-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-border-error)"
+        "value": "0px 0px 0px 2px var(--amplify-colors-border-error)"
     },
     {
         "variable": "--amplify-components-fieldcontrol-focus-border-color",
@@ -2944,11 +2944,15 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-fieldcontrol-focus-box-shadow",
-        "value": "0px 0px 0px 1px var(--amplify-colors-border-focus)"
+        "value": "0px 0px 0px 2px var(--amplify-colors-border-focus)"
     },
     {
         "variable": "--amplify-components-fieldcontrol-font-size",
         "value": "var(--amplify-components-field-font-size)"
+    },
+    {
+        "variable": "--amplify-components-fieldcontrol-info-focus-box-shadow",
+        "value": "0px 0px 0px 2px var(--amplify-colors-blue-100)"
     },
     {
         "variable": "--amplify-components-fieldcontrol-large-font-size",
@@ -2991,6 +2995,10 @@ exports[`CSS Variables Table 1`] = `
         "value": "var(--amplify-outline-widths-medium)"
     },
     {
+        "variable": "--amplify-components-fieldcontrol-overlay-focus-box-shadow",
+        "value": "0px 0px 0px 2px var(--amplify-colors-overlay-90)"
+    },
+    {
         "variable": "--amplify-components-fieldcontrol-padding-block-end",
         "value": "var(--amplify-space-xs)"
     },
@@ -3031,16 +3039,20 @@ exports[`CSS Variables Table 1`] = `
         "value": "var(--amplify-colors-border-error)"
     },
     {
+        "variable": "--amplify-components-fieldcontrol-quiet-error-focus-border-block-end-color",
+        "value": "transparent"
+    },
+    {
         "variable": "--amplify-components-fieldcontrol-quiet-error-focus-box-shadow",
-        "value": "0px 1px 0px  var(--amplify-colors-border-error)"
+        "value": "var(--amplify-components-fieldcontrol-error-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-fieldcontrol-quiet-focus-border-block-end-color",
-        "value": "var(--amplify-colors-border-focus)"
+        "value": "transparent"
     },
     {
         "variable": "--amplify-components-fieldcontrol-quiet-focus-box-shadow",
-        "value": "0px 1px 0px  var(--amplify-colors-border-focus)"
+        "value": "var(--amplify-components-fieldcontrol-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-fieldcontrol-small-font-size",
@@ -3063,8 +3075,16 @@ exports[`CSS Variables Table 1`] = `
         "value": "var(--amplify-space-small)"
     },
     {
+        "variable": "--amplify-components-fieldcontrol-success-focus-box-shadow",
+        "value": "0px 0px 0px 2px var(--amplify-colors-green-100)"
+    },
+    {
         "variable": "--amplify-components-fieldcontrol-transition-duration",
         "value": "var(--amplify-time-medium)"
+    },
+    {
+        "variable": "--amplify-components-fieldcontrol-warning-focus-box-shadow",
+        "value": "0px 0px 0px 2px var(--amplify-colors-orange-100)"
     },
     {
         "variable": "--amplify-components-fieldgroup-gap",
@@ -4440,7 +4460,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-sliderfield-thumb-focus-box-shadow",
-        "value": "0 0 0 2px var(--amplify-colors-border-focus)"
+        "value": "var(--amplify-components-fieldcontrol-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-sliderfield-thumb-height",
@@ -4784,7 +4804,7 @@ exports[`CSS Variables Table 1`] = `
     },
     {
         "variable": "--amplify-components-switchfield-focused-shadow",
-        "value": "0px 0px 0px 2px var(--amplify-colors-border-focus)"
+        "value": "var(--amplify-components-fieldcontrol-focus-box-shadow)"
     },
     {
         "variable": "--amplify-components-switchfield-font-size",

--- a/packages/ui/src/theme/__tests__/__snapshots__/defaultTheme.test.ts.snap
+++ b/packages/ui/src/theme/__tests__/__snapshots__/defaultTheme.test.ts.snap
@@ -167,7 +167,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-outlined-info-focus-border-color: var(--amplify-colors-blue-100);
 --amplify-components-button-outlined-info-focus-background-color: var(--amplify-colors-blue-10);
 --amplify-components-button-outlined-info-focus-color: var(--amplify-colors-blue-100);
---amplify-components-button-outlined-info-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-blue-100);
+--amplify-components-button-outlined-info-focus-box-shadow: var(--amplify-components-fieldcontrol-info-focus-box-shadow);
 --amplify-components-button-outlined-info-active-border-color: var(--amplify-colors-blue-100);
 --amplify-components-button-outlined-info-active-background-color: var(--amplify-colors-blue-20);
 --amplify-components-button-outlined-info-active-color: var(--amplify-colors-blue-100);
@@ -180,7 +180,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-outlined-warning-focus-border-color: var(--amplify-colors-orange-100);
 --amplify-components-button-outlined-warning-focus-background-color: var(--amplify-colors-orange-10);
 --amplify-components-button-outlined-warning-focus-color: var(--amplify-colors-orange-100);
---amplify-components-button-outlined-warning-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-orange-100);
+--amplify-components-button-outlined-warning-focus-box-shadow: var(--amplify-components-fieldcontrol-warning-focus-box-shadow);
 --amplify-components-button-outlined-warning-active-border-color: var(--amplify-colors-orange-100);
 --amplify-components-button-outlined-warning-active-background-color: var(--amplify-colors-orange-20);
 --amplify-components-button-outlined-warning-active-color: var(--amplify-colors-orange-100);
@@ -193,7 +193,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-outlined-success-focus-border-color: var(--amplify-colors-green-100);
 --amplify-components-button-outlined-success-focus-background-color: var(--amplify-colors-green-10);
 --amplify-components-button-outlined-success-focus-color: var(--amplify-colors-green-100);
---amplify-components-button-outlined-success-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-green-100);
+--amplify-components-button-outlined-success-focus-box-shadow: var(--amplify-components-fieldcontrol-success-focus-box-shadow);
 --amplify-components-button-outlined-success-active-border-color: var(--amplify-colors-green-100);
 --amplify-components-button-outlined-success-active-background-color: var(--amplify-colors-green-20);
 --amplify-components-button-outlined-success-active-color: var(--amplify-colors-green-100);
@@ -206,7 +206,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-outlined-error-focus-border-color: var(--amplify-colors-red-100);
 --amplify-components-button-outlined-error-focus-background-color: var(--amplify-colors-red-10);
 --amplify-components-button-outlined-error-focus-color: var(--amplify-colors-red-100);
---amplify-components-button-outlined-error-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-red-100);
+--amplify-components-button-outlined-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-button-outlined-error-active-border-color: var(--amplify-colors-red-100);
 --amplify-components-button-outlined-error-active-background-color: var(--amplify-colors-red-20);
 --amplify-components-button-outlined-error-active-color: var(--amplify-colors-red-100);
@@ -219,7 +219,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-outlined-overlay-focus-border-color: var(--amplify-colors-overlay-90);
 --amplify-components-button-outlined-overlay-focus-background-color: var(--amplify-colors-overlay-5);
 --amplify-components-button-outlined-overlay-focus-color: var(--amplify-colors-neutral-90);
---amplify-components-button-outlined-overlay-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-overlay-90);
+--amplify-components-button-outlined-overlay-focus-box-shadow: var(--amplify-components-fieldcontrol-overlay-focus-box-shadow);
 --amplify-components-button-outlined-overlay-active-border-color: var(--amplify-colors-overlay-90);
 --amplify-components-button-outlined-overlay-active-background-color: var(--amplify-colors-overlay-10);
 --amplify-components-button-outlined-overlay-active-color: var(--amplify-colors-neutral-100);
@@ -253,7 +253,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-primary-info-focus-border-color: transparent;
 --amplify-components-button-primary-info-focus-background-color: var(--amplify-colors-blue-90);
 --amplify-components-button-primary-info-focus-color: var(--amplify-colors-font-inverse);
---amplify-components-button-primary-info-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-blue-100);
+--amplify-components-button-primary-info-focus-box-shadow: var(--amplify-components-fieldcontrol-info-focus-box-shadow);
 --amplify-components-button-primary-info-active-border-color: transparent;
 --amplify-components-button-primary-info-active-background-color: var(--amplify-colors-blue-100);
 --amplify-components-button-primary-info-active-color: var(--amplify-colors-font-inverse);
@@ -266,7 +266,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-primary-warning-focus-border-color: transparent;
 --amplify-components-button-primary-warning-focus-background-color: var(--amplify-colors-orange-90);
 --amplify-components-button-primary-warning-focus-color: var(--amplify-colors-font-inverse);
---amplify-components-button-primary-warning-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-orange-100);
+--amplify-components-button-primary-warning-focus-box-shadow: var(--amplify-components-fieldcontrol-overlay-focus-box-shadow);
 --amplify-components-button-primary-warning-active-border-color: transparent;
 --amplify-components-button-primary-warning-active-background-color: var(--amplify-colors-orange-100);
 --amplify-components-button-primary-warning-active-color: var(--amplify-colors-font-inverse);
@@ -279,7 +279,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-primary-error-focus-border-color: transparent;
 --amplify-components-button-primary-error-focus-background-color: var(--amplify-colors-red-90);
 --amplify-components-button-primary-error-focus-color: var(--amplify-colors-font-inverse);
---amplify-components-button-primary-error-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-red-100);
+--amplify-components-button-primary-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-button-primary-error-active-border-color: transparent;
 --amplify-components-button-primary-error-active-background-color: var(--amplify-colors-red-100);
 --amplify-components-button-primary-error-active-color: var(--amplify-colors-font-inverse);
@@ -292,7 +292,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-primary-success-focus-border-color: transparent;
 --amplify-components-button-primary-success-focus-background-color: var(--amplify-colors-green-90);
 --amplify-components-button-primary-success-focus-color: var(--amplify-colors-font-inverse);
---amplify-components-button-primary-success-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-green-100);
+--amplify-components-button-primary-success-focus-box-shadow: var(--amplify-components-fieldcontrol-success-focus-box-shadow);
 --amplify-components-button-primary-success-active-border-color: transparent;
 --amplify-components-button-primary-success-active-background-color: var(--amplify-colors-green-100);
 --amplify-components-button-primary-success-active-color: var(--amplify-colors-font-inverse);
@@ -305,7 +305,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-primary-overlay-focus-border-color: transparent;
 --amplify-components-button-primary-overlay-focus-background-color: var(--amplify-colors-overlay-90);
 --amplify-components-button-primary-overlay-focus-color: var(--amplify-colors-font-inverse);
---amplify-components-button-primary-overlay-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-overlay-90);
+--amplify-components-button-primary-overlay-focus-box-shadow: var(--amplify-components-fieldcontrol-overlay-focus-box-shadow);
 --amplify-components-button-primary-overlay-active-border-color: transparent;
 --amplify-components-button-primary-overlay-active-background-color: var(--amplify-colors-overlay-90);
 --amplify-components-button-primary-overlay-active-color: var(--amplify-colors-font-inverse);
@@ -348,7 +348,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-link-info-focus-border-color: transparent;
 --amplify-components-button-link-info-focus-background-color: var(--amplify-colors-blue-10);
 --amplify-components-button-link-info-focus-color: var(--amplify-colors-blue-100);
---amplify-components-button-link-info-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-blue-100);
+--amplify-components-button-link-info-focus-box-shadow: var(--amplify-components-fieldcontrol-info-focus-box-shadow);
 --amplify-components-button-link-info-active-border-color: transparent;
 --amplify-components-button-link-info-active-background-color: var(--amplify-colors-blue-20);
 --amplify-components-button-link-info-active-color: var(--amplify-colors-blue-100);
@@ -361,7 +361,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-link-warning-focus-border-color: transparent;
 --amplify-components-button-link-warning-focus-background-color: var(--amplify-colors-orange-10);
 --amplify-components-button-link-warning-focus-color: var(--amplify-colors-orange-100);
---amplify-components-button-link-warning-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-orange-100);
+--amplify-components-button-link-warning-focus-box-shadow: var(--amplify-components-fieldcontrol-warning-focus-box-shadow);
 --amplify-components-button-link-warning-active-border-color: transparent;
 --amplify-components-button-link-warning-active-background-color: var(--amplify-colors-orange-20);
 --amplify-components-button-link-warning-active-color: var(--amplify-colors-orange-100);
@@ -374,7 +374,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-link-success-focus-border-color: transparent;
 --amplify-components-button-link-success-focus-background-color: var(--amplify-colors-green-10);
 --amplify-components-button-link-success-focus-color: var(--amplify-colors-green-100);
---amplify-components-button-link-success-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-green-100);
+--amplify-components-button-link-success-focus-box-shadow: var(--amplify-components-fieldcontrol-success-focus-box-shadow);
 --amplify-components-button-link-success-active-border-color: transparent;
 --amplify-components-button-link-success-active-background-color: var(--amplify-colors-green-20);
 --amplify-components-button-link-success-active-color: var(--amplify-colors-green-100);
@@ -387,7 +387,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-link-error-focus-border-color: transparent;
 --amplify-components-button-link-error-focus-background-color: var(--amplify-colors-red-10);
 --amplify-components-button-link-error-focus-color: var(--amplify-colors-red-100);
---amplify-components-button-link-error-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-red-100);
+--amplify-components-button-link-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-button-link-error-active-border-color: transparent;
 --amplify-components-button-link-error-active-background-color: var(--amplify-colors-red-20);
 --amplify-components-button-link-error-active-color: var(--amplify-colors-red-100);
@@ -400,7 +400,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-button-link-overlay-focus-border-color: transparent;
 --amplify-components-button-link-overlay-focus-background-color: var(--amplify-colors-overlay-5);
 --amplify-components-button-link-overlay-focus-color: var(--amplify-colors-overlay-90);
---amplify-components-button-link-overlay-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-overlay-90);
+--amplify-components-button-link-overlay-focus-box-shadow: var(--amplify-components-fieldcontrol-overlay-focus-box-shadow);
 --amplify-components-button-link-overlay-active-border-color: transparent;
 --amplify-components-button-link-overlay-active-background-color: var(--amplify-colors-overlay-10);
 --amplify-components-button-link-overlay-active-color: var(--amplify-colors-overlay-90);
@@ -494,11 +494,11 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-checkbox-button-focus-outline-width: var(--amplify-outline-widths-medium);
 --amplify-components-checkbox-button-focus-outline-offset: var(--amplify-outline-offsets-medium);
 --amplify-components-checkbox-button-focus-border-color: var(--amplify-colors-transparent);
---amplify-components-checkbox-button-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-border-focus);
+--amplify-components-checkbox-button-focus-box-shadow: var(--amplify-components-fieldcontrol-focus-box-shadow);
 --amplify-components-checkbox-button-disabled-border-color: var(--amplify-colors-border-disabled);
 --amplify-components-checkbox-button-error-border-color: var(--amplify-colors-border-error);
 --amplify-components-checkbox-button-error-focus-border-color: var(--amplify-colors-transparent);
---amplify-components-checkbox-button-error-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-border-error);
+--amplify-components-checkbox-button-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-checkbox-icon-background-color: var(--amplify-colors-primary-80);
 --amplify-components-checkbox-icon-border-radius: 20%;
 --amplify-components-checkbox-icon-opacity: var(--amplify-opacities-0);
@@ -627,19 +627,24 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-fieldcontrol-quiet-border-inline-end: none;
 --amplify-components-fieldcontrol-quiet-border-block-start: none;
 --amplify-components-fieldcontrol-quiet-border-radius: 0;
---amplify-components-fieldcontrol-quiet-focus-border-block-end-color: var(--amplify-colors-border-focus);
---amplify-components-fieldcontrol-quiet-focus-box-shadow: 0px 1px 0px  var(--amplify-colors-border-focus);
+--amplify-components-fieldcontrol-quiet-focus-border-block-end-color: transparent;
+--amplify-components-fieldcontrol-quiet-focus-box-shadow: var(--amplify-components-fieldcontrol-focus-box-shadow);
 --amplify-components-fieldcontrol-quiet-error-border-block-end-color: var(--amplify-colors-border-error);
---amplify-components-fieldcontrol-quiet-error-focus-box-shadow: 0px 1px 0px  var(--amplify-colors-border-error);
+--amplify-components-fieldcontrol-quiet-error-focus-border-block-end-color: transparent;
+--amplify-components-fieldcontrol-quiet-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-fieldcontrol-focus-border-color: var(--amplify-colors-border-focus);
---amplify-components-fieldcontrol-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-border-focus);
+--amplify-components-fieldcontrol-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-border-focus);
 --amplify-components-fieldcontrol-disabled-color: var(--amplify-colors-font-disabled);
 --amplify-components-fieldcontrol-disabled-cursor: not-allowed;
 --amplify-components-fieldcontrol-disabled-border-color: var(--amplify-colors-transparent);
 --amplify-components-fieldcontrol-disabled-background-color: var(--amplify-colors-background-disabled);
 --amplify-components-fieldcontrol-error-border-color: var(--amplify-colors-border-error);
 --amplify-components-fieldcontrol-error-color: var(--amplify-colors-font-error);
---amplify-components-fieldcontrol-error-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-border-error);
+--amplify-components-fieldcontrol-error-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-border-error);
+--amplify-components-fieldcontrol-info-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-blue-100);
+--amplify-components-fieldcontrol-warning-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-orange-100);
+--amplify-components-fieldcontrol-success-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-green-100);
+--amplify-components-fieldcontrol-overlay-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-overlay-90);
 --amplify-components-fieldgroup-gap: var(--amplify-space-zero);
 --amplify-components-fieldgroup-vertical-align-items: center;
 --amplify-components-fieldgroup-outer-align-items: center;
@@ -985,7 +990,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-sliderfield-thumb-hover-background-color: var(--amplify-colors-background-primary);
 --amplify-components-sliderfield-thumb-hover-border-color: var(--amplify-colors-border-focus);
 --amplify-components-sliderfield-thumb-focus-border-color: var(--amplify-colors-border-focus);
---amplify-components-sliderfield-thumb-focus-box-shadow: 0 0 0 2px var(--amplify-colors-border-focus);
+--amplify-components-sliderfield-thumb-focus-box-shadow: var(--amplify-components-fieldcontrol-focus-box-shadow);
 --amplify-components-sliderfield-small-track-height: 0.25rem;
 --amplify-components-sliderfield-small-thumb-width: 1rem;
 --amplify-components-sliderfield-small-thumb-height: 1rem;
@@ -1069,7 +1074,7 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-storagemanager-previewer-body-gap: var(--amplify-space-small);
 --amplify-components-storagemanager-previewer-footer-justify-content: flex-end;
 --amplify-components-switchfield-disabled-opacity: var(--amplify-opacities-60);
---amplify-components-switchfield-focused-shadow: 0px 0px 0px 2px var(--amplify-colors-border-focus);
+--amplify-components-switchfield-focused-shadow: var(--amplify-components-fieldcontrol-focus-box-shadow);
 --amplify-components-switchfield-font-size: var(--amplify-font-sizes-medium);
 --amplify-components-switchfield-large-font-size: var(--amplify-font-sizes-large);
 --amplify-components-switchfield-small-font-size: var(--amplify-font-sizes-small);

--- a/packages/ui/src/theme/__tests__/__snapshots__/defaultTheme.test.ts.snap
+++ b/packages/ui/src/theme/__tests__/__snapshots__/defaultTheme.test.ts.snap
@@ -493,11 +493,11 @@ exports[`@aws-amplify/ui defaultTheme should match snapshot 1`] = `
 --amplify-components-checkbox-button-focus-outline-style: solid;
 --amplify-components-checkbox-button-focus-outline-width: var(--amplify-outline-widths-medium);
 --amplify-components-checkbox-button-focus-outline-offset: var(--amplify-outline-offsets-medium);
---amplify-components-checkbox-button-focus-border-color: var(--amplify-colors-transparent);
+--amplify-components-checkbox-button-focus-border-color: var(--amplify-colors-border-focus);
 --amplify-components-checkbox-button-focus-box-shadow: var(--amplify-components-fieldcontrol-focus-box-shadow);
 --amplify-components-checkbox-button-disabled-border-color: var(--amplify-colors-border-disabled);
 --amplify-components-checkbox-button-error-border-color: var(--amplify-colors-border-error);
---amplify-components-checkbox-button-error-focus-border-color: var(--amplify-colors-transparent);
+--amplify-components-checkbox-button-error-focus-border-color: var(--amplify-colors-border-error);
 --amplify-components-checkbox-button-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-checkbox-icon-background-color: var(--amplify-colors-primary-80);
 --amplify-components-checkbox-icon-border-radius: 20%;

--- a/packages/ui/src/theme/__tests__/__snapshots__/overrides.test.ts.snap
+++ b/packages/ui/src/theme/__tests__/__snapshots__/overrides.test.ts.snap
@@ -493,11 +493,11 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-checkbox-button-focus-outline-style: solid;
 --amplify-components-checkbox-button-focus-outline-width: var(--amplify-outline-widths-medium);
 --amplify-components-checkbox-button-focus-outline-offset: var(--amplify-outline-offsets-medium);
---amplify-components-checkbox-button-focus-border-color: var(--amplify-colors-transparent);
+--amplify-components-checkbox-button-focus-border-color: var(--amplify-colors-border-focus);
 --amplify-components-checkbox-button-focus-box-shadow: var(--amplify-components-fieldcontrol-focus-box-shadow);
 --amplify-components-checkbox-button-disabled-border-color: var(--amplify-colors-border-disabled);
 --amplify-components-checkbox-button-error-border-color: var(--amplify-colors-border-error);
---amplify-components-checkbox-button-error-focus-border-color: var(--amplify-colors-transparent);
+--amplify-components-checkbox-button-error-focus-border-color: var(--amplify-colors-border-error);
 --amplify-components-checkbox-button-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-checkbox-icon-background-color: var(--amplify-colors-primary-80);
 --amplify-components-checkbox-icon-border-radius: 20%;

--- a/packages/ui/src/theme/__tests__/__snapshots__/overrides.test.ts.snap
+++ b/packages/ui/src/theme/__tests__/__snapshots__/overrides.test.ts.snap
@@ -167,7 +167,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-outlined-info-focus-border-color: var(--amplify-colors-blue-100);
 --amplify-components-button-outlined-info-focus-background-color: var(--amplify-colors-blue-10);
 --amplify-components-button-outlined-info-focus-color: var(--amplify-colors-blue-100);
---amplify-components-button-outlined-info-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-blue-100);
+--amplify-components-button-outlined-info-focus-box-shadow: var(--amplify-components-fieldcontrol-info-focus-box-shadow);
 --amplify-components-button-outlined-info-active-border-color: var(--amplify-colors-blue-100);
 --amplify-components-button-outlined-info-active-background-color: var(--amplify-colors-blue-20);
 --amplify-components-button-outlined-info-active-color: var(--amplify-colors-blue-100);
@@ -180,7 +180,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-outlined-warning-focus-border-color: var(--amplify-colors-orange-100);
 --amplify-components-button-outlined-warning-focus-background-color: var(--amplify-colors-orange-10);
 --amplify-components-button-outlined-warning-focus-color: var(--amplify-colors-orange-100);
---amplify-components-button-outlined-warning-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-orange-100);
+--amplify-components-button-outlined-warning-focus-box-shadow: var(--amplify-components-fieldcontrol-warning-focus-box-shadow);
 --amplify-components-button-outlined-warning-active-border-color: var(--amplify-colors-orange-100);
 --amplify-components-button-outlined-warning-active-background-color: var(--amplify-colors-orange-20);
 --amplify-components-button-outlined-warning-active-color: var(--amplify-colors-orange-100);
@@ -193,7 +193,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-outlined-success-focus-border-color: var(--amplify-colors-green-100);
 --amplify-components-button-outlined-success-focus-background-color: var(--amplify-colors-green-10);
 --amplify-components-button-outlined-success-focus-color: var(--amplify-colors-green-100);
---amplify-components-button-outlined-success-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-green-100);
+--amplify-components-button-outlined-success-focus-box-shadow: var(--amplify-components-fieldcontrol-success-focus-box-shadow);
 --amplify-components-button-outlined-success-active-border-color: var(--amplify-colors-green-100);
 --amplify-components-button-outlined-success-active-background-color: var(--amplify-colors-green-20);
 --amplify-components-button-outlined-success-active-color: var(--amplify-colors-green-100);
@@ -206,7 +206,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-outlined-error-focus-border-color: var(--amplify-colors-red-100);
 --amplify-components-button-outlined-error-focus-background-color: var(--amplify-colors-red-10);
 --amplify-components-button-outlined-error-focus-color: var(--amplify-colors-red-100);
---amplify-components-button-outlined-error-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-red-100);
+--amplify-components-button-outlined-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-button-outlined-error-active-border-color: var(--amplify-colors-red-100);
 --amplify-components-button-outlined-error-active-background-color: var(--amplify-colors-red-20);
 --amplify-components-button-outlined-error-active-color: var(--amplify-colors-red-100);
@@ -219,7 +219,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-outlined-overlay-focus-border-color: var(--amplify-colors-overlay-90);
 --amplify-components-button-outlined-overlay-focus-background-color: var(--amplify-colors-overlay-5);
 --amplify-components-button-outlined-overlay-focus-color: var(--amplify-colors-neutral-90);
---amplify-components-button-outlined-overlay-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-overlay-90);
+--amplify-components-button-outlined-overlay-focus-box-shadow: var(--amplify-components-fieldcontrol-overlay-focus-box-shadow);
 --amplify-components-button-outlined-overlay-active-border-color: var(--amplify-colors-overlay-90);
 --amplify-components-button-outlined-overlay-active-background-color: var(--amplify-colors-overlay-10);
 --amplify-components-button-outlined-overlay-active-color: var(--amplify-colors-neutral-100);
@@ -253,7 +253,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-primary-info-focus-border-color: transparent;
 --amplify-components-button-primary-info-focus-background-color: var(--amplify-colors-blue-90);
 --amplify-components-button-primary-info-focus-color: var(--amplify-colors-font-inverse);
---amplify-components-button-primary-info-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-blue-100);
+--amplify-components-button-primary-info-focus-box-shadow: var(--amplify-components-fieldcontrol-info-focus-box-shadow);
 --amplify-components-button-primary-info-active-border-color: transparent;
 --amplify-components-button-primary-info-active-background-color: var(--amplify-colors-blue-100);
 --amplify-components-button-primary-info-active-color: var(--amplify-colors-font-inverse);
@@ -266,7 +266,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-primary-warning-focus-border-color: transparent;
 --amplify-components-button-primary-warning-focus-background-color: var(--amplify-colors-orange-90);
 --amplify-components-button-primary-warning-focus-color: var(--amplify-colors-font-inverse);
---amplify-components-button-primary-warning-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-orange-100);
+--amplify-components-button-primary-warning-focus-box-shadow: var(--amplify-components-fieldcontrol-overlay-focus-box-shadow);
 --amplify-components-button-primary-warning-active-border-color: transparent;
 --amplify-components-button-primary-warning-active-background-color: var(--amplify-colors-orange-100);
 --amplify-components-button-primary-warning-active-color: var(--amplify-colors-font-inverse);
@@ -279,7 +279,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-primary-error-focus-border-color: transparent;
 --amplify-components-button-primary-error-focus-background-color: var(--amplify-colors-red-90);
 --amplify-components-button-primary-error-focus-color: var(--amplify-colors-font-inverse);
---amplify-components-button-primary-error-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-red-100);
+--amplify-components-button-primary-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-button-primary-error-active-border-color: transparent;
 --amplify-components-button-primary-error-active-background-color: var(--amplify-colors-red-100);
 --amplify-components-button-primary-error-active-color: var(--amplify-colors-font-inverse);
@@ -292,7 +292,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-primary-success-focus-border-color: transparent;
 --amplify-components-button-primary-success-focus-background-color: var(--amplify-colors-green-90);
 --amplify-components-button-primary-success-focus-color: var(--amplify-colors-font-inverse);
---amplify-components-button-primary-success-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-green-100);
+--amplify-components-button-primary-success-focus-box-shadow: var(--amplify-components-fieldcontrol-success-focus-box-shadow);
 --amplify-components-button-primary-success-active-border-color: transparent;
 --amplify-components-button-primary-success-active-background-color: var(--amplify-colors-green-100);
 --amplify-components-button-primary-success-active-color: var(--amplify-colors-font-inverse);
@@ -305,7 +305,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-primary-overlay-focus-border-color: transparent;
 --amplify-components-button-primary-overlay-focus-background-color: var(--amplify-colors-overlay-90);
 --amplify-components-button-primary-overlay-focus-color: var(--amplify-colors-font-inverse);
---amplify-components-button-primary-overlay-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-overlay-90);
+--amplify-components-button-primary-overlay-focus-box-shadow: var(--amplify-components-fieldcontrol-overlay-focus-box-shadow);
 --amplify-components-button-primary-overlay-active-border-color: transparent;
 --amplify-components-button-primary-overlay-active-background-color: var(--amplify-colors-overlay-90);
 --amplify-components-button-primary-overlay-active-color: var(--amplify-colors-font-inverse);
@@ -348,7 +348,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-link-info-focus-border-color: transparent;
 --amplify-components-button-link-info-focus-background-color: var(--amplify-colors-blue-10);
 --amplify-components-button-link-info-focus-color: var(--amplify-colors-blue-100);
---amplify-components-button-link-info-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-blue-100);
+--amplify-components-button-link-info-focus-box-shadow: var(--amplify-components-fieldcontrol-info-focus-box-shadow);
 --amplify-components-button-link-info-active-border-color: transparent;
 --amplify-components-button-link-info-active-background-color: var(--amplify-colors-blue-20);
 --amplify-components-button-link-info-active-color: var(--amplify-colors-blue-100);
@@ -361,7 +361,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-link-warning-focus-border-color: transparent;
 --amplify-components-button-link-warning-focus-background-color: var(--amplify-colors-orange-10);
 --amplify-components-button-link-warning-focus-color: var(--amplify-colors-orange-100);
---amplify-components-button-link-warning-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-orange-100);
+--amplify-components-button-link-warning-focus-box-shadow: var(--amplify-components-fieldcontrol-warning-focus-box-shadow);
 --amplify-components-button-link-warning-active-border-color: transparent;
 --amplify-components-button-link-warning-active-background-color: var(--amplify-colors-orange-20);
 --amplify-components-button-link-warning-active-color: var(--amplify-colors-orange-100);
@@ -374,7 +374,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-link-success-focus-border-color: transparent;
 --amplify-components-button-link-success-focus-background-color: var(--amplify-colors-green-10);
 --amplify-components-button-link-success-focus-color: var(--amplify-colors-green-100);
---amplify-components-button-link-success-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-green-100);
+--amplify-components-button-link-success-focus-box-shadow: var(--amplify-components-fieldcontrol-success-focus-box-shadow);
 --amplify-components-button-link-success-active-border-color: transparent;
 --amplify-components-button-link-success-active-background-color: var(--amplify-colors-green-20);
 --amplify-components-button-link-success-active-color: var(--amplify-colors-green-100);
@@ -387,7 +387,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-link-error-focus-border-color: transparent;
 --amplify-components-button-link-error-focus-background-color: var(--amplify-colors-red-10);
 --amplify-components-button-link-error-focus-color: var(--amplify-colors-red-100);
---amplify-components-button-link-error-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-red-100);
+--amplify-components-button-link-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-button-link-error-active-border-color: transparent;
 --amplify-components-button-link-error-active-background-color: var(--amplify-colors-red-20);
 --amplify-components-button-link-error-active-color: var(--amplify-colors-red-100);
@@ -400,7 +400,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-button-link-overlay-focus-border-color: transparent;
 --amplify-components-button-link-overlay-focus-background-color: var(--amplify-colors-overlay-5);
 --amplify-components-button-link-overlay-focus-color: var(--amplify-colors-overlay-90);
---amplify-components-button-link-overlay-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-overlay-90);
+--amplify-components-button-link-overlay-focus-box-shadow: var(--amplify-components-fieldcontrol-overlay-focus-box-shadow);
 --amplify-components-button-link-overlay-active-border-color: transparent;
 --amplify-components-button-link-overlay-active-background-color: var(--amplify-colors-overlay-10);
 --amplify-components-button-link-overlay-active-color: var(--amplify-colors-overlay-90);
@@ -494,11 +494,11 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-checkbox-button-focus-outline-width: var(--amplify-outline-widths-medium);
 --amplify-components-checkbox-button-focus-outline-offset: var(--amplify-outline-offsets-medium);
 --amplify-components-checkbox-button-focus-border-color: var(--amplify-colors-transparent);
---amplify-components-checkbox-button-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-border-focus);
+--amplify-components-checkbox-button-focus-box-shadow: var(--amplify-components-fieldcontrol-focus-box-shadow);
 --amplify-components-checkbox-button-disabled-border-color: var(--amplify-colors-border-disabled);
 --amplify-components-checkbox-button-error-border-color: var(--amplify-colors-border-error);
 --amplify-components-checkbox-button-error-focus-border-color: var(--amplify-colors-transparent);
---amplify-components-checkbox-button-error-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-border-error);
+--amplify-components-checkbox-button-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-checkbox-icon-background-color: var(--amplify-colors-primary-80);
 --amplify-components-checkbox-icon-border-radius: 20%;
 --amplify-components-checkbox-icon-opacity: var(--amplify-opacities-0);
@@ -627,19 +627,24 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-fieldcontrol-quiet-border-inline-end: none;
 --amplify-components-fieldcontrol-quiet-border-block-start: none;
 --amplify-components-fieldcontrol-quiet-border-radius: 0;
---amplify-components-fieldcontrol-quiet-focus-border-block-end-color: var(--amplify-colors-border-focus);
---amplify-components-fieldcontrol-quiet-focus-box-shadow: 0px 1px 0px  var(--amplify-colors-border-focus);
+--amplify-components-fieldcontrol-quiet-focus-border-block-end-color: transparent;
+--amplify-components-fieldcontrol-quiet-focus-box-shadow: var(--amplify-components-fieldcontrol-focus-box-shadow);
 --amplify-components-fieldcontrol-quiet-error-border-block-end-color: var(--amplify-colors-border-error);
---amplify-components-fieldcontrol-quiet-error-focus-box-shadow: 0px 1px 0px  var(--amplify-colors-border-error);
+--amplify-components-fieldcontrol-quiet-error-focus-border-block-end-color: transparent;
+--amplify-components-fieldcontrol-quiet-error-focus-box-shadow: var(--amplify-components-fieldcontrol-error-focus-box-shadow);
 --amplify-components-fieldcontrol-focus-border-color: var(--amplify-colors-border-focus);
---amplify-components-fieldcontrol-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-border-focus);
+--amplify-components-fieldcontrol-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-border-focus);
 --amplify-components-fieldcontrol-disabled-color: var(--amplify-colors-font-disabled);
 --amplify-components-fieldcontrol-disabled-cursor: not-allowed;
 --amplify-components-fieldcontrol-disabled-border-color: var(--amplify-colors-transparent);
 --amplify-components-fieldcontrol-disabled-background-color: var(--amplify-colors-background-disabled);
 --amplify-components-fieldcontrol-error-border-color: var(--amplify-colors-border-error);
 --amplify-components-fieldcontrol-error-color: var(--amplify-colors-font-error);
---amplify-components-fieldcontrol-error-focus-box-shadow: 0px 0px 0px 1px var(--amplify-colors-border-error);
+--amplify-components-fieldcontrol-error-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-border-error);
+--amplify-components-fieldcontrol-info-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-blue-100);
+--amplify-components-fieldcontrol-warning-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-orange-100);
+--amplify-components-fieldcontrol-success-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-green-100);
+--amplify-components-fieldcontrol-overlay-focus-box-shadow: 0px 0px 0px 2px var(--amplify-colors-overlay-90);
 --amplify-components-fieldgroup-gap: var(--amplify-space-zero);
 --amplify-components-fieldgroup-vertical-align-items: center;
 --amplify-components-fieldgroup-outer-align-items: center;
@@ -985,7 +990,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-sliderfield-thumb-hover-background-color: var(--amplify-colors-background-primary);
 --amplify-components-sliderfield-thumb-hover-border-color: var(--amplify-colors-border-focus);
 --amplify-components-sliderfield-thumb-focus-border-color: var(--amplify-colors-border-focus);
---amplify-components-sliderfield-thumb-focus-box-shadow: 0 0 0 2px var(--amplify-colors-border-focus);
+--amplify-components-sliderfield-thumb-focus-box-shadow: var(--amplify-components-fieldcontrol-focus-box-shadow);
 --amplify-components-sliderfield-small-track-height: 0.25rem;
 --amplify-components-sliderfield-small-thumb-width: 1rem;
 --amplify-components-sliderfield-small-thumb-height: 1rem;
@@ -1069,7 +1074,7 @@ exports[`@aws-amplify/ui overrides should match snapshot 1`] = `
 --amplify-components-storagemanager-previewer-body-gap: var(--amplify-space-small);
 --amplify-components-storagemanager-previewer-footer-justify-content: flex-end;
 --amplify-components-switchfield-disabled-opacity: var(--amplify-opacities-60);
---amplify-components-switchfield-focused-shadow: 0px 0px 0px 2px var(--amplify-colors-border-focus);
+--amplify-components-switchfield-focused-shadow: var(--amplify-components-fieldcontrol-focus-box-shadow);
 --amplify-components-switchfield-font-size: var(--amplify-font-sizes-medium);
 --amplify-components-switchfield-large-font-size: var(--amplify-font-sizes-large);
 --amplify-components-switchfield-small-font-size: var(--amplify-font-sizes-small);

--- a/packages/ui/src/theme/css/component/_fieldControl.scss
+++ b/packages/ui/src/theme/css/component/_fieldControl.scss
@@ -94,6 +94,9 @@
         --amplify-components-fieldcontrol-quiet-error-border-block-end-color
       );
       &:focus {
+        border-block-end-color: var(
+          --amplify-components-fieldcontrol-quiet-error-focus-border-block-end-color
+        );
         box-shadow: var(
           --amplify-components-fieldcontrol-quiet-error-focus-box-shadow
         );

--- a/packages/ui/src/theme/tokens/components/button.ts
+++ b/packages/ui/src/theme/tokens/components/button.ts
@@ -178,13 +178,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.blue.10.value}' },
         color: { value: '{colors.blue.100.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.blue.100.value}',
-          },
+          value: '{components.fieldcontrol.info._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -207,13 +201,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.orange.10.value}' },
         color: { value: '{colors.orange.100.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.orange.100.value}',
-          },
+          value: '{components.fieldcontrol.warning._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -236,13 +224,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.green.10.value}' },
         color: { value: '{colors.green.100.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.green.100.value}',
-          },
+          value: '{components.fieldcontrol.success._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -265,13 +247,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.red.10.value}' },
         color: { value: '{colors.red.100.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.red.100.value}',
-          },
+          value: '{components.fieldcontrol._error._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -294,13 +270,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.overlay.5.value}' },
         color: { value: '{colors.neutral.90.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.overlay.90.value}',
-          },
+          value: '{components.fieldcontrol.overlay._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -357,13 +327,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.blue.90.value}' },
         color: { value: '{colors.font.inverse.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.blue.100.value}',
-          },
+          value: '{components.fieldcontrol.info._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -386,13 +350,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.orange.90.value}' },
         color: { value: '{colors.font.inverse.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.orange.100.value}',
-          },
+          value: '{components.fieldcontrol.overlay._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -415,13 +373,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.red.90.value}' },
         color: { value: '{colors.font.inverse.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.red.100.value}',
-          },
+          value: '{components.fieldcontrol._error._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -444,13 +396,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.green.90.value}' },
         color: { value: '{colors.font.inverse.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.green.100.value}',
-          },
+          value: '{components.fieldcontrol.success._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -473,13 +419,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.overlay.90.value}' },
         color: { value: '{colors.font.inverse.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.overlay.90.value}',
-          },
+          value: '{components.fieldcontrol.overlay._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -559,13 +499,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.blue.10.value}' },
         color: { value: '{colors.blue.100.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.blue.100.value}',
-          },
+          value: '{components.fieldcontrol.info._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -588,13 +522,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.orange.10.value}' },
         color: { value: '{colors.orange.100.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.orange.100.value}',
-          },
+          value: '{components.fieldcontrol.warning._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -617,13 +545,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.green.10.value}' },
         color: { value: '{colors.green.100.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.green.100.value}',
-          },
+          value: '{components.fieldcontrol.success._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -646,13 +568,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.red.10.value}' },
         color: { value: '{colors.red.100.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.red.100.value}',
-          },
+          value: '{components.fieldcontrol._error._focus.boxShadow.value}',
         },
       },
       _active: {
@@ -675,13 +591,7 @@ export const button: Required<ButtonTokens<'default'>> = {
         backgroundColor: { value: '{colors.overlay.5.value}' },
         color: { value: '{colors.overlay.90.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '1px',
-            color: '{colors.overlay.90.value}',
-          },
+          value: '{components.fieldcontrol.overlay._focus.boxShadow.value}',
         },
       },
       _active: {

--- a/packages/ui/src/theme/tokens/components/checkbox.ts
+++ b/packages/ui/src/theme/tokens/components/checkbox.ts
@@ -88,15 +88,7 @@ export const checkbox: Required<CheckboxTokens<'default'>> = {
       outlineWidth: { value: '{outlineWidths.medium.value}' },
       outlineOffset: { value: '{outlineOffsets.medium.value}' },
       borderColor: { value: '{colors.transparent.value}' },
-      boxShadow: {
-        value: {
-          offsetX: '0px',
-          offsetY: '0px',
-          blurRadius: '0px',
-          spreadRadius: '2px',
-          color: '{colors.border.focus.value}',
-        },
-      },
+      boxShadow: { value: '{components.fieldcontrol._focus.boxShadow.value}' },
     },
     _disabled: {
       borderColor: { value: '{colors.border.disabled.value}' },
@@ -106,13 +98,7 @@ export const checkbox: Required<CheckboxTokens<'default'>> = {
       _focus: {
         borderColor: { value: '{colors.transparent.value}' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '0px',
-            blurRadius: '0px',
-            spreadRadius: '2px',
-            color: '{colors.border.error.value}',
-          },
+          value: '{components.fieldcontrol._error._focus.boxShadow.value}',
         },
       },
     },

--- a/packages/ui/src/theme/tokens/components/checkbox.ts
+++ b/packages/ui/src/theme/tokens/components/checkbox.ts
@@ -87,7 +87,7 @@ export const checkbox: Required<CheckboxTokens<'default'>> = {
       outlineStyle: { value: 'solid' },
       outlineWidth: { value: '{outlineWidths.medium.value}' },
       outlineOffset: { value: '{outlineOffsets.medium.value}' },
-      borderColor: { value: '{colors.transparent.value}' },
+      borderColor: { value: '{colors.border.focus.value}' },
       boxShadow: { value: '{components.fieldcontrol._focus.boxShadow.value}' },
     },
     _disabled: {
@@ -96,7 +96,7 @@ export const checkbox: Required<CheckboxTokens<'default'>> = {
     _error: {
       borderColor: { value: '{colors.border.error.value}' },
       _focus: {
-        borderColor: { value: '{colors.transparent.value}' },
+        borderColor: { value: '{colors.border.error.value}' },
         boxShadow: {
           value: '{components.fieldcontrol._error._focus.boxShadow.value}',
         },

--- a/packages/ui/src/theme/tokens/components/fieldControl.ts
+++ b/packages/ui/src/theme/tokens/components/fieldControl.ts
@@ -36,7 +36,7 @@ type FieldControlQuietTokens<Output> = DesignTokenProperties<
 > & {
   _focus?: DesignTokenProperties<'borderBlockEndColor' | 'boxShadow', Output>;
   _error?: DesignTokenProperties<'borderBlockEndColor', Output> & {
-    _focus?: DesignTokenProperties<'boxShadow', Output>;
+    _focus?: DesignTokenProperties<'borderBlockEndColor' | 'boxShadow', Output>;
   };
 };
 
@@ -66,6 +66,18 @@ export type FieldControlTokens<Output extends OutputVariantKey> =
     _focus?: FieldControlFocusTokens<Output>;
     _disabled?: FieldControlDisabledTokens<Output>;
     _error?: FieldControlErrorTokens<Output>;
+    info?: {
+      _focus?: DesignTokenProperties<'boxShadow', Output>;
+    };
+    warning?: {
+      _focus?: DesignTokenProperties<'boxShadow', Output>;
+    };
+    success?: {
+      _focus?: DesignTokenProperties<'boxShadow', Output>;
+    };
+    overlay?: {
+      _focus?: DesignTokenProperties<'boxShadow', Output>;
+    };
   };
 
 export const fieldcontrol: Required<FieldControlTokens<'default'>> = {
@@ -133,47 +145,38 @@ export const fieldcontrol: Required<FieldControlTokens<'default'>> = {
     borderBlockStart: { value: 'none' },
     borderRadius: { value: '0' },
     _focus: {
-      borderBlockEndColor: { value: '{colors.border.focus.value}' },
+      borderBlockEndColor: { value: 'transparent' },
       boxShadow: {
-        value: {
-          offsetX: '0px',
-          offsetY: '1px',
-          color: '{colors.border.focus.value}',
-          blurRadius: '0px',
-        },
+        value: '{components.fieldcontrol._focus.boxShadow.value}',
       },
     },
     _error: {
       borderBlockEndColor: { value: '{colors.border.error.value}' },
       _focus: {
+        borderBlockEndColor: { value: 'transparent' },
         boxShadow: {
-          value: {
-            offsetX: '0px',
-            offsetY: '1px',
-            color: '{colors.border.error.value}',
-            blurRadius: '0px',
-          },
+          value: '{components.fieldcontrol._error._focus.boxShadow.value}',
         },
       },
     },
   },
   _focus: {
     // These focus styles have been calibrated to create
-    // a highly visible focus indicator per WCAG 2.1 guidliness:
-    // See: https://www.w3.org/WAI/WCAG21/Techniques/general/G195.html
+    // a highly visible focus indicator per WCAG 2.2 guidlines:
+    // See: https://www.w3.org/TR/WCAG22/#focus-appearance
     //
     // Key features:
-    // * Focus indicator area is at least the 1 CSS px border around the component.
-    // * Contrast between focused and unfocused states has a ratio of 3:1
+    // * Focus indicator area is at least the 2 CSS px perimeter around the component.
+    // * Contrast between focused and unfocused area of contrast has a ratio of 3:1
     //
-    // IMPORTANT: Must recalibrate if `colors.border.primary` or `colors.focus` are changed
+    // IMPORTANT: Must recalibrate if `colors.border.focus` are changed
     borderColor: { value: '{colors.border.focus.value}' },
     boxShadow: {
       value: {
         offsetX: '0px',
         offsetY: '0px',
         blurRadius: '0px',
-        spreadRadius: '1px',
+        spreadRadius: '2px',
         color: '{colors.border.focus.value}',
       },
     },
@@ -193,8 +196,60 @@ export const fieldcontrol: Required<FieldControlTokens<'default'>> = {
           offsetX: '0px',
           offsetY: '0px',
           blurRadius: '0px',
-          spreadRadius: '1px',
+          spreadRadius: '2px',
           color: '{colors.border.error.value}',
+        },
+      },
+    },
+  },
+  info: {
+    _focus: {
+      boxShadow: {
+        value: {
+          offsetX: '0px',
+          offsetY: '0px',
+          blurRadius: '0px',
+          spreadRadius: '2px',
+          color: '{colors.blue.100.value}',
+        },
+      },
+    },
+  },
+  warning: {
+    _focus: {
+      boxShadow: {
+        value: {
+          offsetX: '0px',
+          offsetY: '0px',
+          blurRadius: '0px',
+          spreadRadius: '2px',
+          color: '{colors.orange.100.value}',
+        },
+      },
+    },
+  },
+  success: {
+    _focus: {
+      boxShadow: {
+        value: {
+          offsetX: '0px',
+          offsetY: '0px',
+          blurRadius: '0px',
+          spreadRadius: '2px',
+          color: '{colors.green.100.value}',
+        },
+      },
+    },
+  },
+  overlay: {
+    _focus: {
+      boxShadow: {
+        value: {
+          offsetX: '0px',
+          offsetY: '0px',
+          blurRadius: '0px',
+          spreadRadius: '2px',
+          color: '{colors.overlay.90.value}',
         },
       },
     },

--- a/packages/ui/src/theme/tokens/components/sliderField.ts
+++ b/packages/ui/src/theme/tokens/components/sliderField.ts
@@ -89,15 +89,7 @@ export const sliderfield: Required<SliderFieldTokens<'default'>> = {
     },
     _focus: {
       borderColor: { value: '{colors.border.focus.value}' },
-      boxShadow: {
-        value: {
-          offsetX: '0',
-          offsetY: '0',
-          blurRadius: '0',
-          spreadRadius: '2px',
-          color: '{colors.border.focus.value}',
-        },
-      },
+      boxShadow: { value: '{components.fieldcontrol._focus.boxShadow.value}' },
     },
   },
 

--- a/packages/ui/src/theme/tokens/components/switchField.ts
+++ b/packages/ui/src/theme/tokens/components/switchField.ts
@@ -46,13 +46,7 @@ export const switchfield: Required<SwitchFieldTokens<'default'>> = {
   },
   _focused: {
     shadow: {
-      value: {
-        offsetX: '0px',
-        offsetY: '0px',
-        blurRadius: '0px',
-        spreadRadius: '2px',
-        color: '{colors.border.focus.value}',
-      },
+      value: '{components.fieldcontrol._focus.boxShadow.value}',
     },
   },
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Updates our defaultTheme focus indicator used across primitives to comply with WCAG 2.2 Focus appearance. This is a AAA requirement, but a pretty easy one for us to hit with some changes.
- Our focus indicator ring already meets 3:1 contrast ratio in its contrast area. Our indicator ring sits OUTSIDE of the element since we use a box shadow, so the contrast area is the area taken up by that box shadow; currently a 1px perimeter. That means our box shadow color must be 3:1 against the background color it sits on.

**This PR:**
- Updates the contrast area to a 2px perimeter to meet WCAG 2.2 Focus Appearance; so our boxShadow spread increases from 1px to 2px.
- Adds `info`, `warning`, and `success` fieldControl focus box shadows. fieldControl already has a default focus boxShadow and `error`.
- Updates the `_focus: {boxShadow}` token across primitives to reference those existing or new boxShadow tokens defined in fieldControl.

[Preview link](https://focusringupdates.dvmvffzts1tcu.amplifyapp.com/) You can also check Button, Select, Checkbox, etc. Basically, anything that can be focusable.

**Some references**
[Focus appearance (from WCAG website)](https://www.w3.org/TR/WCAG22/#focus-appearance)
>When the keyboard [focus indicator](https://www.w3.org/TR/WCAG22/#dfn-focus-indicator) is visible, an area of the focus indicator meets all the following:
> - is at least as large as the area of a 2 [CSS pixel](https://www.w3.org/TR/WCAG22/#dfn-css-pixels) thick [perimeter](https://www.w3.org/TR/WCAG22/#dfn-perimeter) of the unfocused component or sub-component, and
> - has a contrast ratio of at least 3:1 between the same pixels in the focused and unfocused states.

[A guide to designing accessible, WCAG-conformant focus indicators](https://www.sarasoueidan.com/blog/focus-indicators/#wcag-2.1-and-wcag-2.2-focus-indicator-accessibility-requirements)


**Components to check**
- [Button](http://localhost:5001/react/components/button) (or any primitive that uses a Button)
- [Input](http://localhost:5001/react/components/input) (or any primitive that uses an Input)
- [RadioGroupField](http://localhost:5001/react/components/radiogroupfield)
- [SelectField](http://localhost:5001/react/components/selectfield)
- [SwitchField](http://localhost:5001/react/components/switchfield)
- The new Tabs and Accordion didn't require changes as they already have 2px focus styles in their new css

Fixes https://github.com/aws-amplify/amplify-ui/issues/4409

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
