### PR TITLE
fix(liveness): fix styling when no face on screen by not showing oval canvas and ensuring full screen camera

### DIFF
--- a/.changeset/moody-badgers-punch.md
+++ b/.changeset/moody-badgers-punch.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+fix(liveness): fix styling when no face on screen by not showing oval canvas and ensuring full screen camera

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -11,7 +11,7 @@ import {
   View,
 } from '@aws-amplify/ui-react';
 import { useColorMode } from '@aws-amplify/ui-react/internal';
-import { FaceMatchState, drawStaticOval } from '../service';
+import { FaceMatchState, clearOvalCanvas, drawStaticOval } from '../service';
 import {
   useLivenessActor,
   useLivenessSelector,
@@ -138,6 +138,7 @@ export const LivenessCameraModule = (
   const isCheckingCamera = state.matches('cameraCheck');
   const isWaitingForCamera = state.matches('waitForDOMAndCameraDetails');
   const isStartView = state.matches('start') || state.matches('userCancel');
+  const isDetectFaceBeforeStart = state.matches('detectFaceBeforeStart');
   const isRecording = state.matches('recording');
   const isCheckSucceeded = state.matches('checkSucceeded');
   const isFlashingFreshness = state.matches({
@@ -220,6 +221,12 @@ export const LivenessCameraModule = (
       );
     }
   }, [send, videoRef, isCameraReady, isMobileScreen]);
+
+  React.useEffect(() => {
+    if (isDetectFaceBeforeStart) {
+      clearOvalCanvas({ canvas: canvasRef.current! });
+    }
+  }, [send, videoRef, isDetectFaceBeforeStart]);
 
   const photoSensitivityWarning = React.useMemo(() => {
     return (

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -226,7 +226,7 @@ export const LivenessCameraModule = (
     if (isDetectFaceBeforeStart) {
       clearOvalCanvas({ canvas: canvasRef.current! });
     }
-  }, [send, videoRef, isDetectFaceBeforeStart]);
+  }, [isDetectFaceBeforeStart]);
 
   const photoSensitivityWarning = React.useMemo(() => {
     return (

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -310,6 +310,64 @@ export const LivenessCameraModule = (
       >
         {!isCameraReady && centeredLoader}
 
+        <Overlay
+          horizontal="center"
+          vertical={
+            isRecording && !isFlashingFreshness ? 'start' : 'space-between'
+          }
+          className={LivenessClassNames.InstructionOverlay}
+        >
+          {isRecording && (
+            <DefaultRecordingIcon
+              recordingIndicatorText={recordingIndicatorText}
+            />
+          )}
+
+          {!isStartView && !isWaitingForCamera && !isCheckSucceeded && (
+            <DefaultCancelButton
+              cancelLivenessCheckText={cancelLivenessCheckText}
+            />
+          )}
+
+          <Flex
+            className={classNames(
+              LivenessClassNames.Hint,
+              shouldShowFullScreenCamera && `${LivenessClassNames.Hint}--mobile`
+            )}
+          >
+            <Hint hintDisplayText={hintDisplayText} />
+          </Flex>
+
+          {errorState && (
+            <ErrorView
+              onRetry={() => {
+                send({ type: 'CANCEL' });
+              }}
+              displayText={errorDisplayText}
+            >
+              {renderErrorModal({
+                errorState,
+                overrideErrorDisplayText: errorDisplayText,
+              })}
+            </ErrorView>
+          )}
+
+          {/* 
+              We only want to show the MatchIndicator when we're recording
+              and when the face is in either the too far state, or the 
+              initial face identified state. Using the a memoized MatchIndicator here
+              so that even when this component re-renders the indicator is only
+              re-rendered if the percentage prop changes.
+            */}
+          {isRecording &&
+          !isFlashingFreshness &&
+          showMatchIndicatorStates.includes(faceMatchState!) ? (
+            <MemoizedMatchIndicator
+              percentage={Math.ceil(faceMatchPercentage!)}
+            />
+          ) : null}
+        </Overlay>
+
         <View
           as="canvas"
           ref={freshnessColorRef}
@@ -344,57 +402,6 @@ export const LivenessCameraModule = (
           >
             <View as="canvas" ref={canvasRef} />
           </Flex>
-
-          {isRecording && (
-            <DefaultRecordingIcon
-              recordingIndicatorText={recordingIndicatorText}
-            />
-          )}
-
-          {!isStartView && !isWaitingForCamera && !isCheckSucceeded && (
-            <DefaultCancelButton
-              cancelLivenessCheckText={cancelLivenessCheckText}
-            />
-          )}
-
-          <Overlay
-            horizontal="center"
-            vertical={
-              isRecording && !isFlashingFreshness ? 'start' : 'space-between'
-            }
-            className={LivenessClassNames.InstructionOverlay}
-          >
-            <Hint hintDisplayText={hintDisplayText} />
-
-            {errorState && (
-              <ErrorView
-                onRetry={() => {
-                  send({ type: 'CANCEL' });
-                }}
-                displayText={errorDisplayText}
-              >
-                {renderErrorModal({
-                  errorState,
-                  overrideErrorDisplayText: errorDisplayText,
-                })}
-              </ErrorView>
-            )}
-
-            {/* 
-              We only want to show the MatchIndicator when we're recording
-              and when the face is in either the too far state, or the 
-              initial face identified state. Using the a memoized MatchIndicator here
-              so that even when this component re-renders the indicator is only
-              re-rendered if the percentage prop changes.
-            */}
-            {isRecording &&
-            !isFlashingFreshness &&
-            showMatchIndicatorStates.includes(faceMatchState!) ? (
-              <MemoizedMatchIndicator
-                percentage={Math.ceil(faceMatchPercentage!)}
-              />
-            ) : null}
-          </Overlay>
 
           {isStartView &&
             !isMobileScreen &&

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -291,8 +291,9 @@ export const LivenessCameraModule = (
     );
   }
 
-  const isRecordingOnMobile =
-    isMobileScreen && !isStartView && !isWaitingForCamera && isRecording;
+  // We don't show full screen camera on the pre check screen (isStartView/isWaitingForCamera)
+  const shouldShowFullScreenCamera =
+    isMobileScreen && !isStartView && !isWaitingForCamera;
 
   return (
     <>
@@ -301,7 +302,8 @@ export const LivenessCameraModule = (
       <Flex
         className={classNames(
           LivenessClassNames.CameraModule,
-          isRecordingOnMobile && `${LivenessClassNames.CameraModule}--mobile`
+          shouldShowFullScreenCamera &&
+            `${LivenessClassNames.CameraModule}--mobile`
         )}
         data-testid={testId}
         gap="zero"
@@ -335,7 +337,8 @@ export const LivenessCameraModule = (
           <Flex
             className={classNames(
               LivenessClassNames.OvalCanvas,
-              isRecordingOnMobile && `${LivenessClassNames.OvalCanvas}--mobile`,
+              shouldShowFullScreenCamera &&
+                `${LivenessClassNames.OvalCanvas}--mobile`,
               isRecordingStopped && LivenessClassNames.FadeOut
             )}
           >

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/index.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/index.ts
@@ -31,7 +31,6 @@ import {
   isCameraDeviceVirtual,
   FreshnessColorDisplay,
   drawStaticOval,
-  clearOvalCanvas,
 } from '../utils';
 import { nanoid } from 'nanoid';
 import { getStaticLivenessOvalDetails } from '../utils/liveness';
@@ -184,7 +183,6 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
         },
       },
       detectFaceBeforeStart: {
-        entry: ['clearOvalCanvas'],
         invoke: {
           src: 'detectFace',
           onDone: {
@@ -484,11 +482,6 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
           context.videoAssociatedParams!;
 
         drawStaticOval(canvasEl!, videoEl!, videoMediaStream!);
-      },
-      clearOvalCanvas: (context) => {
-        const { canvasEl } = context.videoAssociatedParams!;
-
-        clearOvalCanvas({ canvas: canvasEl! });
       },
       updateRecordingStartTimestampMs: assign({
         videoAssociatedParams: (context) => {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/index.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/index.ts
@@ -31,6 +31,7 @@ import {
   isCameraDeviceVirtual,
   FreshnessColorDisplay,
   drawStaticOval,
+  clearOvalCanvas,
 } from '../utils';
 import { nanoid } from 'nanoid';
 import { getStaticLivenessOvalDetails } from '../utils/liveness';
@@ -183,6 +184,7 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
         },
       },
       detectFaceBeforeStart: {
+        entry: ['hideOvalCanvas'],
         invoke: {
           src: 'detectFace',
           onDone: {
@@ -249,7 +251,7 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
         initial: 'ovalDrawing',
         states: {
           ovalDrawing: {
-            entry: ['sendTimeoutAfterOvalDrawingDelay'],
+            entry: ['showOvalCanvas', 'sendTimeoutAfterOvalDrawingDelay'],
             invoke: {
               src: 'detectInitialFaceAndDrawOval',
               onDone: {
@@ -482,6 +484,17 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
           context.videoAssociatedParams!;
 
         drawStaticOval(canvasEl!, videoEl!, videoMediaStream!);
+      },
+      hideOvalCanvas: (context) => {
+        const { canvasEl } = context.videoAssociatedParams!;
+
+        clearOvalCanvas({ canvas: canvasEl! });
+        canvasEl!.style.display = 'none';
+      },
+      showOvalCanvas: (context) => {
+        const { canvasEl } = context.videoAssociatedParams!;
+
+        canvasEl!.style.display = 'unset';
       },
       updateRecordingStartTimestampMs: assign({
         videoAssociatedParams: (context) => {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/index.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/index.ts
@@ -184,7 +184,7 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
         },
       },
       detectFaceBeforeStart: {
-        entry: ['hideOvalCanvas'],
+        entry: ['clearOvalCanvas'],
         invoke: {
           src: 'detectFace',
           onDone: {
@@ -251,7 +251,7 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
         initial: 'ovalDrawing',
         states: {
           ovalDrawing: {
-            entry: ['showOvalCanvas', 'sendTimeoutAfterOvalDrawingDelay'],
+            entry: ['sendTimeoutAfterOvalDrawingDelay'],
             invoke: {
               src: 'detectInitialFaceAndDrawOval',
               onDone: {
@@ -485,16 +485,10 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
 
         drawStaticOval(canvasEl!, videoEl!, videoMediaStream!);
       },
-      hideOvalCanvas: (context) => {
+      clearOvalCanvas: (context) => {
         const { canvasEl } = context.videoAssociatedParams!;
 
         clearOvalCanvas({ canvas: canvasEl! });
-        canvasEl!.style.display = 'none';
-      },
-      showOvalCanvas: (context) => {
-        const { canvasEl } = context.videoAssociatedParams!;
-
-        canvasEl!.style.display = 'unset';
       },
       updateRecordingStartTimestampMs: assign({
         videoAssociatedParams: (context) => {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/liveness.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/liveness.ts
@@ -296,6 +296,21 @@ export function drawLivenessOvalInCanvas({
   }
 }
 
+export function clearOvalCanvas({
+  canvas,
+}: {
+  canvas: HTMLCanvasElement;
+}): void {
+  const ctx = canvas.getContext('2d');
+
+  if (ctx) {
+    ctx.restore();
+    ctx.clearRect(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
+  } else {
+    throw new Error('Cannot find Canvas.');
+  }
+}
+
 interface FaceMatchStateInLivenessOval {
   faceMatchState: FaceMatchState;
   faceMatchPercentage: number;

--- a/packages/ui/src/theme/css/component/liveness.scss
+++ b/packages/ui/src/theme/css/component/liveness.scss
@@ -42,6 +42,7 @@
   left: 0;
   height: 100%;
   width: 100%;
+  z-index: 2;
 }
 
 .amplify-liveness-video {
@@ -110,7 +111,7 @@
 }
 
 .amplify-liveness-instruction-overlay {
-  z-index: 1;
+  z-index: 2;
 }
 
 .amplify-liveness-countdown-container {
@@ -131,6 +132,7 @@
   padding: var(--amplify-space-small);
   max-width: 100%;
 }
+
 .amplify-liveness-toast__message {
   color: var(--amplify-colors-font-primary);
   text-align: center;
@@ -336,6 +338,10 @@
   font-weight: var(--amplify-font-weights-bold);
 }
 
+.amplify-liveness-hint--mobile {
+  margin-top: var(--amplify-space-xxxl);
+}
+
 .amplify-liveness-hint__text {
   align-items: center;
   gap: var(--amplify-space-xs);
@@ -415,5 +421,6 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  text-align: center;
   height: 480px;
 }


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- When no face is on screen we should not show the oval canvas
- new behavior:
<img width="743" alt="Screenshot 2024-01-04 at 8 00 16 PM" src="https://github.com/aws-amplify/amplify-ui/assets/68032955/76aa671e-819b-452f-9757-644d9df69b5b">
- current:

<img width="745" alt="Screenshot 2024-01-04 at 8 00 36 PM" src="https://github.com/aws-amplify/amplify-ui/assets/68032955/12a6e421-8fcf-445c-bc86-e8048e304fd3">

- On mobile we should ensure we have full screen camera on the same screen
- new behavior:
<img width="491" alt="Screenshot 2024-01-04 at 8 00 55 PM" src="https://github.com/aws-amplify/amplify-ui/assets/68032955/f052c51f-32b6-4065-bdee-efae515bcc2c">
- current:

<img width="557" alt="Screenshot 2024-01-04 at 8 01 10 PM" src="https://github.com/aws-amplify/amplify-ui/assets/68032955/662c016a-c758-4e9e-a753-9f36d35f5111">



<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
