### PR TITLE
fix(Menu Primitive): Fix isDisabled prop 

### DIFF
--- a/.changeset/few-eggs-sing.md
+++ b/.changeset/few-eggs-sing.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(Menu Primitive): Fix isDisabled prop
+
+This fixes a bug where the `MenuButton` component was not respecting the `isDisabled` prop.

--- a/packages/react/src/primitives/Menu/Menu.tsx
+++ b/packages/react/src/primitives/Menu/Menu.tsx
@@ -24,6 +24,10 @@ const { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } =
 export const MENU_TRIGGER_TEST_ID = 'amplify-menu-trigger-test-id';
 export const MENU_ITEMS_GROUP_TEST_ID = 'amplify-menu-items-group-test-id';
 
+const isReactElement = (
+  child: React.ReactNode
+): child is React.ReactElement<any> => React.isValidElement<any>(child);
+
 const MenuPrimitive: Primitive<MenuProps, 'div'> = (
   {
     menuAlign = 'start',
@@ -40,9 +44,18 @@ const MenuPrimitive: Primitive<MenuProps, 'div'> = (
   ref
 ) => {
   const icons = useIcons('menu');
+
+  const shouldBeDisabled =
+    isReactElement(trigger) &&
+    // This defaults to false if isDisabled and disabled are undefined
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    trigger.props?.isDisabled | trigger.props?.disabled
+      ? true
+      : false;
+
   return (
     <DropdownMenu onOpenChange={onOpenChange} open={isOpen}>
-      <DropdownMenuTrigger asChild>
+      <DropdownMenuTrigger disabled={shouldBeDisabled} asChild>
         {trigger ?? (
           <MenuButton
             ariaLabel={ariaLabel}

--- a/packages/react/src/primitives/Menu/Menu.tsx
+++ b/packages/react/src/primitives/Menu/Menu.tsx
@@ -24,10 +24,6 @@ const { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } =
 export const MENU_TRIGGER_TEST_ID = 'amplify-menu-trigger-test-id';
 export const MENU_ITEMS_GROUP_TEST_ID = 'amplify-menu-items-group-test-id';
 
-const isReactElement = (
-  child: React.ReactNode
-): child is React.ReactElement<any> => React.isValidElement<any>(child);
-
 const MenuPrimitive: Primitive<MenuProps, 'div'> = (
   {
     menuAlign = 'start',
@@ -46,12 +42,10 @@ const MenuPrimitive: Primitive<MenuProps, 'div'> = (
   const icons = useIcons('menu');
 
   const shouldBeDisabled =
-    isReactElement(trigger) &&
     // This defaults to false if isDisabled and disabled are undefined
+    // @ts-ignore: Property 'props' does not exist on type 'string'.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    trigger.props?.isDisabled | trigger.props?.disabled
-      ? true
-      : false;
+    trigger?.props?.isDisabled || trigger?.props?.disabled ? true : false;
 
   return (
     <DropdownMenu onOpenChange={onOpenChange} open={isOpen}>

--- a/packages/react/src/primitives/Menu/MenuButton.tsx
+++ b/packages/react/src/primitives/Menu/MenuButton.tsx
@@ -44,6 +44,7 @@ const MenuButtonPrimitive: Primitive<MenuButtonProps, 'button'> = (
     <Button
       ref={ref}
       className={componentClasses}
+      disabled={isDisabled ?? isLoading}
       isDisabled={isDisabled ?? isLoading}
       type={type}
       testId={testId}

--- a/packages/react/src/primitives/Menu/MenuButton.tsx
+++ b/packages/react/src/primitives/Menu/MenuButton.tsx
@@ -44,7 +44,7 @@ const MenuButtonPrimitive: Primitive<MenuButtonProps, 'button'> = (
     <Button
       ref={ref}
       className={componentClasses}
-      disabled={isDisabled ?? isLoading}
+      isDisabled={isDisabled ?? isLoading}
       type={type}
       testId={testId}
       aria-label={ariaLabel}

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -215,7 +215,7 @@ describe('Menu', () => {
           <Menu
             isOpen
             trigger={
-              <MenuButton isDisabled={true} testId={MENU_TRIGGER_TEST_ID} />
+              <MenuButton disabled={true} testId={MENU_TRIGGER_TEST_ID} />
             }
           >
             <MenuItem>Option 1</MenuItem>

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { screen, render } from '@testing-library/react';
-
+import { fireEvent, screen, render, waitFor } from '@testing-library/react';
 import { ComponentClassName } from '@aws-amplify/ui';
+import { Button } from '@aws-amplify/ui-react';
 import { Menu, MENU_ITEMS_GROUP_TEST_ID } from '../Menu';
+import { MenuButton } from '../MenuButton';
 import { MenuItem, MENU_ITEM_TEST_ID } from '../MenuItem';
 import { MENU_TRIGGER_TEST_ID } from '../Menu';
 
@@ -115,6 +116,67 @@ describe('Menu', () => {
       const menu = await screen.findByTestId(MENU_TRIGGER_TEST_ID);
 
       expect(menu).toHaveClass('amplify-button--large');
+    });
+
+    it('should render a clickable trigger by default', async () => {
+      const { getByTestId } = render(
+        <Menu>
+          <MenuItem>Option 1</MenuItem>
+          <MenuItem>Option 2</MenuItem>
+          <MenuItem>Option 3</MenuItem>
+        </Menu>
+      );
+
+      const menuButton = getByTestId(MENU_TRIGGER_TEST_ID);
+
+      expect(menuButton).toBeDefined();
+      fireEvent.click(menuButton);
+
+      expect(menuButton).toHaveAttribute('data-state', 'open');
+      expect(screen.queryByText('Option 1')).toBeInTheDocument();
+    });
+
+    it('should disable the trigger with `disabled` prop', async () => {
+      render(
+        <Menu
+          trigger={<Button disabled={true} testId={MENU_TRIGGER_TEST_ID} />}
+        >
+          <MenuItem>Option 1</MenuItem>
+          <MenuItem>Option 2</MenuItem>
+          <MenuItem>Option 3</MenuItem>
+        </Menu>
+      );
+
+      await waitFor(async () => {
+        const disabled = await screen.findByTestId(MENU_TRIGGER_TEST_ID);
+        expect(disabled).toHaveClass('amplify-button--disabled');
+
+        fireEvent.click(disabled);
+        expect(disabled).toHaveAttribute('data-state', 'closed');
+        expect(screen.queryByText('Option 1')).toBeNull();
+      });
+    });
+
+    it('should disable the trigger with `isDisabled` prop', async () => {
+      render(
+        <Menu
+          trigger={
+            <MenuButton isDisabled={true} testId={MENU_TRIGGER_TEST_ID} />
+          }
+        >
+          <MenuItem>Option 1</MenuItem>
+          <MenuItem>Option 2</MenuItem>
+          <MenuItem>Option 3</MenuItem>
+        </Menu>
+      );
+      await waitFor(async () => {
+        const disabled = await screen.findByTestId(MENU_TRIGGER_TEST_ID);
+        expect(disabled).toHaveClass('amplify-button--disabled');
+
+        fireEvent.click(disabled);
+        expect(disabled).toHaveAttribute('data-state', 'closed');
+        expect(screen.queryByText('Option 1')).toBeNull();
+      });
     });
   });
 

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -116,7 +116,7 @@ describe('Menu', () => {
       expect(menu).toHaveClass('amplify-button--large');
     });
 
-    it('should render a clickable trigger by default', async () => {
+    it('should render by default a menu that can be expanded on keyboard press', async () => {
       render(
         <Menu>
           <MenuItem>Option 1</MenuItem>
@@ -151,22 +151,71 @@ describe('Menu', () => {
       });
     });
 
-    it('should disable the trigger with `disabled` prop', async () => {
+    it('should add `disabled` to an html element passed as trigger with `disabled` prop', async () => {
+      render(
+        <Menu trigger={<button disabled={true} id={MENU_TRIGGER_TEST_ID} />}>
+          <MenuItem>Option 1</MenuItem>
+          <MenuItem>Option 2</MenuItem>
+          <MenuItem>Option 3</MenuItem>
+        </Menu>
+      );
+
+      const disabled = await screen.findByRole('button');
+      // Native html elements should only have the `disabled` attribute
+      expect(disabled).toHaveAttribute('disabled');
+    });
+
+    it('should add disabled classnames to an Amplify UI component passed as trigger with `isDisabled` prop', async () => {
       render(
         <div style={{ pointerEvents: 'auto' }}>
-          <Menu trigger={<button disabled={true} id={MENU_TRIGGER_TEST_ID} />}>
+          <Menu
+            trigger={
+              <MenuButton isDisabled={true} testId={MENU_TRIGGER_TEST_ID} />
+            }
+          >
             <MenuItem>Option 1</MenuItem>
             <MenuItem>Option 2</MenuItem>
             <MenuItem>Option 3</MenuItem>
           </Menu>
         </div>
       );
+      const disabled = await screen.findByTestId(MENU_TRIGGER_TEST_ID);
+      expect(disabled).toHaveClass('amplify-button--disabled');
+      expect(disabled).toHaveAttribute('disabled');
+    });
+
+    it('should add disabled classnames to an Amplify UI component passed as trigger with `disabled` prop', async () => {
+      render(
+        <div style={{ pointerEvents: 'auto' }}>
+          <Menu
+            trigger={
+              <MenuButton disabled={true} testId={MENU_TRIGGER_TEST_ID} />
+            }
+          >
+            <MenuItem>Option 1</MenuItem>
+            <MenuItem>Option 2</MenuItem>
+            <MenuItem>Option 3</MenuItem>
+          </Menu>
+        </div>
+      );
+      const disabled = await screen.findByTestId(MENU_TRIGGER_TEST_ID);
+      expect(disabled).toHaveClass('amplify-button--disabled');
+      expect(disabled).toHaveAttribute('disabled');
+    });
+
+    it('should prevent keyboard events with the `disabled` prop', async () => {
+      render(
+        <Menu
+          trigger={<MenuButton disabled={true} testId={MENU_TRIGGER_TEST_ID} />}
+        >
+          <MenuItem>Option 1</MenuItem>
+          <MenuItem>Option 2</MenuItem>
+          <MenuItem>Option 3</MenuItem>
+        </Menu>
+      );
 
       await waitFor(async () => {
-        const disabled = await screen.findByRole('button');
-        // Native html elements should only have the `disabled` attribute
-        expect(disabled).toHaveAttribute('disabled');
-
+        const disabled = await screen.findByTestId(MENU_TRIGGER_TEST_ID);
         disabled.dispatchEvent(
           new KeyboardEvent('keydown', {
             bubbles: true,
@@ -178,7 +227,7 @@ describe('Menu', () => {
       });
     });
 
-    it('should disable the trigger with `isDisabled` prop', async () => {
+    it('should prevent keyboard events with `isDisabled` prop', async () => {
       render(
         <div style={{ pointerEvents: 'auto' }}>
           <Menu
@@ -194,9 +243,6 @@ describe('Menu', () => {
       );
       await waitFor(async () => {
         const disabled = await screen.findByTestId(MENU_TRIGGER_TEST_ID);
-        // Amplify UI components should have the disabled class
-        expect(disabled).toHaveClass('amplify-button--disabled');
-        expect(disabled).toHaveAttribute('disabled');
 
         disabled.dispatchEvent(
           new KeyboardEvent('keydown', {
@@ -209,7 +255,7 @@ describe('Menu', () => {
       });
     });
 
-    it('should disable the trigger with `disabled` prop when menu is open', async () => {
+    it('should prevent keyboard events with `disabled` prop when menu is open', async () => {
       render(
         <div style={{ pointerEvents: 'auto' }}>
           <Menu
@@ -226,9 +272,6 @@ describe('Menu', () => {
       );
       await waitFor(async () => {
         const disabled = await screen.findByTestId(MENU_TRIGGER_TEST_ID);
-
-        expect(disabled).toHaveClass('amplify-button--disabled');
-        expect(disabled).toHaveAttribute('disabled');
 
         disabled.dispatchEvent(
           new KeyboardEvent('keydown', {

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -209,7 +209,7 @@ describe('Menu', () => {
       });
     });
 
-    it('should disable the trigger with `isDisabled` prop when menu is open', async () => {
+    it('should disable the trigger with `disabled` prop when menu is open', async () => {
       render(
         <div style={{ pointerEvents: 'auto' }}>
           <Menu


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Updates the `MenuButton` component to respect both the `isDisabled` and `disabled` props
- Applies disabled styling and prevents the menu from opening on click 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
