### PR TITLE
fix(vue): downgrade @vitejs/plugin-vue

### DIFF
--- a/.changeset/smooth-windows-relate.md
+++ b/.changeset/smooth-windows-relate.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-vue": patch
+---
+
+fix(vue): downgrade @vitejs/plugin-vue

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@types/fs-extra": "11.0.3",
     "@types/jest": "^29.5.5",
     "@types/react-test-renderer": "^18.0.2",
-    "@vitejs/plugin-vue": "^5.0.4",
+    "@vitejs/plugin-vue": "^2.3.4",
     "aws-amplify": "6.0.26",
     "esbuild-register": "^3.5.0",
     "eslint": "^8.44.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8930,10 +8930,10 @@
     "@babel/plugin-transform-typescript" "^7.23.3"
     "@vue/babel-plugin-jsx" "^1.1.5"
 
-"@vitejs/plugin-vue@^5.0.4":
-  version "5.0.4"
-  resolved "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.4.tgz#508d6a0f2440f86945835d903fcc0d95d1bb8a37"
-  integrity sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==
+"@vitejs/plugin-vue@^2.3.4":
+  version "2.3.4"
+  resolved "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.4.tgz#966a6279060eb2d9d1a02ea1a331af071afdcf9e"
+  integrity sha512-IfFNbtkbIm36O9KB8QodlwwYvTEsJb4Lll4c2IwB3VHc2gie2mSPtSzL0eYay7X2jd/2WX02FjSGTWR6OPr/zg==
 
 "@volar/language-core@2.1.6", "@volar/language-core@~2.1.3":
   version "2.1.6"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Downgrade `@vitejs/plugin-vue` from `^5.0.4` to `^2.3.4` due to issues with Vite lib compilation mode and type declaration exposed in `@vitejs/plugin-vue@^3` and greater

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Validated type build outputs

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
