### PR TITLE
chore: update toasts to be assertive

### DIFF
--- a/.changeset/rotten-terms-own.md
+++ b/.changeset/rotten-terms-own.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+chore: update toasts to be assertive

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/Hint.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/Hint.tsx
@@ -37,7 +37,7 @@ export interface HintProps {
 const defaultToast = (text: string, isInitial = false) => {
   return (
     <Toast size="large" variation="primary" isInitial={isInitial}>
-      <View aria-live="polite" aria-label={text}>
+      <View aria-live="assertive" aria-label={text}>
         {text}
       </View>
     </Toast>
@@ -156,7 +156,7 @@ export const Hint: React.FC<HintProps> = ({ hintDisplayText }) => {
             faceMatchState === FaceMatchState.TOO_CLOSE ? 'error' : 'primary'
           }
         >
-          <View aria-live="polite" aria-label={resultHintString}>
+          <View aria-live="assertive" aria-label={resultHintString}>
             {resultHintString}
           </View>
         </Toast>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- UX design is asking that the text on screen be read no matter what. When aria-live is set to polite these hint messages can be cut off or superseded by other a11y messages
- For example, previously the `center your face` message would not be read automatically by some screen readers as it would be overriden by the title being read, this ensures that it is now read

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
