### PR TITLE
chore(deps): update peerDep versions in public packages, point installed version to latest

### DIFF
--- a/.changeset/tricky-eels-tie.md
+++ b/.changeset/tricky-eels-tie.md
@@ -15,4 +15,4 @@
 "@aws-amplify/ui-angular": patch
 ---
 
-[DRAFT] chore(deps): update peerDep versions in public packages, point to latest for examples and docs
+chore(deps): update peerDep versions in public packages, point to 6.0.26 for examples and docs

--- a/.changeset/tricky-eels-tie.md
+++ b/.changeset/tricky-eels-tie.md
@@ -1,0 +1,18 @@
+---
+"@aws-amplify/ui-react-auth": patch
+"@aws-amplify/ui-react-core-auth": patch
+"@aws-amplify/ui-react-core-notifications": patch
+"@aws-amplify/ui-react-core": patch
+"@aws-amplify/ui-react-geo": patch
+"@aws-amplify/ui-react-liveness": patch
+"@aws-amplify/ui-react-native-auth": patch
+"@aws-amplify/ui-react-native": patch
+"@aws-amplify/ui-react-notifications": patch
+"@aws-amplify/ui-react-storage": patch
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+"@aws-amplify/ui-vue": patch
+"@aws-amplify/ui-angular": patch
+---
+
+[DRAFT] chore(deps): update peerDep versions in public packages, point to latest for examples and docs

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,6 @@
     "@mdx-js/loader": "^2.1.0",
     "@mdx-js/mdx": "^2.1.0",
     "@mdx-js/react": "^2.1.0",
-    "aws-amplify": "latest",
     "countries-list": "^2.6.1",
     "dotenv": "^16.0.0",
     "gray-matter": "^4.0.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "@mdx-js/loader": "^2.1.0",
     "@mdx-js/mdx": "^2.1.0",
     "@mdx-js/react": "^2.1.0",
-    "aws-amplify": "^6.0.6",
+    "aws-amplify": "latest",
     "countries-list": "^2.6.1",
     "dotenv": "^16.0.0",
     "gray-matter": "^4.0.3",

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -21,7 +21,6 @@
     "@angular/platform-browser-dynamic": "^14.3.0",
     "@angular/router": "^14.3.0",
     "@aws-amplify/ui-angular": "^5.0.12",
-    "aws-amplify": "latest",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.4"

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser-dynamic": "^14.3.0",
     "@angular/router": "^14.3.0",
     "@aws-amplify/ui-angular": "^5.0.12",
-    "aws-amplify": "^6.0.6",
+    "aws-amplify": "latest",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.4"

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -17,7 +17,6 @@
     "@aws-amplify/ui-react-notifications": "^2.0.14",
     "@aws-amplify/ui-react-storage": "^3.0.16",
     "@aws-sdk/credential-providers": "^3.370.0",
-    "aws-amplify": "latest",
     "next": "^13.5.5",
     "next-global-css": "^1.1.1",
     "react": "18.2.0",

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@aws-amplify/geo": "latest",
     "@aws-amplify/ui-react": "^6.1.6",
     "@aws-amplify/ui-react-geo": "^2.0.12",
     "@aws-amplify/ui-react-liveness": "^3.0.16",

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -10,14 +10,13 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@aws-amplify/geo": "^3.0.1",
     "@aws-amplify/ui-react": "^6.1.6",
     "@aws-amplify/ui-react-geo": "^2.0.12",
     "@aws-amplify/ui-react-liveness": "^3.0.16",
     "@aws-amplify/ui-react-notifications": "^2.0.14",
     "@aws-amplify/ui-react-storage": "^3.0.16",
     "@aws-sdk/credential-providers": "^3.370.0",
-    "aws-amplify": "^6.0.6",
+    "aws-amplify": "latest",
     "next": "^13.5.5",
     "next-global-css": "^1.1.1",
     "react": "18.2.0",

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -21,7 +21,6 @@
     "@react-native-async-storage/async-storage": "^1.17.5",
     "@react-native-community/netinfo": "^8.3.0",
     "@xstate/react": "^3.2.2",
-    "aws-amplify": "latest",
     "react": "18.2.0",
     "react-native": "0.71.16",
     "react-native-get-random-values": "^1.9.0",

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -12,8 +12,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-amplify/react-native": "1.0.2",
-    "@aws-amplify/rtn-web-browser": "1.0.2",
+    "@aws-amplify/react-native": "latest",
+    "@aws-amplify/rtn-web-browser": "latest",
     "@aws-amplify/ui": "*",
     "@aws-amplify/ui-react-core": "*",
     "@aws-amplify/ui-react-core-notifications": "*",
