### PR TITLE
chore: remove usage of brand color namespace in docs/types/tests

### DIFF
--- a/.changeset/small-masks-fail.md
+++ b/.changeset/small-masks-fail.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react-native": patch
+"@aws-amplify/ui-react": patch
+---
+
+chore: Removes the brand namespace from the BrandColor type and updates usage across docs/examples.

--- a/.changeset/small-masks-fail.md
+++ b/.changeset/small-masks-fail.md
@@ -2,4 +2,4 @@
 "@aws-amplify/ui-react": patch
 ---
 
-chore: Removes the brand namespace from the BrandColorKeys type and updates usage across docs/examples.
+chore: Removes the brand namespace from the `BrandColorKeys` type, splits it into `PrimaryColorKeys` and `SecondaryColorKeys`, and updates usage across docs/examples.

--- a/.changeset/small-masks-fail.md
+++ b/.changeset/small-masks-fail.md
@@ -2,4 +2,4 @@
 "@aws-amplify/ui-react": patch
 ---
 
-chore: Removes the brand namespace from the BrandColor type and updates usage across docs/examples.
+chore: Removes the brand namespace from the BrandColorKeys type and updates usage across docs/examples.

--- a/.changeset/small-masks-fail.md
+++ b/.changeset/small-masks-fail.md
@@ -2,4 +2,4 @@
 "@aws-amplify/ui-react": patch
 ---
 
-chore: Removes the brand namespace from the `BrandColorKeys` type, splits it into `PrimaryColorKeys` and `SecondaryColorKeys`, and updates usage across docs/examples.
+chore: Removes the brand namespace from the `BrandColorKeys` type, splits it into `PrimaryColorKey` and `SecondaryColorKey`, and updates usage across docs/examples.

--- a/.changeset/small-masks-fail.md
+++ b/.changeset/small-masks-fail.md
@@ -1,5 +1,4 @@
 ---
-"@aws-amplify/ui-react-native": patch
 "@aws-amplify/ui-react": patch
 ---
 

--- a/docs/src/components/home/HomeFeatureCard.tsx
+++ b/docs/src/components/home/HomeFeatureCard.tsx
@@ -24,15 +24,10 @@ export const HomeFeatureCard = ({
         <View
           as="span"
           padding="1rem"
-          backgroundColor="brand.secondary.10"
+          backgroundColor="secondary.10"
           borderRadius="small"
         >
-          <Icon
-            ariaLabel=""
-            as={icon}
-            fontSize="xl"
-            color="brand.secondary.60"
-          />
+          <Icon ariaLabel="" as={icon} fontSize="xl" color="secondary.60" />
         </View>
       ) : null}
       <View>

