### PR TITLE
chore(react-storage): clean up unit tests

### DIFF
--- a/packages/react-storage/jest.config.ts
+++ b/packages/react-storage/jest.config.ts
@@ -12,9 +12,9 @@ const config: Config = {
   coverageThreshold: {
     global: {
       branches: 80,
-      functions: 80,
-      lines: 80,
-      statements: 80,
+      functions: 87,
+      lines: 93,
+      statements: 93,
     },
   },
   moduleNameMapper: { '^uuid$': '<rootDir>/../../node_modules/uuid' },

--- a/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
+++ b/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
@@ -15,7 +15,15 @@ import { defaultStorageManagerDisplayText } from '../utils';
 
 const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-const uploadDataSpy = jest.spyOn(Storage, 'uploadData');
+const uploadDataSpy = jest
+  .spyOn(Storage, 'uploadData')
+  .mockImplementation((input) => ({
+    cancel: jest.fn(),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    state: 'SUCCESS',
+    result: Promise.resolve({ key: input.key, data: input.data }),
+  }));
 
 const storeManagerProps: StorageManagerProps = {
   accessLevel: 'guest',
@@ -23,8 +31,7 @@ const storeManagerProps: StorageManagerProps = {
 };
 describe('StorageManager', () => {
   beforeEach(() => {
-    uploadDataSpy.mockClear();
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   it('renders as expected', () => {
@@ -143,15 +150,6 @@ describe('StorageManager', () => {
   });
 
   it('calls onUploadSuccess callback when file is successfully uploaded', async () => {
-    uploadDataSpy.mockImplementationOnce((input: Storage.UploadDataInput) => {
-      return {
-        cancel: jest.fn(),
-        pause: jest.fn(),
-        resume: jest.fn(),
-        state: 'SUCCESS',
-        result: Promise.resolve({ key: input.key, data: input.data }),
-      };
-    });
     const onUploadSuccess = jest.fn();
     render(
       <StorageManager
@@ -185,15 +183,6 @@ describe('StorageManager', () => {
   });
 
   it('calls onUploadStart callback when file starts uploading', async () => {
-    uploadDataSpy.mockImplementationOnce((input: Storage.UploadDataInput) => {
-      return {
-        cancel: jest.fn(),
-        pause: jest.fn(),
-        resume: jest.fn(),
-        state: 'SUCCESS',
-        result: Promise.resolve({ key: input.key, data: input.data }),
-      };
-    });
     const onUploadStart = jest.fn();
     render(
       <StorageManager {...storeManagerProps} onUploadStart={onUploadStart} />

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
@@ -8,7 +8,7 @@ import { useUploadFiles, UseUploadFilesProps } from '../useUploadFiles';
 
 const uploadDataSpy = jest
   .spyOn(Storage, 'uploadData')
-  .mockImplementation((input: Storage.UploadDataInput) => {
+  .mockImplementation((input) => {
     return {
       cancel: jest.fn(),
       pause: jest.fn(),

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/FileStatusMessage.test.tsx
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/FileStatusMessage.test.tsx
@@ -91,8 +91,8 @@ describe('FileStatusMessage', () => {
       <IconsProvider
         icons={{
           storageManager: {
-            success: <View testId="success" />,
-            error: <View testId="error" />,
+            success: <View as="span" testId="success" />,
+            error: <View as="span" testId="error" />,
           },
         }}
       >

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileStatusMessage.test.tsx.snap
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileStatusMessage.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`FileStatusMessage renders custom icons from IconProvider 1`] = `
     class="amplify-text amplify-storagemanager__file__status amplify-storagemanager__file__status--error"
   >
     <span>
-      <div
+      <span
         data-testid="error"
       />
     </span>
@@ -94,7 +94,7 @@ exports[`FileStatusMessage renders custom icons from IconProvider 1`] = `
     class="amplify-text amplify-storagemanager__file__status amplify-storagemanager__file__status--success"
   >
     <span>
-      <div
+      <span
         data-testid="success"
       />
     </span>

--- a/packages/react-storage/src/components/StorageManager/utils/uploadFile.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/uploadFile.ts
@@ -19,7 +19,7 @@ export function uploadFile({
   file,
   key,
   level = 'private',
-  progressCallback,
+  progressCallback: onProgress,
   errorCallback,
   completeCallback,
   ...rest
@@ -32,8 +32,7 @@ export function uploadFile({
     options: {
       accessLevel: level,
       contentType,
-      onProgress: ({ transferredBytes, totalBytes }) =>
-        progressCallback({ transferredBytes, totalBytes }),
+      onProgress,
       ...rest,
     },
   };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Clean up _ui-react-storage_ unit test extraneous typing and async tests  
- remove manual typing of `uploadData` spies
- bump unit test coverage thresholds
- fix a DOM warning emiited from a unit test in [FileStatusMessage.test.tsx](https://github.com/aws-amplify/amplify-ui/compare/chore/clean-up-storage-unit-tests?expand=1#diff-d07b37b39948250e6ebfc88c9b0be7f376d230b7c66cf44531499ea8f87803f0)
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
unblocks https://github.com/aws-amplify/amplify-ui/pull/5121 (issues surfaced [here](https://github.com/aws-amplify/amplify-ui/actions/runs/8516464231/job/23325713643#step:14:11))

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Run unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