@@ -21,7 +21,7 @@
     "@react-native-async-storage/async-storage": "^1.17.5",
     "@react-native-community/netinfo": "^8.3.0",
     "@xstate/react": "^3.2.2",
-    "aws-amplify": "^6.0.6",
+    "aws-amplify": "latest",
     "react": "18.2.0",
     "react-native": "0.71.16",
     "react-native-get-random-values": "^1.9.0",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@aws-amplify/ui-vue": "^4.2.3",
-    "aws-amplify": "latest",
     "vue": "^3.0.5",
     "vue-router": "4"
   },

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-vue": "^4.2.3",
-    "aws-amplify": "^6.0.6",
+    "aws-amplify": "latest",
     "vue": "^3.0.5",
     "vue-router": "4"
   },

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@types/fs-extra": "11.0.3",
     "@types/jest": "^29.5.5",
     "@types/react-test-renderer": "^18.0.2",
+    "aws-amplify": "latest",
     "esbuild-register": "^3.5.0",
     "eslint": "^8.44.0",
     "fs-extra": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@types/fs-extra": "11.0.3",
     "@types/jest": "^29.5.5",
     "@types/react-test-renderer": "^18.0.2",
-    "aws-amplify": "latest",
+    "aws-amplify": "6.0.26",
     "esbuild-register": "^3.5.0",
     "eslint": "^8.44.0",
     "fs-extra": "^11.1.1",

--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@angular/core": ">= 14.0.0",
-    "aws-amplify": "^6.0.1"
+    "aws-amplify": "^6.0.26"
   },
   "dependencies": {
     "@aws-amplify/ui": "6.0.12",

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -49,7 +49,7 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },

--- a/packages/react-core-auth/package.json
+++ b/packages/react-core-auth/package.json
@@ -40,7 +40,7 @@
     "xstate": "^4.33.6"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "react": "^16.14.0 || ^17.0 || ^18.0"
   },
   "sideEffects": false

--- a/packages/react-core-notifications/package.json
+++ b/packages/react-core-notifications/package.json
@@ -39,7 +39,7 @@
     "@aws-amplify/ui-react-core": "3.0.12"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "react": "^16.14.0 || ^17.0 || ^18.0"
   },
   "sideEffects": false

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -40,7 +40,7 @@
     "xstate": "^4.33.6"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "react": "^16.14.0 || ^17.0 || ^18.0"
   },
   "sideEffects": false

--- a/packages/react-geo/package.json
+++ b/packages/react-geo/package.json
@@ -52,6 +52,7 @@
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },
   "devDependencies": {
+    "@aws-amplify/geo": "^3.0.26",
     "@types/mapbox__mapbox-gl-draw": "^1.3.3"
   },
   "sideEffects": [

--- a/packages/react-geo/package.json
+++ b/packages/react-geo/package.json
@@ -47,12 +47,12 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
+    "@aws-amplify/geo": "^3.0.26",
     "aws-amplify": "^6.0.26",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },
   "devDependencies": {
-    "@aws-amplify/geo": "^3.0.26",
     "@types/mapbox__mapbox-gl-draw": "^1.3.3"
   },
   "sideEffects": [

--- a/packages/react-geo/package.json
+++ b/packages/react-geo/package.json
@@ -47,8 +47,7 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
-    "@aws-amplify/geo": "^3.0.2",
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },

--- a/packages/react-geo/src/components/MapView/MapView.tsx
+++ b/packages/react-geo/src/components/MapView/MapView.tsx
@@ -1,11 +1,12 @@
-import { Amplify } from 'aws-amplify';
-import { fetchAuthSession } from 'aws-amplify/auth';
 import React, { forwardRef, useEffect, useMemo, useState } from 'react';
+import { Amplify, ResourcesConfig } from 'aws-amplify';
+import { fetchAuthSession } from 'aws-amplify/auth';
 import maplibregl from 'maplibre-gl';
 import { AmplifyMapLibreRequest } from 'maplibre-gl-js-amplify';
 import ReactMapGL from 'react-map-gl';
 import type { MapProps, MapRef, TransformRequestFunction } from 'react-map-gl';
-import { GeoConfig } from '@aws-amplify/geo';
+
+interface GeoConfig extends NonNullable<ResourcesConfig['Geo']> {}
 
 interface MapViewProps extends Omit<MapProps, 'mapLib' | 'transformRequest'> {
   // replace `any` typed MapProps.mapLib

--- a/packages/react-liveness/package.json
+++ b/packages/react-liveness/package.json
@@ -42,7 +42,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },

