### PR TITLE
fix: Update override function calls reference to v6

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.react-native.mdx
@@ -20,7 +20,7 @@ This would be overriden like so:
 
 
 
-Each `handle*` function will return the neccessary values you'll need to make the call to the `Auth.*` function call. Here is a table of each override function name, and the values returned from `formData`.
+Each `handle*` function will return the neccessary values you'll need to make the call to the `Auth` function call. Here is a table of each override function name, and the values returned from `formData`.
 <ResponsiveTable labelWidth="10rem">
   <TableHead>
     <TableRow>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.react-native.mdx
@@ -31,32 +31,38 @@ Each `handle*` function will return the neccessary values you'll need to make th
   </TableHead>
   <TableBody>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`signUp`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`signUp`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.signUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, password, attributes }`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`signIn`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`signIn`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.signIn`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleSignIn` </ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, password}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`confirmSignIn`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`confirmSignIn`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.confirmSignIn`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleConfirmSignIn`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{user, code, mfaType}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`confirmSignUp`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`confirmSignUp`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.confirmSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleConfirmSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, code}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`resetPassword`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`resetPassword`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.forgotPassword`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleForgotPassword`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`confirmResetPassword`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`confirmResetPassword`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.forgotPasswordSubmit`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleForgotPasswordSubmit`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, code, password}`</ResponsiveTableCell>
     </TableRow>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.react-native.mdx
@@ -4,7 +4,7 @@ import { TableCell, TableBody, TableHead, TableRow, Alert } from '@aws-amplify/u
 
 ## Override Function Calls
 
-You can override the call to `signUp`, `signIn`, `confirmSignIn`, `confirmSignUp`, `forgotPassword` and `forgotPasswordSubmit` functions.
+You can override the call to `signUp`, `signIn`, `confirmSignIn`, `confirmSignUp`, `resetPassword` and `confirmResetPassword` functions.
 To override a call you must create a new `services` object with an `async` `handle*` function that returns an `aws-amplify` `Auth.*` promise.
 
 The service object must then be passed into the `authenticator` component as a `services` prop. For example, let's imagine you'd like to lowercase the `username` and the `email` attributes during `signUp`.
@@ -31,32 +31,32 @@ Each `handle*` function will return the neccessary values you'll need to make th
   </TableHead>
   <TableBody>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.signUp`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`signUp()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, password, attributes }`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.signIn`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`signIn()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleSignIn` </ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, password}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.confirmSignIn`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`confirmSignIn()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleConfirmSignIn`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{user, code, mfaType}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.confirmSignUp`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`confirmSignUp()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleConfirmSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, code}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.forgotPassword`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`resetPassword()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleForgotPassword`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.forgotPasswordSubmit`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`confirmResetPassword()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleForgotPasswordSubmit`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, code, password}`</ResponsiveTableCell>
     </TableRow>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.react-native.mdx
@@ -31,32 +31,32 @@ Each `handle*` function will return the neccessary values you'll need to make th
   </TableHead>
   <TableBody>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`signUp()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`signUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, password, attributes }`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`signIn()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`signIn`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleSignIn` </ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, password}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`confirmSignIn()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`confirmSignIn`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleConfirmSignIn`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{user, code, mfaType}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`confirmSignUp()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`confirmSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleConfirmSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, code}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`resetPassword()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`resetPassword`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleForgotPassword`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`confirmResetPassword()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`confirmResetPassword`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleForgotPasswordSubmit`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, code, password}`</ResponsiveTableCell>
     </TableRow>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.web.mdx
@@ -31,32 +31,38 @@ Each `handle*` function will return the neccessary values you'll need to make th
   </TableHead>
   <TableBody>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`signUp()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`signUp`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.signUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, password, attributes }`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`signIn()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`signIn`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.signIn`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleSignIn` </ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, password}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`confirmSignIn()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`confirmSignIn`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.confirmSignIn`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleConfirmSignIn`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{user, code, mfaType}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`confirmSignUp()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`confirmSignUp`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.confirmSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleConfirmSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, code}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`resettPassword()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`resetPassword`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.forgotPassword`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleForgotPassword`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`confirmResetPassword()`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v6">`confirmResetPassword`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call v5">`Auth.forgotPasswordSubmit`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleForgotPasswordSubmit`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, code, password}`</ResponsiveTableCell>
     </TableRow>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.override-function-calls.web.mdx
@@ -4,7 +4,7 @@ import { TableCell, TableBody, TableHead, TableRow, Alert } from '@aws-amplify/u
 
 ## Override Function Calls
 
-You can override the call to `signUp`, `signIn`, `confirmSignIn`, `confirmSignUp`, `forgotPassword` and `forgotPasswordSubmit` functions.
+You can override the call to `signUp`, `signIn`, `confirmSignIn`, `confirmSignUp`, `resetPassword` and `confirmResetPassword` functions.
 To override a call you must create a new `services` object with an `async` `handle*` function that returns an `aws-amplify` `Auth.*` promise.
 
 The service object must then be passed into the `authenticator` component as a `services` prop. For example, let's imagine you'd like to lowercase the `username` and the `email` attributes during `signUp`.
