### PR TITLE
chore(storage-manager): add first-class support for path

### DIFF
--- a/.changeset/fair-tips-deliver.md
+++ b/.changeset/fair-tips-deliver.md
@@ -3,4 +3,6 @@
 "@aws-amplify/ui-react": patch
 ---
 
-feat(storage-manager): add the `prefix` prop to support gen2 use cases
+feat(storage-manager): update `StorageManager` to support differing usages of `path` prop:
+- existing: `accessLevel` prop provided with or without optional `path` prop
+- additive: no `accessLevel` prop provided with required `path` as either a `string` or a callback provided the current `identityId`

--- a/examples/next/pages/ui/components/storage/storage-manager/accept-file-extension/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/accept-file-extension/index.page.tsx
@@ -6,14 +6,12 @@ Amplify.configure(awsExports);
 
 export function StorageManagerExample() {
   return (
-    <>
-      <StorageManager
-        acceptedFileTypes={['.png']}
-        accessLevel="guest"
-        maxFileCount={1}
-        showThumbnails
-      />
-    </>
+    <StorageManager
+      acceptedFileTypes={['.png']}
+      accessLevel="guest"
+      maxFileCount={1}
+      showThumbnails
+    />
   );
 }
 export default StorageManagerExample;

--- a/packages/react-storage/jest.config.ts
+++ b/packages/react-storage/jest.config.ts
@@ -11,7 +11,7 @@ const config: Config = {
   ],
   coverageThreshold: {
     global: {
-      branches: 85,
+      branches: 86,
       functions: 87,
       lines: 93,
       statements: 93,

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -58,7 +58,7 @@
       "name": "StorageManager",
       "path": "dist/esm/index.mjs",
       "import": "{ StorageManager }",
-      "limit": "25 kB"
+      "limit": "25.5 kB"
     }
   ]
 }

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -58,7 +58,7 @@
       "name": "StorageManager",
       "path": "dist/esm/index.mjs",
       "import": "{ StorageManager }",
-      "limit": "25.2 kB"
+      "limit": "25 kB"
     }
   ]
 }

