### PR TITLE
fix(docs): removes the react reference in vite plugin when on vue docs

### DIFF
--- a/docs/src/pages/[platform]/getting-started/troubleshooting/shared/vite-polyfill.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/shared/vite-polyfill.mdx
@@ -1,3 +1,5 @@
+import { InlineFilter } from '@/components/InlineFilter';
+
 **1.** Add the following script tag to the `index.html` file right before the `</body>` tag. This will only run on the client side and will polyfill Node globals.
 
 ```html
@@ -13,6 +15,7 @@
 
 **2.** Update the `vite.config.ts` (or `vite.config.js`) and add a resolve alias inside the `defineConfig({})` as seen below.
 
+<InlineFilter filters={['react']}>
 ```ts
 export default defineConfig({
   plugins: [react()],
@@ -26,3 +29,20 @@ export default defineConfig({
   }
 })
 ```
+</InlineFilter>
+
+<InlineFilter filters={['vue']}>
+```ts
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+      alias: [
+      {
+        find: './runtimeConfig',
+        replacement: './runtimeConfig.browser', // ensures browser compatible version of AWS JS SDK is used
+      },
+    ]
+  }
+})
+```
+</InlineFilter>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This just fixes the react() reference in the Vite `plugins: [] config` when you're on the Vue platform. 

**Before**
<img width="706" alt="Screenshot 2024-02-07 at 3 52 15 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/2783654b-43c0-4086-92b6-6b48fdf39c57">

**After**
<img width="645" alt="Screenshot 2024-02-07 at 3 56 55 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/136ed418-0606-4e9a-8d57-b98d56018e41">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
