### PR TITLE
fix(docs): css variable tables not showing

### DIFF
--- a/docs/src/components/ComponentVariableTable.tsx
+++ b/docs/src/components/ComponentVariableTable.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Alert, Grid, ScrollView, useTheme } from '@aws-amplify/ui-react';
 
 function extractClasses(themeObject) {
-  console.log('themeObject: ', themeObject);
   if (!themeObject || typeof themeObject !== 'object') return [];
   const themeKeys = Object.keys(themeObject);
   let classNames = [];
@@ -21,7 +20,6 @@ function extractClasses(themeObject) {
 
 export const ComponentVariableTable = ({ componentName }) => {
   const { tokens } = useTheme();
-  console.log(componentName);
   const variableNames = extractClasses(
     tokens?.components?.[componentName.toLowerCase()]
   ).sort();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

CSS variable tables were not showing because it expects the component name to be lower case in `useTheme().tokens.components`

Fixes: https://github.com/aws-amplify/amplify-ui/issues/4979

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
