### PR TITLE
feat(angular): add support for onpush change detection strategy 

### DIFF
--- a/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.angular.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.angular.mdx
@@ -9,10 +9,6 @@ import AWSExports from './shared/add-aws-exports-type.mdx';
 
 <AWSExports />
 
-### Problems with `OnPush` change detection
-
-The Authenticator component currently does not support use of the `OnPush` [change detection strategy](https://angular.io/api/core/ChangeDetectionStrategy). Please use the `Default` strategy instead.
-
 ### Warning: CommonJS or AMD dependencies
 
 If you see CommonJS or AMD dependencies optimization bailouts warnings, add the following [content](https://gist.github.com/wlee221/6d98d96740bea6f53327b4db4a432616) to your `angular.json`.

--- a/examples/angular/src/app/app-routing.module.ts
+++ b/examples/angular/src/app/app-routing.module.ts
@@ -13,6 +13,7 @@ import { SignInSMSMFAComponent } from 'src/pages/ui/components/authenticator/sig
 import { SignInTOTPMFAComponent } from 'src/pages/ui/components/authenticator/sign-in-totp-mfa/sign-in-totp-mfa.component';
 import { SignInTOTPSMSComponent } from 'src/pages/ui/components/authenticator/sign-in-totp-sms/sign-in-totp-sms.component';
 import { SignInWithEmailComponent } from 'src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component';
+import { SignInWithEmailOnPushComponent } from 'src/pages/ui/components/authenticator/sign-in-with-email-onpush/sign-in-with-email-onpush.component';
 import { SignInWithPhoneComponent } from 'src/pages/ui/components/authenticator/sign-in-with-phone/sign-in-with-phone.component';
 import { SignInWithUsernameComponent } from 'src/pages/ui/components/authenticator/sign-in-with-username/sign-in-with-username.component';
 import { SignUpWithAttributesComponent } from 'src/pages/ui/components/authenticator/sign-up-with-attributes/sign-up-with-attributes.component';
@@ -51,6 +52,10 @@ const routes: Routes = [
   {
     path: 'ui/components/authenticator/sign-in-with-email',
     component: SignInWithEmailComponent,
+  },
+  {
+    path: 'ui/components/authenticator/sign-in-with-email-onpush',
+    component: SignInWithEmailOnPushComponent,
   },
   {
     path: 'ui/components/authenticator/i18n',

--- a/examples/angular/src/app/app.module.ts
+++ b/examples/angular/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { SignInSMSMFAComponent } from 'src/pages/ui/components/authenticator/sig
 import { SignInTOTPMFAComponent } from 'src/pages/ui/components/authenticator/sign-in-totp-mfa/sign-in-totp-mfa.component';
 import { SignInTOTPSMSComponent } from 'src/pages/ui/components/authenticator/sign-in-totp-sms/sign-in-totp-sms.component';
 import { SignInWithEmailComponent } from 'src/pages/ui/components/authenticator/sign-in-with-email/sign-in-with-email.component';
+import { SignInWithEmailOnPushComponent } from 'src/pages/ui/components/authenticator/sign-in-with-email-onpush/sign-in-with-email-onpush.component';
 import { SignInWithPhoneComponent } from 'src/pages/ui/components/authenticator/sign-in-with-phone/sign-in-with-phone.component';
 import { SignInWithUsernameComponent } from 'src/pages/ui/components/authenticator/sign-in-with-username/sign-in-with-username.component';
 import { SignUpWithAttributesComponent } from 'src/pages/ui/components/authenticator/sign-up-with-attributes/sign-up-with-attributes.component';
@@ -43,6 +44,7 @@ import { UseAuthenticatorHomeComponent } from 'src/pages/ui/components/authentic
     SignInTOTPMFAComponent,
     SignInTOTPSMSComponent,
     SignInWithEmailComponent,
+    SignInWithEmailOnPushComponent,
     SignInWithPhoneComponent,
     SignInWithUsernameComponent,
     SignUpWithAttributesComponent,

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email-onpush/aws-exports.d.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email-onpush/aws-exports.d.ts
@@ -1,0 +1,2 @@
+declare const awsmobile: Record<string, any>;
+export default awsmobile;

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email-onpush/aws-exports.js
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email-onpush/aws-exports.js
@@ -1,0 +1,2 @@
+import awsExports from '@environments/auth/auth-with-email/src/aws-exports';
+export default awsExports;

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email-onpush/sign-in-with-email-onpush.component.html
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email-onpush/sign-in-with-email-onpush.component.html
@@ -1,0 +1,34 @@
+<amplify-authenticator [formFields]="formFields" [hideSignUp]="true">
+  <ng-template amplifySlot="verify-user-header">
+    <h3
+      class="amplify-heading"
+      style="padding: var(--amplify-space-xl) 0 0 var(--amplify-space-xl)"
+    >
+      Enter Information:
+    </h3>
+  </ng-template>
+
+  <ng-template amplifySlot="verify-user-footer">
+    <div>Footer Information</div>
+  </ng-template>
+  <ng-template amplifySlot="confirm-verify-user-header">
+    <h3
+      class="amplify-heading"
+      style="padding: var(--amplify-space-xl) 0 0 var(--amplify-space-xl)"
+    >
+      Enter Information:
+    </h3>
+  </ng-template>
+
+  <ng-template amplifySlot="confirm-verify-user-footer">
+    <div>Footer Information</div>
+  </ng-template>
+  <ng-template
+    amplifySlot="authenticated"
+    let-user="user"
+    let-signOut="signOut"
+  >
+    <h2>Welcome, {{ user.username }}!</h2>
+    <button (click)="signOut()">Sign Out</button>
+  </ng-template>
+</amplify-authenticator>

--- a/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email-onpush/sign-in-with-email-onpush.component.ts
+++ b/examples/angular/src/pages/ui/components/authenticator/sign-in-with-email-onpush/sign-in-with-email-onpush.component.ts
@@ -1,0 +1,29 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Amplify } from 'aws-amplify';
+import awsExports from './aws-exports';
+
+@Component({
+  selector: 'sign-in-with-email-onpush',
+  templateUrl: 'sign-in-with-email-onpush.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SignInWithEmailOnPushComponent {
+  constructor() {
+    Amplify.configure(awsExports);
+  }
+
+  public formFields = {
+    signIn: {
+      username: {
+        placeholder: 'Enter your cool email',
+      },
+    },
+    confirmVerifyUser: {
+      confirmation_code: {
+        label: 'New Label',
+        placeholder: 'Enter your Confirmation Code:',
+        isRequired: false,
+      },
+    },
+  };
+}

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterContentInit,
   ChangeDetectorRef,
+  ChangeDetectionStrategy,
   Component,
   ContentChildren,
   Input,
@@ -28,6 +29,7 @@ const { getSignInTabText, getSignUpTabText } = authenticatorTextUtil;
   templateUrl: './authenticator.component.html',
   providers: [CustomComponentsService], // make sure custom components are scoped to this authenticator only
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AuthenticatorComponent
   implements OnInit, AfterContentInit, OnDestroy
@@ -49,7 +51,6 @@ export class AuthenticatorComponent
   public signUpTitle = getSignUpTabText();
 
   private hasInitialized = false;
-  private isHandlingHubEvent = false;
   private unsubscribeMachine: () => void;
   private clearUserAgent: () => void;
 
@@ -86,58 +87,27 @@ export class AuthenticatorComponent
 
     const { initializeMachine } = this.authenticator;
 
-    this.authenticator.hubSubject.subscribe(() => {
-      /*
-       * Hub events aren't properly caught by Angular, because they are
-       * synchronous events. Angular tracks async network events and
-       * html events, but not synchronous events like hub.
-       *
-       * On any notable hub events, we run change detection manually.
-       */
-      this.changeDetector.detectChanges();
+    // subscribe to the auth state observable to handle changes in machine state
+    this.unsubscribeMachine = this.authenticator.authStateObservable$.subscribe(
+      () => {
+        const { route } = this.authenticator;
 
-      /*
-       * Hub events that we handle can lead to multiple state changes:
-       * e.g. `authenticated` -> `signOut` -> initialState.
-       *
-       * We want to ensure change detection runs all the way, until
-       * we reach back to the initial state. Setting the below flag
-       * to true to until we reach initial state.
-       */
-      this.isHandlingHubEvent = true;
-    });
+        if (!this.hasInitialized && route === 'setup') {
+          initializeMachine({
+            initialState,
+            loginMechanisms,
+            services,
+            signUpAttributes,
+            socialProviders,
+            formFields,
+          });
 
-    /**
-     * Subscribes to state machine changes and sends INIT event
-     * once machine reaches 'setup' state.
-     */
-    this.unsubscribeMachine = this.authenticator.subscribe(() => {
-      const { route } = this.authenticator;
-
-      if (this.isHandlingHubEvent) {
-        this.changeDetector.detectChanges();
-
-        const initialStateWithDefault = initialState ?? 'signIn';
-
-        // We can stop manual change detection if we're back to the initial state
-        if (route === initialStateWithDefault) {
-          this.isHandlingHubEvent = false;
+          this.hasInitialized = true;
         }
+        // manually run change detection when machine state changes
+        this.changeDetector.detectChanges();
       }
-
-      if (!this.hasInitialized && route === 'setup') {
-        initializeMachine({
-          initialState,
-          loginMechanisms,
-          services,
-          signUpAttributes,
-          socialProviders,
-          formFields,
-        });
-
-        this.hasInitialized = true;
-      }
-    }).unsubscribe;
+    ).unsubscribe;
 
     /**
      * handling translations after content init, because authenticator and its

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
@@ -87,7 +87,10 @@ export class AuthenticatorComponent
 
     const { initializeMachine } = this.authenticator;
 
-    // subscribe to the auth state observable to handle changes in machine state
+    /**
+     * Subscribes to state machine changes and sends INIT event
+     * once machine reaches 'setup' state.
+     */
     this.unsubscribeMachine = this.authenticator.authStateObservable$.subscribe(
       () => {
         const { route } = this.authenticator;

--- a/packages/angular/projects/ui-angular/src/lib/services/__tests__/authenticator.service.test.ts
+++ b/packages/angular/projects/ui-angular/src/lib/services/__tests__/authenticator.service.test.ts
@@ -1,60 +1,18 @@
 import { AuthenticatorService } from '../authenticator.service';
 
-import * as UIModule from '@aws-amplify/ui';
-import * as XState from 'xstate';
-
-// mock state machine service
-// based on https://github.com/statelyai/xstate/blob/main/packages/core/src/interpreter.ts
-class MockAuthService {
-  private listeners: (() => void)[] = [];
-
-  subscribe(callback: () => void): { unsubscribe: () => void } {
-    this.listeners.push(callback);
-    const unsubscribe = jest.fn();
-    return { unsubscribe };
-  }
-
-  start(): this {
-    return this;
-  }
-
-  send(): void {
-    for (const listener of this.listeners) {
-      listener();
-    }
-  }
-}
-
-const mockFacade = {} as unknown as ReturnType<
-  (typeof UIModule)['getServiceFacade']
->;
-
-jest.spyOn(UIModule, 'getServiceFacade').mockReturnValue(mockFacade);
-// mock interpreted authservice
-jest
-  .spyOn(XState, 'interpret')
-  .mockReturnValue(
-    new MockAuthService() as unknown as ReturnType<typeof XState.interpret>
-  );
-
 describe('AuthenticatorService', () => {
-  let authService: AuthenticatorService;
+  const authService: AuthenticatorService = new AuthenticatorService();
 
-  beforeEach(() => {
-    authService = new AuthenticatorService();
-    jest.clearAllMocks();
-  });
-
-  it('subscribe returns state machine facade', () => {
-    const handler = jest.fn();
-    const subscription = authService.subscribe(handler);
-
+  it('callback is called when interpreted authservice changes', () => {
+    const callback = jest.fn();
+    const subscription = authService.authStateObservable$.subscribe(callback);
+    expect(callback).toHaveBeenCalledTimes(1);
     // trigger a mock transition
     authService.send('INIT');
+    expect(callback).toHaveBeenCalledTimes(2);
 
-    expect(handler).toHaveBeenCalledTimes(1);
-
-    expect(handler).toHaveBeenCalledWith(mockFacade);
+    authService.send('SIGN_IN');
+    expect(callback).toHaveBeenCalledTimes(3);
 
     subscription.unsubscribe();
   });

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-email-onpush.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-email-onpush.feature
@@ -1,0 +1,96 @@
+Feature: Sign In with Email with OnPush (Angular only)
+
+  Amplify's SignIn component uses AWS Cognito's authentication
+  service to provide a sign in experience to your application's
+  users.
+
+  Amplify can be configured to allow a user to use their email
+  when signing into your application.
+
+  Background:
+    Given I'm running the example "/ui/components/authenticator/sign-in-with-email-onpush"
+
+  @angular
+  Scenario: Sign in returns force reset password exception
+    Given I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth" } }' with error fixture "force-reset-password"
+    Then I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.ForgotPassword" } }' with fixture "forgot-password-email"
+    When I type my "email" with status "CONFIRMED"
+    Then I type my password
+    Then I click the "Sign in" button
+    Then I see "Reset Password"
+    Then I see "Code *"
+    Then I type a valid code
+    Then I type my new password
+    Then I confirm my password
+    Then I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmForgotPassword" } }' with error fixture "AWSCognitoIdentityProviderService.ConfirmSignUp-invalid-code.json"
+    Then I click the "Submit" button
+
+  @angular
+  Scenario: Sign in with unknown credentials
+    When I type my "email" with status "UNKNOWN"
+    Then I type my password
+    Then I click the "Sign in" button
+    Then I see "User does not exist."
+
+
+  Scenario: Sign in with unconfirmed credentials
+
+  If you sign in with an unconfirmed account, Authenticator will redirect you to `confirmSignUp` route.
+
+    When I type my "email" with status "UNCONFIRMED"
+    Then I type my password
+    Then I click the "Sign in" button
+    Then I spy request '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth" } }'
+    Then I confirm request '{"headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth" } }'
+    Then I see "Confirmation Code"
+    Then I type a valid confirmation code
+    Then I spy request '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmSignUp" } }'
+    Then I click the "Confirm" button
+    Then I confirm request '{"headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmSignUp" } }'
+
+  @angular
+  Scenario: Sign in with confirmed credentials
+    When I type my "email" with status "CONFIRMED"
+    Then I type my password
+    Then I click the "Sign in" button
+    Then I see "Sign out"
+    Then I click the "Sign out" button
+    Then I see "Sign in"
+
+  @angular
+  Scenario: Sign in with confirmed credentials then sign out
+    When I type my "email" with status "CONFIRMED"
+    Then I type my password
+    Then I click the "Sign in" button
+    Then I see "Sign out"
+    Then I click the "Sign out" button
+    Then I see "Sign in"
+
+  @angular
+  Scenario: Sign Up Tab Is Not Present 
+    Then I see "Sign in"
+    Then I don't see "Create Account"
+
+  @angular
+  Scenario: Email field autocompletes username
+
+  On sign in form, autocomplete prefers usage of username instead of email. 
+  See https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/.
+
+    Then "Email" field autocompletes "username"
+
+  @angular
+  Scenario: Password fields autocomplete "current-password"
+    Then "Password" field autocompletes "current-password"
+
+  @angular
+  Scenario: Sign in with confirmed credentials, reload, sign out, then see custom form fields
+    When I type my "email" with status "CONFIRMED"
+    Then I type my password
+    Then I click the "Sign in" button
+    Then I see "Sign out"
+    When I reload the page
+    Then I see "Sign out"
+    Then I click the "Sign out" button
+    Then I see "Sign in"
+    Then I see placeholder "Enter your cool email"

--- a/packages/ui/src/helpers/authenticator/defaultAuthHubHandler.ts
+++ b/packages/ui/src/helpers/authenticator/defaultAuthHubHandler.ts
@@ -48,7 +48,7 @@ export const defaultAuthHubHandler: AuthMachineHubHandler = (
  *
  * @param service - contains state machine `send` function
  * @param handler - auth event handler
- * @returns function that unsubscribes to the hub evenmt
+ * @returns function that unsubscribes to the hub event
  */
 export const listenToAuthHub = (
   service: AuthInterpreter,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Changes authenticator component to use `OnPush` strategy, which means it can be consumed by components that use either `OnPush` or `Default` strategy. 

e.g.
```
@Component({
  selector: 'sign-in-with-email',
  templateUrl: 'sign-in-with-email.component.html',
})
```
works the same as 
```
@Component({
  selector: 'sign-in-with-email',
  templateUrl: 'sign-in-with-email.component.html',
  changeDetection: ChangeDetectionStrategy.OnPush
})
```

Because authenticator now uses `OnPush`, we run change detection manually (`changeDetector.detectChanges()`) whenever the `authService` updates. This is achieved by creating an observable from the auth service
```
this._authStateObservable$ = from(this._authService);
```
using rxjs, which can then be natively subscribed to emit events when `authService` updates. 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
fixes #4899 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