--- a/packages/react-native-auth/package.json
+++ b/packages/react-native-auth/package.json
@@ -34,7 +34,7 @@
     "qrcode": "1.5.0"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "react": "^18",
     "react-native": "^0.70 || ^0.71 || ^0.72"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -34,7 +34,7 @@
     "@aws-amplify/ui-react-core-notifications": "2.0.12"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "react-native": "^0.70 || ^0.71 || ^0.72 || ^0.73",
     "react-native-safe-area-context": "^4.2.5"
   },

--- a/packages/react-notifications/package.json
+++ b/packages/react-notifications/package.json
@@ -45,7 +45,7 @@
     "tinycolor2": "1.4.2"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -46,7 +46,7 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,7 +60,7 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,7 +50,7 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.2",
+    "aws-amplify": "^6.0.26",
     "xstate": "^4.33.6"
   },
   "peerDependenciesMeta": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -68,7 +68,7 @@
     "vue-tsc": "~0.40.10"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.0.1",
+    "aws-amplify": "^6.0.26",
     "vue": "^3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,6 +518,16 @@
     rxjs "^7.8.1"
     ulid "^2.3.0"
 
+"@aws-amplify/geo@^3.0.26", "@aws-amplify/geo@latest":
+  version "3.0.26"
+  resolved "https://registry.npmjs.org/@aws-amplify/geo/-/geo-3.0.26.tgz#8b9a6d3749638ac2db57123fbf62d930a8dbfdc0"
+  integrity sha512-Pbj70HmZAvA848H8d+7k5g8v3nM+X1OY8eR/nMyFjoavbVHDom3cvVzz3lMQXRhm8UGQ3PPawfG8PEjD+UqnXw==
+  dependencies:
+    "@aws-sdk/client-location" "3.398.0"
+    "@turf/boolean-clockwise" "6.5.0"
+    camelcase-keys "6.2.2"
+    tslib "^2.5.0"
+
 "@aws-amplify/notifications@2.0.26":
   version "2.0.26"
   resolved "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.26.tgz#510f9e53925602201bb699fc61b2264d3a0872b1"
@@ -766,6 +776,49 @@
     "@smithy/util-retry" "^2.0.0"
     "@smithy/util-utf8" "^2.0.0"
     "@smithy/util-waiter" "^2.0.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/client-location@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.398.0.tgz#d37029485e3e7a69f1daa9d5d7ffda4b3fa2da01"
+  integrity sha512-DvXRkg3hjtr2Npmu201CGIqXYWX189wc0tCVRE/kmc0i7q33U3szsXhzuh7/4W4SsmV9DeFOZ0HCxqBtkq6UKA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/client-sts" "3.398.0"
+    "@aws-sdk/credential-provider-node" "3.398.0"
+    "@aws-sdk/middleware-host-header" "3.398.0"
+    "@aws-sdk/middleware-logger" "3.398.0"
+    "@aws-sdk/middleware-recursion-detection" "3.398.0"
+    "@aws-sdk/middleware-signing" "3.398.0"
+    "@aws-sdk/middleware-user-agent" "3.398.0"
+    "@aws-sdk/types" "3.398.0"
+    "@aws-sdk/util-endpoints" "3.398.0"
+    "@aws-sdk/util-user-agent-browser" "3.398.0"
+    "@aws-sdk/util-user-agent-node" "3.398.0"
+    "@smithy/config-resolver" "^2.0.5"
+    "@smithy/fetch-http-handler" "^2.0.5"
+    "@smithy/hash-node" "^2.0.5"
+    "@smithy/invalid-dependency" "^2.0.5"
+    "@smithy/middleware-content-length" "^2.0.5"
+    "@smithy/middleware-endpoint" "^2.0.5"
+    "@smithy/middleware-retry" "^2.0.5"
+    "@smithy/middleware-serde" "^2.0.5"
+    "@smithy/middleware-stack" "^2.0.0"
+    "@smithy/node-config-provider" "^2.0.5"
+    "@smithy/node-http-handler" "^2.0.5"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/smithy-client" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    "@smithy/url-parser" "^2.0.5"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.1.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.5"
+    "@smithy/util-defaults-mode-node" "^2.0.5"
+    "@smithy/util-retry" "^2.0.0"
+    "@smithy/util-stream" "^2.0.5"
+    "@smithy/util-utf8" "^2.0.0"
     tslib "^2.5.0"
 
 "@aws-sdk/client-personalize-events@3.398.0":
@@ -7380,6 +7433,14 @@
     "@turf/helpers" "^6.5.0"
     "@turf/invariant" "^6.5.0"
 
