### PR TITLE
chore: align docs Demo CopyButton with other code examples

### DIFF
--- a/docs/src/components/CopyButton.tsx
+++ b/docs/src/components/CopyButton.tsx
@@ -6,14 +6,15 @@ import { trackCopy } from '@/utils/track';
 
 interface CopyButtonProps
   extends Pick<ButtonProps, 'className' | 'size' | 'variation'> {
-  copyText: string;
+  target: string;
 }
 
 export const CopyButton = ({
   className,
-  copyText,
-  size,
-  variation,
+  target,
+  size = 'small',
+  variation = 'link',
+  ...rest
 }: CopyButtonProps) => {
   const [copied, setCopied] = React.useState(false);
 
@@ -22,12 +23,13 @@ export const CopyButton = ({
     setTimeout(() => {
       setCopied(false);
     }, 2000);
-    trackCopy(copyText);
+    trackCopy(target);
   };
 
   return (
-    <CopyToClipboard text={copyText} onCopy={copy}>
+    <CopyToClipboard text={target} onCopy={copy}>
       <Button
+        {...rest}
         className={className}
         isDisabled={copied}
         size={size}

--- a/docs/src/components/Demo.tsx
+++ b/docs/src/components/Demo.tsx
@@ -21,13 +21,6 @@ export const Demo = ({
   const [copied, setCopied] = React.useState(false);
   const { tokens } = useTheme();
 
-  const copy = () => {
-    setCopied(true);
-    setTimeout(() => {
-      setCopied(false);
-    }, 2000);
-  };
-
   return (
     <View
       className="docs-component-demo"
@@ -58,11 +51,7 @@ export const Demo = ({
           position="relative"
           backgroundColor={tokens.colors.background.secondary}
         >
-          <CopyButton
-            className="example-copy-button"
-            copyText={code}
-            size="small"
-          />
+          <CopyButton className="example-copy-button" target={code} />
           <Highlight Prism={defaultProps.Prism} code={code} language="jsx">
             {({ className, style, tokens, getLineProps, getTokenProps }) => (
               <pre

--- a/docs/src/components/Example.tsx
+++ b/docs/src/components/Example.tsx
@@ -31,12 +31,7 @@ export function ExampleCode({ children }) {
 
   return (
     <div className="example-code">
-      <CopyButton
-        className="example-copy-button"
-        copyText={text}
-        size="small"
-        variation="link"
-      />
+      <CopyButton className="example-copy-button" target={text} />
       <div ref={ref}>{children}</div>
     </div>
   );

--- a/docs/src/components/InstallScripts.tsx
+++ b/docs/src/components/InstallScripts.tsx
@@ -47,12 +47,7 @@ export const TerminalCommand = ({
   return (
     <div className={`install-code__container ${variant}`}>
       <code className="install-code__content">{terminalCommand}</code>
-      <CopyButton
-        className="install-code__button"
-        copyText={terminalCommand}
-        size="small"
-        variation="link"
-      />
+      <CopyButton className="install-code__button" target={terminalCommand} />
     </div>
   );
 };

--- a/docs/src/styles/docs/example.scss
+++ b/docs/src/styles/docs/example.scss
@@ -48,13 +48,6 @@
     white-space: pre-wrap;
     margin: 0;
   }
-
-  & .example-copy-button {
-    background: var(--amplify-colors-background-secondary);
-    bottom: var(--amplify-space-small);
-    top: auto;
-    right: var(--amplify-space-medium);
-  }
 }
 
 .example-styling-demo > .amplify-flex {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Align the position and variation of the `CopyButton` used in the UI Primitives `Demo` component

**Screenshots:**
_Baseline Code Snippet Example_

<img width="1131" alt="baseline" src="https://github.com/aws-amplify/amplify-ui/assets/15002885/9221efe3-a9b6-4495-909a-d530204fcc3e">

_After: Demo Code Snippet Example_
<img width="1119" alt="after" src="https://github.com/aws-amplify/amplify-ui/assets/15002885/bdf4a85f-e79d-411d-aed6-258a842017c4">

_Before: Demo Code Snippet Example_
<img width="1115" alt="before" src="https://github.com/aws-amplify/amplify-ui/assets/15002885/343c6b43-d430-4137-84d9-bc0ef6946a6d">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
