### PR TITLE
fix(auth): fix refreshing page not hydrating custom formfields/services into the auth machine

### DIFF
--- a/.changeset/curly-lamps-love.md
+++ b/.changeset/curly-lamps-love.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(auth): fix refreshing page not hydrating custom formfields/services into the auth machine

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component.ts
@@ -12,6 +12,11 @@ export class SignInWithEmailComponent {
   }
 
   public formFields = {
+    signIn: {
+      password: {
+        placeholder: 'Enter your cool password',
+      },
+    },
     confirmVerifyUser: {
       confirmation_code: {
         label: 'New Label',

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component.ts
@@ -13,8 +13,8 @@ export class SignInWithEmailComponent {
 
   public formFields = {
     signIn: {
-      password: {
-        placeholder: 'Enter your cool password',
+      username: {
+        placeholder: 'Enter your cool email',
       },
     },
     confirmVerifyUser: {

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
@@ -10,8 +10,8 @@ Amplify.configure(awsExports);
 
 const formFields = {
   signIn: {
-    password: {
-      placeholder: 'Enter your cool password',
+    username: {
+      placeholder: 'Enter your cool email',
     },
   },
   confirmVerifyUser: {

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
@@ -9,6 +9,11 @@ import awsExports from './aws-exports';
 Amplify.configure(awsExports);
 
 const formFields = {
+  signIn: {
+    password: {
+      placeholder: 'Enter your cool password',
+    },
+  },
   confirmVerifyUser: {
     confirmation_code: {
       label: 'New Label',

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
@@ -65,7 +65,6 @@ export default function App() {
       formFields={formFields}
       components={components}
       hideSignUp={true}
-      services={services}
     >
       {({ signOut, user }) => {
         return (

--- a/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/sign-in-with-email/index.page.tsx
@@ -65,6 +65,7 @@ export default function App() {
       formFields={formFields}
       components={components}
       hideSignUp={true}
+      services={services}
     >
       {({ signOut, user }) => {
         return (

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
@@ -6,6 +6,11 @@ import aws_exports from './aws-exports';
 
 Amplify.configure(aws_exports);
 const formFields = {
+  signIn: {
+    password: {
+      placeholder: 'Enter your cool password',
+    },
+  },
   confirmVerifyUser: {
     confirmation_code: {
       label: 'New Label',
@@ -24,7 +29,10 @@ const formFields = {
     </template>
 
     <template v-slot:verify-user-header>
-      <h3 class="amplify-heading" style="padding: var(--amplify-space-xl) 0 0 var(--amplify-space-xl)">
+      <h3
+        class="amplify-heading"
+        style="padding: var(--amplify-space-xl) 0 0 var(--amplify-space-xl)"
+      >
         Enter Information:
       </h3>
     </template>
@@ -34,7 +42,10 @@ const formFields = {
     </template>
 
     <template v-slot:confirm-verify-user-header>
-      <h3 class="amplify-heading" style="padding: var(--amplify-space-xl) 0 0 var(--amplify-space-xl)">
+      <h3
+        class="amplify-heading"
+        style="padding: var(--amplify-space-xl) 0 0 var(--amplify-space-xl)"
+      >
         Enter Information:
       </h3>
     </template>

--- a/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/sign-in-with-email/index.vue
@@ -7,8 +7,8 @@ import aws_exports from './aws-exports';
 Amplify.configure(aws_exports);
 const formFields = {
   signIn: {
-    password: {
-      placeholder: 'Enter your cool password',
+    username: {
+      placeholder: 'Enter your cool email',
     },
   },
   confirmVerifyUser: {

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
@@ -93,4 +93,4 @@ Feature: Sign In with Email
     Then I see "Sign out"
     Then I click the "Sign out" button
     Then I see "Sign in"
-    Then I see placeholder "Enter your cool password"
+    Then I see placeholder "Enter your cool email"

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-email.feature
@@ -82,3 +82,15 @@ Feature: Sign In with Email
   @angular @react @vue
   Scenario: Password fields autocomplete "current-password"
     Then "Password" field autocompletes "current-password"
+
+  @angular @react @vue @react-native
+  Scenario: Sign in with confirmed credentials, reload, sign out, then see custom form fields
+    When I type my "email" with status "CONFIRMED"
+    Then I type my password
+    Then I click the "Sign in" button
+    Then I see "Sign out"
+    When I reload the page
+    Then I see "Sign out"
+    Then I click the "Sign out" button
+    Then I see "Sign in"
+    Then I see placeholder "Enter your cool password"

--- a/packages/ui/src/machines/authenticator/__tests__/index.test.ts
+++ b/packages/ui/src/machines/authenticator/__tests__/index.test.ts
@@ -425,21 +425,53 @@ describe('authenticator', () => {
 
   it('should refresh token', async () => {
     service = interpret(
-      createAuthenticatorMachine().withConfig({
-        actions: {
-          setUser: jest.fn(() => Promise.resolve),
-        },
-        services: {
-          handleGetCurrentUser: jest.fn(async () => Promise.resolve),
-        },
-        guards: {},
-      })
+      createAuthenticatorMachine()
+        .withConfig({
+          actions: {
+            setUser: jest.fn(() => Promise.resolve),
+          },
+          services: {
+            handleGetCurrentUser: jest.fn(async () => Promise.resolve),
+            getAmplifyConfig: () =>
+              Promise.resolve({}) as ReturnType<
+                (typeof defaultServices)['getAmplifyConfig']
+              >,
+          },
+          guards: {
+            hasUser: () => true,
+          },
+        })
+        .withConfig({
+          actions: {
+            forwardToActor: jest.fn(() => Promise.resolve),
+            setActorDoneData: jest.fn(() => Promise.resolve),
+            clearUser: jest.fn(() => Promise.resolve),
+            clearActorDoneData: jest.fn(() => Promise.resolve),
+            applyAmplifyConfig: jest.fn(() => Promise.resolve),
+            setUser: jest.fn(() => Promise.resolve),
+            spawnForgotPasswordActor: jest.fn(() => Promise.resolve),
+            spawnSignOutActor: jest.fn(() => Promise.resolve),
+            stopSignInActor: jest.fn(() => Promise.resolve),
+            stopResetPasswordActor: jest.fn(() => Promise.resolve),
+            stopSignOutActor: jest.fn(() => Promise.resolve),
+            configure: jest.fn(() => Promise.resolve),
+            setHasSetup: jest.fn(() => Promise.resolve),
+          },
+        })
     );
 
     service.start();
 
     expect(service.getSnapshot().value).toStrictEqual('idle');
 
+    await flushPromises();
+    expect(service.getSnapshot().value).toStrictEqual({
+      setup: 'initConfig',
+    });
+
+    service.send({
+      type: 'INIT',
+    });
     await flushPromises();
     expect(service.getSnapshot().value).toStrictEqual({
       authenticated: 'idle',

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -86,7 +86,7 @@ export function createAuthenticatorMachine(
         idle: {
           invoke: {
             src: 'handleGetCurrentUser',
-            onDone: { actions: 'setUser', target: 'authenticated' },
+            onDone: { actions: 'setUser', target: 'setup' },
             onError: { target: 'setup' },
           },
         },
@@ -97,10 +97,17 @@ export function createAuthenticatorMachine(
             getConfig: {
               invoke: {
                 src: 'getAmplifyConfig',
-                onDone: {
-                  actions: ['applyAmplifyConfig', 'setHasSetup'],
-                  target: 'goToInitialState',
-                },
+                onDone: [
+                  {
+                    actions: ['applyAmplifyConfig', 'setHasSetup'],
+                    cond: 'hasUser',
+                    target: '#authenticator.authenticated',
+                  },
+                  {
+                    actions: ['applyAmplifyConfig', 'setHasSetup'],
+                    target: 'goToInitialState',
+                  },
+                ],
               },
             },
             goToInitialState: {
@@ -396,6 +403,9 @@ export function createAuthenticatorMachine(
         isInitialStateResetPassword: ({ config }) =>
           config.initialState === 'forgotPassword',
         shouldSetup: ({ hasSetup }) => !hasSetup,
+        hasUser: ({ user }) => {
+          return !!user;
+        },
       },
       services: {
         getAmplifyConfig: ({ services }) => services.getAmplifyConfig(),

--- a/packages/ui/src/machines/authenticator/index.ts
+++ b/packages/ui/src/machines/authenticator/index.ts
@@ -54,6 +54,7 @@ const LEGACY_WAIT_CONFIG = {
       actions: ['configure'],
       target: 'getConfig',
     },
+    SIGN_OUT: '#authenticator.signOut',
   },
 };
 
@@ -387,7 +388,7 @@ export function createAuthenticatorMachine(
             overrideConfigServices
           )
             ? overrideConfigServices
-            : event.data;
+            : event.data ?? {};
 
           return {
             services: { ...defaultServices, ...customServices },


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- https://github.com/aws-amplify/amplify-ui/issues/4818
  - Bug where refreshing the page when signed in does not honor custom form fields or services
  - This was happening because when refreshing the page while logged in the xstate machine was not hitting the `setup` state in the machine which we use to determine when to hydrate the machine's initial configuration
    - https://github.com/aws-amplify/amplify-ui/blob/main/packages/react-core/src/Authenticator/hooks/useAuthenticatorInitMachine/useAuthenticatorInitMachine.tsx#L19
    - InitializeMachine is only called if `route === 'setup'`
- Fixed this by changing the existing signedIn refresh logic to hit the setup state

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
