### PR TITLE
fix(react-liveness): use Uint8Array for VideoChunk

### DIFF
--- a/.changeset/slow-pumpkins-notice.md
+++ b/.changeset/slow-pumpkins-notice.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react-liveness': patch
+---
+
+fix type of empty VideoChunk

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
@@ -2,6 +2,7 @@ import { getAmplifyUserAgent } from '@aws-amplify/core/internals/utils';
 import { fetchAuthSession } from 'aws-amplify/auth';
 import {
   ClientSessionInformationEvent,
+  LivenessRequestStream,
   LivenessResponseStream,
   RekognitionStreamingClient,
   RekognitionStreamingClientConfig,
@@ -154,7 +155,7 @@ export class LivenessStreamProvider {
   // Creates a generator from a stream of video chunks and livenessActionDocuments and yields VideoEvent and ClientEvents
   private getAsyncGeneratorFromReadableStream(
     stream: ReadableStream
-  ): () => AsyncGenerator<any> {
+  ): () => AsyncGenerator<LivenessRequestStream> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const current = this;
     this._reader = stream.getReader();
@@ -171,7 +172,7 @@ export class LivenessStreamProvider {
           // sending an empty video chunk signals that we have ended sending video
           yield {
             VideoEvent: {
-              VideoChunk: [],
+              VideoChunk: new Uint8Array([]),
               TimestampMillis: Date.now(),
             },
           };
@@ -195,7 +196,7 @@ export class LivenessStreamProvider {
         } else if (isEndStreamWithCodeEvent(value)) {
           yield {
             VideoEvent: {
-              VideoChunk: [],
+              VideoChunk: new Uint8Array([]),
               TimestampMillis: { closeCode: value.code },
             },
           };

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
@@ -197,7 +197,9 @@ export class LivenessStreamProvider {
           yield {
             VideoEvent: {
               VideoChunk: new Uint8Array([]),
-              TimestampMillis: { closeCode: value.code },
+              // this is a custom type that does not match LivenessRequestStream.
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              TimestampMillis: { closeCode: value.code } as any,
             },
           };
         }


### PR DESCRIPTION
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md

#### Description of changes

Change empty VideoChunk from `[]` to `new Uint8Array([])`, and use typed AsyncIterator instead of `any`.

#### Issue #, if available

https://github.com/smithy-lang/smithy-typescript/pull/1185
https://github.com/aws-amplify/amplify-ui/issues/5057
https://github.com/aws-amplify/amplify-ui/issues/5058

#### Description of how you validated changes

Updated behavior and unit tests in https://github.com/smithy-lang/smithy-typescript/pull/1185.

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