+"@turf/boolean-clockwise@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-6.5.0.tgz#34573ecc18f900080f00e4ff364631a8b1135794"
+  integrity sha512-45+C7LC5RMbRWrxh3Z0Eihsc8db1VGBO5d9BLTOAwU4jR6SgsunTfRWR16X7JUwIDYlCVEmnjcXJNi/kIU3VIw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
 "@turf/circle@^6.0.1", "@turf/circle@^6.5.0":
   version "6.5.0"
   resolved "https://registry.npmjs.org/@turf/circle/-/circle-6.5.0.tgz#dc017d8c0131d1d212b7c06f76510c22bbeb093c"
@@ -10246,7 +10307,7 @@ camel-case@^4.1.2:
     pascal-case "^3.1.2"
     tslib "^2.0.3"
 
-camelcase-keys@^6.2.2:
+camelcase-keys@6.2.2, camelcase-keys@^6.2.2:
   version "6.2.2"
   resolved "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
   integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,10 +436,10 @@
   resolved "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz#70e45678f06c72fa2e350e8553ec4a4d72b92e06"
   integrity sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==
 
-"@aws-amplify/analytics@7.0.17":
-  version "7.0.17"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/analytics/-/analytics-7.0.17.tgz#db79396b539b7189ffb72ab440167025344afe0a"
-  integrity sha512-GNT/jyztx61FQ1Xr7V18llDRpBSFqTHk8WcshCDFm9ZQAXC1TvnpxavoKIolBeXTpPJ0L3HJ7X3TxvWnUYkYIQ==
+"@aws-amplify/analytics@7.0.26":
+  version "7.0.26"
+  resolved "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.26.tgz#8f4620ae1b6929568fa90f8c8976075232d345b4"
+  integrity sha512-I9YPTVVtaV525GGhTzbFkL8wSoLNfW2fc1uKIWZ6hpGsvvPVzoHhfShf26fjyIeKu9w6KK0ZT/0dlwGWgnJiRQ==
   dependencies:
     "@aws-sdk/client-firehose" "3.398.0"
     "@aws-sdk/client-kinesis" "3.398.0"
@@ -447,47 +447,47 @@
     "@smithy/util-utf8" "2.0.0"
     tslib "^2.5.0"
 
-"@aws-amplify/api-graphql@4.0.17":
-  version "4.0.17"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/api-graphql/-/api-graphql-4.0.17.tgz#1f93d5e4aa3947935c4424c8464f392ad1420e09"
-  integrity sha512-/3g5GJ1vvDoux1SPHzrDWghoJR101EKhUnjgt5+uS7+zcLJlT6s5mOz0unhMD5Phvtjhcc33sukoC7A7y3xAYA==
+"@aws-amplify/api-graphql@4.0.26":
+  version "4.0.26"
+  resolved "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.0.26.tgz#97b5d27110320682d0d500e6bfb8165e2c5070c0"
+  integrity sha512-Oi7dM6hBGvIzpya4q3b7pDiiFwEFBODSyTrRfElCL5ncyPya6zqy0BdxthsjBrp9ISSpDLfR7utQadhAqF4Vjw==
   dependencies:
-    "@aws-amplify/api-rest" "4.0.17"
-    "@aws-amplify/core" "6.0.17"
-    "@aws-amplify/data-schema-types" "^0.7.2"
+    "@aws-amplify/api-rest" "4.0.26"
+    "@aws-amplify/core" "6.0.26"
+    "@aws-amplify/data-schema-types" "^0.7.11"
     "@aws-sdk/types" "3.387.0"
     graphql "15.8.0"
     rxjs "^7.8.1"
     tslib "^2.5.0"
     uuid "^9.0.0"
 
-"@aws-amplify/api-rest@4.0.17":
-  version "4.0.17"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/api-rest/-/api-rest-4.0.17.tgz#1c6f8e5923abb7c06b69e3e020ce82257fe29e0e"
-  integrity sha512-cpl9sIn7pJscnHmQa5LYd2gdItuWu4pJ/zjsRXXhp1/Or2iX0fxUs1r3oPEq+eDjSmDmO5c89bQbNO4spqgs0g==
+"@aws-amplify/api-rest@4.0.26":
+  version "4.0.26"
+  resolved "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.26.tgz#3fbbf10f1a3737ee44aa8f37b0cec8b705eb4398"
+  integrity sha512-hlurqFHx3g+I513RIJWmH5Z4ShKpOWsMLv5sNhlKUyLVpAlk0YNFWsstIY7Zx0sREHaLU1Tlx0C/wZV0sc2ZsQ==
   dependencies:
     tslib "^2.5.0"
 
