### PR TITLE
chore(docs): update links in storage docs to reference gen1/gen2

### DIFF
--- a/docs/src/pages/[platform]/connected-components/storage/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/react.mdx
@@ -7,4 +7,77 @@ Amplify UI Storage components use [Amplify Storage](https://docs.amplify.aws/rea
 
 ## Quick start
 
+### Setup with Amplify Gen 2 Backend
+
 Follow the steps in [this guide](https://docs.amplify.aws/react/build-a-backend/storage/set-up-storage/) to set up your Amplify Storage backend.
+
+### Setup with Amplify Gen 1 Backend
+
+To set up Amplify using the [Gen 1 CLI](https://docs.amplify.aws/gen1/react/start/getting-started/installation/), follow the steps below: 
+
+First, update `@aws-amplify/cli` with [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)
+if you're using a version before `6.4.0`:
+
+<Tabs.Container defaultValue="npm">
+<Tabs.List>
+  <Tabs.Item value="npm">npm</Tabs.Item>
+  <Tabs.Item value="yarn">yarn</Tabs.Item>
+</Tabs.List>
+<Tabs.Panel value="npm">
+
+```shell
+npm install -g @aws-amplify/cli@latest
+```
+
+</Tabs.Panel>
+<Tabs.Panel title="yarn">
+
+```shell
+yarn global add @aws-amplify/cli@latest
+```
+
+</Tabs.Panel>
+</Tabs.Container>
+
+
+Now that you have the Amplify CLI installed, you can set up your Amplify project by running `amplify init` in your project's root directory. 
+
+Then run `amplify add storage` and follow the prompts to add storage to your backend configuration.
+
+<Alert role="none" variation="info" heading="Auth">
+  The Amplify Storage category requires you have auth set up. When you run `amplify add storage` it will prompt you to add auth as well.
+</Alert>
+
+_If you have an existing backend, run `amplify pull` to sync your `aws-exports.js` with your cloud backend._
+
+You should now have an `aws-exports.js` file in your `src/` directory with your latest backend configuration.
+
+After setting up Amplify make sure to install the Amplify libraries.
+
+<InstallScripts component="storage" />
+
+#### Configuring Amplify for Storage UI Components
+To use Storage UI components with Amplify, you'll need to call `Amplify.configure()` as shown below. 
+<Example>
+  <Image alt='cat' src='/cats/1.jpg' width="400px" height="400px" />
+  <ExampleCode>
+    ```tsx
+    import { Amplify } from 'aws-amplify';
+    import { StorageImage, StorageManager } from '@aws-amplify/ui-react-storage';
+    import awsExports from './aws-exports';
+
+    Amplify.configure(awsExports);
+
+    export const App = () => {
+      return (
+        <>
+          <StorageImage alt="sleepy-cat" path="public/cat.jpeg" />
+          <StorageManager path="my_prefix/public" maxFileCount={3} />
+        </>
+      );
+    };
+    ```
+  </ExampleCode>
+</Example>
+
+<NextSteps />

--- a/docs/src/pages/[platform]/connected-components/storage/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/react.mdx
@@ -3,76 +3,8 @@ import { Example, ExampleCode } from '@/components/Example';
 import { InstallScripts } from '@/components/InstallScripts';
 import { NextSteps } from './NextSteps';
 
-Amplify UI Storage components use [Amplify Storage](https://docs.amplify.aws/javascript/build-a-backend/storage/set-up-storage/) to allow your users to upload and interact with files stored in Amazon S3 with minimal boilerplate.
+Amplify UI Storage components use [Amplify Storage](https://docs.amplify.aws/react/build-a-backend/storage/) to allow your users to upload and interact with files stored in Amazon S3 with minimal boilerplate.
 
 ## Quick start
 
-The Amplify UI Storage components work seamlessly with the [Amplify CLI](https://docs.amplify.aws/cli/start/install/)
-to **automatically** work with your backend.
-
-First, update `@aws-amplify/cli` with [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)
-if you're using a version before `6.4.0`:
-
-<Tabs.Container defaultValue="npm">
-<Tabs.List>
-  <Tabs.Item value="npm">npm</Tabs.Item>
-  <Tabs.Item value="yarn">yarn</Tabs.Item>
-</Tabs.List>
-<Tabs.Panel value="npm">
-
-```shell
-npm install -g @aws-amplify/cli@latest
-```
-
-</Tabs.Panel>
-<Tabs.Panel title="yarn">
-
-```shell
-yarn global add @aws-amplify/cli@latest
-```
-
-</Tabs.Panel>
-</Tabs.Container>
-
-
-Now that you have the Amplify CLI installed, you can set up your Amplify project by running `amplify init` in your project's root directory. 
-
-Then run `amplify add storage` and follow the prompts to add storage to your backend configuration.
-
-<Alert role="none" variation="info" heading="Auth">
-  The Amplify Storage category requires you have auth set up. When you run `amplify add storage` it will prompt you to add auth as well.
-</Alert>
-
-_If you have an existing backend, run `amplify pull` to sync your `aws-exports.js` with your cloud backend._
-
-You should now have an `aws-exports.js` file in your `src/` directory with your latest backend configuration.
-
-After setting up Amplify make sure to install the Amplify libraries.
-
-<InstallScripts component="storage" />
-
-## Configuring Amplify for Storage UI Components
-To use Storage UI components with Amplify, you'll need to call `Amplify.configure()` as shown below. 
-<Example>
-  <Image alt='cat' src='/cats/1.jpg' width="400px" height="400px" />
-  <ExampleCode>
-    ```tsx
-    import { Amplify } from 'aws-amplify';
-    import { StorageImage, StorageManager } from '@aws-amplify/ui-react-storage';
-    import awsExports from './aws-exports';
-
-    Amplify.configure(awsExports);
-
-    export const App = () => {
-      return (
-        <>
-          <StorageImage alt="sleepy-cat" path="public/cat.jpeg" />
-          <StorageManager path="my_prefix/public" maxFileCount={3} />
-        </>
-      );
-    };
-    ```
-  </ExampleCode>
-</Example>
-
-<NextSteps />
+Follow the steps in [this guide](https://docs.amplify.aws/react/build-a-backend/storage/set-up-storage/) to set up your Amplify Storage backend.

--- a/docs/src/pages/[platform]/connected-components/storage/storageimage/props.ts
+++ b/docs/src/pages/[platform]/connected-components/storage/storageimage/props.ts
@@ -12,19 +12,20 @@ export const STORAGE_IMAGE = [
   },
   {
     name: 'imgKey',
-    description: 'Deprecated, use path instead. The key of an image.',
+    description:
+      'Deprecated, use path instead. The key of an image. See https://docs.amplify.aws/gen1/react/build-a-backend/storage/download/',
     type: 'string',
   },
   {
     name: 'accessLevel',
     description:
-      'Deprecated, use path instead. Access level for files in Storage.',
+      'Deprecated, use path instead. Access level for files in Storage. See https://docs.amplify.aws/gen1/react/build-a-backend/storage/configure-access/',
     type: `'guest' | 'protected' | 'private'`,
   },
   {
     name: 'identityId?',
     description:
-      'Deprecated, use path instead. The unique Amazon Cognito Identity ID of the image owner. Required when loading a protected or private image.',
+      'Deprecated, use path instead. The unique Amazon Cognito Identity ID of the image owner.',
     type: 'string',
   },
   {
@@ -47,7 +48,7 @@ export const STORAGE_IMAGE = [
   {
     name: 'validateObjectExistence?',
     description:
-      'Whether to check for the existence of a file. Defaults to true. See https://docs.amplify.aws/javascript/build-a-backend/storage/download/#check-for-existence-of-a-file',
+      'Whether to check for the existence of a file. Defaults to true. See https://docs.amplify.aws/react/build-a-backend/storage/download-files/#more-geturl-options',
     type: `boolean`,
   },
 ];

--- a/docs/src/pages/[platform]/connected-components/storage/storageimage/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storageimage/react.mdx
@@ -29,7 +29,7 @@ import '@aws-amplify/ui-react/styles.css';
 ```
 </ExampleCode>
 
-At a minimum you must include the `alt` and `path` props. `path` is a full S3 object key and refers to the [Amplify Storage path](https://docs.amplify.aws/react/build-a-backend/storage/path/). It is either a `string` or a callback function that accepts the current user's Cognito `identityId` and returns a `string`.
+At a minimum you must include the `alt` and `path` props. `path` is a full S3 object key and refers to the Amplify Storage path (See [Download Files](https://docs.amplify.aws/react/build-a-backend/storage/download-files/)). It is either a `string` or a callback function that accepts the current user's Cognito `identityId` and returns a `string`.
 
 ### Public Image
 <Example>

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/props.ts
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/props.ts
@@ -34,7 +34,7 @@ export const STORAGE_MANAGER = [
   {
     name: `accessLevel`,
     description:
-      'Deprecated in favor of `path`. S3 access level of upload target files. See https://docs.amplify.aws/javascript/build-a-backend/storage/configure-access/',
+      'Deprecated in favor of `path`. S3 access level of upload target files. See https://docs.amplify.aws/gen1/react/build-a-backend/storage/configure-access/',
     type: `'guest' | 'protected' | 'private'`,
   },
   {

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/react.mdx
@@ -45,10 +45,10 @@ import '@aws-amplify/ui-react/styles.css';
 ```
 </ExampleCode>
 
-At a minimum you must include the `path` and `maxFileCount` props. `path` refers to the S3 image path that will be prefixed to each file key. It is either a `string` or a callback function that accepts the current user's Cognito `identityId` and returns a `string`. See [upload files](https://docs.amplify.aws/react/build-a-backend/storage/upload) 
+At a minimum you must include the `path` and `maxFileCount` props. `path` refers to the S3 image path that will be prefixed to each file key. It is either a `string` or a callback function that accepts the current user's Cognito `identityId` and returns a `string`. See [upload files](https://docs.amplify.aws/react/build-a-backend/storage/upload-files) 
 
 <Alert variation="info" heading="Version 3.0.18">
-  Using `@aws-amplify/ui-react-storage` version 3.0.18 or below and looking for docs on `accessLevel`? See [`accessLevel`](#accesslevel-props)
+  Using `@aws-amplify/ui-react-storage` version 3.0.18 or below and looking for the `accessLevel` prop? See [`Deprecated Props`](#deprecated-props)
 </Alert>
 
 <Example>
@@ -85,7 +85,7 @@ The example below shows configuring the StorageManager to upload to the `protect
       <Accordion.Icon />
     </Accordion.Trigger>
     <Accordion.Content>
-      Versions 3.0.18 and earlier use `accessLevel` and an optional `path` prop in place of the required `path`. `accessLevel` refers to the [Amplify Storage access level](https://docs.amplify.aws/lib/storage/configureaccess/q/platform/js/), which is `'guest' | 'protected' | 'private'`, and `path` is a `string`.
+      Versions 3.0.18 and earlier use `accessLevel` and an optional `path` prop in place of the required `path`. `accessLevel` refers to the [Amplify Storage access level](https://docs.amplify.aws/gen1/react/build-a-backend/storage/configure-access/), which is `'guest' | 'protected' | 'private'`, and `path` is a `string`.
     ```tsx
     <StorageManager
       accessLevel="guest"
@@ -186,7 +186,7 @@ Other uses-cases for processing the file before upload:
 1. Performing file optimizations like removing unnecessary metadata.
 1. Performing custom file validations like reading the contents of a file to ensure it is in the proper structure.
 
-You can also add any other [Amplify Storage options](https://docs.amplify.aws/javascript/build-a-backend/storage/upload) by adding them to the return object of `processFile`
+You can also add any other [Amplify Storage options](https://docs.amplify.aws/react/build-a-backend/storage/upload-files) by adding them to the return object of `processFile`
 
 ## Event Handling
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Updates storage docs to point to gen1/gen2 links where relevant 
- Update quickstart guide to include gen 2 and gen 1


<img width="673" alt="Screenshot 2024-05-02 at 6 14 48 PM" src="https://github.com/aws-amplify/amplify-ui/assets/70536670/7e7d673e-517b-4477-852f-cb02713e6162">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
