### PR TITLE
fix(rna): replace useAuthenticator signOut with default version

### DIFF
--- a/.changeset/nice-pens-wait.md
+++ b/.changeset/nice-pens-wait.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-native": patch
+---
+
+fix(rna): replace useAuthenticator signOut with default version

--- a/packages/react-native/src/Authenticator/index.ts
+++ b/packages/react-native/src/Authenticator/index.ts
@@ -1,6 +1,4 @@
 export { default as Authenticator } from './Authenticator';
 export { AuthenticatorProps, WithAuthenticatorOptions } from './types';
+export { useAuthenticator, UseAuthenticator } from './useAuthenticator';
 export { default as withAuthenticator } from './withAuthenticator';
-
-// re-export shared `Authenticator` exports
-export { useAuthenticator, UseAuthenticator } from '@aws-amplify/ui-react-core';

--- a/packages/react-native/src/Authenticator/useAuthenticator.ts
+++ b/packages/react-native/src/Authenticator/useAuthenticator.ts
@@ -1,0 +1,34 @@
+// re-export `UseAuthenticator` export
+export { UseAuthenticator } from '@aws-amplify/ui-react-core';
+
+import { signOut as _signOut } from 'aws-amplify/auth';
+import { AuthEventData } from '@aws-amplify/ui';
+
+import {
+  useAuthenticator as _useAuthenticator,
+  UseAuthenticator,
+} from '@aws-amplify/ui-react-core';
+
+// wrap and re-export `useAuthenticator` to replace state machine `signOut` with
+// `aws-amplify/auth` version due to iOS specifc requirements for federated sign
+// out handling with JS. On iOS sign out, JS prmnpts the end user with a native
+// Alert requesting confirmation of sign out, if the end user cancels they will
+// have already been signed out of the state machine, but will still be
+// authenticated on the JS singleton
+
+// input utility function to prevent breaking changes in consumers.
+// State machine sign out handling does not pass input to underlying `signOut`
+// call; replicate that behavior here
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const signOut = (data?: AuthEventData) => {
+  _signOut();
+};
+
+// selector utility type to prevent breaking type changes in consumers
+type UseAuthenticatorSelector = Parameters<typeof _useAuthenticator>[0];
+
+export function useAuthenticator(
+  selector?: UseAuthenticatorSelector
+): UseAuthenticator {
+  return { ..._useAuthenticator(selector), signOut };
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update React Native `useAuthenticator` to use `signOut` from `aws-amplify/auth` version due to iOS specifc requirements for federated sign out handling with `@aws-amplify/rtn-web-browser`. On iOS sign out, the end user is prompted with a native alert requesting confirmation of sign out. If the end user cancels they will have already been signed out of the state machine, but will still continue to be authenticated on the JS singleton.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-ui/issues/4910
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual testing
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
