### PR TITLE
fix(docs): Fix visual glitch on usage pages, move Footer down

### DIFF
--- a/docs/src/styles/docs/layout.scss
+++ b/docs/src/styles/docs/layout.scss
@@ -24,7 +24,7 @@
   position: relative;
   color: var(--amplify-colors-font-tertiary);
   max-width: 60rem;
-  margin: 0 auto;
+  margin: 4rem auto 0;
   text-align: center;
 
   &::before {


### PR DESCRIPTION
#### Description of changes

This fixes #4957 

This adds some margin to the Footer, so it doesn't overlap the content above it
Before:
<img width="1232" alt="image" src="https://github.com/aws-amplify/amplify-ui/assets/65630/4dd71b8f-3c89-475c-b3fa-095d39866922">


After:
<img width="1250" alt="image" src="https://github.com/aws-amplify/amplify-ui/assets/65630/8bc4f6a2-467f-446a-8760-536d85130658">

#### Description of how you validated changes
Checked visually

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
