### PR TITLE
feat(storage-manager): add prefix prop to support gen2 use cases

### DIFF
--- a/.changeset/fair-tips-deliver.md
+++ b/.changeset/fair-tips-deliver.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react-storage": minor
+"@aws-amplify/ui-react": patch
+---
+
+feat(storage-manager): add the `prefix` prop to support gen2 use cases

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -58,7 +58,7 @@
       "name": "StorageManager",
       "path": "dist/esm/index.mjs",
       "import": "{ StorageManager }",
-      "limit": "25 kB"
+      "limit": "26 kB"
     }
   ]
 }

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -58,7 +58,7 @@
       "name": "StorageManager",
       "path": "dist/esm/index.mjs",
       "import": "{ StorageManager }",
-      "limit": "26 kB"
+      "limit": "25.2 kB"
     }
   ]
 }

--- a/packages/react-storage/src/components/StorageManager/StorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/StorageManager.tsx
@@ -53,6 +53,12 @@ function StorageManagerBase(
   }: StorageManagerProps,
   ref: React.ForwardedRef<StorageManagerHandle>
 ): JSX.Element {
+  useDeprecationWarning({
+    message:
+      'The `accessLevel` and `path` props have been deprecated in favor of the `prefix` prop.',
+    shouldWarn: Boolean(accessLevel ?? path),
+  });
+
   if (!maxFileCount) {
     logger.warn(
       '`StorageManager` requires the `maxFileCount` prop to be specified'
@@ -60,10 +66,8 @@ function StorageManagerBase(
   }
 
   if (!prefix && !accessLevel) {
-    // accessLevel will be depreacted so only guide users to pass prefix prop
-    throw new Error(
-      '`StorageManager` requires the `prefix` prop to be specified'
-    );
+    // set accessLevel to private to respect the current default
+    accessLevel = 'private';
   }
 
   if (prefix && accessLevel) {
@@ -77,12 +81,6 @@ function StorageManagerBase(
       'The `prefix` and `path` props cannot be specified at the same time. Prefer usage of `prefix` as `path` has been deprecated and will be removed in a future major version'
     );
   }
-
-  useDeprecationWarning({
-    message:
-      'The `accessLevel` and `path` props have been deprecated in favor of the `prefix` prop.',
-    shouldWarn: Boolean(accessLevel ?? path),
-  });
 
   const Components = {
     Container,

--- a/packages/react-storage/src/components/StorageManager/StorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/StorageManager.tsx
@@ -66,8 +66,10 @@ function StorageManagerBase(
   }
 
   if (!prefix && !accessLevel) {
-    // set accessLevel to private to respect the current default
+    // set accessLevel to private to respect the default before adding the `prefix` prop
     accessLevel = 'private';
+    // accessLevel has been depreacted so only guide the user to pass the `prefix` prop
+    logger.warn('`StorageManager` requires the `prefix` prop to be specified');
   }
 
   if (prefix && accessLevel) {

--- a/packages/react-storage/src/components/StorageManager/StorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/StorageManager.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
 
-import { UploadDataOutput } from 'aws-amplify/storage';
+import {
+  UploadDataOutput,
+  UploadDataWithPathOutput,
+} from 'aws-amplify/storage';
 import { getLogger, ComponentClassName } from '@aws-amplify/ui';
 import { VisuallyHidden } from '@aws-amplify/ui-react';
 import { useSetUserAgent } from '@aws-amplify/ui-react-core';
-import { useDropZone } from '@aws-amplify/ui-react/internal';
+import {
+  useDropZone,
+  useDeprecationWarning,
+} from '@aws-amplify/ui-react/internal';
 
 import { useStorageManager, useUploadFiles } from './hooks';
 import { FileStatus, StorageManagerProps, StorageManagerHandle } from './types';
@@ -43,12 +49,40 @@ function StorageManagerBase(
     processFile,
     components,
     path,
+    prefix,
   }: StorageManagerProps,
   ref: React.ForwardedRef<StorageManagerHandle>
 ): JSX.Element {
-  if (!accessLevel || !maxFileCount) {
-    logger.warn('StorageManager requires accessLevel and maxFileCount props');
+  if (!maxFileCount) {
+    logger.warn(
+      '`StorageManager` requires the `maxFileCount` prop to be specified'
+    );
   }
+
+  if (!prefix && !accessLevel) {
+    // accessLevel will be depreacted so only guide users to pass prefix prop
+    throw new Error(
+      '`StorageManager` requires the `prefix` prop to be specified'
+    );
+  }
+
+  if (prefix && accessLevel) {
+    throw new Error(
+      'The `prefix` and `accessLevel` props cannot be specified at the same time. Prefer usage of `prefix` as `accessLevel` has been deprecated and will be removed in a future major version'
+    );
+  }
+
+  if (prefix && path) {
+    throw new Error(
+      'The `prefix` and `path` props cannot be specified at the same time. Prefer usage of `prefix` as `path` has been deprecated and will be removed in a future major version'
+    );
+  }
+
+  useDeprecationWarning({
+    message:
+      'The `accessLevel` and `path` props have been deprecated in favor of the `prefix` prop.',
+    shouldWarn: Boolean(accessLevel ?? path),
+  });
 
   const Components = {
     Container,
@@ -127,6 +161,7 @@ function StorageManagerBase(
     setUploadSuccess,
     processFile,
     path,
+    prefix,
   });
 
   const onFilePickerChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -155,7 +190,7 @@ function StorageManagerBase(
     uploadTask,
   }: {
     id: string;
-    uploadTask: UploadDataOutput;
+    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
   }) => {
     uploadTask.pause();
     setUploadPaused({ id });
@@ -166,7 +201,7 @@ function StorageManagerBase(
     uploadTask,
   }: {
     id: string;
-    uploadTask: UploadDataOutput;
+    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
   }) => {
     uploadTask.resume();
     setUploadResumed({ id });
@@ -177,7 +212,7 @@ function StorageManagerBase(
     uploadTask,
   }: {
     id: string;
-    uploadTask: UploadDataOutput;
+    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
   }) => {
     // At this time we don't know if the delete
     // permissions are enabled (required to cancel upload),

--- a/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
+++ b/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
@@ -290,11 +290,6 @@ describe('StorageManager', () => {
     expect(mockClearFiles).toHaveBeenCalledWith();
   });
 
-  it('should throw an error if both prefix and accessLevel are missing', () => {
-    expect(() => render(<StorageManager maxFileCount={1} />)).toThrow();
-    expect(errorSpy).toHaveBeenCalled();
-  });
-
   it('should throw an error if both prefix and accessLevel are specified', () => {
     expect(() =>
       render(

--- a/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
+++ b/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
@@ -290,6 +290,20 @@ describe('StorageManager', () => {
     expect(mockClearFiles).toHaveBeenCalledWith();
   });
 
+  it('should set accessLevel to private if neither prefix nor accessLevel is specified', () => {
+    const mockUseUploadFiles = jest.fn();
+    jest
+      .spyOn(StorageHooks, 'useUploadFiles')
+      .mockImplementationOnce(mockUseUploadFiles);
+
+    render(<StorageManager maxFileCount={1} />);
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(mockUseUploadFiles).toHaveBeenCalledWith(
+      expect.objectContaining({ accessLevel: 'private' })
+    );
+  });
+
   it('should throw an error if both prefix and accessLevel are specified', () => {
     expect(() =>
       render(

--- a/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
+++ b/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
@@ -14,6 +14,7 @@ import {
 import { defaultStorageManagerDisplayText } from '../utils';
 
 const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+const errorSpy = jest.spyOn(console, 'error').mockImplementation();
 
 const uploadDataSpy = jest
   .spyOn(Storage, 'uploadData')
@@ -71,7 +72,8 @@ describe('StorageManager', () => {
       getByText(defaultStorageManagerDisplayText.dropFilesText)
     ).toBeVisible();
 
-    expect(warnSpy).not.toHaveBeenCalled();
+    // acceessLevel prop deprecation warning
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it('renders as expected with autoUpload turned off', () => {
@@ -215,7 +217,8 @@ describe('StorageManager', () => {
   it('renders a warning if maxFileCount is zero', () => {
     render(<StorageManager {...storeManagerProps} maxFileCount={0} />);
 
-    expect(warnSpy).toHaveBeenCalledTimes(1);
+    // missing maxFileCount prop + accessLevel prop deprecation = 2
+    expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should trigger hidden input onChange', async () => {
@@ -285,5 +288,30 @@ describe('StorageManager', () => {
     act(() => ref.current?.clearFiles());
     expect(mockClearFiles).toHaveBeenCalledTimes(1);
     expect(mockClearFiles).toHaveBeenCalledWith();
+  });
+
+  it('should throw an error if both prefix and accessLevel are missing', () => {
+    expect(() => render(<StorageManager maxFileCount={1} />)).toThrow();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('should throw an error if both prefix and accessLevel are specified', () => {
+    expect(() =>
+      render(
+        <StorageManager
+          prefix="prefix/"
+          accessLevel="private"
+          maxFileCount={1}
+        />
+      )
+    ).toThrow();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('should throw an error if both prefix and path are specified', () => {
+    expect(() =>
+      render(<StorageManager prefix="prefix/" path="path/" maxFileCount={1} />)
+    ).toThrow();
+    expect(errorSpy).toHaveBeenCalled();
   });
 });

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/actions.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/actions.ts
@@ -1,4 +1,7 @@
-import { UploadDataOutput } from 'aws-amplify/storage';
+import {
+  UploadDataOutput,
+  UploadDataWithPathOutput,
+} from 'aws-amplify/storage';
 
 import { FileStatus } from '../../types';
 
@@ -38,7 +41,7 @@ export const setUploadingFileAction = ({
   uploadTask,
 }: {
   id: string;
-  uploadTask: UploadDataOutput | undefined;
+  uploadTask: UploadDataOutput | UploadDataWithPathOutput | undefined;
 }): Action => {
   return {
     type: StorageManagerActionTypes.SET_STATUS_UPLOADING,

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/reducer.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/reducer.ts
@@ -73,7 +73,7 @@ export function storageManagerStateReducer(
               ...currentFile,
               status: FileStatus.UPLOADING,
               progress: 0,
-              uploadTask: uploadTask ? uploadTask : undefined,
+              uploadTask,
             },
           ];
         }

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/types.ts
@@ -1,4 +1,7 @@
-import { UploadDataOutput } from 'aws-amplify/storage';
+import {
+  UploadDataOutput,
+  UploadDataWithPathOutput,
+} from 'aws-amplify/storage';
 
 import { FileStatus, StorageFiles } from '../../types';
 
@@ -39,7 +42,7 @@ export type Action =
   | {
       type: StorageManagerActionTypes.SET_STATUS_UPLOADING;
       id: string;
-      uploadTask?: UploadDataOutput;
+      uploadTask?: UploadDataOutput | UploadDataWithPathOutput;
     }
   | {
       type: StorageManagerActionTypes.SET_UPLOAD_PROGRESS;

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/useStorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/useStorageManager.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import { UploadDataOutput } from 'aws-amplify/storage';
+import {
+  UploadDataOutput,
+  UploadDataWithPathOutput,
+} from 'aws-amplify/storage';
 import { isObject } from '@aws-amplify/ui';
 
 import { StorageFiles, FileStatus, DefaultFile } from '../../types';
@@ -26,7 +29,7 @@ export interface UseStorageManager {
   queueFiles: () => void;
   setUploadingFile: (params: {
     id: string;
-    uploadTask?: UploadDataOutput;
+    uploadTask?: UploadDataOutput | UploadDataWithPathOutput;
   }) => void;
   setUploadProgress: (params: { id: string; progress: number }) => void;
   setUploadSuccess: (params: { id: string }) => void;

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
@@ -14,7 +14,10 @@ const uploadDataSpy = jest
       pause: jest.fn(),
       resume: jest.fn(),
       state: 'SUCCESS',
-      result: Promise.resolve({ key: input.key, data: input.data }),
+      result: Promise.resolve({
+        key: input.key,
+        data: input.data,
+      }),
     };
   });
 
@@ -209,6 +212,31 @@ describe('useUploadFiles', () => {
       expect(uploadDataSpy).toHaveBeenCalledTimes(1);
       expect(uploadDataSpy).toHaveBeenCalledWith(
         expect.objectContaining(expected)
+      );
+    });
+  });
+
+  it('prepends valid provided `prefix` to `processedKey`', async () => {
+    const prefix = 'test-prefix/';
+    const { waitForNextUpdate } = renderHook(() =>
+      useUploadFiles({
+        ...props,
+        isResumable: true,
+        files: [mockQueuedFile],
+        prefix,
+        accessLevel: undefined,
+      })
+    );
+
+    waitForNextUpdate();
+
+    await waitFor(() => {
+      expect(mockOnUploadStart).toHaveBeenCalledWith({
+        key: `${prefix}${mockQueuedFile.key}`,
+      });
+      expect(uploadDataSpy).toHaveBeenCalledTimes(1);
+      expect(uploadDataSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ path: `${prefix}${mockQueuedFile.key}` })
       );
     });
   });

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/useUploadFiles.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/useUploadFiles.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { TransferProgressEvent } from 'aws-amplify/storage';
-import { isFunction, isString } from '@aws-amplify/ui';
+import { isFunction } from '@aws-amplify/ui';
 
 import { uploadFile } from '../../utils/uploadFile';
 import { FileStatus } from '../../types';
@@ -20,6 +20,7 @@ export interface UseUploadFilesProps
       | 'maxFileCount'
       | 'processFile'
       | 'path'
+      | 'prefix'
     >,
     Pick<
       UseStorageManager,
@@ -39,6 +40,7 @@ export function useUploadFiles({
   maxFileCount,
   processFile,
   path,
+  prefix,
 }: UseUploadFilesProps): void {
   React.useEffect(() => {
     const filesReadyToUpload = files.filter(
@@ -72,10 +74,9 @@ export function useUploadFiles({
       if (file) {
         resolveFile({ processFile, file, key }).then(
           ({ key: processedKey, ...rest }) => {
-            // prepend `path` to `processedKey`
-            const resolvedKey = isString(path)
-              ? `${path}${processedKey}`
-              : processedKey;
+            // prepend `prefix` or `path` to `processedKey`
+            // TODO: path will be deprecated in the future
+            const resolvedKey = `${prefix ?? path ?? ''}${processedKey}`;
 
             if (isFunction(onUploadStart)) {
               onUploadStart({ key: resolvedKey });
@@ -83,7 +84,9 @@ export function useUploadFiles({
 
             const uploadTask = uploadFile({
               ...rest,
+              // key will be deprecated in the future
               key: resolvedKey,
+              path: resolvedKey,
               level: accessLevel,
               progressCallback: onProgress,
               errorCallback: (error: string) => {
@@ -112,5 +115,6 @@ export function useUploadFiles({
     setUploadSuccess,
     processFile,
     path,
+    prefix,
   ]);
 }

--- a/packages/react-storage/src/components/StorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/types.ts
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-import type { UploadDataOutput } from 'aws-amplify/storage';
+import type {
+  UploadDataOutput,
+  UploadDataWithPathOutput,
+} from 'aws-amplify/storage';
 import type { StorageAccessLevel } from '@aws-amplify/core';
 
 import {
@@ -27,7 +30,7 @@ export interface StorageFile {
   file?: File;
   status: FileStatus;
   progress: number;
-  uploadTask?: UploadDataOutput;
+  uploadTask?: UploadDataOutput | UploadDataWithPathOutput;
   key: string;
   error: string;
   isImage: boolean;
@@ -55,10 +58,10 @@ export interface StorageManagerProps {
    */
   acceptedFileTypes?: string[];
   /**
-   * Access level for file uploads
-   * @see https://docs.amplify.aws/lib/storage/configureaccess/q/platform/js/
+   * @deprectaed
+   * `accessLevel` has been deprecated in favor of `prefix` and will be removed in a future major version
    */
-  accessLevel: StorageAccessLevel;
+  accessLevel?: StorageAccessLevel;
 
   /**
    * Determines if the upload will automatically start after a file is selected, default value: true
@@ -120,9 +123,12 @@ export interface StorageManagerProps {
    */
   showThumbnails?: boolean;
   /**
-   * A path to put files in the s3 bucket.
-   * This will be prepended to the key sent to
-   * s3 for each file.
+   * @deprectaed
+   * `path` has been deprecated in favor of `prefix` and will be removed in a future major version
    */
   path?: string;
+  /**
+   * A string prefixed to the key of each file
+   */
+  prefix?: string;
 }

--- a/packages/react-storage/src/components/StorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/types.ts
@@ -58,7 +58,7 @@ export interface StorageManagerProps {
    */
   acceptedFileTypes?: string[];
   /**
-   * @deprectaed
+   * @deprecated
    * `accessLevel` has been deprecated in favor of `prefix` and will be removed in a future major version
    */
   accessLevel?: StorageAccessLevel;
@@ -123,7 +123,7 @@ export interface StorageManagerProps {
    */
   showThumbnails?: boolean;
   /**
-   * @deprectaed
+   * @deprecated
    * `path` has been deprecated in favor of `prefix` and will be removed in a future major version
    */
   path?: string;

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/FileList.test.tsx
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/FileList.test.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import { UploadDataOutput } from 'aws-amplify/storage';
+import {
+  UploadDataOutput,
+  UploadDataWithPathOutput,
+} from 'aws-amplify/storage';
 import { ComponentClassName } from '@aws-amplify/ui';
 
 import { FileList } from '../FileList';
@@ -16,7 +19,7 @@ const mockFile: StorageFile = {
   error: '',
   isImage: false,
   key: '',
-  uploadTask: {} as UploadDataOutput,
+  uploadTask: {} as UploadDataOutput | UploadDataWithPathOutput,
 };
 
 const mockOnCancelUpload = jest.fn();

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/types.ts
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/types.ts
@@ -1,4 +1,7 @@
-import { UploadDataOutput } from 'aws-amplify/storage';
+import {
+  UploadDataOutput,
+  UploadDataWithPathOutput,
+} from 'aws-amplify/storage';
 
 import { StorageManagerDisplayTextDefault } from '../../utils';
 import { FileStatus, StorageFile } from '../../types';
@@ -9,11 +12,17 @@ export interface FileListProps {
   isResumable: boolean;
   onCancelUpload: (params: {
     id: string;
-    uploadTask: UploadDataOutput;
+    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
   }) => void;
   onDeleteUpload: (params: { id: string }) => void;
-  onPause: (params: { id: string; uploadTask: UploadDataOutput }) => void;
-  onResume: (params: { id: string; uploadTask: UploadDataOutput }) => void;
+  onPause: (params: {
+    id: string;
+    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
+  }) => void;
+  onResume: (params: {
+    id: string;
+    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
+  }) => void;
   showThumbnails: boolean;
   hasMaxFilesError: boolean;
   maxFileCount: number;

--- a/packages/react-storage/src/components/StorageManager/utils/__tests__/uploadFile.test.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/__tests__/uploadFile.test.ts
@@ -4,6 +4,7 @@ import { UploadFileProps, uploadFile } from '../uploadFile';
 
 const imageFile = new File(['hello'], 'hello.png', { type: 'image/png' });
 const key = imageFile.name;
+const path = imageFile.name;
 const file = imageFile;
 
 const errorCallback = jest.fn();
@@ -13,6 +14,7 @@ const progressCallback = jest.fn();
 const defaultProps: UploadFileProps = {
   file,
   key,
+  path,
   level: 'guest',
   progressCallback,
   errorCallback,
@@ -50,6 +52,24 @@ describe('uploadFile', () => {
       data: file,
       options: {
         accessLevel: 'guest',
+        contentType: imageFile.type,
+        onProgress: expect.any(Function),
+      },
+    });
+
+    expect(completeCallback).toHaveBeenCalledWith({ key });
+    expect(errorCallback).not.toHaveBeenCalled();
+  });
+
+  it('should uploads a file with path prop', async () => {
+    const { result } = uploadFile({ ...defaultProps, level: undefined });
+
+    await result;
+
+    expect(uploadDataSpy).toHaveBeenCalledWith({
+      path,
+      data: file,
+      options: {
         contentType: imageFile.type,
         onProgress: expect.any(Function),
       },

--- a/packages/react-storage/src/components/StorageManager/utils/uploadFile.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/uploadFile.ts
@@ -4,39 +4,59 @@ import {
   TransferProgressEvent,
   UploadDataInput,
   UploadDataOutput,
+  UploadDataWithPathInput,
+  UploadDataWithPathOutput,
 } from 'aws-amplify/storage';
 
 export type UploadFileProps = {
   file: File;
   key: string;
-  level: StorageAccessLevel;
+  path: string;
+  level?: StorageAccessLevel;
   progressCallback: (event: TransferProgressEvent) => void;
   errorCallback: (error: string) => void;
   completeCallback: (event: { key: string | undefined }) => void;
 } & Record<string, any>;
 
+type UploadData = (
+  input: UploadDataInput | UploadDataWithPathInput
+) => UploadDataOutput | UploadDataWithPathOutput;
+
 export function uploadFile({
   file,
   key,
-  level = 'private',
+  path,
+  level,
   progressCallback: onProgress,
   errorCallback,
   completeCallback,
   ...rest
-}: UploadFileProps): UploadDataOutput {
+}: UploadFileProps): UploadDataOutput | UploadDataWithPathOutput {
   const contentType = file.type || 'binary/octet-stream';
 
-  const input: UploadDataInput = {
-    key,
-    data: file,
-    options: {
-      accessLevel: level,
-      contentType,
-      onProgress,
-      ...rest,
-    },
-  };
-  const output = uploadData(input);
+  const input: UploadDataInput | UploadDataWithPathInput = level
+    ? {
+        // key will be deprecated in the future
+        key,
+        data: file,
+        options: {
+          accessLevel: level,
+          contentType,
+          onProgress,
+          ...rest,
+        },
+      }
+    : {
+        path,
+        data: file,
+        options: {
+          contentType,
+          onProgress,
+          ...rest,
+        },
+      };
+
+  const output = (uploadData as UploadData)(input);
 
   output.result
     .then(() => {

--- a/packages/react-storage/src/components/StorageManager/utils/uploadFile.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/uploadFile.ts
@@ -36,7 +36,7 @@ export function uploadFile({
 
   const input: UploadDataInput | UploadDataWithPathInput = level
     ? {
-        // key will be deprecated in the future
+        // key will be deprecated in aws-amplify@v7
         key,
         data: file,
         options: {

--- a/packages/react/__tests__/__snapshots__/exports.ts.snap
+++ b/packages/react/__tests__/__snapshots__/exports.ts.snap
@@ -107,6 +107,7 @@ exports[`@aws-amplify/ui-react/internal exports should match snapshot 1`] = `
   "PrimitiveCatalog",
   "useAuth",
   "useColorMode",
+  "useDeprecationWarning",
   "useDropZone",
   "useIcons",
   "useStorageURL",

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -1,6 +1,7 @@
 export * from './hooks/useAuth';
 export * from './hooks/useStorageURL';
 export * from './hooks/useThemeBreakpoint';
+export { useDeprecationWarning } from './hooks/useDeprecationWarning';
 export { useColorMode } from './hooks/useTheme';
 
 export * from './components/FilterChildren';


### PR DESCRIPTION
#### Description of changes

- This PR will add `prefix` prop to `StorageManger` to support the Gen2 use cases while maintaining backwards compatibility with `accessLevel` and `path` props, both of which will be deprecated in the future in favor of `prefix`
- Docs updates and e2e tests will be added in separate PRs

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
