### PR TITLE
fix(e2e): add error fixture for sign-in-sms-mfa invalid code test

### DIFF
--- a/packages/e2e/cypress/fixtures/code-mismatch-exception.json
+++ b/packages/e2e/cypress/fixtures/code-mismatch-exception.json
@@ -1,0 +1,4 @@
+{
+  "__type": "CodeMismatchException",
+  "message": "Invalid code or auth state for the user."
+}

--- a/packages/e2e/features/ui/components/authenticator/sign-in-sms-mfa.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-sms-mfa.feature
@@ -12,6 +12,7 @@ Feature: Sign In with SMS MFA
     Then I type my "phone number" with status "CONFIRMED"
     Then I type my password
     Then I click the "Sign in" button
+    Then I will be redirected to the confirm sms mfa page
     Then I see "Confirm SMS Code"
     Then I type a valid SMS confirmation code
     Then I spy request '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge" } }'
@@ -19,15 +20,7 @@ Feature: Sign In with SMS MFA
     Then I confirm request '{"headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge" } }'
 
   @angular @react @vue
-  Scenario: Sign in using a valid phone number and SMS MFA
-    When I select my country code with status "CONFIRMED"
-    Then I type my "phone number" with status "CONFIRMED"
-    Then I type my password
-    Then I click the "Sign in" button
-    Then I will be redirected to the confirm sms mfa page
-
-  @angular @react @vue
-  Scenario: Redirect to sign in page
+  Scenario: Sign in and navigate back to sign in page
     When I select my country code with status "CONFIRMED"
     Then I type my "phone number" with status "CONFIRMED"
     Then I type my password

--- a/packages/e2e/features/ui/components/authenticator/sign-in-sms-mfa.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-sms-mfa.feature
@@ -43,6 +43,7 @@ Feature: Sign In with SMS MFA
     Then I click the "Sign in" button
     Then I type an invalid SMS code
     Then I click the "Confirm" button
+    Then I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge" } }' with error fixture "code-mismatch-exception"
     Then I see "invalid code"
     
   @angular @react @vue


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add and integrate code mismatch exception fixture for "Incorrect SMS code with translated text" e2e test ensuring that a  stable error is returned in CI. 

Too many subsequent calls to `AWSCognitoIdentityProviderService.RespondToAuthChallenge` for the same test user results in a `NotAuthorizedException`:
```json
{
    "__type": "NotAuthorizedException",
    "message": "Too many invalid credentials attempts. User temporarily locked. Please try again after few seconds."
}
```

Leading to transient errors in CI ([example failure](https://github.com/aws-amplify/amplify-ui/actions/runs/7577363730/job/20638173520#step:40:911)) as the test expects a `CodeMismatchException`.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran e2e tests locally, verified fixture usage in cypress test "ROUTES"

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
