### PR TITLE
fix(docs): update instructions for Liveness custom CDN  / use of wasm files

### DIFF
--- a/docs/src/pages/[platform]/connected-components/liveness/customization/CustomizationCdn.tsx
+++ b/docs/src/pages/[platform]/connected-components/liveness/customization/CustomizationCdn.tsx
@@ -12,7 +12,7 @@ export function CustomizationCdn() {
       region="us-east-1"
       onAnalysisComplete={async () => {}}
       config={{
-        binaryPath: 'http://example.com/path/to/your/wasm/file/',
+        binaryPath: 'http://example.com/path/to/your/wasm/files/',
         faceModelUrl:
           'http://example.com/path/to/your/blazeface/file/model.json',
       }}

--- a/docs/src/pages/[platform]/connected-components/liveness/customization/customization.cdn.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/liveness/customization/customization.cdn.react.mdx
@@ -30,5 +30,5 @@ Learn more about the differences between the three different `.wasm`  files in [
 ```
 
 <Alert role="none" variation="warning">
-`binaryPath` must be a path to a folder with `.wasm` files. `faceModelUrl` must point to the `model.json` file and will also expect the `group1-shard1of1.bin` file is colocated in the same path.
+`binaryPath` must be a path to a folder with `.wasm` files. `faceModelUrl` must point to the `model.json` file and will also expect the `group1-shard1of1.bin` file to be colocated in the same path.
 </Alert>

--- a/docs/src/pages/[platform]/connected-components/liveness/customization/customization.cdn.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/liveness/customization/customization.cdn.react.mdx
@@ -4,21 +4,31 @@ import { CustomizationCdn } from './CustomizationCdn';
 
 ## Custom CDN
 
-FaceLivenessDetector allows overriding the default hosted CDN and providing your own. The CDN files are used by the TensorFlow library to load in files at runtime. You can host your own CDN by following the instructions below:
+FaceLivenessDetector allows overriding the default hosted CDN and providing your own. The CDN files are used by the TensorFlow library to load in files at runtime. You can host your own CDN by following the instructions below.
 
-1. Download the TFJS wasm and blazeface files for the corresponding version of `@aws-amplify/ui-react-liveness`
-    - Download the wasm file for tfjs here.
-        - \<= v2.x - https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@3.11.0/dist/tfjs-backend-wasm-simd.wasm
-        - v3.x - https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@4.11.0/dist/tfjs-backend-wasm-simd.wasm
+<Alert role="none" variation="info">
+Learn more about the differences between the three different `.wasm`  files in the [TensorFlow blog post](https://blog.tensorflow.org/2020/09/supercharging-tensorflowjs-webassembly.html).
+</Alert>
+
+1. Download the TFJS wasm and blazeface files for the corresponding version of `@aws-amplify/ui-react-liveness`.
+    - Download wasm files for tfjs here:
+        - \<= v2.x
+            - https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@3.11.0/dist/tfjs-backend-wasm.wasm
+            - https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@3.11.0/dist/tfjs-backend-wasm-simd.wasm
+            - https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@3.11.0/dist/tfjs-backend-wasm-threaded-simd.wasm
+        - v3.x
+            - https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@4.11.0/dist/tfjs-backend-wasm.wasm
+            - https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@4.11.0/dist/tfjs-backend-wasm-simd.wasm
+            - https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@4.11.0/dist/tfjs-backend-wasm-threaded-simd.wasm
     - Download and unzip the tar file. It should contain a `model.json` file and a `group1-shard1of1.bin` file.
         - \<= v2.x - https://tfhub.dev/tensorflow/tfjs-model/blazeface/1/default/1
         - v3.x - https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1
-1. Host all three files alongside your JS files on your own server
+1. Host all files alongside your JS files on your own server
 1. Update FaceLivenessDetector code:
 
 ```tsx file=./CustomizationCdn.tsx
 ```
 
 <Alert role="none" variation="warning">
-`binaryPath` must be a path to a folder with `tfjs-backend-wasm-simd.wasm` but should not include the file name. `faceModelUrl` must point to the `model.json` file and will also expect the `group1-shard1of1.bin` file is colocated in the same path.  
+`binaryPath` must be a path to a folder with `.wasm` files. `faceModelUrl` must point to the `model.json` file and will also expect the `group1-shard1of1.bin` file is colocated in the same path.
 </Alert>

--- a/docs/src/pages/[platform]/connected-components/liveness/customization/customization.cdn.react.mdx
+++ b/docs/src/pages/[platform]/connected-components/liveness/customization/customization.cdn.react.mdx
@@ -7,7 +7,7 @@ import { CustomizationCdn } from './CustomizationCdn';
 FaceLivenessDetector allows overriding the default hosted CDN and providing your own. The CDN files are used by the TensorFlow library to load in files at runtime. You can host your own CDN by following the instructions below.
 
 <Alert role="none" variation="info">
-Learn more about the differences between the three different `.wasm`  files in the [TensorFlow blog post](https://blog.tensorflow.org/2020/09/supercharging-tensorflowjs-webassembly.html).
+Learn more about the differences between the three different `.wasm`  files in [this TensorFlow blog post](https://blog.tensorflow.org/2020/09/supercharging-tensorflowjs-webassembly.html).
 </Alert>
 
 1. Download the TFJS wasm and blazeface files for the corresponding version of `@aws-amplify/ui-react-liveness`.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This PR fixes missing documentation on downloading and hosting the default and multithreaded versions of the WASM file mentioned [here](https://github.com/tensorflow/tfjs/blob/master/tfjs-backend-wasm/README.md#using-bundlers) and [here](https://blog.tensorflow.org/2020/09/supercharging-tensorflowjs-webassembly.html).
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes: https://github.com/aws-amplify/amplify-ui/issues/5128

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
* Verified that each file is available at the jsdelivr.net url via links in the doc changes:
![CleanShot 2024-04-03 at 12 27 29@2x](https://github.com/aws-amplify/amplify-ui/assets/6165315/0dd0c757-d406-49e7-b5de-d753eff53452)



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
