### PR TITLE
chore(build-system-tests): bump vue/vite2 test to vite3

### DIFF
--- a/build-system-tests/package.json
+++ b/build-system-tests/package.json
@@ -33,7 +33,7 @@
     "angular-14-angular-cli-14-ts": "npm run setup:angular:cli -- -f 14 -b 14 -n angular-14-angular-cli-v14-ts",
     "vue-3-vue-cli-latest-ts": "npm run setup:vue:cli -- -f 3 -P yarn",
     "vue-latest-vite-latest-ts": "npm run setup:vue:vite",
-    "vue-latest-vite-2-ts": "npm run setup:vue:vite -- -b 2",
+    "vue-latest-vite-3-ts": "npm run setup:vue:vite -- -b 3",
     "vue-latest-nuxt-latest-ts": "npm run setup:vue:nuxt",
     "rnlatestclilatesttsios": "npm run setup:react-native:cli -- -A ios -n rnLatestCliLatestTsIos",
     "rnlatestclilatesttsandroid": "npm run setup:react-native:cli -- -A android -n rnLatestCliLatestTsAndroid",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

The recent release of [Vue@3.4](https://github.com/vuejs/core/blob/main/CHANGELOG.md#340-slam-dunk-2023-12-29) caused some breaking changes for our vue + vite@2 test. Bumping vue-tsc to ^1.8.27 allowed it to build but given:
- Vue's recommendation to use @vitejs/plugin-vue@^5.0.0 (which has a peer dependency of vite@5)
- Vite is now on v5 and [notes that only the previous major version will receive important fixes/security updates](https://vitejs.dev/releases#release-cycle%E2%80%8B)

we'll bump up to the next working version which is vite@3 as our lowest version to test.

Tested locally by running `npm run vue-latest-vite-3-ts` in build-system-tests folder with no parent node_modules folders.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