-"@aws-amplify/api@6.0.17":
-  version "6.0.17"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/api/-/api-6.0.17.tgz#e1ee9275fba09646e6ec72226c8b5c8f1375019f"
-  integrity sha512-76PvRRhbkzenr2X5a9DNupFKu6kBmbZ0KI0yFqaqXdAMQjvtm8GrqY/1yFnMcSqHH8mlUmexYP8lKrOX5sZqmQ==
+"@aws-amplify/api@6.0.26":
+  version "6.0.26"
+  resolved "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.26.tgz#bc3f7dc42b93f8c2e5a79466ccb07ee631155d4c"
+  integrity sha512-5TNvJc743i96fkgbuEyiv0FtyWrtZlwoIzlkhPQBa0kydp1XLzUOYDrctNuIlbgh4ZsUbzilln+5i3BvGGWjOQ==
   dependencies:
-    "@aws-amplify/api-graphql" "4.0.17"
-    "@aws-amplify/api-rest" "4.0.17"
+    "@aws-amplify/api-graphql" "4.0.26"
+    "@aws-amplify/api-rest" "4.0.26"
     tslib "^2.5.0"
 
-"@aws-amplify/auth@6.0.17":
-  version "6.0.17"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/auth/-/auth-6.0.17.tgz#3afbffb201c17548d57d9e17ff4d7afd118ca17e"
-  integrity sha512-VnksOAjBRm/TskkSjkLq7rzGJItpT2oDlUIddzGlGeILAumpTpv2PX5Jx3tfqghsQpn9kXE1AP8YgpOhuVDIDw==
+"@aws-amplify/auth@6.0.26":
+  version "6.0.26"
+  resolved "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.0.26.tgz#881cbe591db870af8bdec2890bb3711f3623612c"
+  integrity sha512-GaJWP8pP6eTuLNJzE+Usip7OANyEIG/vVc7C4Pw9ghG2sRbmWPpK7gNx/fs11ies8hH1ETy0O/j8Dumetop6tQ==
   dependencies:
     tslib "^2.5.0"
 
-"@aws-amplify/core@6.0.17":
-  version "6.0.17"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/core/-/core-6.0.17.tgz#79367fcca4e1b516d457ac96ad1d2f68b126e015"
-  integrity sha512-ruQuDN6owk6z3R6baQf/JV391DkgJr6IP0n/BdiiQR+jeLLoHtQbWrMUfVR4wwyIYSPph6fH2PMvggutAkD1fw==
+"@aws-amplify/core@6.0.26":
+  version "6.0.26"
+  resolved "https://registry.npmjs.org/@aws-amplify/core/-/core-6.0.26.tgz#dd3d58e39e9917b1074a145fd1fa17840359ca0b"
+  integrity sha512-5O4pnoZPhLZde5XjxDzJpgYMNf9EJI9+PEp1qFTTUBD+dLfVOFntS0Vu4t0mSCDhs8ZaYnkY59EjoBt9C29HRw==
   dependencies:
     "@aws-crypto/sha256-js" "5.2.0"
     "@aws-sdk/types" "3.398.0"
@@ -498,51 +498,38 @@
     tslib "^2.5.0"
     uuid "^9.0.0"
 
-"@aws-amplify/data-schema-types@^0.7.2":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.7.5.tgz#5bfc46b7231290fe2ed6224ec13e16e5409c4c9d"
-  integrity sha512-C6kd+w1/D/+SEyFa7a/SaOwfNK4lewsSM54Lm8KozDDLNWtVTYcMieDy4Gw+S4O/J/7u3cF40regAnh2x/jGtg==
+"@aws-amplify/data-schema-types@^0.7.11":
+  version "0.7.14"
+  resolved "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-0.7.14.tgz#75504d040d7a85e1d1328e388f35e5ebd02572f4"
+  integrity sha512-zvo1j6NljHsV62KnEz560rTx9jJ1KfTz0OOqZjW/CP1AtWdlakM2ADBAn9z4AL+bKrt31CrAr55ZOAo6Uk+LTw==
   dependencies:
+    "@aws-amplify/plugin-types" "^0.9.0-beta.1"
     rxjs "^7.8.1"
 
