### PR TITLE
chore: add gen2 storage environment

### DIFF
--- a/environments/storage/gen2/package.json
+++ b/environments/storage/gen2/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "@aws-amplify/ui-gen2-storage-environment",
+  "version": "0.0.1",
+  "scripts": {
+    "generate": "AWS_REGION=us-east-2 npx @aws-amplify/backend-cli@latest generate config --branch gen2-storage-backend --app-id d3w3sj6rqvjdb0 --config-version 1"
+  }
+}

--- a/environments/storage/package.json
+++ b/environments/storage/package.json
@@ -3,6 +3,6 @@
   "name": "@aws-amplify/ui-environments-storage",
   "version": "0.0.1",
   "scripts": {
-    "pull": "../pull-environments.sh -r us-east-2"
+    "pull": "../pull-environments.sh -r us-east-2 && yarn --cwd gen2/ generate"
   }
 }


### PR DESCRIPTION
#### Description of changes

Add gen2 storage environment for e2e testing. The backend resource code is stored in the staging repo https://github.com/aws-amplify/amplify-ui-staging/tree/gen2-storage-backend

New permission required in `AmplifyCLIPull` policies: `"cloudformation:GetTemplateSummary"`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
