### PR TITLE
fix(docs): update storage links that need to point to gen1 pages still

### DIFF
--- a/docs/src/pages/[platform]/connected-components/storage/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/react.mdx
@@ -3,7 +3,7 @@ import { Example, ExampleCode } from '@/components/Example';
 import { InstallScripts } from '@/components/InstallScripts';
 import { NextSteps } from './NextSteps';
 
-Amplify UI Storage components use [Amplify Storage](https://docs.amplify.aws/lib/storage/getting-started/q/platform/js/) to allow your users to upload and interact with files stored in Amazon S3 with minimal boilerplate.
+Amplify UI Storage components use [Amplify Storage](https://docs.amplify.aws/javascript/build-a-backend/storage/set-up-storage/) to allow your users to upload and interact with files stored in Amazon S3 with minimal boilerplate.
 
 ## Quick start
 

--- a/docs/src/pages/[platform]/connected-components/storage/storageimage/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storageimage/react.mdx
@@ -29,7 +29,7 @@ import '@aws-amplify/ui-react/styles.css';
 ```
 </ExampleCode>
 
-At a minimum you must include the `alt` and `path` props. `path` is a full S3 object key and refers to the [Amplify Storage path](https://docs.amplify.aws/react/build-a-backend/storage/download-files/). It is either a `string` or a callback function that accepts the current user's Cognito `identityId` and returns a `string`.
+At a minimum you must include the `alt` and `path` props. `path` is a full S3 object key and refers to the [Amplify Storage path](https://docs.amplify.aws/react/build-a-backend/storage/path/). It is either a `string` or a callback function that accepts the current user's Cognito `identityId` and returns a `string`.
 
 ### Public Image
 <Example>

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
@@ -45,7 +45,7 @@ import '@aws-amplify/ui-react/styles.css';
 ```
 </ExampleCode>
 
-At a minimum you must include the `path` and `maxFileCount` props. `path` refers to the S3 image path that will be prefixed to each file key. It is either a `string` or a callback function that accepts the current user's Cognito `identityId` and returns a `string`. See [upload files](https://docs.amplify.aws/react/build-a-backend/storage/upload-files/) 
+At a minimum you must include the `path` and `maxFileCount` props. `path` refers to the S3 image path that will be prefixed to each file key. It is either a `string` or a callback function that accepts the current user's Cognito `identityId` and returns a `string`. See [upload files](https://docs.amplify.aws/react/build-a-backend/storage/upload) 
 
 <Alert variation="info" heading="Version 3.0.18">
   Using `@aws-amplify/ui-react-storage` version 3.0.18 or below and looking for docs on `accessLevel`? See [`accessLevel`](#accesslevel-props)
@@ -186,7 +186,7 @@ Other uses-cases for processing the file before upload:
 1. Performing file optimizations like removing unnecessary metadata.
 1. Performing custom file validations like reading the contents of a file to ensure it is in the proper structure.
 
-You can also add any other [Amplify Storage options](https://docs.amplify.aws/lib/storage/upload/q/platform/js/#encrypted-uploads) by adding them to the return object of `processFile`
+You can also add any other [Amplify Storage options](https://docs.amplify.aws/javascript/build-a-backend/storage/upload/#encrypted-uploads) by adding them to the return object of `processFile`
 
 ## Event Handling
 

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
@@ -186,7 +186,7 @@ Other uses-cases for processing the file before upload:
 1. Performing file optimizations like removing unnecessary metadata.
 1. Performing custom file validations like reading the contents of a file to ensure it is in the proper structure.
 
-You can also add any other [Amplify Storage options](https://docs.amplify.aws/javascript/build-a-backend/storage/upload/#encrypted-uploads) by adding them to the return object of `processFile`
+You can also add any other [Amplify Storage options](https://docs.amplify.aws/javascript/build-a-backend/storage/upload) by adding them to the return object of `processFile`
 
 ## Event Handling
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
