### PR TITLE
fix(docs) incorrect i18n import path in code examples

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
@@ -21,7 +21,7 @@ The `Authenticator` ships with [translations](https://github.com/aws-amplify/amp
 These [translations](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts) can be customized using the [Amplify JS' `I18n`](https://docs.amplify.aws/lib/utilities/i18n/q/platform/js/) module:
 
 ```js
-import { I18n } from 'aws-amplify';
+import { I18n } from 'aws-amplify/utils';
 import { translations } from '@aws-amplify/ui';
 I18n.putVocabularies(translations);
 I18n.setLanguage('fr');

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
@@ -21,7 +21,7 @@ The `Authenticator` ships with [translations](https://github.com/aws-amplify/amp
 These [translations](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts) can be customized using the [Amplify JS' `I18n`](https://docs.amplify.aws/lib/utilities/i18n/q/platform/js/) module:
 
 <Message colorTheme="info" variation="filled">
-<Text fontWeight="bold" as="span">Note:</Text> The import path for i18n changed from `aws-amplify` to `aws-amplify/utils` in `aws-amplify@6`
+<Text fontWeight="bold" as="span">Note:</Text> The import path for `i18n` changed from `aws-amplify` to `aws-amplify/utils` in `aws-amplify@6`
 </Message>
 
 ```js

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
@@ -1,4 +1,4 @@
-import { Alert } from '@aws-amplify/ui-react';
+import { Message, Text, Alert } from '@aws-amplify/ui-react';
 
 The `Authenticator` ships with [translations](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts) for:
 
@@ -19,6 +19,10 @@ The `Authenticator` ships with [translations](https://github.com/aws-amplify/amp
 - `tr` – Turkish
 
 These [translations](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts) can be customized using the [Amplify JS' `I18n`](https://docs.amplify.aws/lib/utilities/i18n/q/platform/js/) module:
+
+<Message colorTheme="info" variation="filled">
+<Text fontWeight="bold" as="span">Note:</Text> The import path for i18n changed from `aws-amplify` to `aws-amplify/utils` in `aws-amplify@6`
+</Message>
 
 ```js
 import { I18n } from 'aws-amplify/utils';

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
@@ -26,7 +26,7 @@ These [translations](https://github.com/aws-amplify/amplify-ui/blob/main/package
 
 <InlineFilter filters={['angular']}>
 ```js
-import { I18n } from 'aws-amplify';
+import { I18n } from 'aws-amplify/utils';
 import { translations } from '@aws-amplify/ui-angular';
 I18n.putVocabularies(translations);
 I18n.setLanguage('fr');
@@ -45,7 +45,7 @@ I18n.putVocabularies({
 </InlineFilter>
 <InlineFilter filters={['react']}>
 ```js
-import { I18n } from 'aws-amplify';
+import { I18n } from 'aws-amplify/utils';
 import { translations } from '@aws-amplify/ui-react';
 I18n.putVocabularies(translations);
 I18n.setLanguage('fr');
@@ -64,7 +64,7 @@ I18n.putVocabularies({
 </InlineFilter>
 <InlineFilter filters={['vue']}>
 ```js
-import { I18n } from 'aws-amplify';
+import { I18n } from 'aws-amplify/utils';
 import { translations } from '@aws-amplify/ui-vue';
 I18n.putVocabularies(translations);
 I18n.setLanguage('fr');

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
@@ -25,7 +25,7 @@ The `Authenticator` ships with [translations](https://github.com/aws-amplify/amp
 These [translations](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts) can be customized using the [Amplify JS' `I18n`](https://docs.amplify.aws/lib/utilities/i18n/q/platform/js/) module:
 
 <Message colorTheme="info" variation="filled">
-<Text fontWeight="bold" as="span">Note:</Text> The import path for i18n changed from `aws-amplify` to `aws-amplify/utils` in `aws-amplify@6`
+<Text fontWeight="bold" as="span">Note:</Text> The import path for `i18n` changed from `aws-amplify` to `aws-amplify/utils` in `aws-amplify@6`
 </Message>
 
 <InlineFilter filters={['angular']}>

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
@@ -1,5 +1,5 @@
 import { InlineFilter } from '@/components/InlineFilter';
-import { Alert } from '@aws-amplify/ui-react';
+import { Message, Text, Alert } from '@aws-amplify/ui-react';
 
 The `Authenticator` ships with [translations](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts) for:
 
@@ -23,6 +23,10 @@ The `Authenticator` ships with [translations](https://github.com/aws-amplify/amp
 - `ua` – Ukrainian
 
 These [translations](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts) can be customized using the [Amplify JS' `I18n`](https://docs.amplify.aws/lib/utilities/i18n/q/platform/js/) module:
+
+<Message colorTheme="info" variation="filled">
+<Text fontWeight="bold" as="span">Note:</Text> The import path for i18n changed from `aws-amplify` to `aws-amplify/utils` in `aws-amplify@6`
+</Message>
 
 <InlineFilter filters={['angular']}>
 ```js


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Updates the code examples for i18n from 
```js
import { I18n } from 'aws-amplify';
``` 

to

```js
import { I18n } from 'aws-amplify/utils';
```

which is the correct path for v6


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
