### PR TITLE
fix(e2e): add extended assertion timeout util for liveness

### DIFF
--- a/packages/e2e/cypress/integration/common/liveness.ts
+++ b/packages/e2e/cypress/integration/common/liveness.ts
@@ -1,0 +1,14 @@
+import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { escapeRegExp } from 'lodash';
+
+// the current value returned by the service is 15000,
+// the below value can be increased as needed
+const LIVENESS_TIMEOUT = 16000;
+
+Then('I see the {string} timeout error', (message: string) => {
+  cy.findByRole('document')
+    .contains(new RegExp(escapeRegExp(message), 'i'), {
+      timeout: LIVENESS_TIMEOUT,
+    })
+    .should('exist');
+});

--- a/packages/e2e/cypress/integration/common/liveness.ts
+++ b/packages/e2e/cypress/integration/common/liveness.ts
@@ -3,7 +3,7 @@ import { escapeRegExp } from 'lodash';
 
 // the current value returned by the service is 15000,
 // the below value can be increased as needed
-const LIVENESS_TIMEOUT = 16000;
+const LIVENESS_TIMEOUT = 60000;
 
 Then('I see the {string} timeout error', (message: string) => {
   cy.findByRole('document')

--- a/packages/e2e/features/ui/components/liveness/disable-start-screen.feature
+++ b/packages/e2e/features/ui/components/liveness/disable-start-screen.feature
@@ -13,6 +13,6 @@ Feature: Disable Start Screen
   Scenario: See camera module and instructions
       Then I see "liveness-detector" element
       Then I see "connecting"
-      Then I see "Face didn't fit inside oval in time limit."
+      Then I see the "Face didn't fit inside oval in time limit." timeout error
       Then I click the "Try again" button
       Then I see "Loading"

--- a/packages/e2e/features/ui/components/liveness/disable-start-screen.feature
+++ b/packages/e2e/features/ui/components/liveness/disable-start-screen.feature
@@ -9,7 +9,7 @@ Feature: Disable Start Screen
   Scenario: See camera module and close with the close icon
       Then I see "Loading"
 
-  @react @skip
+  @react
   Scenario: See camera module and instructions
       Then I see "liveness-detector" element
       Then I see "connecting"

--- a/packages/e2e/features/ui/components/liveness/liveness-detector.feature
+++ b/packages/e2e/features/ui/components/liveness/liveness-detector.feature
@@ -24,6 +24,6 @@ Feature: Liveness Detector
       Then I see "liveness-detector" element
       Then I see "connecting"
       Then I see "Move closer"
-      Then I see "Face didn't fit inside oval in time limit."
+      Then I see the "Face didn't fit inside oval in time limit." timeout error
       Then I click the "Try again" button
       Then I see the "Start video check" button

--- a/packages/e2e/features/ui/components/liveness/liveness-detector.feature
+++ b/packages/e2e/features/ui/components/liveness/liveness-detector.feature
@@ -18,7 +18,7 @@ Feature: Liveness Detector
       Then I click the "close-icon"
       Then I see the "Start video check" button
 
-  @react @skip
+  @react
   Scenario: See camera module and instructions
       Then I click the "Start video check" button
       Then I see "liveness-detector" element

--- a/packages/e2e/features/ui/components/liveness/with-credential-provider.feature
+++ b/packages/e2e/features/ui/components/liveness/with-credential-provider.feature
@@ -17,6 +17,6 @@ Liveness component supports using a custom credential provider.
       Then I see "liveness-detector" element
       Then I see "connecting"
       Then I see "Move closer"
-      Then I see "Face didn't fit inside oval in time limit."
+      Then I see the "Face didn't fit inside oval in time limit." timeout error
       Then I click the "Try again" button
       Then I see the "Start video check" button

--- a/packages/e2e/features/ui/components/liveness/with-credential-provider.feature
+++ b/packages/e2e/features/ui/components/liveness/with-credential-provider.feature
@@ -11,7 +11,7 @@ Liveness component supports using a custom credential provider.
       Then I click the "close-icon"
       Then I see the "Start video check" button
 
-  @react @skip
+  @react
   Scenario: See camera module and instructions
       Then I click the "Start video check" button
       Then I see "liveness-detector" element


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add a new cucumber util for extended assertion timeouts for error toasts. Also reverts https://github.com/aws-amplify/amplify-ui/pull/5061

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Run e2e tests locally
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
