### PR TITLE
Fix/update storage manager path handling

### DIFF
--- a/.changeset/healthy-rings-deny.md
+++ b/.changeset/healthy-rings-deny.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-storage": patch
+---
+
+Fix/update storage manager path handling

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/examples/StorageManagerPathPropExample.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/examples/StorageManagerPathPropExample.tsx
@@ -4,7 +4,7 @@ export const StorageManagerPathPropExample = () => {
   return (
     <StorageManager
       accessLevel="guest"
-      // uploaded files can be found in S3 inside `guest/images/`
+      // uploaded files can be found in S3 inside `public/images/`
       path="images/"
       acceptedFileTypes={['image/*']}
       maxFileCount={1}

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/examples/StorageManagerPathPropExample.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/examples/StorageManagerPathPropExample.tsx
@@ -1,0 +1,13 @@
+import { StorageManager } from '@aws-amplify/ui-react-storage';
+
+export const StorageManagerPathPropExample = () => {
+  return (
+    <StorageManager
+      accessLevel="guest"
+      // uploaded files can be found in S3 inside `guest/images/`
+      path="images/"
+      acceptedFileTypes={['image/*']}
+      maxFileCount={1}
+    />
+  );
+};

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
@@ -14,12 +14,13 @@ import {
   StorageManagerDisplayTextExample,
   StorageManagerEventExample,
   StorageManagerFileTypesExample,
+  StorageManagerHandleExample,
   StorageManagerHashExample,
   StorageManageri18nExample,
   StorageManagerMetadataExample,
+  StorageManagerPathPropExample,
   StorageManagerResumableExample,
   StorageManagerThemeExample,
-  StorageManagerHandleExample,
   StorageManagerUploadActionsExample,
 } from './examples'
 
@@ -139,6 +140,17 @@ The StorageManager component has several event handlers: `onUploadStart`, `onUpl
 <Alert variation="warning" heading="Use a previousState">
 Be careful setting state in the `onUploadSuccess` because that function is bound when the upload _starts_. Make sure to use the previous state argument rather than the current state in the component.
 </Alert>
+
+## `path` Usage
+
+The `path` prop of the `StorageManager` is prepended to the `key` value (resolved from either the file itself or the returned `key` of `processFile`) submitted to S3. Using a `'/'` as the last character of `path` allows uploading to a specific folder inside the provided `accessLevel` folder.
+
+<Example>
+  <ExampleCode>
+    ```jsx file=./examples/StorageManagerPathPropExample.tsx
+    ```
+  </ExampleCode>
+</Example>
 
 ## Adding metadata
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fix `path` prop handling in `StorageManager`
- prepend `path` to `key` returned from `processFile` before passing to `uploadFile` in `useUploadFiles`
- pass `resolvedKey` value to `onUploadStart` and `onUploadError`
- add `isFunction` checks for event handler props called in `useUploadFiles` (`onUploadError`, `onUploadStart`, `onUploadSuccess`)
- clean up `useUploadFiles` unit test file
- added `path` documentation example

<img width="1169" alt="CleanShot 2024-02-15 at 13 01 33@2x" src="https://github.com/aws-amplify/amplify-ui/assets/15002885/c4e78b86-3d23-408d-ad39-6e4a9386cb32">

 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-ui/issues/5008

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manually confirmed `path` in S3
- Added unit test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