--- a/packages/react-storage/src/components/StorageManager/StorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/StorageManager.tsx
@@ -63,7 +63,7 @@ const StorageManagerBase = React.forwardRef(function StorageManager(
 ): JSX.Element {
   if (!maxFileCount) {
     // eslint-disable-next-line no-console
-    console.warn(MISSING_REQUIRED_PROPS_MESSAGE);
+    logger.warn(MISSING_REQUIRED_PROPS_MESSAGE);
   }
 
   if (accessLevel && typeof path === 'function') {

--- a/packages/react-storage/src/components/StorageManager/StorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/StorageManager.tsx
@@ -63,7 +63,7 @@ const StorageManagerBase = React.forwardRef(function StorageManager(
 ): JSX.Element {
   if (!maxFileCount) {
     // eslint-disable-next-line no-console
-    logger.warn(MISSING_REQUIRED_PROPS_MESSAGE);
+    console.warn(MISSING_REQUIRED_PROPS_MESSAGE);
   }
 
   if (accessLevel && typeof path === 'function') {

--- a/packages/react-storage/src/components/StorageManager/StorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/StorageManager.tsx
@@ -1,19 +1,20 @@
 import * as React from 'react';
 
-import {
-  UploadDataOutput,
-  UploadDataWithPathOutput,
-} from 'aws-amplify/storage';
 import { getLogger, ComponentClassName } from '@aws-amplify/ui';
 import { VisuallyHidden } from '@aws-amplify/ui-react';
-import { useSetUserAgent } from '@aws-amplify/ui-react-core';
 import {
-  useDropZone,
   useDeprecationWarning,
-} from '@aws-amplify/ui-react/internal';
+  useSetUserAgent,
+} from '@aws-amplify/ui-react-core';
+import { useDropZone } from '@aws-amplify/ui-react/internal';
 
 import { useStorageManager, useUploadFiles } from './hooks';
-import { FileStatus, StorageManagerProps, StorageManagerHandle } from './types';
+import {
+  FileStatus,
+  StorageManagerProps,
+  StorageManagerPathProps,
+  StorageManagerHandle,
+} from './types';
 import {
   Container,
   DropZone,
@@ -26,63 +27,53 @@ import {
   checkMaxFileSize,
   defaultStorageManagerDisplayText,
   filterAllowedFiles,
+  TaskHandler,
 } from './utils';
 import { VERSION } from '../../version';
 
 const logger = getLogger('Storage');
 
-function StorageManagerBase(
+export const MISSING_REQUIRED_PROPS_MESSAGE =
+  '`StorageManager` requires a `maxFileCount` prop to be provided.';
+export const ACCESS_LEVEL_WITH_PATH_CALLBACK_MESSAGE =
+  '`StorageManager` does not allow usage of a `path` callback prop with an `accessLevel` prop.';
+export const ACCESS_LEVEL_DEPRECATION_MESSAGE =
+  '`accessLevel` has been deprecated and will be removed in a future major version. See migration notes at https://ui.docs.amplify.aws/react/connected-components/storage/storagemanager';
+
+const StorageManagerBase = React.forwardRef(function StorageManager(
   {
     acceptedFileTypes = [],
     accessLevel,
     autoUpload = true,
+    components,
     defaultFiles,
     displayText: overrideDisplayText,
     isResumable = false,
     maxFileCount,
     maxFileSize,
-    onUploadError,
-    onUploadSuccess,
     onFileRemove,
+    onUploadError,
     onUploadStart,
-    showThumbnails = true,
-    processFile,
-    components,
+    onUploadSuccess,
     path,
-    prefix,
-  }: StorageManagerProps,
+    processFile,
+    showThumbnails = true,
+  }: StorageManagerPathProps | StorageManagerProps,
   ref: React.ForwardedRef<StorageManagerHandle>
 ): JSX.Element {
-  useDeprecationWarning({
-    message:
-      'The `accessLevel` and `path` props have been deprecated in favor of the `prefix` prop.',
-    shouldWarn: Boolean(accessLevel ?? path),
-  });
-
   if (!maxFileCount) {
-    logger.warn(
-      '`StorageManager` requires the `maxFileCount` prop to be specified'
-    );
+    // eslint-disable-next-line no-console
+    console.warn(MISSING_REQUIRED_PROPS_MESSAGE);
   }
 
-  if (!prefix && !accessLevel) {
-    // set accessLevel to private to respect the default before adding the `prefix` prop
-    accessLevel = 'private';
-    // accessLevel has been depreacted so only guide the user to pass the `prefix` prop
-    logger.warn('`StorageManager` requires the `prefix` prop to be specified');
+  if (accessLevel && typeof path === 'function') {
+    throw new Error(ACCESS_LEVEL_WITH_PATH_CALLBACK_MESSAGE);
   }
 
-  if (prefix && accessLevel) {
-    throw new Error(
-      'The `prefix` and `accessLevel` props cannot be specified at the same time. Prefer usage of `prefix` as `accessLevel` has been deprecated and will be removed in a future major version'
-    );
-  }
-
-  if (prefix && path) {
-    throw new Error(
-      'The `prefix` and `path` props cannot be specified at the same time. Prefer usage of `prefix` as `path` has been deprecated and will be removed in a future major version'
-    );
-  }
+  useDeprecationWarning({
+    message: ACCESS_LEVEL_DEPRECATION_MESSAGE,
+    shouldWarn: !!accessLevel,
+  });
 
   const Components = {
     Container,
@@ -161,7 +152,6 @@ function StorageManagerBase(
     setUploadSuccess,
     processFile,
     path,
-    prefix,
   });
 
   const onFilePickerChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -185,35 +175,17 @@ function StorageManagerBase(
     queueFiles();
   };
 
-  const onPauseUpload = ({
-    id,
-    uploadTask,
-  }: {
-    id: string;
-    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
-  }) => {
+  const onPauseUpload: TaskHandler = ({ id, uploadTask }) => {
     uploadTask.pause();
     setUploadPaused({ id });
   };
 
-  const onResumeUpload = ({
-    id,
-    uploadTask,
-  }: {
-    id: string;
-    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
-  }) => {
+  const onResumeUpload: TaskHandler = ({ id, uploadTask }) => {
     uploadTask.resume();
     setUploadResumed({ id });
   };
 
-  const onCancelUpload = ({
-    id,
-    uploadTask,
-  }: {
-    id: string;
-    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
-  }) => {
+  const onCancelUpload: TaskHandler = ({ id, uploadTask }) => {
     // At this time we don't know if the delete
     // permissions are enabled (required to cancel upload),
     // so we do a pause instead and remove from files
@@ -329,20 +301,16 @@ function StorageManagerBase(
       ) : null}
     </Components.Container>
   );
-}
+});
 
-const StorageManager = Object.assign(
-  React.forwardRef<StorageManagerHandle, StorageManagerProps>(
-    StorageManagerBase
-  ),
-  {
-    Container,
-    DropZone,
-    FileList,
-    FileListHeader,
-    FileListFooter,
-    FilePicker,
-  }
-);
+// pass an empty object as first param to avoid destructive action on `StorageManagerBase`
+const StorageManager = Object.assign({}, StorageManagerBase, {
+  Container,
+  DropZone,
+  FileList,
+  FileListHeader,
+  FileListFooter,
+  FilePicker,
+});
 
 export { StorageManager };

--- a/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
+++ b/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
@@ -8,7 +8,6 @@ import * as StorageHooks from '../hooks';
 import {
   StorageManager,
   MISSING_REQUIRED_PROPS_MESSAGE,
-  ACCESS_LEVEL_WITH_PATH_CALLBACK_MESSAGE,
   ACCESS_LEVEL_DEPRECATION_MESSAGE,
 } from '../StorageManager';
 import {

--- a/packages/react-storage/src/components/StorageManager/__tests__/__snapshots__/StorageManager.test.tsx.snap
+++ b/packages/react-storage/src/components/StorageManager/__tests__/__snapshots__/StorageManager.test.tsx.snap
@@ -1,6 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StorageManager renders as expected 1`] = `
+exports[`StorageManager behaves as expected with a path prop 1`] = `
+<div>
+  <div
+    class="amplify-storagemanager "
+  >
+    <div
+      class="amplify-storagemanager__dropzone"
+    >
+      <span
+        aria-hidden="true"
+        class="amplify-storagemanager__dropzone__icon"
+      >
+        <span
+          class="amplify-icon"
+          style="width: 1em; height: 1em;"
+        >
+          <svg
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zM8 15.01l1.41 1.41L11 14.84V19h2v-4.16l1.59 1.59L16 15.01 12.01 11 8 15.01z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </span>
+      <p
+        class="amplify-text amplify-storagemanager__dropzone__text"
+      >
+        Drop files here or
+      </p>
+      <button
+        class="amplify-button amplify-field-group__control amplify-button--small amplify-storagemanager__file__picker"
+        type="button"
+      >
+        Browse files
+      </button>
+      <span
+        class="amplify-visually-hidden"
+      >
+        <input
+          accept=""
+          multiple=""
+          tabindex="-1"
+          type="file"
+        />
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StorageManager behaves as expected with an accessLevel prop 1`] = `
 <div>
   <div
     class="amplify-storagemanager "

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/__tests__/useStorageManager.test.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/__tests__/useStorageManager.test.ts
@@ -90,7 +90,15 @@ describe('useUploadFiles', () => {
     act(() =>
       result.current.setUploadingFile({
         id: 'file1',
-        uploadTask: undefined,
+        uploadTask: {
+          cancel: jest.fn(),
+          pause: jest.fn(),
+          resume: jest.fn(),
+          state: 'IN_PROGRESS',
+          result: Promise.resolve({
+            key: 'key',
+          }),
+        },
       })
     );
 

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/actions.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/actions.ts
@@ -1,8 +1,3 @@
-import {
-  UploadDataOutput,
-  UploadDataWithPathOutput,
-} from 'aws-amplify/storage';
-
 import { FileStatus } from '../../types';
 
 import {
@@ -10,45 +5,35 @@ import {
   AddFilesActionParams,
   StorageManagerActionTypes,
 } from './types';
+import { TaskEvent } from '../../utils';
 
 export const addFilesAction = ({
   files,
   status,
   getFileErrorMessage,
-}: AddFilesActionParams): Action => {
-  return {
-    type: StorageManagerActionTypes.ADD_FILES,
-    files,
-    status,
-    getFileErrorMessage,
-  };
-};
+}: AddFilesActionParams): Action => ({
+  type: StorageManagerActionTypes.ADD_FILES,
+  files,
+  status,
+  getFileErrorMessage,
+});
 
-export const clearFilesAction = (): Action => {
-  return {
-    type: StorageManagerActionTypes.CLEAR_FILES,
-  };
-};
+export const clearFilesAction = (): Action => ({
+  type: StorageManagerActionTypes.CLEAR_FILES,
+});
 
-export const queueFilesAction = (): Action => {
-  return {
-    type: StorageManagerActionTypes.QUEUE_FILES,
-  };
-};
+export const queueFilesAction = (): Action => ({
+  type: StorageManagerActionTypes.QUEUE_FILES,
+});
 
 export const setUploadingFileAction = ({
   id,
   uploadTask,
-}: {
-  id: string;
-  uploadTask: UploadDataOutput | UploadDataWithPathOutput | undefined;
-}): Action => {
-  return {
-    type: StorageManagerActionTypes.SET_STATUS_UPLOADING,
-    id,
-    uploadTask,
-  };
-};
+}: TaskEvent): Action => ({
+  type: StorageManagerActionTypes.SET_STATUS_UPLOADING,
+  id,
+  uploadTask,
+});
 
 export const setUploadProgressAction = ({
   id,
@@ -56,13 +41,11 @@ export const setUploadProgressAction = ({
 }: {
   id: string;
   progress: number;
-}): Action => {
-  return {
-    type: StorageManagerActionTypes.SET_UPLOAD_PROGRESS,
-    id,
-    progress,
-  };
-};
+}): Action => ({
+  type: StorageManagerActionTypes.SET_UPLOAD_PROGRESS,
+  id,
+  progress,
+});
 
 export const setUploadStatusAction = ({
   id,
@@ -70,17 +53,13 @@ export const setUploadStatusAction = ({
 }: {
   id: string;
   status: FileStatus;
-}): Action => {
-  return {
-    type: StorageManagerActionTypes.SET_STATUS,
-    id,
-    status,
-  };
-};
+}): Action => ({
+  type: StorageManagerActionTypes.SET_STATUS,
+  id,
+  status,
+});
 
-export const removeUploadAction = ({ id }: { id: string }): Action => {
-  return {
-    type: StorageManagerActionTypes.REMOVE_UPLOAD,
-    id,
-  };
-};
+export const removeUploadAction = ({ id }: { id: string }): Action => ({
+  type: StorageManagerActionTypes.REMOVE_UPLOAD,
+  id,
+});

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/types.ts
@@ -1,9 +1,5 @@
-import {
-  UploadDataOutput,
-  UploadDataWithPathOutput,
-} from 'aws-amplify/storage';
-
 import { FileStatus, StorageFiles } from '../../types';
+import { UploadTask } from '../../utils';
 
 export interface UseStorageManagerState {
   files: StorageFiles;
@@ -42,7 +38,7 @@ export type Action =
   | {
       type: StorageManagerActionTypes.SET_STATUS_UPLOADING;
       id: string;
-      uploadTask?: UploadDataOutput | UploadDataWithPathOutput;
+      uploadTask?: UploadTask;
     }
   | {
       type: StorageManagerActionTypes.SET_UPLOAD_PROGRESS;

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/useStorageManager.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/useStorageManager.ts
@@ -1,9 +1,5 @@
 import React from 'react';
 
-import {
-  UploadDataOutput,
-  UploadDataWithPathOutput,
-} from 'aws-amplify/storage';
 import { isObject } from '@aws-amplify/ui';
 
 import { StorageFiles, FileStatus, DefaultFile } from '../../types';
@@ -18,6 +14,7 @@ import {
   setUploadProgressAction,
   setUploadStatusAction,
 } from './actions';
+import { TaskHandler } from '../../utils';
 
 export interface UseStorageManager {
   addFiles: (params: {
@@ -27,10 +24,7 @@ export interface UseStorageManager {
   }) => void;
   clearFiles: () => void;
   queueFiles: () => void;
-  setUploadingFile: (params: {
-    id: string;
-    uploadTask?: UploadDataOutput | UploadDataWithPathOutput;
-  }) => void;
+  setUploadingFile: TaskHandler;
   setUploadProgress: (params: { id: string; progress: number }) => void;
   setUploadSuccess: (params: { id: string }) => void;
   setUploadResumed: (params: { id: string }) => void;

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
@@ -14,10 +14,7 @@ const uploadDataSpy = jest
       pause: jest.fn(),
       resume: jest.fn(),
       state: 'SUCCESS',
-      result: Promise.resolve({
-        key: input.key,
-        data: input.data,
-      }),
+      result: Promise.resolve({ key: input.key, data: input.data }),
     };
   });
 
@@ -212,31 +209,6 @@ describe('useUploadFiles', () => {
       expect(uploadDataSpy).toHaveBeenCalledTimes(1);
       expect(uploadDataSpy).toHaveBeenCalledWith(
         expect.objectContaining(expected)
-      );
-    });
-  });
-
-  it('prepends valid provided `prefix` to `processedKey`', async () => {
-    const prefix = 'test-prefix/';
-    const { waitForNextUpdate } = renderHook(() =>
-      useUploadFiles({
-        ...props,
-        isResumable: true,
-        files: [mockQueuedFile],
-        prefix,
-        accessLevel: undefined,
-      })
-    );
-
-    waitForNextUpdate();
-
-    await waitFor(() => {
-      expect(mockOnUploadStart).toHaveBeenCalledWith({
-        key: `${prefix}${mockQueuedFile.key}`,
-      });
-      expect(uploadDataSpy).toHaveBeenCalledTimes(1);
-      expect(uploadDataSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ path: `${prefix}${mockQueuedFile.key}` })
       );
     });
   });

--- a/packages/react-storage/src/components/StorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/types.ts
@@ -1,9 +1,5 @@
 import * as React from 'react';
 
-import type {
-  UploadDataOutput,
-  UploadDataWithPathOutput,
-} from 'aws-amplify/storage';
 import type { StorageAccessLevel } from '@aws-amplify/core';
 
 import {
@@ -14,7 +10,7 @@ import {
   FileListProps,
   FilePickerProps,
 } from './ui';
-import { StorageManagerDisplayText } from './utils';
+import { StorageManagerDisplayText, PathCallback, UploadTask } from './utils';
 
 export enum FileStatus {
   ADDED = 'added',
@@ -30,7 +26,7 @@ export interface StorageFile {
   file?: File;
   status: FileStatus;
   progress: number;
-  uploadTask?: UploadDataOutput | UploadDataWithPathOutput;
+  uploadTask?: UploadTask;
   key: string;
   error: string;
   isImage: boolean;
@@ -40,8 +36,10 @@ export type StorageFiles = StorageFile[];
 
 export type DefaultFile = Pick<StorageFile, 'key'>;
 
-export type ProcessFileParams = Required<Pick<StorageFile, 'file' | 'key'>> &
-  Record<string, any>;
+export interface ProcessFileParams extends Record<string, any> {
+  file: File;
+  key: string;
+}
 
 export type ProcessFile = (
   params: ProcessFileParams
@@ -58,10 +56,10 @@ export interface StorageManagerProps {
    */
   acceptedFileTypes?: string[];
   /**
-   * @deprecated
-   * `accessLevel` has been deprecated in favor of `prefix` and will be removed in a future major version
+   * Access level for file uploads
+   * @see https://docs.amplify.aws/lib/storage/configureaccess/q/platform/js/
    */
-  accessLevel?: StorageAccessLevel;
+  accessLevel: StorageAccessLevel;
 
   /**
    * Determines if the upload will automatically start after a file is selected, default value: true
@@ -123,12 +121,19 @@ export interface StorageManagerProps {
    */
   showThumbnails?: boolean;
   /**
-   * @deprecated
-   * `path` has been deprecated in favor of `prefix` and will be removed in a future major version
+   * Provided value is prefixed to the file `key` for each file
    */
   path?: string;
+}
+
+export interface StorageManagerPathProps
+  extends Omit<StorageManagerProps, 'accessLevel' | 'path'> {
   /**
-   * A string prefixed to the key of each file
+   * S3 bucket key, allows either a `string` or a `PathCallback`:
+   * - `string`: `path` is prefixed to the file `key` for each file
+   * - `PathCallback`: callback provided an input containing the current `identityId`,
+   *    resolved value is prefixed to the file `key` for each file
    */
-  prefix?: string;
+  path: string | PathCallback;
+  accessLevel?: never;
 }

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/FileList.test.tsx
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/FileList.test.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import {
-  UploadDataOutput,
-  UploadDataWithPathOutput,
-} from 'aws-amplify/storage';
+import { UploadDataOutput } from 'aws-amplify/storage';
 import { ComponentClassName } from '@aws-amplify/ui';
 
 import { FileList } from '../FileList';
@@ -19,7 +16,7 @@ const mockFile: StorageFile = {
   error: '',
   isImage: false,
   key: '',
-  uploadTask: {} as UploadDataOutput | UploadDataWithPathOutput,
+  uploadTask: {} as UploadDataOutput,
 };
 
 const mockOnCancelUpload = jest.fn();

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/types.ts
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/types.ts
@@ -1,28 +1,14 @@
-import {
-  UploadDataOutput,
-  UploadDataWithPathOutput,
-} from 'aws-amplify/storage';
-
-import { StorageManagerDisplayTextDefault } from '../../utils';
+import { StorageManagerDisplayTextDefault, TaskHandler } from '../../utils';
 import { FileStatus, StorageFile } from '../../types';
 
 export interface FileListProps {
   displayText: StorageManagerDisplayTextDefault;
   files: StorageFile[];
   isResumable: boolean;
-  onCancelUpload: (params: {
-    id: string;
-    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
-  }) => void;
+  onCancelUpload: TaskHandler;
   onDeleteUpload: (params: { id: string }) => void;
-  onPause: (params: {
-    id: string;
-    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
-  }) => void;
-  onResume: (params: {
-    id: string;
-    uploadTask: UploadDataOutput | UploadDataWithPathOutput;
-  }) => void;
+  onPause: TaskHandler;
+  onResume: TaskHandler;
   showThumbnails: boolean;
   hasMaxFilesError: boolean;
   maxFileCount: number;

--- a/packages/react-storage/src/components/StorageManager/utils/__tests__/getInput.spec.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/__tests__/getInput.spec.ts
@@ -1,0 +1,171 @@
+import * as AuthModule from 'aws-amplify/auth';
+import { UploadDataWithPathInput, UploadDataInput } from 'aws-amplify/storage';
+import { getInput, GetInputParams } from '../getInput';
+
+const identityId = 'identity-id';
+jest.spyOn(AuthModule, 'fetchAuthSession').mockResolvedValue({ identityId });
+
+const file = new File(['hello'], 'hello.png', { type: 'image/png' });
+const key = file.name;
+const onProgress = jest.fn();
+const accessLevel = 'guest';
+
+const processFilePrefix = 'my-prefix/';
+const processFile: GetInputParams['processFile'] = ({ key, ...rest }) => ({
+  key: `${processFilePrefix}${key}`,
+  ...rest,
+});
+
+const stringPath = 'my-path/';
+
+const inputBase: Omit<GetInputParams, 'path' | 'accessLevel'> = {
+  file,
+  key,
+  onProgress,
+  processFile: undefined,
+};
+const pathStringInput: GetInputParams = {
+  ...inputBase,
+  accessLevel: undefined,
+  path: stringPath,
+};
+const pathCallbackInput: GetInputParams = {
+  ...inputBase,
+  accessLevel: undefined,
+  path: ({ identityId }) => `${stringPath}${identityId}`,
+};
+
+const accessLevelWithoutPathInput: GetInputParams = {
+  ...inputBase,
+  accessLevel,
+  path: undefined,
+};
+
+const accessLevelWithPathInput: GetInputParams = {
+  ...inputBase,
+  accessLevel,
+  file,
+  key,
+  path: stringPath,
+};
+
+describe('getInput', () => {
+  it('resolves an UploadDataWithPathInput with a string `path` as expected', async () => {
+    const expected: UploadDataWithPathInput = {
+      data: file,
+      options: { contentType: file.type, onProgress },
+      path: `${stringPath}${key}`,
+    };
+
+    const input = getInput(pathStringInput);
+
+    const output = await input();
+
+    expect(output).toStrictEqual(expected);
+  });
+
+  it('resolves an UploadDataWithPathInput with a callback `path` as expected', async () => {
+    const expected: UploadDataWithPathInput = {
+      data: file,
+      options: { contentType: file.type, onProgress },
+      path: `${stringPath}${identityId}${key}`,
+    };
+
+    const input = getInput(pathCallbackInput);
+
+    const output = await input();
+
+    expect(output).toStrictEqual(expected);
+  });
+
+  it('resolves an UploadDataInput without a `path` as expected', async () => {
+    const expected: UploadDataInput = {
+      data: file,
+      options: { accessLevel, contentType: file.type, onProgress },
+      key,
+    };
+
+    const input = getInput(accessLevelWithoutPathInput);
+
+    const output = await input();
+
+    expect(output).toStrictEqual(expected);
+  });
+
+  it('resolves an UploadDataInput with a `path` as expected', async () => {
+    const expected: UploadDataInput = {
+      data: file,
+      options: { accessLevel, contentType: file.type, onProgress },
+      key: `${stringPath}${key}`,
+    };
+
+    const input = getInput(accessLevelWithPathInput);
+
+    const output = await input();
+
+    expect(output).toStrictEqual(expected);
+  });
+
+  it('handles a `processFile` param expected', async () => {
+    const expected: UploadDataWithPathInput = {
+      data: file,
+      options: { contentType: file.type, onProgress },
+      path: `${stringPath}${identityId}${processFilePrefix}${key}`,
+    };
+
+    const input = getInput({ ...pathCallbackInput, processFile });
+
+    const output = await input();
+
+    expect(output).toStrictEqual(expected);
+  });
+
+  it('includes additional values returned from `processFile` in `options`', async () => {
+    const contentDisposition = 'attachment';
+    const metadata = { key };
+
+    const expected: UploadDataWithPathInput = {
+      data: file,
+      options: {
+        contentDisposition,
+        contentType: file.type,
+        metadata,
+        onProgress,
+      },
+      path: `${stringPath}${processFilePrefix}${key}`,
+    };
+
+    const input = getInput({
+      ...pathStringInput,
+      processFile: ({ key, ...rest }) => ({
+        key: `${processFilePrefix}${key}`,
+        metadata,
+        contentDisposition,
+        ...rest,
+      }),
+    });
+
+    const output = await input();
+
+    expect(output).toStrictEqual(expected);
+    expect(output.options?.metadata).toStrictEqual(metadata);
+    expect(output.options?.contentDisposition).toStrictEqual(
+      contentDisposition
+    );
+  });
+});
+
+it('defaults `options.contentType` to "binary/octet-stream" when no file type is provided', async () => {
+  const data = new File(['hello'], 'hello.png');
+  const expected: UploadDataWithPathInput = {
+    data,
+    options: { contentType: 'binary/octet-stream', onProgress },
+    path: `${stringPath}${key}`,
+  };
+
+  const input = getInput({ ...pathStringInput, file: data });
+
+  const output = await input();
+
+  expect(output).toStrictEqual(expected);
+});

--- a/packages/react-storage/src/components/StorageManager/utils/__tests__/uploadFile.test.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/__tests__/uploadFile.test.ts
@@ -4,52 +4,46 @@ import { UploadFileProps, uploadFile } from '../uploadFile';
 
 const imageFile = new File(['hello'], 'hello.png', { type: 'image/png' });
 const key = imageFile.name;
-const path = imageFile.name;
-const file = imageFile;
+const data = imageFile;
 
-const errorCallback = jest.fn();
-const completeCallback = jest.fn();
-const progressCallback = jest.fn();
+const onError = jest.fn();
+const onComplete = jest.fn();
+const onProgress = jest.fn();
 
-const defaultProps: UploadFileProps = {
-  file,
-  key,
-  path,
-  level: 'guest',
-  progressCallback,
-  errorCallback,
-  completeCallback,
-};
-
-const uploadDataOutput: Storage.UploadDataOutput = {
-  cancel: jest.fn(),
-  pause: jest.fn(),
-  resume: jest.fn(),
-  state: 'SUCCESS',
-  result: Promise.resolve({
-    key: defaultProps.key,
-    data: defaultProps.data,
-  }),
-};
-
-const uploadDataSpy = jest
-  .spyOn(Storage, 'uploadData')
-  .mockReturnValue(uploadDataOutput);
+const uploadDataSpy = jest.spyOn(Storage, 'uploadData');
 
 describe('uploadFile', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    uploadDataSpy.mockReturnValue(uploadDataOutput);
   });
 
-  it('uploads a file with default options', async () => {
-    const { result } = uploadFile(defaultProps);
+  it('behaves as expected with an accessLevel provided in the input', async () => {
+    const uploadDataOutput: Storage.UploadDataOutput = {
+      cancel: jest.fn(),
+      pause: jest.fn(),
+      resume: jest.fn(),
+      state: 'SUCCESS',
+      result: Promise.resolve({ key, data }),
+    };
+
+    uploadDataSpy.mockReturnValueOnce(uploadDataOutput);
+    const input: UploadFileProps['input'] = () =>
+      Promise.resolve({
+        data,
+        key,
+        options: {
+          accessLevel: 'guest',
+          contentType: 'image/png',
+          onProgress,
+        },
+      });
+    const { result } = await uploadFile({ input, onComplete });
 
     await result;
 
     expect(uploadDataSpy).toHaveBeenCalledWith({
+      data,
       key,
-      data: file,
       options: {
         accessLevel: 'guest',
         contentType: imageFile.type,
@@ -57,83 +51,111 @@ describe('uploadFile', () => {
       },
     });
 
-    expect(completeCallback).toHaveBeenCalledWith({ key });
-    expect(errorCallback).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledWith({ key, data });
+    expect(onError).not.toHaveBeenCalled();
   });
 
-  it('should uploads a file with path prop', async () => {
-    const { result } = uploadFile({ ...defaultProps, level: undefined });
+  it('behaves as expected without an accessLevel provided in the input', async () => {
+    const path = `my-path/${key}`;
+    const uploadDataPathOutput: Storage.UploadDataWithPathOutput = {
+      cancel: jest.fn(),
+      pause: jest.fn(),
+      resume: jest.fn(),
+      state: 'SUCCESS',
+      result: Promise.resolve({ path, data }),
+    };
+    // @ts-expect-error amplify storage doesn't expose the base overload of `uploadData`
+    uploadDataSpy.mockReturnValueOnce(uploadDataPathOutput);
+    const input: UploadFileProps['input'] = () =>
+      Promise.resolve({
+        data,
+        path,
+        options: { contentType: 'image/png', onProgress },
+      });
+    const { result } = await uploadFile({
+      input,
+      onComplete,
+    });
 
     await result;
 
     expect(uploadDataSpy).toHaveBeenCalledWith({
-      path,
-      data: file,
+      data,
       options: {
+        contentType: imageFile.type,
+        onProgress: expect.any(Function),
+      },
+      path,
+    });
+
+    expect(onComplete).toHaveBeenCalledWith({ path, data });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('calls onStart as expected', async () => {
+    const onStart = jest.fn();
+    const uploadDataOutput: Storage.UploadDataOutput = {
+      cancel: jest.fn(),
+      pause: jest.fn(),
+      resume: jest.fn(),
+      state: 'SUCCESS',
+      result: Promise.resolve({ key, data }),
+    };
+
+    uploadDataSpy.mockReturnValueOnce(uploadDataOutput);
+    const input: UploadFileProps['input'] = () =>
+      Promise.resolve({
+        data,
+        key,
+        options: {
+          accessLevel: 'guest',
+          contentType: 'image/png',
+          onProgress,
+        },
+      });
+    const { result } = await uploadFile({ input, onComplete, onStart });
+
+    await result;
+
+    expect(uploadDataSpy).toHaveBeenCalledWith({
+      data,
+      key,
+      options: {
+        accessLevel: 'guest',
         contentType: imageFile.type,
         onProgress: expect.any(Function),
       },
     });
 
-    expect(completeCallback).toHaveBeenCalledWith({ key });
-    expect(errorCallback).not.toHaveBeenCalled();
+    expect(onStart).toHaveBeenCalledWith({ key, uploadTask: uploadDataOutput });
   });
 
   it('calls errorCallback on upload error', async () => {
+    const error = new Error('Error');
     uploadDataSpy.mockReturnValueOnce({
-      ...uploadDataOutput,
-      result: Promise.reject(new Error('Error')),
+      cancel: jest.fn(),
+      pause: jest.fn(),
+      resume: jest.fn(),
+      result: Promise.reject(error),
       state: 'ERROR',
     });
 
-    const { result } = uploadFile(defaultProps);
+    const input: UploadFileProps['input'] = () =>
+      Promise.resolve({
+        data,
+        key,
+        options: {
+          accessLevel: 'guest',
+          contentType: 'image/png',
+          onProgress,
+        },
+      });
+    const { result } = await uploadFile({ input, onComplete, onError });
 
     await expect(result).rejects.toThrow();
-    expect(progressCallback).not.toHaveBeenCalled();
-    expect(errorCallback).toHaveBeenCalledTimes(1);
-    expect(errorCallback).toHaveBeenCalledWith('Error');
-    expect(completeCallback).not.toHaveBeenCalled();
-  });
-
-  it('calls uploadFile with contentType binary/octet-stream when file.type is undefined', () => {
-    const imageFileTypeUndefined = new File(['hello2'], 'hello2.png', {
-      type: undefined,
-    });
-
-    uploadFile({
-      ...defaultProps,
-      file: imageFileTypeUndefined,
-      key: imageFileTypeUndefined.name,
-    });
-
-    expect(uploadDataSpy).toHaveBeenCalledWith({
-      data: imageFileTypeUndefined,
-      key: imageFileTypeUndefined.name,
-      options: {
-        accessLevel: 'guest',
-        onProgress: expect.any(Function),
-        contentType: 'binary/octet-stream',
-      },
-    });
-  });
-
-  it('passes other options to uploadData', () => {
-    uploadFile({
-      ...defaultProps,
-      contentDisposition: 'attachment',
-      metadata: { foo: 'bar' },
-    });
-
-    expect(uploadDataSpy).toHaveBeenCalledWith({
-      data: imageFile,
-      key: imageFile.name,
-      options: {
-        accessLevel: 'guest',
-        onProgress: expect.any(Function),
-        contentType: 'image/png',
-        contentDisposition: 'attachment',
-        metadata: { foo: 'bar' },
-      },
-    });
+    expect(onProgress).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith({ error, key });
+    expect(onComplete).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-storage/src/components/StorageManager/utils/getInput.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/getInput.ts
@@ -1,0 +1,59 @@
+import { fetchAuthSession } from 'aws-amplify/auth';
+import { StorageAccessLevel } from '@aws-amplify/core';
+import { UploadDataWithPathInput, UploadDataInput } from 'aws-amplify/storage';
+
+import { isString, isTypedFunction } from '@aws-amplify/ui';
+
+import { ProcessFile } from '../types';
+import { resolveFile } from './resolveFile';
+import { PathCallback, PathInput } from './uploadFile';
+
+export interface GetInputParams {
+  accessLevel: StorageAccessLevel | undefined;
+  file: File;
+  key: string;
+  onProgress: NonNullable<UploadDataWithPathInput['options']>['onProgress'];
+  path: string | PathCallback | undefined;
+  processFile: ProcessFile | undefined;
+}
+
+export const getInput = ({
+  accessLevel,
+  file,
+  key,
+  onProgress,
+  path,
+  processFile,
+}: GetInputParams) => {
+  return async (): Promise<PathInput | UploadDataInput> => {
+    const hasCallbackPath = isTypedFunction<PathCallback>(path);
+    const hasStringPath = isString(path);
+
+    const hasKeyInput = !!accessLevel && !hasCallbackPath;
+
+    const {
+      file: data,
+      key: fileKey,
+      ...rest
+    } = await resolveFile({ file, key, processFile });
+
+    const contentType = file.type || 'binary/octet-stream';
+
+    // IMPORTANT: always pass `...rest` here for backwards compatibility
+    const options = { contentType, onProgress, ...rest };
+
+    if (hasKeyInput) {
+      // legacy handling of `path` is to prefix to `fileKey`
+      const resolvedKey = hasStringPath ? `${path}${fileKey}` : fileKey;
+
+      return { data, key: resolvedKey, options: { ...options, accessLevel } };
+    }
+
+    const { identityId } = await fetchAuthSession();
+    const resolvedPath = `${
+      hasCallbackPath ? path({ identityId }) : path
+    }${fileKey}`;
+
+    return { data: file, path: resolvedPath, options };
+  };
+};

--- a/packages/react-storage/src/components/StorageManager/utils/index.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/index.ts
@@ -6,4 +6,12 @@ export {
 } from './displayText';
 export { filterAllowedFiles } from './filterAllowedFiles';
 export { humanFileSize } from './humanFileSize';
-export { uploadFile } from './uploadFile';
+export { getInput } from './getInput';
+
+export {
+  PathCallback,
+  TaskEvent,
+  TaskHandler,
+  uploadFile,
+  UploadTask,
+} from './uploadFile';

--- a/packages/react-storage/src/components/StorageManager/utils/resolveFile.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/resolveFile.ts
@@ -1,9 +1,5 @@
 import { isFunction } from '@aws-amplify/ui';
-import { ProcessFileParams, StorageManagerProps } from '../../types';
-
-interface ResolveFileParams
-  extends Pick<StorageManagerProps, 'processFile'>,
-    ProcessFileParams {}
+import { ProcessFile, ProcessFileParams } from '../types';
 
 /**
  * Utility function that takes the processFile prop, along with a file a key
@@ -12,13 +8,12 @@ interface ResolveFileParams
  */
 export const resolveFile = ({
   processFile,
-  file,
-  key,
-}: ResolveFileParams): Promise<ProcessFileParams> => {
+  ...input
+}: ProcessFileParams & {
+  processFile?: ProcessFile;
+}): Promise<ProcessFileParams> => {
   return new Promise((resolve, reject) => {
-    const result = isFunction(processFile)
-      ? processFile({ file, key })
-      : { file, key };
+    const result = isFunction(processFile) ? processFile(input) : input;
     if (result instanceof Promise) {
       result.then(resolve).catch(reject);
     } else {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add first class support for `path` as callback
- remove `prefix` prop
- allow `accessLevel` to be `undefined` to support `path` only use cases
- remove default `accessLevel` value
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual tests, unit tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
