### PR TITLE
chore(authenticator): Make the quick start example complete

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/quick-start.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/quick-start.mdx
@@ -176,19 +176,39 @@ import AmplifyCLI from './amplify-cli.mdx';
   Add the Authenticator to your app by wrapping your component (represented here by the `@Composable` function `SignedInContent`) with the `Authenticator` component.
 
   ```kotlin
-  import com.amplifyframework.ui.authenticator.rememberAuthenticatorState
+  import android.os.Bundle
+  import androidx.activity.ComponentActivity
+  import androidx.activity.compose.setContent
+  import androidx.compose.foundation.layout.Column
+  import androidx.compose.material3.Button
+  import androidx.compose.material3.Text
+  import androidx.compose.runtime.Composable
+  import androidx.compose.runtime.rememberCoroutineScope
+  import com.amplifyframework.ui.authenticator.SignedInState
   import com.amplifyframework.ui.authenticator.ui.Authenticator
+  import kotlinx.coroutines.launch
 
   class MainActivity : ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-      super.onCreate(savedInstanceState)
+      override fun onCreate(savedInstanceState: Bundle?) {
+          super.onCreate(savedInstanceState)
 
-      setContent {
-        Authenticator { state ->
-            SignedInContent(state)
-        }
+          setContent {
+              Authenticator { state ->
+                  SignedInContent(state)
+              }
+          }
       }
-    }
+  }
+
+  @Composable
+  fun SignedInContent(state: SignedInState) {
+      val scope = rememberCoroutineScope()
+      Column {
+          Text("You've signed in as ${state.user.username}")
+          Button(onClick = { scope.launch { state.signOut() } }) {
+              Text("Sign Out")
+          }
+      }
   }
   ```
 </InlineFilter>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Updates the quick start example for Authenticator on Android to be more complete, showing a bare-bones implementation of an example `SignedInContent`. The indentation in this block is now also consistent with elsewhere in the document.

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui-android/issues/134

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- Ran the code sample change in a test app and validated it compiled and ran correctly.
- Ran the docs site locally and validated the changes appeared as desired.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
