### PR TITLE
fix(react-storage): use targetIdentityId to get url

### DIFF
--- a/.changeset/curvy-grapes-clean.md
+++ b/.changeset/curvy-grapes-clean.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui-react-storage": patch
+---
+
+fix(react-storage): use targetIdentityId instead of identityId to get URL of image
+
+Fixes an issue in `<StorageImage />` where users could not load an image with `accessLevel` of "protected" even when an `identityId` was supplied.

--- a/packages/react-storage/src/components/StorageImage/StorageImage.tsx
+++ b/packages/react-storage/src/components/StorageImage/StorageImage.tsx
@@ -24,7 +24,7 @@ export const StorageImage = ({
   const options = React.useMemo(
     () => ({
       accessLevel,
-      identityId,
+      targetIdentityId: identityId,
       validateObjectExistence: resolvedValidateObjectExistence,
     }),
     [accessLevel, identityId, resolvedValidateObjectExistence]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Updates the property passed to useStorageUrl from `identityId` to `targetIdentityId`

Currently we're building the URL for StorageImage with these options:

```js
{
      accessLevel,
      identityId
      validateObjectExistence
}
```

However, `indentityId` should be `targetIdentityId` based [on the storage docs ](https://docs.amplify.aws/javascript/build-a-backend/storage/download/#generate-a-download-url). 

#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-ui/issues/4990

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I setup a new Auth + storage Amplify app, and used "protected" accessLevel on `<StorageManager />`. I uploaded a test image with "User A" then looked up its identityId to load it with `<StorageImage />`. Then I logged in with "User B" to verify that the image 404's.

After making the change from this PR and testing in next-example dev, I can now see "User A"s image when logged in with User B.
 
```jsx
<Authenticator>
      {({ signOut, user }) => (
        <main>
          <h1>Hello {user.username}</h1>

          <StorageImage
            alt="test"
            imgKey="test-image.png"
            identityId="us-east-1:some-id"
            accessLevel="protected"
          />

          <StorageManager
            acceptedFileTypes={["image/*"]}
            accessLevel="protected"
            maxFileCount={1}
            isResumable
          />

          <button onClick={signOut}>Sign out</button>
        </main>
      )}
    </Authenticator>
 ```

 I logged in with one user (user A) and uploaded an image

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
