### PR TITLE
chore(docs): move iOS min deployment target callout in to Accordion

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/quick-start.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/quick-start.mdx
@@ -1,4 +1,4 @@
-import { Alert, Link, Text, Tabs } from '@aws-amplify/ui-react';
+import { Accordion, Alert, Link, Text, Tabs } from '@aws-amplify/ui-react';
 import { Example, ExampleCode } from '@/components/Example';
 import { InstallScripts } from '@/components/InstallScripts';
 import { TerminalCommand } from '@/components/InstallScripts';
@@ -117,12 +117,21 @@ import AmplifyCLI from './amplify-cli.mdx';
 
   <InstallScripts command="npm install @aws-amplify/rtn-web-browser" framework="react-native" />
 
-  `@aws-amplify/react-native` and `@aws-amplify/rtn-web-browser` require a minimum iOS deployment target of `13.0`, open the _Podfile_ located in the _ios_ directory and update the `target` value:
-
-  ```diff
-  - platform :ios, min_ios_version_supported
-  + platform :ios, 13.0
-  ```
+  <Accordion.Container>
+    <Accordion.Item value="Accordion-item">
+      <Accordion.Trigger>
+        Important note for integration with React Native projects using version `0.72` or below
+        <Accordion.Icon />
+      </Accordion.Trigger>
+    <Accordion.Content>
+      `@aws-amplify/react-native` and `@aws-amplify/rtn-web-browser` require a minimum iOS deployment target of `13.0`, open the _Podfile_ located in the _ios_ directory and update the `target` value:
+      ```diff
+      - platform :ios, min_ios_version_supported
+      + platform :ios, 13.0
+      ```
+    </Accordion.Content>
+    </Accordion.Item>
+  </Accordion.Container>
 
   Then install the iOS cocoapods, by running:
 

--- a/docs/src/pages/[platform]/getting-started/installation/dependencies.mdx
+++ b/docs/src/pages/[platform]/getting-started/installation/dependencies.mdx
@@ -1,6 +1,6 @@
 import { InlineFilter } from '@/components/InlineFilter';
 import { Example, ExampleCode } from '@/components/Example';
-import { Alert, Link, Text, Tabs } from '@aws-amplify/ui-react';
+import {Accordion, Alert, Link, Text, Tabs } from '@aws-amplify/ui-react';
 import { InstallScripts, TerminalCommand } from '@/components/InstallScripts.tsx';
 
 <InlineFilter filters={['android']}>
@@ -86,12 +86,21 @@ import { InstallScripts, TerminalCommand } from '@/components/InstallScripts.tsx
 
   <InstallScripts command="npm install @aws-amplify/rtn-web-browser" framework="react-native" />
 
-  `@aws-amplify/react-native` and `@aws-amplify/rtn-web-browser` require a minimum iOS deployment target of `13.0`, open the _Podfile_ located in the _ios_ directory and update the `target` value:
-
-  ```diff
-  - platform :ios, min_ios_version_supported
-  + platform :ios, 13.0
-  ```
+  <Accordion.Container>
+    <Accordion.Item value="Accordion-item">
+      <Accordion.Trigger>
+        Important note for integration with React Native projects using version `0.72` or below
+        <Accordion.Icon />
+      </Accordion.Trigger>
+    <Accordion.Content>
+      `@aws-amplify/react-native` and `@aws-amplify/rtn-web-browser` require a minimum iOS deployment target of `13.0`, open the _Podfile_ located in the _ios_ directory and update the `target` value:
+      ```diff
+      - platform :ios, min_ios_version_supported
+      + platform :ios, 13.0
+      ```
+    </Accordion.Content>
+    </Accordion.Item>
+  </Accordion.Container>
 
   Then install the iOS cocoapods, by running:
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
A React Native specific Getting Started callout was added at the release of `aws-amplify@6` as it introduced two new React Native packages, `@aws-amplify/react-native` and `@aws-amplify/rtn-web-browser`, both of which required consumers to manually updated the iOS deployment target to meet the version required by the packages.

Starting with React Native version `0.73`, the callout is no longer required as version `0.73` ships with an iOS deployment target that meets the version required by the new packages.

As React Native version `<0.73` are still supported, move the callout in to an `Accordion` and highlight that it is only required for projects using React Native version `0.72` or below

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual validation of both pages where the callout exists

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