-"@aws-amplify/datastore@5.0.17":
-  version "5.0.17"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/datastore/-/datastore-5.0.17.tgz#baabb30423b3ac94308829a26acbb91c59f9de42"
-  integrity sha512-bzV24IueXIBAy4+UAi90bZeSPHcVKmUWr05Y5MCB/GzX0TibppkE0FdE3zgMXk0pRcxzmxG+Bg6dUh5Nkco4Ow==
+"@aws-amplify/datastore@5.0.26":
+  version "5.0.26"
+  resolved "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.26.tgz#9f611e4513947922c8354fe5c2c935aa82083243"
+  integrity sha512-dKteLFPGOyRGNwfm2EeFkXGSybHhgpzwXKkvYbn20+vHhCx51Bsj6LzPk5W5RHSbnXCwo+JYPPXiQV8sBrc1Sw==
   dependencies:
-    "@aws-amplify/api" "6.0.17"
+    "@aws-amplify/api" "6.0.26"
     buffer "4.9.2"
     idb "5.0.6"
     immer "9.0.6"
     rxjs "^7.8.1"
     ulid "^2.3.0"
 
-"@aws-amplify/geo@^3.0.1":
-  version "3.0.17"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/geo/-/geo-3.0.17.tgz#3f12af103d3010d936bcf561b1b1a1aa3324d83c"
-  integrity sha512-RLfGUN94LLjN3RuRGa29amRGYS9Lmnfp5UiZCsi78oM87PW0li91Up+9yxlbDfCIjC1bOffbQcMJY6ZAVTIdXw==
-  dependencies:
-    "@aws-sdk/client-location" "3.398.0"
-    "@turf/boolean-clockwise" "6.5.0"
-    camelcase-keys "6.2.2"
-    tslib "^2.5.0"
-
-"@aws-amplify/notifications@2.0.17":
-  version "2.0.17"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/notifications/-/notifications-2.0.17.tgz#5657f89021e53c33b1abfd4d309510836bb8eb08"
-  integrity sha512-xi+cm/b3KQInD/U4f3xmxcbzqOm1kbbkF6GPG1Bt62MEnEjVQqcXOMS0zfUpa5OKp8ocaDSlZR+RQzVy6moFSQ==
+"@aws-amplify/notifications@2.0.26":
+  version "2.0.26"
+  resolved "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.26.tgz#510f9e53925602201bb699fc61b2264d3a0872b1"
+  integrity sha512-RHgz/E3rrXd/B4xri5yg8kvv5B1OLsb88eBzAmirowSj+2KN5rhJYj/bp86DqdPiJKEdS2x1UJD6pW8D+73phA==
   dependencies:
     lodash "^4.17.21"
     tslib "^2.5.0"
 
-"@aws-amplify/react-native@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/react-native/-/react-native-1.0.2.tgz#521db96bd9784bf4a813c2c9631a4eff4f597198"
-  integrity sha512-HQdJZAgVwdxrMfzwtrqRUnmO1ahPJsYlKyTlgnwGH2nTi8yo1dNzv1B0haw8QMC1t9tUSZnR1UkUmivLRmqlug==
-  dependencies:
-    base-64 "^1.0.0"
-    buffer "^6.0.3"
-    react-native-url-polyfill "^2.0.0"
+"@aws-amplify/plugin-types@^0.9.0-beta.1":
+  version "0.9.0-beta.1"
+  resolved "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-0.9.0-beta.1.tgz#066af0646b379b4c999668253e87754e67fc7427"
+  integrity sha512-5eJ2SYoXbq4ZSvBjCgStXSejNOKuBkxYVXqOXZP4xP5C9iIpUYG36s9xP+IdhWDm9K/yxklp8OUMr8YGc0g7tw==
 
 "@aws-amplify/react-native@^1.0.1":
   version "1.0.17"
@@ -553,15 +540,24 @@
     buffer "^6.0.3"
     react-native-url-polyfill "^2.0.0"
 
-"@aws-amplify/rtn-web-browser@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/rtn-web-browser/-/rtn-web-browser-1.0.2.tgz#32de308b2efd7b24f484c8d51443aea26fdbdaf1"
-  integrity sha512-r0GceWySsvoR9nkk3PDObSr4fOvMcvJpfcfxoVfYgPLks//iXDRTnRz6sP4OMvCior7KwHekUnuOYcRpLQnxuw==
+"@aws-amplify/react-native@latest":
+  version "1.0.27"
+  resolved "https://registry.npmjs.org/@aws-amplify/react-native/-/react-native-1.0.27.tgz#a0b0d33ab095183f74ab8e495f203d6338addb69"
+  integrity sha512-lIUDE92ML0ZwJev6mnHCGCWFLGihlJXEB8YfE8tv+ek+uGxbfjhOlHwY2jTCG0C88ZMN8y9uvAXsEjt2fZPPoQ==
+  dependencies:
+    base-64 "^1.0.0"
+    buffer "^6.0.3"
+    react-native-url-polyfill "^2.0.0"
 
