### PR TITLE
fix: update vite.js guide to remove polyfill workarounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 aws-exports.js
 aws-exports.ts
 amplifyconfiguration.json
+docs/public/previews
 
 # We have mock exports in the following locations
 !examples/angular/src/pages/ui/components/*/*/aws-exports.js

--- a/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.react.mdx
@@ -197,7 +197,7 @@ These errors will not affect the use and functionality of the client, nor will e
   Note: this issue was fixed in `aws-amplify` version 6. Polyfill is only required for `aws-amplify < 6` and Webpack 5+.
 </Message>
 
-Follow the instructions below to if you are using Webpack 5:
+Follow the instructions below if you are using Webpack 5:
 
 
 1. Add

--- a/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.react.mdx
@@ -194,7 +194,7 @@ These errors will not affect the use and functionality of the client, nor will e
   variation="filled"
   colorTheme="info"
   >
-  Note: this issue was fixed in `aws-amplify` version 6. Polyfill is only required for `aws-amplify < 6` and Webpack 5+.
+  Note: this issue has been fixed in `aws-amplify` version 6. The polyfill is only required for projects that use `aws-amplify` version 5 (or earlier) with Webpack version 5 (or later).
 </Message>
 
 Follow the instructions below if you are using Webpack 5:

--- a/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.react.mdx
@@ -1,4 +1,4 @@
-import { Alert, Tabs } from '@aws-amplify/ui-react';
+import { Alert, Tabs, Message } from '@aws-amplify/ui-react';
 import { TerminalCommand } from '@/components/InstallScripts';
 import VitePolyfill from './shared/vite-polyfill.mdx';
 import VitePolyfillTS from './shared/vite-polyfill-ts.mdx';
@@ -6,6 +6,13 @@ import VitePolyfillTS from './shared/vite-polyfill-ts.mdx';
 ## Astro
 
 ### `Uncaught ReferenceError: global is not defined`
+
+<Message
+  variation="filled"
+  colorTheme="info"
+  >
+  Note: this issue was fixed in `aws-amplify` version 6
+</Message>
 
 When working with a [Astro](https://astro.build/) project you must make a few modifications. Please follow the steps below.
 <Tabs.Container defaultValue="TypeScript">
@@ -183,19 +190,15 @@ These errors will not affect the use and functionality of the client, nor will e
 
 ### Webpack 5+: `Uncaught ReferenceError: process is not defined`
 
+<Message
+  variation="filled"
+  colorTheme="info"
+  >
+  Note: this issue was fixed in `aws-amplify` version 6. Polyfill is only required for `aws-amplify < 6` and Webpack 5+.
+</Message>
+
 Follow the instructions below to if you are using Webpack 5:
 
-<Alert role="none" variation="info">
-*Note:*
-Polyfill is only required for Webpack 5+. In this version Node.js global variable shims required by the `aws-amplify` package were removed, which results in the following error message:
-
-```
-Uncaught ReferenceError: process is not defined
-```
-
-Webpack 4 already includes this polyfill.
-
-</Alert>
 
 1. Add
    [node-polyfill-webpack-plugin](https://www.npmjs.com/package/node-polyfill-webpack-plugin)
@@ -230,6 +233,13 @@ Follow [here](#cra-4-cant-import-the-named-export-amplify-from-non-ecmascript-mo
 ## Vite
 
 ### `Uncaught ReferenceError: global is not defined`
+
+<Message
+  variation="filled"
+  colorTheme="info"
+  >
+  Note: this issue was fixed in `aws-amplify` version 6
+</Message>
 
 When working with a [Vite](https://vitejs.dev) project you must make a few modifications. Please follow the steps below.
 

--- a/docs/src/pages/[platform]/getting-started/usage/vite/react.mdx
+++ b/docs/src/pages/[platform]/getting-started/usage/vite/react.mdx
@@ -1,4 +1,4 @@
-import { Tabs, } from '@aws-amplify/ui-react';
+import { Tabs } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
 import { BasicShoppingCard, AdvancedShoppingCard } from '../shared';
 import { TerminalCommand } from '@/components/InstallScripts.tsx';

--- a/docs/src/pages/[platform]/getting-started/usage/vite/react.mdx
+++ b/docs/src/pages/[platform]/getting-started/usage/vite/react.mdx
@@ -1,9 +1,7 @@
-import { Tabs } from '@aws-amplify/ui-react';
+import { Tabs, } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
 import { BasicShoppingCard, AdvancedShoppingCard } from '../shared';
-import { InstallScripts, TerminalCommand } from '@/components/InstallScripts.tsx';
-import VitePolyfill from '../../troubleshooting/shared/vite-polyfill.mdx';
-import VitePolyfillTS from '../../troubleshooting/shared/vite-polyfill-ts.mdx';
+import { TerminalCommand } from '@/components/InstallScripts.tsx';
 
 ## Tutorial
 
@@ -26,10 +24,6 @@ First, execute the command below in your terminal. When prompted for the name of
 
     <TerminalCommand command="npm install @aws-amplify/ui-react aws-amplify"/>
 
-    **When working with a [Vite](https://vitejs.dev) project you must make a few modifications. Please follow the steps below.**
-
-    <VitePolyfill />
-
   </Tabs.Panel>
   <Tabs.Panel value="TypeScript">
     #### npm 7+
@@ -38,15 +32,8 @@ First, execute the command below in your terminal. When prompted for the name of
 
     <TerminalCommand command="npm install @aws-amplify/ui-react aws-amplify"/>
 
-    **When working with a [Vite](https://vitejs.dev) project you must make a few modifications. Please follow the steps below.**
-
-    <VitePolyfill />
-    <VitePolyfillTS />
   </Tabs.Panel>
 </Tabs.Container>
-
-> If you are still having issues, please see comments on the following issue for additional [Vite workarounds](https://github.com/aws-amplify/amplify-js/issues/9639). Note that there is active ongoing work to make these modifications unnecessary.
-
 
 ### Basic Demo
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update the Vite getting started guide to remove unneeded workarounds. These are no longer necessary due to fixes in `aws-amplify@6`. Updated the troubleshooting guide to callout that the workarounds for Vite/Webpack/Astro are only needed in older versions of `aws-amplify`.

Before:
![CleanShot 2024-01-24 at 16 10 21@2x](https://github.com/aws-amplify/amplify-ui/assets/6165315/60af6a88-f615-49f3-8ffd-654e1251f04d)

After:
![CleanShot 2024-01-24 at 16 09 20@2x](https://github.com/aws-amplify/amplify-ui/assets/6165315/2d508dde-6694-4aa4-8f4d-dcdaa93f53ab)

Message showing in Troubleshooting:
![CleanShot 2024-01-24 at 16 08 29@2x](https://github.com/aws-amplify/amplify-ui/assets/6165315/f8a4fc5e-f672-42ef-a83c-f33563f806a8)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
