### PR TITLE
Remove angular and vue from list of supported frameworks

### DIFF
--- a/docs/__tests__/__snapshots__/sitemap.test.ts.snap
+++ b/docs/__tests__/__snapshots__/sitemap.test.ts.snap
@@ -30,7 +30,6 @@ exports[`Sitemap Snapshot 1`] = `
 /angular/theming/default-theme/colors, 
 /angular/theming/default-theme/sizes, 
 /angular/theming/default-theme/typography, 
-/angular/theming/responsive, 
 /flutter, 
 /flutter/connected-components/authenticator, 
 /flutter/connected-components/authenticator/configuration, 
@@ -161,6 +160,5 @@ exports[`Sitemap Snapshot 1`] = `
 /vue/theming/default-theme, 
 /vue/theming/default-theme/colors, 
 /vue/theming/default-theme/sizes, 
-/vue/theming/default-theme/typography, 
-/vue/theming/responsive"
+/vue/theming/default-theme/typography"
 `;

--- a/docs/src/pages/[platform]/theming/responsive/index.page.mdx
+++ b/docs/src/pages/[platform]/theming/responsive/index.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Responsive Design
 metaDescription: Amplify UI supports responsive design out of the box. Build responsive layouts in your applications using responsive style props with the built-in set of breakpoints, write custom media queries in CSS, or use the Flex and Grid components.
-supportedFrameworks: react|angular|vue
+supportedFrameworks: react
 ---
 
 import { getCustomStaticPath } from '@/utils/getCustomStaticPath';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Removing `angular` and `vue` from list of supported frameworks for the `/theming/responsive` page since responsive theming doesn't exist for angular and vue

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
