### PR TITLE
fix(vue): translate checkbox label

### DIFF
--- a/.changeset/proud-kiwis-smash.md
+++ b/.changeset/proud-kiwis-smash.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-vue": patch
+---
+
+fix(vue): translate checkbox label

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/sign-up-fields.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/sign-up-fields.web.mdx
@@ -12,7 +12,7 @@ import { InlineFilter } from '@/components/InlineFilter';
 The following example customizes the Sign Up screen by:
 
 - Re-using the default Sign Up form fields
-- Appending a custom "Terms & Conditions" checkbox with a `validateCustomSignUp` service
+- Appending a custom "Terms and Conditions" checkbox with a `validateCustomSignUp` service
 
 **Note**: In the example code below, `preferred_username` is not set as an attribute because it has already been defined through [Zero Configuration](./configuration#sign-up-attributes). You may also notice that the `acknowledgement` field is not being sent. This occurs since `acknowledgement` is not a known attribute to Cognito. To assign it as a custom attribute instead, the name field must have the `custom:` prefix.
 
@@ -58,7 +58,7 @@ _app.component.html_
                 hasError={!!validationErrors.acknowledgement}
                 name="acknowledgement"
                 value="yes"
-                label="I agree with the Terms & Conditions"
+                label="I agree with the Terms and Conditions"
               />
             </>
           );
@@ -69,7 +69,7 @@ _app.component.html_
       async validateCustomSignUp(formData) {
         if (!formData.acknowledgement) {
           return {
-            acknowledgement: 'You must agree to the Terms & Conditions',
+            acknowledgement: 'You must agree to the Terms and Conditions',
           };
         }
       },

--- a/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.html
@@ -7,14 +7,14 @@
     <!-- Re-use default `Authenticator.SignUp.FormFields` -->
     <amplify-sign-up-form-fields></amplify-sign-up-form-fields>
 
-    <!-- Append & require Terms & Conditions field to sign up -->
+    <!-- Append & require Terms and Conditions field to sign up -->
     <amplify-checkbox
       [errorMessage]="validationErrors.acknowledgement"
       [hasError]="!!validationErrors.acknowledgement"
       name="acknowledgement"
       value="yes"
     >
-      I agree with the Terms & Conditions
+      I agree with the Terms and Conditions
     </amplify-checkbox>
   </ng-template>
 

