### PR TITLE
chore: add explicit aria tags to hints

### DIFF
--- a/.changeset/khaki-glasses-deny.md
+++ b/.changeset/khaki-glasses-deny.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+chore: add explicit aria tags to hints

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/Hint.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/Hint.tsx
@@ -34,6 +34,16 @@ export interface HintProps {
   hintDisplayText: Required<HintDisplayText>;
 }
 
+const defaultToast = (text: string, isInitial = false) => {
+  return (
+    <Toast size="large" variation="primary" isInitial={isInitial}>
+      <View aria-live="polite" aria-label={text}>
+        {text}
+      </View>
+    </Toast>
+  );
+};
+
 export const Hint: React.FC<HintProps> = ({ hintDisplayText }) => {
   const [state] = useLivenessActor();
 
@@ -80,11 +90,7 @@ export const Hint: React.FC<HintProps> = ({ hintDisplayText }) => {
 
   const getInstructionContent = () => {
     if (isStartView) {
-      return (
-        <Toast size="large" variation="primary" isInitial>
-          {hintDisplayText.hintCenterFaceText}
-        </Toast>
-      );
+      return defaultToast(hintDisplayText.hintCenterFaceText, true);
     }
 
     if (errorState ?? (isCheckFailed || isCheckSuccessful)) {
@@ -94,17 +100,11 @@ export const Hint: React.FC<HintProps> = ({ hintDisplayText }) => {
     if (!isRecording) {
       if (isCheckFaceDetectedBeforeStart) {
         if (faceMatchStateBeforeStart === FaceMatchState.TOO_MANY) {
-          return (
-            <Toast size="large" variation="primary">
-              {FaceMatchStateStringMap[faceMatchStateBeforeStart]}
-            </Toast>
+          return defaultToast(
+            FaceMatchStateStringMap[faceMatchStateBeforeStart]!
           );
         }
-        return (
-          <Toast size="large" variation="primary">
-            {hintDisplayText.hintMoveFaceFrontOfCameraText}
-          </Toast>
-        );
+        return defaultToast(hintDisplayText.hintMoveFaceFrontOfCameraText);
       }
 
       // Specifically checking for false here because initially the value is undefined and we do not want to show the instruction
@@ -112,16 +112,15 @@ export const Hint: React.FC<HintProps> = ({ hintDisplayText }) => {
         isCheckFaceDistanceBeforeRecording &&
         isFaceFarEnoughBeforeRecordingState === false
       ) {
-        return (
-          <Toast size="large" variation="primary">
-            {hintDisplayText.hintTooCloseText}
-          </Toast>
-        );
+        return defaultToast(hintDisplayText.hintTooCloseText);
       }
 
       if (isNotRecording) {
         return (
-          <Toast>
+          <Toast
+            aria-live="polite"
+            aria-label={hintDisplayText.hintConnectingText}
+          >
             <Flex className={LivenessClassNames.HintText}>
               <Loader />
               <View>{hintDisplayText.hintConnectingText}</View>
@@ -132,7 +131,10 @@ export const Hint: React.FC<HintProps> = ({ hintDisplayText }) => {
 
       if (isUploading) {
         return (
-          <Toast>
+          <Toast
+            aria-live="polite"
+            aria-label={hintDisplayText.hintVerifyingText}
+          >
             <Flex className={LivenessClassNames.HintText}>
               <Loader />
               <View>{hintDisplayText.hintVerifyingText}</View>
@@ -142,20 +144,12 @@ export const Hint: React.FC<HintProps> = ({ hintDisplayText }) => {
       }
 
       if (illuminationState && illuminationState !== IlluminationState.NORMAL) {
-        return (
-          <Toast size="large" variation="primary">
-            {IlluminationStateStringMap[illuminationState]}
-          </Toast>
-        );
+        return defaultToast(IlluminationStateStringMap[illuminationState]);
       }
     }
 
     if (isFlashingFreshness) {
-      return (
-        <Toast size="large" variation="primary">
-          {hintDisplayText.hintHoldFaceForFreshnessText}
-        </Toast>
-      );
+      return defaultToast(hintDisplayText.hintHoldFaceForFreshnessText);
     }
 
     if (isRecording && !isFlashingFreshness) {
@@ -178,7 +172,9 @@ export const Hint: React.FC<HintProps> = ({ hintDisplayText }) => {
             faceMatchState === FaceMatchState.TOO_CLOSE ? 'error' : 'primary'
           }
         >
-          {resultHintString}
+          <View aria-live="polite" aria-label={resultHintString}>
+            {resultHintString}
+          </View>
         </Toast>
       );
     }

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/Hint.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/Hint.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Flex, Loader, View } from '@aws-amplify/ui-react';
+import { View } from '@aws-amplify/ui-react';
 
 import { IlluminationState, FaceMatchState } from '../service';
 
@@ -11,7 +11,7 @@ import {
 } from '../hooks';
 import { Toast } from './Toast';
 import { HintDisplayText } from '../displayText';
-import { LivenessClassNames } from '../types/classNames';
+import { ToastWithLoader } from './ToastWithLoader';
 
 export const selectErrorState = createLivenessSelector(
   (state) => state.context.errorState
@@ -117,29 +117,13 @@ export const Hint: React.FC<HintProps> = ({ hintDisplayText }) => {
 
       if (isNotRecording) {
         return (
-          <Toast
-            aria-live="polite"
-            aria-label={hintDisplayText.hintConnectingText}
-          >
-            <Flex className={LivenessClassNames.HintText}>
-              <Loader />
-              <View>{hintDisplayText.hintConnectingText}</View>
-            </Flex>
-          </Toast>
+          <ToastWithLoader displayText={hintDisplayText.hintConnectingText} />
         );
       }
 
       if (isUploading) {
         return (
-          <Toast
-            aria-live="polite"
-            aria-label={hintDisplayText.hintVerifyingText}
-          >
-            <Flex className={LivenessClassNames.HintText}>
-              <Loader />
-              <View>{hintDisplayText.hintVerifyingText}</View>
-            </Flex>
-          </Toast>
+          <ToastWithLoader displayText={hintDisplayText.hintVerifyingText} />
         );
       }
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/ToastWithLoader.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/ToastWithLoader.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { Flex, Loader, View } from '@aws-amplify/ui-react';
+import { LivenessClassNames } from '../types/classNames';
+import { Toast } from './Toast';
+
+interface ToastWithLoaderProps {
+  displayText: string;
+  labelText?: string;
+}
+
+export const ToastWithLoader: React.FC<ToastWithLoaderProps> = ({
+  displayText,
+  labelText,
+}) => {
+  return (
+    <Toast aria-live="polite" aria-label={labelText ?? displayText}>
+      <Flex className={LivenessClassNames.HintText}>
+        <Loader />
+        <View>{displayText}</View>
+      </Flex>
+    </Toast>
+  );
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- This adds explicitly aria labels to the hint component. Screen readers were already working previously but this just makes it more obvious

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
