### PR TITLE
fix(react-liveness): remove retry status code to allow for timeout event

### DIFF
--- a/.changeset/funny-weeks-juggle.md
+++ b/.changeset/funny-weeks-juggle.md
@@ -2,4 +2,6 @@
 "@aws-amplify/ui-react-liveness": patch
 ---
 
-fix: removes 500 status code sent to Rekognition service in the event of a timeout during websocket connection
+fix: removes 500 status code sent upon websocket connection timeout.
+
+A websocket connection timeout will now return the error "Websocket connection timeout"

--- a/.changeset/funny-weeks-juggle.md
+++ b/.changeset/funny-weeks-juggle.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+fix: removes 500 status code sent to Rekognition service in the event of a timeout during websocket connection

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/CustomWebSocketFetchHandler.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/CustomWebSocketFetchHandler.ts
@@ -159,14 +159,9 @@ export class CustomWebSocketFetchHandler {
     socket: WebSocket,
     connectionTimeout: number
   ): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const timeout = setTimeout(() => {
         this.removeNotUsableSockets(socket.url);
-        reject({
-          $metadata: {
-            httpStatusCode: 500,
-          },
-        });
       }, connectionTimeout);
 
       socket.onopen = () => {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/CustomWebSocketFetchHandler.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/CustomWebSocketFetchHandler.ts
@@ -159,9 +159,10 @@ export class CustomWebSocketFetchHandler {
     socket: WebSocket,
     connectionTimeout: number
   ): Promise<void> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.removeNotUsableSockets(socket.url);
+        reject(new Error(`Websocket connection timeout`));
       }, connectionTimeout);
 
       socket.onopen = () => {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/__tests__/CustomWebsocketFetchHandler.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/__tests__/CustomWebsocketFetchHandler.test.ts
@@ -123,45 +123,6 @@ describe(CustomWebSocketFetchHandler.name, () => {
         expect(handler.sockets[mockUrl].length).toBe(0);
       }
     });
-
-    it('should return retryable error if cannot setup ws connection', async () => {
-      expect.assertions(5);
-      const originalFn = setTimeout;
-      (global as any).setTimeout = jest.fn().mockImplementation(setTimeout);
-      const connectionTimeout = 1000;
-      const handler = new CustomWebSocketFetchHandler(async () => ({
-        connectionTimeout,
-      }));
-      //Using Node stream is fine because they are also async iterables.
-      const payload = new PassThrough();
-      const mockInvalidHostname = 'localhost:9876';
-      const mockInvalidUrl = `ws://${mockInvalidHostname}/`;
-
-      try {
-        await handler.handle(
-          new HttpRequest({
-            body: payload,
-            hostname: mockInvalidHostname, //invalid websocket endpoint
-            protocol: 'ws:',
-          })
-        );
-      } catch (err) {
-        expect(err).toBeDefined();
-        expect((err as any).$metadata).toBeDefined();
-        expect((err as any).$metadata.httpStatusCode >= 500).toBe(true);
-        expect(
-          ((global as any).setTimeout as jest.Mock).mock.calls.filter(
-            (args) => {
-              //find the 'setTimeout' call from the websocket handler
-              return args[0].toString().indexOf('$metadata') >= 0;
-            }
-          )[0][1]
-        ).toBe(connectionTimeout);
-        // @ts-expect-error Property 'sockets' is private and only accessible within class 'WebSocketHandler'.
-        expect(handler.sockets[mockInvalidUrl].length).toBe(0);
-      }
-      (global as any).setTimeout = originalFn;
-    });
   });
 
   describe('should handle http requests', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This removes the 500 status code we were previously setting during timeout errors because it is causing the AWS SDK to retry with expired session id. It also adds an error message "Websocket connection timeout". 

Because we are no longer sending a '500' status, the SDK will no longer retry during it's 60 second timeout, and instead we will timeout after 10 seconds.

Currently, the timeout will throw a generic `error: Error`:

<img width="1069" alt="Screenshot 2024-04-09 at 2 22 00 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/a92af33e-29df-4881-b0cf-68d21d592357">


Now it will show `Error: Websocket connection timeout`

<img width="799" alt="Screenshot 2024-04-10 at 2 42 49 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/9899150d-0b10-4950-bc6e-e7dda385b5fd">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

In Chrome, I added a 70k ms latency network throttle:

<img width="300" alt="Screenshot 2024-04-09 at 2 10 38 PM" src="https://github.com/aws-amplify/amplify-ui/assets/376920/1b494a1b-ccec-409c-8ff1-f212f9599cae">

Then I enabled this throttle before clicking "Start video check". The connection should eventually timeout and throw an error in the console:
```
{
    "state": "SERVER_ERROR",
    "error": {
        "name": "ValidationException",
        "$fault": "client",
        "$metadata": {},
        "message": "End event timeoutExceeded"
    }
}
```


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
