### PR TITLE
fix(AccountSettings): pass displayText to WarningView

### DIFF
--- a/.changeset/clever-queens-relate.md
+++ b/.changeset/clever-queens-relate.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(AccountSettings): pass displayText to WarningView

--- a/examples/next/pages/ui/components/account-settings/delete-user-display-text/aws-exports.js
+++ b/examples/next/pages/ui/components/account-settings/delete-user-display-text/aws-exports.js
@@ -1,0 +1,2 @@
+import awsExports from '@environments/auth/auth-with-email/src/aws-exports';
+export default awsExports;

--- a/examples/next/pages/ui/components/account-settings/delete-user-display-text/index.page.tsx
+++ b/examples/next/pages/ui/components/account-settings/delete-user-display-text/index.page.tsx
@@ -1,0 +1,36 @@
+import { Amplify } from 'aws-amplify';
+
+import {
+  Authenticator,
+  Button,
+  Card,
+  Flex,
+  AccountSettings,
+} from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+import awsExports from './aws-exports';
+Amplify.configure(awsExports);
+
+export default function App() {
+  return (
+    <Authenticator>
+      {({ signOut, user }) => (
+        <Card width="800px">
+          <h1>Hello {user?.username}</h1>
+          <Flex direction="column">
+            <AccountSettings.DeleteUser
+              displayText={{
+                cancelButtonText: 'Cancel!',
+                confirmDeleteButtonText: 'Are you sure?',
+                deleteAccountButtonText: 'Delete!',
+                warningText: "Maybe don't do it",
+              }}
+            />
+            <Button onClick={signOut}>Sign Out</Button>
+          </Flex>
+        </Card>
+      )}
+    </Authenticator>
+  );
+}

--- a/packages/e2e/features/ui/components/account-settings/delete-user-display-text.feature
+++ b/packages/e2e/features/ui/components/account-settings/delete-user-display-text.feature
@@ -1,0 +1,18 @@
+Feature: Delete User With Overrides
+
+  Developers can customize the delete user page.
+
+  Background:
+    Given I'm running the example "ui/components/account-settings/delete-user-display-text"
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.DeleteUser" } }' with fixture "delete-user"
+
+  @react
+  Scenario: Customize DeleteUser displayText
+    When I type my "email" with status "CONFIRMED"
+    Then I type my password
+    Then I click the "Sign in" button
+    Then I click the "Delete!" button
+    Then I see "Maybe don't do it"
+    Then I see "Are you sure?"
+    Then I click the "Cancel!" button
+    Then I click the "Sign Out" button

--- a/packages/react/src/components/AccountSettings/DeleteUser/DeleteUser.tsx
+++ b/packages/react/src/components/AccountSettings/DeleteUser/DeleteUser.tsx
@@ -114,8 +114,9 @@ function DeleteUser({
       </DeleteButton>
       {state === 'CONFIRMATION' || state === 'DELETING' ? (
         <WarningView
-          onCancel={handleCancel}
+          displayText={displayText}
           isDisabled={state === 'DELETING'}
+          onCancel={handleCancel}
           onConfirm={handleConfirmDelete}
         />
       ) : null}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Pass `displayText` prop to `WarningView` from `DeleteUser`
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-ui/issues/4963
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- manual testing
- add an e2e test
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
