### PR TITLE
fix(build-system-tests-angular): pin @types/node to 20.11.7

### DIFF
--- a/build-system-tests/package.json
+++ b/build-system-tests/package.json
@@ -30,7 +30,7 @@
     "react-18-next-12-ts": "npm run setup:react:next -- -f 18 -b 12",
     "react-latest-vite-2-ts": "npm run setup:react:vite -- -b 2",
     "angular-latest-angular-cli-latest-ts": "npm run setup:angular:cli",
-    "angular-14-angular-cli-14-ts": "npm run setup:angular:cli -- -f 14 -b 14 -n angular-14-angular-cli-v14-ts",
+    "angular-14-angular-cli-14-ts": "npm run setup:angular:cli -- -f 14 -b 14 -n angular-14-angular-cli-14-ts",
     "vue-3-vue-cli-latest-ts": "npm run setup:vue:cli -- -f 3 -P yarn",
     "vue-latest-vite-latest-ts": "npm run setup:vue:vite",
     "vue-latest-vite-3-ts": "npm run setup:vue:vite -- -b 3",

--- a/build-system-tests/scripts/mega-app-copy-files.sh
+++ b/build-system-tests/scripts/mega-app-copy-files.sh
@@ -152,6 +152,12 @@ if [[ "$FRAMEWORK" == 'angular' ]]; then
         echo "npx strip-json-comments mega-apps/${MEGA_APP_NAME}/tsconfig.app.json | npx json -a -e 'this.files.push(\"src/polyfills.ts\")' >tsconfig.app.json.tmp && mv tsconfig.app.json.tmp ./mega-apps/$MEGA_APP_NAME/tsconfig.app.json && rm -f tsconfig.app.json.tmp"
         npx strip-json-comments mega-apps/${MEGA_APP_NAME}/tsconfig.app.json | npx json -a -e 'this.files.push("src/polyfills.ts")' >tsconfig.app.json.tmp && mv tsconfig.app.json.tmp ./mega-apps/$MEGA_APP_NAME/tsconfig.app.json && rm -f tsconfig.app.json.tmp
     fi
+    if [[ "$FRAMEWORK_VERSION" == 14 ]]; then
+        echo "pin @types/node version in mega-apps/${MEGA_APP_NAME}/package.json"
+        echo "npx json -I -f mega-apps/${MEGA_APP_NAME}/package.json -e 'this.overrides = { "@types/node": "20.11.7" }'"
+        npx json -I -f mega-apps/${MEGA_APP_NAME}/package.json -e 'this.overrides = { "@types/node": "20.11.7" }' 
+    fi
+
 fi
 
 if [[ "$FRAMEWORK" == 'vue' ]]; then

--- a/build-system-tests/scripts/mega-app-copy-files.sh
+++ b/build-system-tests/scripts/mega-app-copy-files.sh
@@ -152,6 +152,7 @@ if [[ "$FRAMEWORK" == 'angular' ]]; then
         echo "npx strip-json-comments mega-apps/${MEGA_APP_NAME}/tsconfig.app.json | npx json -a -e 'this.files.push(\"src/polyfills.ts\")' >tsconfig.app.json.tmp && mv tsconfig.app.json.tmp ./mega-apps/$MEGA_APP_NAME/tsconfig.app.json && rm -f tsconfig.app.json.tmp"
         npx strip-json-comments mega-apps/${MEGA_APP_NAME}/tsconfig.app.json | npx json -a -e 'this.files.push("src/polyfills.ts")' >tsconfig.app.json.tmp && mv tsconfig.app.json.tmp ./mega-apps/$MEGA_APP_NAME/tsconfig.app.json && rm -f tsconfig.app.json.tmp
     fi
+    # Angular 14 is incompatible with @types/node > 20.11.7, so pin at this version
     if [[ "$FRAMEWORK_VERSION" == 14 ]]; then
         echo "pin @types/node version in mega-apps/${MEGA_APP_NAME}/package.json"
         echo "npx json -I -f mega-apps/${MEGA_APP_NAME}/package.json -e 'this.dependencies["@types/node"] = "20.11.7"'"

--- a/build-system-tests/scripts/mega-app-copy-files.sh
+++ b/build-system-tests/scripts/mega-app-copy-files.sh
@@ -154,8 +154,8 @@ if [[ "$FRAMEWORK" == 'angular' ]]; then
     fi
     if [[ "$FRAMEWORK_VERSION" == 14 ]]; then
         echo "pin @types/node version in mega-apps/${MEGA_APP_NAME}/package.json"
-        echo "npx json -I -f mega-apps/${MEGA_APP_NAME}/package.json -e 'this.overrides = { "@types/node": "20.11.7" }'"
-        npx json -I -f mega-apps/${MEGA_APP_NAME}/package.json -e 'this.overrides = { "@types/node": "20.11.7" }' 
+        echo "npx json -I -f mega-apps/${MEGA_APP_NAME}/package.json -e 'this.dependencies["@types/node"] = "20.11.7"'"
+        npx json -I -f mega-apps/${MEGA_APP_NAME}/package.json -e 'this.dependencies["@types/node"] = "20.11.7"'
     fi
 
 fi


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fixes angular 14 build system tests. `@types/node` > 20.11.7 is incompatible with angular 14, so pin at 20.11.7. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Passing workflow: https://github.com/aws-amplify/amplify-ui/actions/runs/7715263726

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
