### PR TITLE
fix(docs): migration page tabs

### DIFF
--- a/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.angular.mdx
@@ -130,13 +130,16 @@ import { ConfirmSignInInput } from 'aws-amplify';
 ### Installation
 Install the 4.x version of the `@aws-amplify/ui-angular` library.
 
-<Tabs.Container>
-<Tabs.Item title="npm">
-<TerminalCommand command="npm install @aws-amplify/ui-angular@4.x" />
-</Tabs.Item>
-<Tabs.Item title="yarn">
-<TerminalCommand command="yarn add @aws-amplify/ui-angular@4.x" />
-</Tabs.Item>
+<Tabs.Container defaultValue="npm">
+  <Tabs.List>
+    <Tabs.Item value="npm">npm</Tabs.Item>
+    <Tabs.Item value="yarn">yarn</Tabs.Item>
+  </Tabs.List>
+  <Tabs.Panel value="npm">
+    <TerminalCommand command="npm install @aws-amplify/ui-angular@4.x" />
+  </Tabs.Panel>
+  <Tabs.Panel value="yarn">
+  <TerminalCommand command="yarn add @aws-amplify/ui-angular@4.x" /></Tabs.Panel>
 </Tabs.Container>
 
 ### Update and usage
@@ -168,13 +171,18 @@ Then open your `angular.json` file, and add `node_modules/@aws-amplify/ui-angula
 ### Installation
 Install the 3.x version of the `@aws-amplify/ui-angular` library and the 5.x version of the `aws-amplify` library.
 
-<Tabs.Container>
-<Tabs.Item title="npm">
-<TerminalCommand command="npm install aws-amplify@5.x @aws-amplify/ui-angular@3.x" />
-</Tabs.Item>
-<Tabs.Item title="yarn">
-<TerminalCommand command="yarn add aws-amplify@5.x @aws-amplify/ui-angular@3.x" />
-</Tabs.Item>
+
+<Tabs.Container defaultValue="npm">
+  <Tabs.List>
+    <Tabs.Item value="npm">npm</Tabs.Item>
+    <Tabs.Item value="yarn">yarn</Tabs.Item>
+  </Tabs.List>
+  <Tabs.Panel value="npm">
+    <TerminalCommand command="npm install aws-amplify@5.x @aws-amplify/ui-angular@3.x" />
+  </Tabs.Panel>
+  <Tabs.Panel value="yarn">
+    <TerminalCommand command="yarn add aws-amplify@5.x @aws-amplify/ui-angular@3.x" />
+  </Tabs.Panel>
 </Tabs.Container>
 
 ### Update and usage
@@ -248,13 +256,17 @@ The following deprecated components imported from `@aws-amplify/ui-angular/legac
 
 If you wish to still use the legacy components, you can do so by installing `@aws-amplify@2.x` under an alias:
 
-<Tabs.Container>
-<Tabs.Item title="npm">
-<TerminalCommand command="npm install @aws-amplify/ui-angular-v2@npm:@aws-amplify/ui-angular@^2.4.27" />
-</Tabs.Item>
-<Tabs.Item title="yarn">
-<TerminalCommand command="yarn add @aws-amplify/ui-angular-v2@npm:@aws-amplify/ui-angular@^2.4.27" />
-</Tabs.Item>
+<Tabs.Container defaultValue="npm">
+  <Tabs.List>
+    <Tabs.Item value="npm">npm</Tabs.Item>
+    <Tabs.Item value="yarn">yarn</Tabs.Item>
+  </Tabs.List>
+  <Tabs.Panel value="npm">
+    <TerminalCommand command="npm install @aws-amplify/ui-angular-v2@npm:@aws-amplify/ui-angular@^2.4.27" />
+  </Tabs.Panel>
+  <Tabs.Panel value="yarn">
+    <TerminalCommand command="yarn add @aws-amplify/ui-angular-v2@npm:@aws-amplify/ui-angular@^2.4.27" />
+  </Tabs.Panel>
 </Tabs.Container>
 
 Then you can use the legacy components by registering `LegacyAmplifyUiModule` in your `app.module.ts`:
@@ -285,13 +297,17 @@ For more details on how to use the components, please see the [v1 documentation]
 
 Install the 2.x version of the `@aws-amplify/ui-angular` library.
 
