### PR TITLE
fix(react-notifications): add async to skipped unit tests

### DIFF
--- a/packages/react-notifications/jest.config.ts
+++ b/packages/react-notifications/jest.config.ts
@@ -9,26 +9,14 @@ const config: Config = {
     // do not collect from top level styles file
     '!<rootDir>/src/styles.ts',
   ],
-  // coverageThreshold: {
-  //   global: {
-  //     branches: 80,
-  //     functions: 80,
-  //     lines: 80,
-  //     statements: 80,
-  //   },
-  // },
   coverageThreshold: {
     global: {
-      branches: 67.18,
-      functions: 52.08,
-      lines: 58.19,
-      statements: 58.46,
+      branches: 95,
+      functions: 93,
+      lines: 95,
+      statements: 95,
     },
   },
-  // @todo-migration update test API usage and remove temp thresholds
-  testPathIgnorePatterns: [
-    '<rootDir>/src/components/InAppMessaging/MessageLayout/__tests__/MessageLayout.test.tsx',
-  ],
   moduleNameMapper: { '^uuid$': '<rootDir>/../../node_modules/uuid' },
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
   preset: 'ts-jest',

--- a/packages/react-notifications/src/components/InAppMessaging/MessageLayout/__tests__/MessageLayout.test.tsx
+++ b/packages/react-notifications/src/components/InAppMessaging/MessageLayout/__tests__/MessageLayout.test.tsx
@@ -124,11 +124,11 @@ describe('MessageLayout component', () => {
     expect(textContainer).toHaveClass(`${TEXT_CONTAINER_CLASS}--horizontal`);
   });
 
-  it('should trigger onClose function', () => {
+  it('should trigger onClose function', async () => {
     render(<MessageLayout {...TEST_PROPS} />);
 
     const closeButton = screen.getByRole('button');
-    userEvent.click(closeButton);
+    await userEvent.click(closeButton);
     expect(mockOnClose).toHaveBeenCalled();
   });
 
@@ -172,7 +172,7 @@ describe('MessageLayout component', () => {
     );
   });
 
-  it('should trigger the button onAction functions', () => {
+  it('should trigger the button onAction functions', async () => {
     render(
       <MessageLayout
         {...TEST_PROPS}
@@ -181,10 +181,11 @@ describe('MessageLayout component', () => {
       />
     );
 
-    userEvent.click(screen.getByText(PRIMARY_BUTTON));
+    await userEvent.click(screen.getByText(PRIMARY_BUTTON));
     expect(mockPrimaryButtonOnAction).toHaveBeenCalled();
     expect(mockSecondaryButtonOnAction).not.toHaveBeenCalled();
-    userEvent.click(screen.getByText(SECONDARY_BUTTON));
+
+    await userEvent.click(screen.getByText(SECONDARY_BUTTON));
     expect(mockSecondaryButtonOnAction).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fix a couple unit tests broken during the MV migration and bump the unit test coverage thresholds for `@aws-amplify/ui-react-notifications`
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`yarn react-notifications test`
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