--- a/docs/src/components/home/ThemeSwitcher.tsx
+++ b/docs/src/components/home/ThemeSwitcher.tsx
@@ -150,12 +150,12 @@ const Preview = ({ platform }) => {
               </Flex>
               <Flex direction="row" gap="xs">
                 {colorKeys.map((key) => (
-                  <Swatch key={key} color={`brand.primary.${key}`} />
+                  <Swatch key={key} color={`primary.${key}`} />
                 ))}
               </Flex>
               <Flex direction="row" gap="xs">
                 {colorKeys.map((key) => (
-                  <Swatch key={key} color={`brand.secondary.${key}`} />
+                  <Swatch key={key} color={`secondary.${key}`} />
                 ))}
               </Flex>
             </Flex>

--- a/docs/src/pages/[platform]/components/accordion/examples/StylePropsExample.tsx
+++ b/docs/src/pages/[platform]/components/accordion/examples/StylePropsExample.tsx
@@ -4,10 +4,7 @@ import { Accordion } from '@aws-amplify/ui-react';
 
 export const StylePropsAccordion = () => {
   return (
-    <Accordion.Container
-      backgroundColor="brand.secondary.80"
-      color="font.inverse"
-    >
+    <Accordion.Container backgroundColor="secondary.80" color="font.inverse">
       <Accordion.Item value="item-1">
         <Accordion.Trigger>
           Section 1 title

--- a/docs/src/pages/[platform]/components/input/examples/InputStylePropsExample.tsx
+++ b/docs/src/pages/[platform]/components/input/examples/InputStylePropsExample.tsx
@@ -26,7 +26,7 @@ export const InputStylePropsExample = () => {
         <Label htmlFor="special">Special Field</Label>
         <Input
           id="special"
-          backgroundColor="brand.primary.10"
+          backgroundColor="primary.10"
           border={`1px solid ${tokens.colors.primary[60]}`}
         />
       </Flex>

--- a/docs/src/pages/[platform]/components/passwordfield/examples/PasswordFieldStyledPropsExample.tsx
+++ b/docs/src/pages/[platform]/components/passwordfield/examples/PasswordFieldStyledPropsExample.tsx
@@ -16,7 +16,7 @@ export const PasswordFieldStyledPropsExample = () => {
       <PasswordField
         label="Password"
         inputStyles={{
-          backgroundColor: 'brand.primary.10',
+          backgroundColor: 'primary.10',
         }}
       />
     </>

--- a/docs/src/pages/[platform]/components/phonenumberfield/examples/StylePropsExample.tsx
+++ b/docs/src/pages/[platform]/components/phonenumberfield/examples/StylePropsExample.tsx
@@ -19,7 +19,7 @@ export const StylePropsExample = () => {
         defaultDialCode="+1"
         label="Phone number"
         inputStyles={{
-          backgroundColor: 'brand.primary.10',
+          backgroundColor: 'primary.10',
         }}
       />
     </>

--- a/docs/src/pages/[platform]/components/selectfield/examples/SelectFieldStylePropsExample.tsx
+++ b/docs/src/pages/[platform]/components/selectfield/examples/SelectFieldStylePropsExample.tsx
@@ -16,7 +16,7 @@ export const SelectFieldStylePropsExample = () => {
       <SelectField
         label="Fruit"
         inputStyles={{
-          backgroundColor: 'brand.primary.10',
+          backgroundColor: 'primary.10',
           border: `1px solid ${tokens.colors.primary[60]}`,
         }}
       >

--- a/docs/src/pages/[platform]/components/stepperfield/examples/StepperFieldStylePropsExample.tsx
+++ b/docs/src/pages/[platform]/components/stepperfield/examples/StepperFieldStylePropsExample.tsx
@@ -20,7 +20,7 @@ export const StepperFieldStylePropsExample = () => {
         max={10}
         step={1}
         inputStyles={{
-          backgroundColor: 'brand.primary.10',
+          backgroundColor: 'primary.10',
         }}
       />
     </>

--- a/docs/src/pages/[platform]/components/tabs/examples/StyleProps.tsx
+++ b/docs/src/pages/[platform]/components/tabs/examples/StyleProps.tsx
@@ -7,7 +7,7 @@ export const StyleProps = () => {
         <Tabs.Item value="1" color="font.secondary">
           Tab 1
         </Tabs.Item>
-        <Tabs.Item value="2" color="brand.secondary.60">
+        <Tabs.Item value="2" color="secondary.60">
           Tab 2
         </Tabs.Item>
       </Tabs.List>

--- a/docs/src/pages/[platform]/components/textareafield/examples/TextAreaFieldStylePropsExample.tsx
+++ b/docs/src/pages/[platform]/components/textareafield/examples/TextAreaFieldStylePropsExample.tsx
@@ -19,7 +19,7 @@ export const TextAreaFieldStylePropsExample = () => {
       <TextAreaField
         label="Special Field"
         inputStyles={{
-          backgroundColor: 'brand.primary.10',
+          backgroundColor: 'primary.10',
           border: `1px solid ${tokens.colors.primary[60]}`,
         }}
       />

--- a/docs/src/pages/[platform]/components/textfield/examples/TextFieldStylePropsExample.tsx
+++ b/docs/src/pages/[platform]/components/textfield/examples/TextFieldStylePropsExample.tsx
@@ -19,7 +19,7 @@ export const TextFieldStylePropsExample = () => {
       <TextField
         label="Special Field"
         inputStyles={{
-          backgroundColor: 'brand.primary.10',
+          backgroundColor: 'primary.10',
           border: `1px solid ${tokens.colors.primary[60]}`,
         }}
       />

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/AuthStyle.tsx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/AuthStyle.tsx
@@ -23,13 +23,11 @@ export function AuthStyle() {
             value: tokens.colors.white.value,
           },
         },
-        brand: {
-          primary: {
-            '10': tokens.colors.teal['100'],
-            '80': tokens.colors.teal['40'],
-            '90': tokens.colors.teal['20'],
-            '100': tokens.colors.teal['10'],
-          },
+        primary: {
+          '10': tokens.colors.teal['100'],
+          '80': tokens.colors.teal['40'],
+          '90': tokens.colors.teal['20'],
+          '100': tokens.colors.teal['10'],
         },
       },
       components: {

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/examples/StorageManagerComponentOverridesExample.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/examples/StorageManagerComponentOverridesExample.tsx
@@ -27,7 +27,7 @@ export const StorageManagerComponentOverridesExample = () => {
               alignItems="center"
               direction="column"
               padding="medium"
-              backgroundColor={inDropZone ? 'brand.primary.10' : ''}
+              backgroundColor={inDropZone ? 'primary.10' : ''}
               {...rest}
             >
               <Text>Drop files here</Text>

--- a/docs/src/pages/[platform]/theming/style-props/examples/BackgroundExamples.tsx
+++ b/docs/src/pages/[platform]/theming/style-props/examples/BackgroundExamples.tsx
@@ -25,7 +25,7 @@ export const BackgroundThemeTokenExample = () => {
 // use a design token name
 export const BackgroundTokenNameExample = () => {
   return (
-    <Card backgroundColor="brand.primary.80" color="white">
+    <Card backgroundColor="primary.80" color="white">
       Background Styling Example
     </Card>
   );

--- a/docs/src/pages/[platform]/theming/style-props/examples/ColorExamples.tsx
+++ b/docs/src/pages/[platform]/theming/style-props/examples/ColorExamples.tsx
@@ -25,7 +25,7 @@ export const ColorThemeTokenExample = () => {
 // use a design token name
 export const ColorTokenNameExample = () => {
   return (
-    <Alert backgroundColor="white" color="brand.primary.60">
+    <Alert backgroundColor="white" color="primary.60">
       Color Styling Example
     </Alert>
   );

--- a/docs/src/pages/[platform]/theming/style-props/examples/SizeExamples.tsx
+++ b/docs/src/pages/[platform]/theming/style-props/examples/SizeExamples.tsx
@@ -25,7 +25,5 @@ export const SizeThemeTokenExample = () => {
 
 // use a design token name
 export const SizeTokenNameExample = () => {
-  return (
-    <View backgroundColor="brand.primary.60" width="xxxl" height="xxxl"></View>
-  );
+  return <View backgroundColor="primary.60" width="xxxl" height="xxxl"></View>;
 };

--- a/docs/src/pages/[platform]/theming/theming.react-native.mdx
+++ b/docs/src/pages/[platform]/theming/theming.react-native.mdx
@@ -39,16 +39,14 @@ You can define as much or as little as you like in your theme. A simple might de
 const theme = {
   tokens: {
     colors: {
-      brand: {
-        primary: {
-          10: '{colors.pink.10}',
-          20: '{colors.pink.20}',
-          40: '{colors.pink.40}',
-          60: '{colors.pink.60}',
-          80: '{colors.pink.80}',
-          90: '{colors.pink.90}',
-          100: '{colors.pink.100}',
-        }
+      primary: {
+        10: '{colors.pink.10}',
+        20: '{colors.pink.20}',
+        40: '{colors.pink.40}',
+        60: '{colors.pink.60}',
+        80: '{colors.pink.80}',
+        90: '{colors.pink.90}',
+        100: '{colors.pink.100}',
       }
     }
   }

--- a/examples/react-native/src/features/Theming/Basic/Example.tsx
+++ b/examples/react-native/src/features/Theming/Basic/Example.tsx
@@ -13,16 +13,14 @@ function App() {
       theme={{
         tokens: {
           colors: {
-            brand: {
-              primary: {
-                10: '{colors.pink.10}',
-                20: '{colors.pink.20}',
-                40: '{colors.pink.40}',
-                60: '{colors.pink.60}',
-                80: '{colors.pink.80}',
-                90: '{colors.pink.90}',
-                100: '{colors.pink.100}',
-              },
+            primary: {
+              10: '{colors.pink.10}',
+              20: '{colors.pink.20}',
+              40: '{colors.pink.40}',
+              60: '{colors.pink.60}',
+              80: '{colors.pink.80}',
+              90: '{colors.pink.90}',
+              100: '{colors.pink.100}',
             },
           },
         },

--- a/examples/react-native/src/features/Theming/DarkMode/Example.tsx
+++ b/examples/react-native/src/features/Theming/DarkMode/Example.tsx
@@ -20,16 +20,14 @@ function App() {
       theme={{
         tokens: {
           colors: {
-            brand: {
-              primary: {
-                10: '{colors.pink.10}',
-                20: '{colors.pink.20}',
-                40: '{colors.pink.40}',
-                60: '{colors.pink.60}',
-                80: '{colors.pink.80}',
-                90: '{colors.pink.90}',
-                100: '{colors.pink.100}',
-              },
+            primary: {
+              10: '{colors.pink.10}',
+              20: '{colors.pink.20}',
+              40: '{colors.pink.40}',
+              60: '{colors.pink.60}',
+              80: '{colors.pink.80}',
+              90: '{colors.pink.90}',
+              100: '{colors.pink.100}',
             },
           },
         },

--- a/packages/react-native/src/theme/__tests__/useTheme.spec.tsx
+++ b/packages/react-native/src/theme/__tests__/useTheme.spec.tsx
@@ -11,10 +11,8 @@ describe('useTheme', () => {
       name: 'my-theme',
       tokens: {
         colors: {
-          brand: {
-            primary: {
-              10: 'red',
-            },
+          primary: {
+            10: 'red',
           },
         },
       },

--- a/packages/react/src/primitives/types/theme.ts
+++ b/packages/react/src/primitives/types/theme.ts
@@ -112,7 +112,7 @@ type OverlayKeys =
   | 'overlay.80'
   | 'overlay.90';
 
-type PrimaryColorKeys =
+type PrimaryColorKey =
   | 'primary.10'
   | 'primary.20'
   | 'primary.40'

--- a/packages/react/src/primitives/types/theme.ts
+++ b/packages/react/src/primitives/types/theme.ts
@@ -112,14 +112,16 @@ type OverlayKeys =
   | 'overlay.80'
   | 'overlay.90';
 
-type BrandColorKeys =
+type PrimaryColorKeys =
   | 'primary.10'
   | 'primary.20'
   | 'primary.40'
   | 'primary.60'
   | 'primary.80'
   | 'primary.90'
-  | 'primary.100'
+  | 'primary.100';
+
+type SecondaryColorKeys =
   | 'secondary.10'
   | 'secondary.20'
   | 'secondary.40'
@@ -184,7 +186,8 @@ export type ColorKeys<PropertyType> =
   | PinkKeys
   | NeutralKeys
   | OverlayKeys
-  | BrandColorKeys
+  | PrimaryColorKeys
+  | SecondaryColorKeys
   | FontColorKeys
   | BackgroundColorKeys
   | BorderColorKeys

--- a/packages/react/src/primitives/types/theme.ts
+++ b/packages/react/src/primitives/types/theme.ts
@@ -121,7 +121,7 @@ type PrimaryColorKey =
   | 'primary.90'
   | 'primary.100';
 
-type SecondaryColorKeys =
+type SecondaryColorKey =
   | 'secondary.10'
   | 'secondary.20'
   | 'secondary.40'

--- a/packages/react/src/primitives/types/theme.ts
+++ b/packages/react/src/primitives/types/theme.ts
@@ -113,20 +113,20 @@ type OverlayKeys =
   | 'overlay.90';
 
 type BrandColorKeys =
-  | 'brand.primary.10'
-  | 'brand.primary.20'
-  | 'brand.primary.40'
-  | 'brand.primary.60'
-  | 'brand.primary.80'
-  | 'brand.primary.90'
-  | 'brand.primary.100'
-  | 'brand.secondary.10'
-  | 'brand.secondary.20'
-  | 'brand.secondary.40'
-  | 'brand.secondary.60'
-  | 'brand.secondary.80'
-  | 'brand.secondary.90'
-  | 'brand.secondary.100';
+  | 'primary.10'
+  | 'primary.20'
+  | 'primary.40'
+  | 'primary.60'
+  | 'primary.80'
+  | 'primary.90'
+  | 'primary.100'
+  | 'secondary.10'
+  | 'secondary.20'
+  | 'secondary.40'
+  | 'secondary.60'
+  | 'secondary.80'
+  | 'secondary.90'
+  | 'secondary.100';
 
 type FontColorKeys =
   | 'font.primary'

--- a/packages/react/src/primitives/types/theme.ts
+++ b/packages/react/src/primitives/types/theme.ts
@@ -186,8 +186,8 @@ export type ColorKeys<PropertyType> =
   | PinkKeys
   | NeutralKeys
   | OverlayKeys
-  | PrimaryColorKeys
-  | SecondaryColorKeys
+  | PrimaryColorKey
+  | SecondaryColorKey
   | FontColorKeys
   | BackgroundColorKeys
   | BorderColorKeys


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Removes usage of brand namespace in docs, tests, examples, and types.

We had some straggler cases of the brand color namespace still being used, namely in the following packages:

- **ui-react:** the BrandColorKeys type
- **react-native:** a test for theme provider

And also scattered throughout the docs and some react-native examples.


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
