### PR TITLE
chore(docs): fix spelling of CognitoAttributes in migration guides

### DIFF
--- a/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
@@ -65,7 +65,7 @@ The `user` object provided after an end user has been authenticated has been upd
 ```diff
 - interface AmplifyUser {
 -   challengeName?: ChallengeName;
--   attributes?: CognitpAttributes;
+-   attributes?: CognitoAttributes;
 -   username: string;  
 - }
 + interface AuthUser  {

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react-native.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react-native.mdx
@@ -52,7 +52,7 @@ The `user` object provided after an end user has been authenticated has been upd
 ```diff
 - interface AmplifyUser {
 -   challengeName?: ChallengeName;
--   attributes?: CognitpAttributes;
+-   attributes?: CognitoAttributes;
 -   username: string;  
 - }
 + interface AuthUser  {

--- a/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.react.mdx
@@ -55,7 +55,7 @@ The `user` object provided after an end user has been authenticated has been upd
 ```diff
 - interface AmplifyUser {
 -   challengeName?: ChallengeName;
--   attributes?: CognitpAttributes;
+-   attributes?: CognitoAttributes;
 -   username: string;  
 - }
 + interface AuthUser  {

--- a/docs/src/pages/[platform]/getting-started/migration/migration.vue.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.vue.mdx
@@ -63,7 +63,7 @@ The `user` object provided after an end user has been authenticated has been upd
 ```diff
 - interface AmplifyUser {
 -   challengeName?: ChallengeName;
--   attributes?: CognitpAttributes;
+-   attributes?: CognitoAttributes;
 -   username: string;  
 - }
 + interface AuthUser  {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fixes naming of `CognitoAttributes` in migration docs, which was misspelled as `CognitpAttributes`.

```diff
  interface AmplifyUser {
    challengeName?: ChallengeName;
-   attributes?: CognitpAttributes;
+   attributes?: CognitoAttributes;
    username: string;
  }
```

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Completed the steps outlined in https://github.com/aws-amplify/amplify-ui/blob/main/docs/README.md#contributing

- [x] Started docs in dev
  ```
  yarn install
  yarn setup
  yarn docs dev
  ```
- [x] Ran `yarn docs test`


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
