### PR TITLE
fix(docs): update style and theming examples for Authenticator

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/AuthStyle.tsx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/AuthStyle.tsx
@@ -50,7 +50,7 @@ export function AuthStyle() {
   return (
     <ThemeProvider theme={theme}>
       <View padding="xxl">
-        <Authenticator></Authenticator>
+        <Authenticator />
       </View>
     </ThemeProvider>
   );

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/AuthStyle.tsx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/AuthStyle.tsx
@@ -13,33 +13,32 @@ export function AuthStyle() {
       components: {
         authenticator: {
           router: {
-            boxShadow: '0 0 16px hsla(0, 0%, 0%, 0.1)',
+            boxShadow: `0 0 16px ${tokens.colors.overlay['10']}`,
             borderWidth: '0',
           },
           form: {
-            padding:
-              'var(--amplify-space-medium) var(--amplify-space-xl) var(--amplify-space-xl)',
+            padding: `${tokens.space.medium} ${tokens.space.xl} ${tokens.space.medium}`,
           },
         },
         button: {
           primary: {
-            backgroundColor: { value: '{colors.neutral.100}' },
+            backgroundColor: tokens.colors.neutral['100'],
           },
           link: {
-            color: { value: '{colors.purple.80}' },
+            color: tokens.colors.purple['80'],
           },
         },
         fieldcontrol: {
           _focus: {
-            boxShadow: '0 0 0 2px var(--amplify-colors-purple-60)',
+            boxShadow: `0 0 0 2px ${tokens.colors.purple['60']}`,
           },
         },
         tabs: {
           item: {
-            color: { value: '{colors.neutral.80}' },
+            color: tokens.colors.neutral['80'],
             _active: {
-              borderColor: { value: '{colors.neutral.100}' },
-              color: { value: '{colors.purple.100}' },
+              borderColor: tokens.colors.neutral['100'],
+              color: tokens.colors.purple['100'],
             },
           },
         },

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/AuthStyle.tsx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/AuthStyle.tsx
@@ -3,50 +3,43 @@ import {
   ThemeProvider,
   Theme,
   useTheme,
+  View,
 } from '@aws-amplify/ui-react';
 export function AuthStyle() {
   const { tokens } = useTheme();
   const theme: Theme = {
     name: 'Auth Example Theme',
     tokens: {
-      colors: {
-        background: {
-          primary: {
-            value: tokens.colors.neutral['90'].value,
-          },
-          secondary: {
-            value: tokens.colors.neutral['100'].value,
-          },
-        },
-        font: {
-          interactive: {
-            value: tokens.colors.white.value,
-          },
-        },
-        primary: {
-          '10': tokens.colors.teal['100'],
-          '80': tokens.colors.teal['40'],
-          '90': tokens.colors.teal['20'],
-          '100': tokens.colors.teal['10'],
-        },
-      },
       components: {
+        authenticator: {
+          router: {
+            boxShadow: '0 0 16px hsla(0, 0%, 0%, 0.1)',
+            borderWidth: '0',
+          },
+          form: {
+            padding:
+              'var(--amplify-space-medium) var(--amplify-space-xl) var(--amplify-space-xl)',
+          },
+        },
+        button: {
+          primary: {
+            backgroundColor: { value: '{colors.neutral.100}' },
+          },
+          link: {
+            color: { value: '{colors.purple.80}' },
+          },
+        },
+        fieldcontrol: {
+          _focus: {
+            boxShadow: '0 0 0 2px var(--amplify-colors-purple-60)',
+          },
+        },
         tabs: {
           item: {
-            _focus: {
-              color: {
-                value: tokens.colors.white.value,
-              },
-            },
-            _hover: {
-              color: {
-                value: tokens.colors.yellow['80'].value,
-              },
-            },
+            color: { value: '{colors.neutral.80}' },
             _active: {
-              color: {
-                value: tokens.colors.white.value,
-              },
+              borderColor: { value: '{colors.neutral.100}' },
+              color: { value: '{colors.purple.100}' },
             },
           },
         },
@@ -56,7 +49,9 @@ export function AuthStyle() {
 
   return (
     <ThemeProvider theme={theme}>
-      <Authenticator></Authenticator>
+      <View padding="xxl">
+        <Authenticator></Authenticator>
+      </View>
     </ThemeProvider>
   );
 }

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.styling.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.styling.web.mdx
@@ -10,21 +10,22 @@ You can customize the Authenticator's default style by using [CSS variables](../
 
 ### CSS style
 
-The example below uses a `<style>` tag to change the default colors to a dark theme:
+The example below uses a `<style>` tag to change the appearance of some of the components used for the Authenticator:
 
 ```css
+
 [data-amplify-authenticator] {
-  --amplify-colors-background-primary: var(--amplify-colors-neutral-90);
-  --amplify-colors-background-secondary: var(--amplify-colors-neutral-100);
-  --amplify-colors-primary-10: var(--amplify-colors-teal-100);
-  --amplify-colors-primary-80: var(--amplify-colors-teal-40);
-  --amplify-colors-primary-90: var(--amplify-colors-teal-20);
-  --amplify-colors-primary-100: var(--amplify-colors-teal-10);
-  --amplify-colors-font-interactive: var(--amplify-colors-white);
-  --amplify-components-tabs-item-active-color: var(--amplify-colors-white);
-  --amplify-components-tabs-item-focus-color: var(--amplify-colors-white);
-  --amplify-components-tabs-item-hover-color: var(--amplify-colors-orange);
+  --amplify-components-authenticator-router-box-shadow: 0 0 16px hsla(0, 0%, 0%, 0.1);
+  --amplify-components-authenticator-router-border-width: 0;
+  --amplify-components-authenticator-form-padding: var(--amplify-space-medium) var(--amplify-space-xl) var(--amplify-space-xl);
+  --amplify-components-button-primary-background-color: var(--amplify-colors-neutral-100);
+  --amplify-components-fieldcontrol-focus-box-shadow: 0 0 0 2px var(--amplify-colors-purple-60);
+  --amplify-components-tabs-item-active-border-color: var(--amplify-colors-neutral-100);
+  --amplify-components-tabs-item-color: var(--amplify-colors-neutral-80);
+  --amplify-components-tabs-item-active-color: var(--amplify-colors-purple-100);
+  --amplify-components-button-link-color: var(--amplify-colors-purple-80);
 }
+
 ```
 
 <Example>
@@ -39,7 +40,7 @@ You can update the style of the Authenticator by using the [ThemeProvider](/reac
 
 Then create a [theme object](/react/theming#theme-object), with all your font and color updates. Feel free to use [design tokens](/react/theming#design-tokens), as a way of designing your theme further.
 
-Below is an example of changing the default colors to a dark theme.
+Below is an example of changing the appearance of the Authenticator and its related components using the theme object.
 
 ```jsx file=./AuthStyle.tsx
 
@@ -57,17 +58,17 @@ Below is an example of changing the default colors to a dark theme.
 
 You can also override the authenticator's `amplify-*` classes.
 
-For example, if you'd like to hide the sign up tab, you can override the `amplify-tabs` class.
+For example, if you'd like to hide the sign up tab, you can override the `amplify-tabs__list` class.
 
 ```css
-.amplify-tabs {
+.amplify-tabs__list {
   display: none;
 }
 ```
 
 <Example>
   <style>{`
-    .customization-hide-sign-up .amplify-tabs {
+    .customization-hide-sign-up .amplify-tabs__list {
       display: none;
     }
   `}</style>
@@ -77,7 +78,7 @@ For example, if you'd like to hide the sign up tab, you can override the `amplif
 If you'd like to update the primary color of your submit button you can override the `amplify-button` class.
 
 ```css
-.amplify-button[data-variation='primary'] {
+.amplify-button--primary {
   background: linear-gradient(
     to right,
     var(--amplify-colors-green-80),
@@ -87,10 +88,6 @@ If you'd like to update the primary color of your submit button you can override
 ```
 
 <Example>
-  <style>{`
-    .customization-button .amplify-button[data-variation="primary"] {
-      background:linear-gradient(to right, var(--amplify-colors-green-80),var(--amplify-colors-orange-40) );
-    }
-  `}</style>
+  <style>{`.customization-button .amplify-button--primary { background: linear-gradient(to right, var(--amplify-colors-green-80), var(--amplify-colors-orange-40));}`}</style>
   <Authenticator className="customization-button" />
 </Example>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.styling.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.styling.web.mdx
@@ -15,7 +15,7 @@ The example below uses a `<style>` tag to change the appearance of some of the c
 ```css
 
 [data-amplify-authenticator] {
-  --amplify-components-authenticator-router-box-shadow: 0 0 16px hsla(0, 0%, 0%, 0.1);
+  --amplify-components-authenticator-router-box-shadow: 0 0 16px var(--amplify-colors-overlay-10);
   --amplify-components-authenticator-router-border-width: 0;
   --amplify-components-authenticator-form-padding: var(--amplify-space-medium) var(--amplify-space-xl) var(--amplify-space-xl);
   --amplify-components-button-primary-background-color: var(--amplify-colors-neutral-100);

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.styling.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.styling.web.mdx
@@ -36,11 +36,9 @@ The example below uses a `<style>` tag to change the appearance of some of the c
 <InlineFilter filters={['react']}>
 ### Theme Provider Theme
 
-You can update the style of the Authenticator by using the [ThemeProvider](/react/theming) [theme object](/react/theming#theme-object). To do this, you must surround the `Authenticator` in the `ThemeProvider`.
+Below is an example of updating the style of the Authenticator by using the [ThemeProvider](/react/theming) [theme object](/react/theming#theme-object). To do this, you must surround the `Authenticator` in the `ThemeProvider`.
 
 Then create a [theme object](/react/theming#theme-object), with all your font and color updates. Feel free to use [design tokens](/react/theming#design-tokens), as a way of designing your theme further.
-
-Below is an example of changing the appearance of the Authenticator and its related components using the theme object.
 
 ```jsx file=./AuthStyle.tsx
 
@@ -56,26 +54,7 @@ Below is an example of changing the appearance of the Authenticator and its rela
 
 ## Additional CSS Styling
 
-You can also override the authenticator's `amplify-*` classes.
-
-For example, if you'd like to hide the sign up tab, you can override the `amplify-tabs__list` class.
-
-```css
-.amplify-tabs__list {
-  display: none;
-}
-```
-
-<Example>
-  <style>{`
-    .customization-hide-sign-up .amplify-tabs__list {
-      display: none;
-    }
-  `}</style>
-  <Authenticator className="customization-hide-sign-up" />
-</Example>
-
-If you'd like to update the primary color of your submit button you can override the `amplify-button` class.
+You can also override the authenticator's `amplify-*` classes. For example, if you'd like to update the primary color of your submit button you can override the `amplify-button` class.
 
 ```css
 .amplify-button--primary {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Updates our Authenticator styling/theme examples to work with the latest UI changes.

Fixes https://github.com/aws-amplify/amplify-ui/issues/4977

**Fixes overriding amplify classes example**
- Removes mention of hiding sign up tab with css since users can now use the `hideSignUp` prop instead
- Updates class name used

| Before        | After       | 
| ------------- | ------------ | 
| <img width="400" alt="Screenshot 2024-02-06 at 12 07 52 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/7d57cfec-173d-45d2-bca9-9f18dcb22699">      | <img width="400" alt="Screenshot 2024-02-06 at 12 07 18 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/75432997-d170-4c07-9787-9364c5030dfa"> |

**Fixes CSS style example**
- I removed mention of making it a dark theme because it's too hard to show a very short example of that without it looking kind of jank like it currently does
- I vetted the styles to make sure they work here https://codesandbox.io/p/sandbox/auth-styling-fxg239?file=%2Fsrc%2Fstyles.css%3A1%2C28

| Before        | After       | 
| ------------- | ------------ | 
| <img width="400" alt="Screenshot 2024-02-06 at 12 11 12 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/149d4fb8-a9d6-4cb6-a07c-4027d9823be6">      | <img width="400" alt="Screenshot 2024-02-06 at 12 10 59 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/03f950b3-bb61-4a45-9005-302e3f81f8c2"> |

Also updated the theming example to match what's used in the CSS style example since they use the same component for a preview





#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