-"@aws-amplify/storage@6.0.17":
-  version "6.0.17"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/storage/-/storage-6.0.17.tgz#a94e51ffb4f45cda58073a2c48f21cfdb2b11670"
-  integrity sha512-WUXKQ1q5BrxJtR9of7ffqQmZT/v2YaIvl7kJcQKMiTJ6Sk/lKb2lNncpaIHu4nl89j7tgCaqJiGVuB76HqybSg==
+"@aws-amplify/rtn-web-browser@latest":
+  version "1.0.27"
+  resolved "https://registry.npmjs.org/@aws-amplify/rtn-web-browser/-/rtn-web-browser-1.0.27.tgz#a2b21b85e3e1a3d36a9e04357f062a3c6f83bf6f"
+  integrity sha512-k7e1BREqiRwzlOUH4KkDlsTVX4D3PLfUlOH86xWzIBe+2nZkqcFLjkOcgKemhl1EWjVymg2eiUT3d4q7jmeI8A==
+
+"@aws-amplify/storage@6.0.26":
+  version "6.0.26"
+  resolved "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.0.26.tgz#0f1790b0e673b8bfe3e476c905d845a121e65e47"
+  integrity sha512-SuInXMIId47s+yFtOBmuPJp2YZc015F/2sm8BYtfEV2XAmgtil/fXSn48hxAqiQsXQds913vE4PT03EVSbSzbg==
   dependencies:
     "@aws-sdk/types" "3.398.0"
     "@smithy/md5-js" "2.0.7"
@@ -770,49 +766,6 @@
     "@smithy/util-retry" "^2.0.0"
     "@smithy/util-utf8" "^2.0.0"
     "@smithy/util-waiter" "^2.0.5"
-    tslib "^2.5.0"
-
-"@aws-sdk/client-location@3.398.0":
-  version "3.398.0"
-  resolved "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.398.0.tgz#d37029485e3e7a69f1daa9d5d7ffda4b3fa2da01"
-  integrity sha512-DvXRkg3hjtr2Npmu201CGIqXYWX189wc0tCVRE/kmc0i7q33U3szsXhzuh7/4W4SsmV9DeFOZ0HCxqBtkq6UKA==
-  dependencies:
-    "@aws-crypto/sha256-browser" "3.0.0"
-    "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/client-sts" "3.398.0"
-    "@aws-sdk/credential-provider-node" "3.398.0"
-    "@aws-sdk/middleware-host-header" "3.398.0"
-    "@aws-sdk/middleware-logger" "3.398.0"
-    "@aws-sdk/middleware-recursion-detection" "3.398.0"
-    "@aws-sdk/middleware-signing" "3.398.0"
-    "@aws-sdk/middleware-user-agent" "3.398.0"
-    "@aws-sdk/types" "3.398.0"
-    "@aws-sdk/util-endpoints" "3.398.0"
-    "@aws-sdk/util-user-agent-browser" "3.398.0"
-    "@aws-sdk/util-user-agent-node" "3.398.0"
-    "@smithy/config-resolver" "^2.0.5"
-    "@smithy/fetch-http-handler" "^2.0.5"
-    "@smithy/hash-node" "^2.0.5"
-    "@smithy/invalid-dependency" "^2.0.5"
-    "@smithy/middleware-content-length" "^2.0.5"
-    "@smithy/middleware-endpoint" "^2.0.5"
-    "@smithy/middleware-retry" "^2.0.5"
-    "@smithy/middleware-serde" "^2.0.5"
-    "@smithy/middleware-stack" "^2.0.0"
-    "@smithy/node-config-provider" "^2.0.5"
-    "@smithy/node-http-handler" "^2.0.5"
-    "@smithy/protocol-http" "^2.0.5"
-    "@smithy/smithy-client" "^2.0.5"
-    "@smithy/types" "^2.2.2"
-    "@smithy/url-parser" "^2.0.5"
-    "@smithy/util-base64" "^2.0.0"
-    "@smithy/util-body-length-browser" "^2.0.0"
-    "@smithy/util-body-length-node" "^2.1.0"
-    "@smithy/util-defaults-mode-browser" "^2.0.5"
-    "@smithy/util-defaults-mode-node" "^2.0.5"
-    "@smithy/util-retry" "^2.0.0"
-    "@smithy/util-stream" "^2.0.5"
-    "@smithy/util-utf8" "^2.0.0"
     tslib "^2.5.0"
 
 "@aws-sdk/client-personalize-events@3.398.0":
