### PR TITLE
chore(gen2 storage): update StorageImage deprecation warnings

### DIFF
--- a/.changeset/rude-yaks-kiss.md
+++ b/.changeset/rude-yaks-kiss.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-storage": patch
+---
+
+chore(gen2 storage): update StorageImage deprecation warnings to reference docs.

--- a/packages/react-storage/src/components/StorageImage/StorageImage.tsx
+++ b/packages/react-storage/src/components/StorageImage/StorageImage.tsx
@@ -12,13 +12,13 @@ export const MISSING_REQUIRED_PROP_MESSAGE =
   '`StorageImage` requires either an `imgKey` or `path` prop.';
 
 export const HAS_DEPRECATED_PROPS_MESSAGE =
-  '`imgKey`, `accessLevel`, and `identityId` will be replaced with `path` in a future major version.';
+  '`imgKey`, `accessLevel`, and `identityId` will be replaced with `path` in a future major version. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props';
 
 export const HAS_PATH_AND_KEY_MESSAGE =
   '`imgKey` is ignored when both `imgKey` and `path` props are provided.';
 
 export const HAS_PATH_AND_UNSUPPORTED_OPTIONS_MESSAGE =
-  '``accessLevel` and `identityId` are ignored when the `path` prop is provided.';
+  '`accessLevel` and `identityId` are ignored when the `path` prop is provided.';
 
 const getDeprecationMessage = ({
   hasImgkey,

--- a/packages/react-storage/src/components/StorageImage/types.ts
+++ b/packages/react-storage/src/components/StorageImage/types.ts
@@ -7,17 +7,17 @@ export interface StorageImageProps extends Omit<ImageProps, 'src'> {
   // Note: a new Storage.get request is made only when the imgKey gets updated after the initial
   /**
    * @deprecated
-   * `imgKey` will be replaced with `path` in the next major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
+   * `imgKey` will be replaced with `path` in a future major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
    */
   imgKey: string;
   /**
    * @deprecated
-   * `accessLevel` will be replaced with `path` in the next major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
+   * `accessLevel` will be replaced with `path` in a future major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
    */
   accessLevel: StorageAccessLevel;
   /**
    * @deprecated
-   * `identityId` will be replaced with `path` in the next major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
+   * `identityId` will be replaced with `path` in a future major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
    */
   identityId?: string;
   fallbackSrc?: string;
@@ -25,7 +25,7 @@ export interface StorageImageProps extends Omit<ImageProps, 'src'> {
   /**
    * @deprecated use `onGetUrlError`
    *
-   * `onStorageGetError` will be replaced with `onGetUrlError` in the next major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
+   * `onStorageGetError` will be replaced with `onGetUrlError` in a future major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
    */
   onStorageGetError?: (error: Error) => void;
   // Allow user to migrate from `onStorageGetError` without changing to `path` props

--- a/packages/react-storage/src/components/StorageImage/types.ts
+++ b/packages/react-storage/src/components/StorageImage/types.ts
@@ -7,17 +7,17 @@ export interface StorageImageProps extends Omit<ImageProps, 'src'> {
   // Note: a new Storage.get request is made only when the imgKey gets updated after the initial
   /**
    * @deprecated
-   * `imgKey` will be replaced with `path` in the next major version of Amplify UI
+   * `imgKey` will be replaced with `path` in the next major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
    */
   imgKey: string;
   /**
    * @deprecated
-   * `accessLevel` will be replaced with `path` in the next major version of Amplify UI
+   * `accessLevel` will be replaced with `path` in the next major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
    */
   accessLevel: StorageAccessLevel;
   /**
    * @deprecated
-   * `identityId` will be replaced with `path` in the next major version of Amplify UI
+   * `identityId` will be replaced with `path` in the next major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
    */
   identityId?: string;
   fallbackSrc?: string;
@@ -25,7 +25,7 @@ export interface StorageImageProps extends Omit<ImageProps, 'src'> {
   /**
    * @deprecated use `onGetUrlError`
    *
-   * `onStorageGetError` will be replaced with `onGetUrlError` in the next major version of Amplify UI
+   * `onStorageGetError` will be replaced with `onGetUrlError` in the next major version of Amplify UI. See https://ui.docs.amplify.aws/react/connected-components/storage/storageimage#props
    */
   onStorageGetError?: (error: Error) => void;
   // Allow user to migrate from `onStorageGetError` without changing to `path` props


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update `StorageImage` deprecation warnings to point to props table in docs 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