-<Tabs.Container>
-<Tabs.Item title="npm">
-<TerminalCommand command="npm install aws-amplify @aws-amplify/ui-angular@2.x" />
-</Tabs.Item>
-<Tabs.Item title="yarn">
-<TerminalCommand command="yarn add aws-amplify @aws-amplify/ui-angular@2.x" />
-</Tabs.Item>
+<Tabs.Container defaultValue="npm">
+  <Tabs.List>
+    <Tabs.Item value="npm">npm</Tabs.Item>
+    <Tabs.Item value="yarn">yarn</Tabs.Item>
+  </Tabs.List>
+  <Tabs.Panel value="npm">
+    <TerminalCommand command="npm install aws-amplify @aws-amplify/ui-angular@2.x" />
+  </Tabs.Panel>
+  <Tabs.Panel value="yarn">
+    <TerminalCommand command="yarn add aws-amplify @aws-amplify/ui-angular@2.x" />
+  </Tabs.Panel>
 </Tabs.Container>
 
 ### Update

--- a/docs/src/pages/[platform]/getting-started/migration/migration.vue.mdx
+++ b/docs/src/pages/[platform]/getting-started/migration/migration.vue.mdx
@@ -91,13 +91,17 @@ const userAttributes = await fetchUserAttributes();
 ### Installation
 Install the 3.x version of the `@aws-amplify/ui-vue` library and the 5.x version of the `aws-amplify` library.
 
-<Tabs.Container>
-<Tabs.Item title="npm">
-<TerminalCommand command="npm install aws-amplify@5.x @aws-amplify/ui-vue@3.x" />
-</Tabs.Item>
-<Tabs.Item title="yarn">
-<TerminalCommand command="yarn add aws-amplify@5.x @aws-amplify/ui-vue@3.x" />
-</Tabs.Item>
+<Tabs.Container defaultValue='npm'>
+  <Tabs.List>
+    <Tabs.Item value="npm">npm</Tabs.Item>
+    <Tabs.Item value="yarn">yarn</Tabs.Item>
+  </Tabs.List>
+  <Tabs.Panel value="npm">
+    <TerminalCommand command="npm install aws-amplify@5.x @aws-amplify/ui-vue@3.x" />
+  </Tabs.Panel>
+  <Tabs.Panel value="yarn">
+    <TerminalCommand command="yarn add aws-amplify@5.x @aws-amplify/ui-vue@3.x" />
+  </Tabs.Panel>
 </Tabs.Container>
 
 ### Update and usage
@@ -136,19 +140,21 @@ If you are overriding `Auth.signUp`, update the override function call to includ
 If you were using `I18n` to translate those keys, please update your translations accordingly to match the new strings.
 
 ## 1.x to 2.x
-## Installation
+
+### Installation
 Install the 2.x version of the `@aws-amplify/ui-vue` library.
 
-<Tabs.Container>
-<Tabs.Item title="npm">
-
-<TerminalCommand command="npm install aws-amplify @aws-amplify/ui-vue@2" />
-
-</Tabs.Item>
-<Tabs.Item title="yarn">
-<TerminalCommand command="yarn add aws-amplify @aws-amplify/ui-vue@2" />
-
-</Tabs.Item>
+<Tabs.Container defaultValue='npm'>
+  <Tabs.List>
+    <Tabs.Item value="npm">npm</Tabs.Item>
+    <Tabs.Item value="yarn">yarn</Tabs.Item>
+  </Tabs.List>
+  <Tabs.Panel value="npm">
+    <TerminalCommand command="npm install aws-amplify @aws-amplify/ui-vue@2" />
+  </Tabs.Panel>
+  <Tabs.Panel value="yarn">
+    <TerminalCommand command="yarn add aws-amplify @aws-amplify/ui-vue@2" />
+  </Tabs.Panel>
 </Tabs.Container>
 
 <Alert role="none" variation="info" heading="UI Components">


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Updates the tabs on the migration pages to use the correct format.

**Before**
<img width="536" alt="Screenshot 2024-02-08 at 10 58 15 AM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/30dbd193-fec2-491e-8f37-d2efdf6f8cab">

**After**
<img width="916" alt="Screenshot 2024-02-08 at 10 58 25 AM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/c5215b37-c555-4a0a-9805-89613e4e091c">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