@@ -7427,14 +7380,6 @@
     "@turf/helpers" "^6.5.0"
     "@turf/invariant" "^6.5.0"
 
-"@turf/boolean-clockwise@6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-clockwise/-/boolean-clockwise-6.5.0.tgz#34573ecc18f900080f00e4ff364631a8b1135794"
-  integrity sha512-45+C7LC5RMbRWrxh3Z0Eihsc8db1VGBO5d9BLTOAwU4jR6SgsunTfRWR16X7JUwIDYlCVEmnjcXJNi/kIU3VIw==
-  dependencies:
-    "@turf/helpers" "^6.5.0"
-    "@turf/invariant" "^6.5.0"
-
 "@turf/circle@^6.0.1", "@turf/circle@^6.5.0":
   version "6.5.0"
   resolved "https://registry.npmjs.org/@turf/circle/-/circle-6.5.0.tgz#dc017d8c0131d1d212b7c06f76510c22bbeb093c"
@@ -9635,18 +9580,18 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-amplify@^6.0.6:
-  version "6.0.17"
-  resolved "https://registry.yarnpkg.com/aws-amplify/-/aws-amplify-6.0.17.tgz#b8ace1dbbb09c5bb55128678a01848c57a799416"
-  integrity sha512-57tFeE89XsVIe+2zusu4SDXHMGkUbc5vs4hHahDimkMYaiQJFSJWZ7yhMVVmfL9sCEG8BQXUxp4q46qZkANOJw==
+aws-amplify@latest:
+  version "6.0.26"
+  resolved "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.0.26.tgz#93fa517cf124ba2c4dfe7e160c0a7192bba26e8c"
+  integrity sha512-kSKFUWNSvyIfJsSorUl3Rq5ANCsjTuZ7ML4RVHhcxi6bey6V3T3+JujerIgAzLeBoMQOF2lSrkHOOD9M2Qh2uQ==
   dependencies:
-    "@aws-amplify/analytics" "7.0.17"
-    "@aws-amplify/api" "6.0.17"
-    "@aws-amplify/auth" "6.0.17"
-    "@aws-amplify/core" "6.0.17"
-    "@aws-amplify/datastore" "5.0.17"
-    "@aws-amplify/notifications" "2.0.17"
-    "@aws-amplify/storage" "6.0.17"
+    "@aws-amplify/analytics" "7.0.26"
+    "@aws-amplify/api" "6.0.26"
+    "@aws-amplify/auth" "6.0.26"
+    "@aws-amplify/core" "6.0.26"
+    "@aws-amplify/datastore" "5.0.26"
+    "@aws-amplify/notifications" "2.0.26"
+    "@aws-amplify/storage" "6.0.26"
     tslib "^2.5.0"
 
 aws-sign2@~0.7.0:
@@ -10301,7 +10246,7 @@ camel-case@^4.1.2:
     pascal-case "^3.1.2"
     tslib "^2.0.3"
 
-camelcase-keys@6.2.2, camelcase-keys@^6.2.2:
+camelcase-keys@^6.2.2:
   version "6.2.2"
   resolved "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
   integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9641,7 +9641,7 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-amplify@latest:
+aws-amplify@6.0.26:
   version "6.0.26"
   resolved "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.0.26.tgz#93fa517cf124ba2c4dfe7e160c0a7192bba26e8c"
   integrity sha512-kSKFUWNSvyIfJsSorUl3Rq5ANCsjTuZ7ML4RVHhcxi6bey6V3T3+JujerIgAzLeBoMQOF2lSrkHOOD9M2Qh2uQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,7 +518,7 @@
     rxjs "^7.8.1"
     ulid "^2.3.0"
 
-"@aws-amplify/geo@^3.0.26", "@aws-amplify/geo@latest":
+"@aws-amplify/geo@latest":
   version "3.0.26"
   resolved "https://registry.npmjs.org/@aws-amplify/geo/-/geo-3.0.26.tgz#8b9a6d3749638ac2db57123fbf62d930a8dbfdc0"
   integrity sha512-Pbj70HmZAvA848H8d+7k5g8v3nM+X1OY8eR/nMyFjoavbVHDom3cvVzz3lMQXRhm8UGQ3PPawfG8PEjD+UqnXw==


### PR DESCRIPTION
…

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Upgrade `aws-amplify` depedencies:
- update all public package `aws-amplify` versions to point at a minimum version of `6.0.26`
- point docs and example apps used in e2e tests to `latest`
- remove extraneous peerDep on `@aws-amplify/geo` from `@aws-amplify/ui-react-geo`
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Verified changes in _yarn.lock_
- Pending e2e tests in CI

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
