### PR TITLE
fix(docs): link contrast in messages/alerts

### DIFF
--- a/docs/src/styles/docs/base.scss
+++ b/docs/src/styles/docs/base.scss
@@ -86,6 +86,17 @@ a {
   }
 }
 
+.amplify-alert,
+.amplify-message {
+  a {
+    color: var(--amplify-colors-font-primary);
+    text-decoration: underline;
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}
+
 blockquote {
   padding: var(--amplify-space-medium);
   border-left: var(--amplify-border-widths-large) solid


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Our link contrast for some links within messages and alerts is too low (namely the blue info color theme). This updates them on the docs to use `colors.font.primary` and specifies a `text-decoration: underline` so that both `.amplify-link` and `a:not[class]` both have underlines (currently only the latter does)

<img width="288" alt="Screenshot 2024-02-08 at 10 28 48 AM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/8705a2e8-0fd2-4524-ba02-11c214174482">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