--- a/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/custom-sign-up-fields/custom-sign-up-fields.component.ts
@@ -15,7 +15,7 @@ export class CustomSignUpFieldsComponent {
     async validateCustomSignUp(formData: Record<string, string>) {
       if (!formData.acknowledgement) {
         return {
-          acknowledgement: 'You must agree to the Terms & Conditions',
+          acknowledgement: 'You must agree to the Terms and Conditions',
         };
       }
     },

--- a/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/custom-sign-up-fields/index.page.tsx
@@ -26,13 +26,13 @@ export default function App() {
                 {/* Re-use default `Authenticator.SignUp.FormFields` */}
                 <Authenticator.SignUp.FormFields />
 
-                {/* Append & require Terms & Conditions field to sign up  */}
+                {/* Append & require Terms and Conditions field to sign up  */}
                 <CheckboxField
                   errorMessage={validationErrors.acknowledgement as string}
                   hasError={!!validationErrors.acknowledgement}
                   name="acknowledgement"
                   value="yes"
-                  label="I agree with the Terms & Conditions"
+                  label="I agree with the Terms and Conditions"
                 />
               </>
             );
@@ -43,7 +43,7 @@ export default function App() {
         async validateCustomSignUp(formData) {
           if (!formData.acknowledgement) {
             return {
-              acknowledgement: 'You must agree to the Terms & Conditions',
+              acknowledgement: 'You must agree to the Terms and Conditions',
             };
           }
         },

--- a/examples/vue/src/pages/ui/components/authenticator/custom-sign-up-fields/index.vue
+++ b/examples/vue/src/pages/ui/components/authenticator/custom-sign-up-fields/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Amplify } from 'aws-amplify';
+import { I18n } from 'aws-amplify/utils';
 import {
   Authenticator,
   AuthenticatorSignUpFormFields,
@@ -20,7 +21,7 @@ const services = {
   async validateCustomSignUp(formData) {
     if (!formData.acknowledgement) {
       return {
-        acknowledgement: 'You must agree to the Terms & Conditions',
+        acknowledgement: 'You must agree to the Terms and Conditions',
       };
     }
   },

--- a/packages/e2e/features/ui/components/authenticator/custom-sign-up-fields.feature
+++ b/packages/e2e/features/ui/components/authenticator/custom-sign-up-fields.feature
@@ -5,11 +5,11 @@ Feature: Custom Sign Up Fields
   Background:
     Given I'm running the example "ui/components/authenticator/custom-sign-up-fields"
     Then I see "Preferred Username" as an input field
-    Then I see "I agree with the Terms & Conditions"
+    Then I see "I agree with the Terms and Conditions"
 
   @angular @react @vue
   Scenario: Form is invalid by default
-    When I see "You must agree to the Terms & Conditions"
+    When I see "You must agree to the Terms and Conditions"
     Then the "Create Account" button is disabled
 
   @angular @react @vue
@@ -18,27 +18,27 @@ Feature: Custom Sign Up Fields
     Then I type an invalid password
     Then I confirm my password
     Then I see "Your passwords must match"
-    Then I click the "I agree with the Terms & Conditions" checkbox
-    Then I don't see "You must agree to the Terms & Conditions"
+    Then I click the "I agree with the Terms and Conditions" checkbox
+    Then I don't see "You must agree to the Terms and Conditions"
     Then the "Create Account" button is disabled
 
   @angular @react @vue
-  Scenario: Form is valid when I check the Terms & Conditions checkbox, but missing `preferred_username` for Cognito
+  Scenario: Form is valid when I check the Terms and Conditions checkbox, but missing `preferred_username` for Cognito
     Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with error fixture "custom-sign-up-fields-missing-preferred_username"
     When I type a new "email"
     Then I type my password
     Then I confirm my password
-    Then I click the "I agree with the Terms & Conditions" checkbox
+    Then I click the "I agree with the Terms and Conditions" checkbox
     Then I click the "Create Account" button
     Then the "Preferred Username" field is invalid
 
   @angular @react @vue
-  Scenario: Form successfully submits with `preferred_username` and Terms & Conditions checked
+  Scenario: Form successfully submits with `preferred_username` and Terms and Conditions checked
     Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp" } }' with fixture "custom-sign-up-fields"
     When I type a new "preferred username"
     Then I type a new "email"
     Then I type my password
     Then I confirm my password
-    Then I click the "I agree with the Terms & Conditions" checkbox
+    Then I click the "I agree with the Terms and Conditions" checkbox
     Then I click the "Create Account" button
     Then I see "Confirmation Code"

--- a/packages/vue/src/components/primitives/amplify-check-box.vue
+++ b/packages/vue/src/components/primitives/amplify-check-box.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { ref, toRefs } from 'vue';
+import { translate } from '@aws-amplify/ui';
+
 const checked = ref(false);
+// one off translation for Vue only, default value was initially hard coded
+const checkboxLabel = ref(translate('I agree with the Terms and Conditions'));
 
 const props = withDefaults(defineProps<{ errorMessage: string }>(), {
   errorMessage: '',
@@ -14,11 +18,7 @@ const { errorMessage } = toRefs(props);
       ><span class="amplify-visually-hidden"
         ><input
           @click="checked = !checked"
-          class="
-            amplify-input
-            amplify-field-group__control
-            amplify-checkbox__input
-          "
+          class="amplify-input amplify-field-group__control amplify-checkbox__input"
           aria-invalid="false"
           type="checkbox"
           name="acknowledgement"
@@ -46,7 +46,7 @@ const { errorMessage } = toRefs(props);
             d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
           ></path></svg></span
       ><span class="amplify-text amplify-checkbox__label">
-        I agree with the Terms &amp; Conditions</span
+        {{ checkboxLabel }}</span
       ></label
     >
     <p v-if="!checked" class="amplify-text amplify-field__error-message">


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add Vue checkbox element label translation
- update hardcoded label value in Vue checkbox to read from Amplify JS `I18n` module using `translate` util
- replace ampersands with `and` in examples and e2e tests

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-ui/issues/4891
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual tests, run e2e tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
