### PR TITLE
Revert "chore(deps): bump changesets/action from b98cec97583b917ff1dc6179dd4d230d3e439894 to 63ffd93140be6000b385d611d886a82c86214719"

### DIFF
--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Build packages
         run: yarn build
       - name: Publish to @latest
-        uses: changesets/action@63ffd93140be6000b385d611d886a82c86214719 # v1.4.7 https://github.com/changesets/action/commit/63ffd93140be6000b385d611d886a82c86214719
+        uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
         with:
           publish: yarn publish:latest
         env:

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Build packages
         run: yarn build
       - name: Publish to @latest
-        uses: changesets/action@63ffd93140be6000b385d611d886a82c86214719 # v1.4.7 https://github.com/changesets/action/commit/63ffd93140be6000b385d611d886a82c86214719
+        uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
         with:
           publish: yarn publish:latest
         env:

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -39,7 +39,7 @@ jobs:
         run: yarn --frozen-lockfile
       - name: Create or update Version Packages PR
         if: ${{ steps.has-changesets.outputs.has-changesets == 'true' }}
-        uses: changesets/action@63ffd93140be6000b385d611d886a82c86214719 # v1.4.7 https://github.com/changesets/action/commit/63ffd93140be6000b385d611d886a82c86214719
+        uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
         with:
           version: yarn bumpVersions
         env:


### PR DESCRIPTION
This PR reverts the aws-amplify/amplify-ui#5091 because it broke the [Version Packages workflow](https://github.com/aws-amplify/amplify-ui/actions/workflows/version-packages.yml) as well as the [Test and Publish workflow](https://github.com/aws-amplify/amplify-ui/actions/workflows/publish-latest.yml). 