### PR TITLE
fix(Menu): Fix ability to disable menu component

### DIFF
--- a/.changeset/clean-fireants-argue.md
+++ b/.changeset/clean-fireants-argue.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(Menu): Fix ability to disable menu component
+
+This fixes a bug where the `Menu` component was not respecting the `isDisabled` prop.

--- a/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/primitives/ButtonGroup/ButtonGroup.tsx
@@ -17,6 +17,7 @@ const ButtonGroupPrimitive: Primitive<ButtonGroupProps, 'div'> = (
   {
     className,
     children,
+    isDisabled: _isDisabled = false,
     role = 'group',
     size: _size,
     variation: _variation,
@@ -32,8 +33,12 @@ const ButtonGroupPrimitive: Primitive<ButtonGroupProps, 'div'> = (
   >
     {React.Children.map(children, (child) => {
       if (React.isValidElement<ButtonProps>(child)) {
-        const { size = _size, variation = _variation } = child.props;
-        return React.cloneElement(child, { size, variation });
+        const {
+          size = _size,
+          variation = _variation,
+          isDisabled = _isDisabled,
+        } = child.props;
+        return React.cloneElement(child, { isDisabled, size, variation });
       }
       return child;
     })}

--- a/packages/react/src/primitives/Menu/Menu.tsx
+++ b/packages/react/src/primitives/Menu/Menu.tsx
@@ -35,6 +35,7 @@ const MenuPrimitive: Primitive<MenuProps, 'div'> = (
     triggerClassName,
     ariaLabel,
     onOpenChange,
+    isDisabled,
     ...rest
   },
   ref
@@ -42,7 +43,7 @@ const MenuPrimitive: Primitive<MenuProps, 'div'> = (
   const icons = useIcons('menu');
   return (
     <DropdownMenu onOpenChange={onOpenChange} open={isOpen}>
-      <DropdownMenuTrigger asChild>
+      <DropdownMenuTrigger disabled={isDisabled} asChild>
         {trigger ?? (
           <MenuButton
             ariaLabel={ariaLabel}
@@ -64,6 +65,7 @@ const MenuPrimitive: Primitive<MenuProps, 'div'> = (
         <ButtonGroup
           className={classNames(ComponentClassName.MenuContent, className)}
           ref={ref}
+          isDisabled={isDisabled}
           size={size}
           testId={MENU_ITEMS_GROUP_TEST_ID}
           {...rest}

--- a/packages/react/src/primitives/Menu/MenuButton.tsx
+++ b/packages/react/src/primitives/Menu/MenuButton.tsx
@@ -21,7 +21,7 @@ const MenuButtonPrimitive: Primitive<MenuButtonProps, 'button'> = (
     ariaLabel,
     className,
     children,
-    isDisabled,
+    isDisabled = false,
     isLoading,
     size,
     style,
@@ -44,7 +44,8 @@ const MenuButtonPrimitive: Primitive<MenuButtonProps, 'button'> = (
     <Button
       ref={ref}
       className={componentClasses}
-      disabled={isDisabled ?? isLoading}
+      disabled={isDisabled || isLoading}
+      isDisabled={isDisabled || isLoading}
       type={type}
       testId={testId}
       aria-label={ariaLabel}

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -273,7 +273,6 @@ describe('Menu', () => {
   describe('MenuButton', () => {
     it('has the expected class when disabled', async () => {
       const MENU_BUTTON_TEST_ID = 'amplify-menu-button-test-id';
-      const clickHandler = jest.fn();
       render(
         <MenuButton
           isDisabled={true}

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -274,7 +274,7 @@ describe('Menu', () => {
     it('should add the Amplify UI Button disabled class to disabled MenuButton', async () => {
       const MENU_BUTTON_TEST_ID = 'amplify-menu-button-test-id';
       const clickHandler = jest.fn();
-      const { rerender } = render(
+      render(
         <MenuButton
           isDisabled={true}
           testId={MENU_BUTTON_TEST_ID}

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -270,7 +270,7 @@ describe('Menu', () => {
     });
   });
 
-  describe('menu button', () => {
+  describe('MenuButton', () => {
     it('should add the Amplify UI Button disabled class to disabled MenuButton', async () => {
       const MENU_BUTTON_TEST_ID = 'amplify-menu-button-test-id';
       const clickHandler = jest.fn();

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { screen, render } from '@testing-library/react';
+import { act, screen, render } from '@testing-library/react';
 
 import { ComponentClassName } from '@aws-amplify/ui';
-import { Menu, MENU_ITEMS_GROUP_TEST_ID } from '../Menu';
+import { Menu, MENU_ITEMS_GROUP_TEST_ID, MENU_TRIGGER_TEST_ID } from '../Menu';
+import { MenuButton } from '../MenuButton';
 import { MenuItem, MENU_ITEM_TEST_ID } from '../MenuItem';
-import { MENU_TRIGGER_TEST_ID } from '../Menu';
 
 // Needed because of the Radix Popper used by Menu
 // https://github.com/radix-ui/primitives/blob/main/packages/react/popper/src/Popper.tsx#L127
@@ -88,6 +88,52 @@ describe('Menu', () => {
     expect(menuItemsGroupClosed).toBeNull();
   });
 
+  it('behaves as expected when disabled', async () => {
+    const { rerender } = render(
+      <Menu isDisabled={false}>
+        <MenuItem>Option 1</MenuItem>
+        <MenuItem>Option 2</MenuItem>
+        <MenuItem isDisabled testId="disabled_option">
+          Option 3
+        </MenuItem>
+      </Menu>
+    );
+
+    const menuTrigger = await screen.findByTestId(MENU_TRIGGER_TEST_ID);
+    expect(menuTrigger).toHaveAttribute('data-state', 'closed');
+    expect(screen.queryByTestId(MENU_ITEMS_GROUP_TEST_ID)).toBeNull();
+
+    act(() => {
+      // Using keydown event because of the specific way radix-ui handles click
+      // https://github.com/radix-ui/primitives/blob/b32a93318cdfce383c2eec095710d35ffbd33a1c/packages/react/dropdown-menu/src/DropdownMenu.tsx#L127
+      menuTrigger.dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' })
+      );
+    });
+
+    expect(menuTrigger).toHaveAttribute('data-state', 'open');
+    expect(screen.queryByTestId(MENU_ITEMS_GROUP_TEST_ID)).not.toBeNull();
+
+    rerender(
+      <Menu isDisabled>
+        <MenuItem>Option 1</MenuItem>
+        <MenuItem>Option 2</MenuItem>
+        <MenuItem isDisabled testId="disabled_option">
+          Option 3
+        </MenuItem>
+      </Menu>
+    );
+
+    act(() => {
+      menuTrigger.dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' })
+      );
+    });
+
+    expect(menuTrigger).toHaveAttribute('data-state', 'open');
+    expect(screen.queryByTestId(MENU_ITEMS_GROUP_TEST_ID)).not.toBeNull();
+  });
+
   describe('trigger', () => {
     it('should have default and custom classnames', async () => {
       const triggerClassName = 'trigger-class-test';
@@ -160,6 +206,86 @@ describe('Menu', () => {
       const disabled = await screen.findByTestId('disabled_option');
 
       expect(disabled).toHaveClass('amplify-button--disabled');
+    });
+
+    it('should add the Amplify UI Button disabled class to when Menu is disabled', async () => {
+      render(
+        <Menu isOpen isDisabled>
+          {/* Force open to test menu items */}
+          <MenuItem>Option 1</MenuItem>
+          <MenuItem>Option 2</MenuItem>
+          <MenuItem testId="disabled_option">Option 3</MenuItem>
+        </Menu>
+      );
+
+      const disabled = await screen.findByTestId('disabled_option');
+
+      expect(disabled).toHaveClass('amplify-button--disabled');
+    });
+
+    it('should behave as expected when Menu is disabled', async () => {
+      const clickHandler = jest.fn();
+      const { rerender } = render(
+        <Menu isOpen isDisabled={false}>
+          <MenuItem>Option 1</MenuItem>
+          <MenuItem>Option 2</MenuItem>
+          <MenuItem testId="enabled_menu_item" onClick={clickHandler}>
+            Option 3
+          </MenuItem>
+        </Menu>
+      );
+
+      const menuItem = await screen.findByTestId('enabled_menu_item');
+      expect(menuItem).not.toHaveAttribute('disabled');
+      expect(menuItem).not.toHaveClass('amplify-button--disabled');
+
+      act(() => {
+        menuItem.dispatchEvent(
+          new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' })
+        );
+      });
+
+      expect(clickHandler).toHaveBeenCalledTimes(1);
+
+      rerender(
+        <Menu isOpen isDisabled>
+          <MenuItem>Option 1</MenuItem>
+          <MenuItem>Option 2</MenuItem>
+          <MenuItem testId="enabled_menu_item" onClick={clickHandler}>
+            Option 3
+          </MenuItem>
+        </Menu>
+      );
+
+      expect(menuItem).toHaveAttribute('disabled');
+      expect(menuItem).toHaveClass('amplify-button--disabled');
+
+      act(() => {
+        menuItem.dispatchEvent(
+          new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' })
+        );
+      });
+
+      expect(clickHandler).toHaveBeenCalledTimes(1); // Should not be called an additional time
+    });
+  });
+
+  describe('menu button', () => {
+    it('should add the Amplify UI Button disabled class to disabled MenuButton', async () => {
+      const MENU_BUTTON_TEST_ID = 'amplify-menu-button-test-id';
+      const clickHandler = jest.fn();
+      const { rerender } = render(
+        <MenuButton
+          isDisabled={true}
+          testId={MENU_BUTTON_TEST_ID}
+          onClick={clickHandler}
+        />
+      );
+
+      const menuButton = await screen.findByTestId(MENU_BUTTON_TEST_ID);
+
+      expect(menuButton).toHaveAttribute('disabled');
+      expect(menuButton).toHaveClass('amplify-button--disabled');
     });
   });
 });

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -277,7 +277,6 @@ describe('Menu', () => {
         <MenuButton
           isDisabled={true}
           testId={MENU_BUTTON_TEST_ID}
-          onClick={clickHandler}
         />
       );
 

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -223,7 +223,7 @@ describe('Menu', () => {
       expect(disabled).toHaveClass('amplify-button--disabled');
     });
 
-    it('should behave as expected when Menu is disabled', async () => {
+    it('behaves as expected when `isDisabled` is updated from `false` to `true`', async () => {
       const clickHandler = jest.fn();
       const { rerender } = render(
         <Menu isOpen isDisabled={false}>

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -208,7 +208,7 @@ describe('Menu', () => {
       expect(disabled).toHaveClass('amplify-button--disabled');
     });
 
-    it('should add the Amplify UI Button disabled class to when Menu is disabled', async () => {
+    it('has the expected class when disabled and open', async () => {
       render(
         <Menu isOpen isDisabled>
           {/* Force open to test menu items */}

--- a/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
+++ b/packages/react/src/primitives/Menu/__tests__/menu.test.tsx
@@ -271,7 +271,7 @@ describe('Menu', () => {
   });
 
   describe('MenuButton', () => {
-    it('should add the Amplify UI Button disabled class to disabled MenuButton', async () => {
+    it('has the expected class when disabled', async () => {
       const MENU_BUTTON_TEST_ID = 'amplify-menu-button-test-id';
       const clickHandler = jest.fn();
       render(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Actually disables the Menu component when `isDisabled` prop is passed in 
- Applies disabled styling and prevents the menu from opening on click

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#5164 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
