### PR TITLE
fix(ui/liveness): fix flex-direction of landscape error message

### DIFF
--- a/.changeset/young-plums-fold.md
+++ b/.changeset/young-plums-fold.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+fix(ui/liveness): fix flex-direction of landscape error message in FaceLiveness component

--- a/packages/ui/src/theme/css/component/liveness.scss
+++ b/packages/ui/src/theme/css/component/liveness.scss
@@ -279,7 +279,7 @@
 
 .amplify-liveness-landscape-error-modal {
   background-color: var(--amplify-colors-background-primary);
-  direction: column;
+  flex-direction: column;
   text-align: center;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

The flex-direction was not set properly on `.amplify-liveness-landscape-error-modal {}`

**Before**
<img width="300" src="https://github.com/aws-amplify/amplify-ui/assets/376920/fdfc8ee4-712b-44c3-9655-384cfd142008" />

**After**
<img width="300" src="https://github.com/aws-amplify/amplify-ui/assets/376920/7f290eb0-1800-442d-8444-a05f7d8b6367" />

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