@@ -31,32 +31,32 @@ Each `handle*` function will return the neccessary values you'll need to make th
   </TableHead>
   <TableBody>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.signUp`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`signUp()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, password, attributes }`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.signIn`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`signIn()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleSignIn` </ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, password}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.confirmSignIn`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`confirmSignIn()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleConfirmSignIn`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{user, code, mfaType}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.confirmSignUp`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`confirmSignUp()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleConfirmSignUp`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, code}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.forgotPassword`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`resettPassword()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleForgotPassword`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username}`</ResponsiveTableCell>
     </TableRow>
     <TableRow>
-      <ResponsiveTableCell label="Function Call">`Auth.forgotPasswordSubmit`</ResponsiveTableCell>
+      <ResponsiveTableCell label="Function Call">`confirmResetPassword()`</ResponsiveTableCell>
       <ResponsiveTableCell label="Override Name">`handleForgotPasswordSubmit`</ResponsiveTableCell>
       <ResponsiveTableCell label="formData Properties">`{username, code, password}`</ResponsiveTableCell>
     </TableRow>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.angular.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.angular.mdx
@@ -43,10 +43,12 @@ export class SignUpWithEmailComponent implements OnInit {
       return signUp({
         username,
         password,
-        attributes,
-        autoSignIn: {
-          enabled: true,
-        },
+        options: {
+          userAttributes: {
+            ...attributes
+          },
+          autoSignIn: true
+        }
       });
     },
   };

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.angular.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.angular.mdx
@@ -21,8 +21,9 @@ _app.component.ts_
 
 ```js{14}
 import { Component, OnInit } from '@angular/core';
-import { Amplify, Auth } from 'aws-amplify';
-import awsExports from './aws-exports';
+import { Amplify } from 'aws-amplify';
+import { signUp } from 'aws-amplify/auth'
+import amplifyconfig from './amplifyconfiguration.json';
 
 @Component({
   selector: 'sign-up-with-email',
@@ -30,7 +31,7 @@ import awsExports from './aws-exports';
 })
 export class SignUpWithEmailComponent implements OnInit {
   constructor() {
-    Amplify.configure(awsExports);
+    Amplify.configure(amplifyconfig);
   }
 
   services = {
@@ -39,7 +40,7 @@ export class SignUpWithEmailComponent implements OnInit {
       // custom username
       username = username.toLowerCase();
       attributes.email = attributes.email.toLowerCase();
-      return Auth.signUp({
+      return signUp({
         username,
         password,
         attributes,

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.react.mdx
@@ -16,10 +16,12 @@ export default function AuthenticatorWithEmail() {
       return signUp({
         username,
         password,
-        attributes,
-        autoSignIn: {
-          enabled: true,
-        },
+        options: {
+          userAttributes: {
+            ...attributes
+          },
+          autoSignIn: true
+        }
       });
     },
   };

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.react.mdx
@@ -1,9 +1,10 @@
 ```jsx{8}
-import { Amplify, Auth } from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
+import { signUp } from 'aws-amplify/auth';
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
-import awsExports from './aws-exports';
-Amplify.configure(awsExports);
+import amplifyconfig from './amplifyconfiguration.json';
+Amplify.configure(amplifyconfig);
 
 export default function AuthenticatorWithEmail() {
   const services = {
@@ -12,7 +13,7 @@ export default function AuthenticatorWithEmail() {
       // custom username
       username = username.toLowerCase();
       attributes.email = attributes.email.toLowerCase();
-      return Auth.signUp({
+      return signUp({
         username,
         password,
         attributes,

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.vue.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.vue.mdx
@@ -16,10 +16,12 @@
       return signUp({
         username,
         password,
-        attributes,
-        autoSignIn: {
-          enabled: true,
-        },
+        options: {
+          userAttributes: {
+            ...attributes
+          },
+          autoSignIn: true
+        }
       });
     },
   };

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.vue.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/overrides/username.vue.mdx
@@ -1,10 +1,11 @@
 ```html
 <script setup lang="ts">
-  import { Amplify, Auth } from 'aws-amplify';
+  import { Amplify } from 'aws-amplify';
+  import { signUp } from 'aws-amplify/auth';
   import { Authenticator } from '@aws-amplify/ui-vue';
   import '@aws-amplify/ui-vue/styles.css';
-  import aws_exports from './aws-exports';
-  Amplify.configure(aws_exports);
+  import amplifyconfig from './amplifyconfiguration';
+  Amplify.configure(amplifyconfig);
 
   const services = {
     async handleSignUp(formData) {
@@ -12,7 +13,7 @@
       // custom username
       username = username.toLowerCase();
       attributes.email = attributes.email.toLowerCase();
-      return Auth.signUp({
+      return signUp({
         username,
         password,
         attributes,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

The override function calls for Authenticator reference APIs as they appear in v5 of `aws-amplify`. This PR updates them to reference usage in v6.
- https://ui.docs.amplify.aws/react/connected-components/authenticator/customization#override-function-calls
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
N/A
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
