### PR TITLE
chore(docs): Adding Sign Up customization example for Swift

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.full-ui-customization.swift.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.full-ui-customization.swift.mdx
@@ -1,6 +1,6 @@
 ## Full UI Customization
 
-### Step customization
+### Customize the UI for the Authenticator flows
 
 In addition to customizing fields and theming, you can also provide a custom UI for one or more of the Authenticator steps.
 
@@ -22,7 +22,7 @@ Authenticator(
 
 For more complex cases, you can completely replace the UI for any particular step. 
 
-Every view has an associated `*State` class that they observe, and that can be used to implement a custom UI. These steps have `@Published` properties for their fields, which you can bind to your custom view.
+Every view has an associated `*State` class that they observe, and that can be used to implement a custom UI. These states have `@Published` properties for their fields, which you can bind to your custom view.
 
 This example shows how to fully replace the content displayed for the Sign In step, but a similar approach can be used for most steps:
 
@@ -60,11 +60,11 @@ struct CustomSignInView: View {
 
 ```
 
-#### Sign Up Step
+#### Customize the UI for the Sign Up flow
 
-Customizing the Sign Up step is slightly different, as the `SignUpState` does not individually publish each of its fields, but rather has one `fields: [SignUpState.Field]` property. 
+Customizing the Sign Up step is slightly different, as `SignUpState` does not individually publish each of its fields, but rather has one `fields: [SignUpState.Field]` property. 
 
-A `SignUpState.Field` is an `@ObservableObject` that has the `SignUpField` that it represents, and the `@Published` property you need to set (called `value`). 
+A `SignUpState.Field` is itself an `@ObservableObject` that has the `SignUpField` that it represents, and the `@Published` property (called `value`) that you need to bind to your view. 
 
 The following example shows how to fully replace the content displayed for the Sign Up step by iterating through the array of fields:
 
@@ -84,7 +84,7 @@ struct CustomSignUpView: View {
     var body: some View {
         VStack {
             ForEach(state.fields, id: \.self) { field in
-                createField(for: field)
+                createCustomField(for: field)
             }
 
             Button("Sign Up") {
@@ -97,7 +97,7 @@ struct CustomSignUpView: View {
 
     /// Creates a view for a SignUpField according to its SignUpAttribute
     @ViewBuilder
-    private func createField(for signUpField: SignUpState.Field) -> some View {
+    private func createCustomField(for signUpField: SignUpState.Field) -> some View {
         @ObservedObject var observedField = signUpField
         switch signUpField.field.attributeType {
         case .username:
@@ -110,7 +110,7 @@ struct CustomSignUpView: View {
             TextField("Phone Number", text: $observedField.value)
         case .email:
             TextField("Email", text: $observedField.value)
-        /// ... etc.
+        /// ... An so on for all cases of SignUpAttribute
         }
     }
 }

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.full-ui-customization.swift.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.full-ui-customization.swift.mdx
@@ -1,5 +1,7 @@
 ## Full UI Customization
 
+### Step customization
+
 In addition to customizing fields and theming, you can also provide a custom UI for one or more of the Authenticator steps.
 
 For simple use cases (such as adding additional information), you can use a combination of default views from the **Authenticator** library and views that you define yourself:
@@ -19,16 +21,17 @@ Authenticator(
 ```
 
 For more complex cases, you can completely replace the UI for any particular step. 
-Every view has an associated `*State` class that they observe, and that can be used to implement a custom UI.
 
-This example shows how to fully replace the content displayed for the Sign In step:
+Every view has an associated `*State` class that they observe, and that can be used to implement a custom UI. These steps have `@Published` properties for their fields, which you can bind to your custom view.
+
+This example shows how to fully replace the content displayed for the Sign In step, but a similar approach can be used for most steps:
 
 ```swift
 Authenticator(
     signInContent: { state in
         CustomSignInView(state: state)
     }
-) {
+) { _ in
     // ...
 }
 
@@ -57,6 +60,62 @@ struct CustomSignInView: View {
 
 ```
 
+#### Sign Up Step
+
+Customizing the Sign Up step is slightly different, as the `SignUpState` does not individually publish each of its fields, but rather has one `fields: [SignUpState.Field]` property. 
+
+A `SignUpState.Field` is an `@ObservableObject` that has the `SignUpField` that it represents, and the `@Published` property you need to set (called `value`). 
+
+The following example shows how to fully replace the content displayed for the Sign Up step by iterating through the array of fields:
+
+```swift
+Authenticator(
+    signUpContent: { state in
+        CustomSignUpView(state: state)
+    }
+) { _ in
+    // ...
+}
+
+/// Custom Sign Up view
+struct CustomSignUpView: View {
+    @ObservedObject var state: SignUpState
+
+    var body: some View {
+        VStack {
+            ForEach(state.fields, id: \.self) { field in
+                createField(for: field)
+            }
+
+            Button("Sign Up") {
+                Task {
+                    try? await state.signUp()
+                }
+            }
+        }
+    }
+
+    /// Creates a view for a SignUpField according to its SignUpAttribute
+    @ViewBuilder
+    private func createField(for signUpField: SignUpState.Field) -> some View {
+        @ObservedObject var observedField = signUpField
+        switch signUpField.field.attributeType {
+        case .username:
+            TextField("Username", text: $observedField.value)
+        case .password:
+            SecureField("Password", text: $observedField.value)
+        case .passwordConfirmation:
+            SecureField("Confirm password", text: $observedField.value)
+        case .phoneNumber:
+            TextField("Phone Number", text: $observedField.value)
+        case .email:
+            TextField("Email", text: $observedField.value)
+        /// ... etc.
+        }
+    }
+}
+```
+
 ### TOTP Setup
 
 You can also customize the TOTP setup experience. We make available arguments in the `ContinueSignInWithTOTPSetupView` i.e. `qrCodeContent` and `copyKeyContent` that can help you provide custom content for the TOTP Setup Experience. In the example below, examine how you could customize the setup screen.
@@ -73,13 +132,12 @@ Authenticator(
 
             },
             copyKeyContent: { state in
-                // YOUR custom implementation goes here
+                // Your custom implementation goes here
             }
         )
-    },
-    content: { state in
-        Text("Signed In Content")
     }
-)
+) { _ in
+    // ...
+}
 
 ```


### PR DESCRIPTION
#### Description of changes

This PR adds an explicit example on how to customize the **Sign Up** step in the Authenticator for Swift.
Since this particular step is different than the others, customers might get confused on how to proceed.

I've also added some additional context to the original customization example (for other steps), plus updated other code snippets in this file to be consistent with each other.

#### Issue #, if available

- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/36

#### Description of how you validated changes

Manually tested by deploying locally

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [X] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [X] `yarn test` passes and tests are updated/added
- [X] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
