### PR TITLE
test(storage): update to use gen2 environment

### DIFF
--- a/environments/.gitignore
+++ b/environments/.gitignore
@@ -17,6 +17,7 @@
 **/node_modules/
 **/aws-exports.js
 **/awsconfiguration.json
+**/amplify_outputs.json
 **/amplifyconfiguration.json
 **/amplifyconfiguration.dart
 **/amplify-build-config.json

--- a/environments/storage/gen2/package.json
+++ b/environments/storage/gen2/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "@aws-amplify/ui-gen2-storage-environment",
+  "version": "0.0.1",
+  "scripts": {
+    "generate": "AWS_REGION=us-east-2 npx @aws-amplify/backend-cli@latest generate outputs --branch gen2-storage-backend --app-id d3w3sj6rqvjdb0 --outputs-version 1"
+  }
+}

--- a/environments/storage/gen2/package.json
+++ b/environments/storage/gen2/package.json
@@ -3,6 +3,6 @@
   "name": "@aws-amplify/ui-gen2-storage-environment",
   "version": "0.0.1",
   "scripts": {
-    "generate": "AWS_REGION=us-east-2 npx @aws-amplify/backend-cli@latest generate outputs --branch gen2-storage-backend --app-id d3w3sj6rqvjdb0 --outputs-version 1"
+    "generate": "AWS_REGION=us-east-2 npx @aws-amplify/backend-cli@latest generate outputs --branch gen2-storage-backend --app-id d3w3sj6rqvjdb0"
   }
 }

--- a/environments/storage/package.json
+++ b/environments/storage/package.json
@@ -3,6 +3,6 @@
   "name": "@aws-amplify/ui-environments-storage",
   "version": "0.0.1",
   "scripts": {
-    "pull": "../pull-environments.sh -r us-east-2"
+    "pull": "../pull-environments.sh -r us-east-2 && yarn --cwd gen2/ generate"
   }
 }

--- a/examples/next/pages/ui/components/storage/storage-image/error/amplify_outputs.js
+++ b/examples/next/pages/ui/components/storage/storage-image/error/amplify_outputs.js
@@ -1,0 +1,2 @@
+import amplifyOutputs from '@environments/storage/gen2/amplify_outputs';
+export default amplifyOutputs;

--- a/examples/next/pages/ui/components/storage/storage-image/error/aws-exports.js
+++ b/examples/next/pages/ui/components/storage/storage-image/error/aws-exports.js
@@ -1,2 +1,0 @@
-import awsExports from '@environments/storage/file-uploader/src/aws-exports';
-export default awsExports;

--- a/examples/next/pages/ui/components/storage/storage-image/error/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-image/error/index.page.tsx
@@ -5,9 +5,9 @@ import { Text, Loader } from '@aws-amplify/ui-react';
 import { StorageImage } from '@aws-amplify/ui-react-storage';
 
 import '@aws-amplify/ui-react/styles.css';
-import awsExports from './aws-exports';
+import amplifyOutputs from './amplify_outputs';
 
-Amplify.configure(awsExports);
+Amplify.configure(amplifyOutputs);
 
 export function StorageImageExample() {
   const [isLoaded, setIsLoaded] = React.useState(false);

--- a/examples/next/pages/ui/components/storage/storage-image/private-image/amplify_outputs.js
+++ b/examples/next/pages/ui/components/storage/storage-image/private-image/amplify_outputs.js
@@ -1,0 +1,2 @@
+import amplifyOutputs from '@environments/storage/gen2/amplify_outputs';
+export default amplifyOutputs;

--- a/examples/next/pages/ui/components/storage/storage-image/private-image/aws-exports.js
+++ b/examples/next/pages/ui/components/storage/storage-image/private-image/aws-exports.js
@@ -1,2 +1,0 @@
-import awsExports from '@environments/storage/file-uploader/src/aws-exports';
-export default awsExports;

--- a/examples/next/pages/ui/components/storage/storage-image/private-image/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-image/private-image/index.page.tsx
@@ -11,9 +11,9 @@ import {
 } from '@aws-amplify/ui-react';
 import { StorageImage } from '@aws-amplify/ui-react-storage';
 import '@aws-amplify/ui-react/styles.css';
-import awsExports from './aws-exports';
+import amplifyOutputs from './amplify_outputs';
 
-Amplify.configure(awsExports);
+Amplify.configure(amplifyOutputs);
 
 export function StorageImageExample() {
   const [isFirstImgLoaded, setIsFirstImgLoaded] = React.useState(false);

--- a/examples/next/pages/ui/components/storage/storage-image/protected-image/amplify_outputs.js
+++ b/examples/next/pages/ui/components/storage/storage-image/protected-image/amplify_outputs.js
@@ -1,0 +1,2 @@
+import amplifyOutputs from '@environments/storage/gen2/amplify_outputs';
+export default amplifyOutputs;

--- a/examples/next/pages/ui/components/storage/storage-image/protected-image/aws-exports.js
+++ b/examples/next/pages/ui/components/storage/storage-image/protected-image/aws-exports.js
@@ -1,2 +1,0 @@
-import awsExports from '@environments/storage/file-uploader/src/aws-exports';
-export default awsExports;

--- a/examples/next/pages/ui/components/storage/storage-image/protected-image/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-image/protected-image/index.page.tsx
@@ -11,9 +11,9 @@ import {
 } from '@aws-amplify/ui-react';
 import { StorageImage } from '@aws-amplify/ui-react-storage';
 import '@aws-amplify/ui-react/styles.css';
-import awsExports from './aws-exports';
+import amplifyOutputs from './amplify_outputs';
 
-Amplify.configure(awsExports);
+Amplify.configure(amplifyOutputs);
 
 export function StorageImageExample() {
   const [isFirstImgLoaded, setIsFirstImgLoaded] = React.useState(false);

--- a/examples/next/pages/ui/components/storage/storage-image/public-image/amplify_outputs.js
+++ b/examples/next/pages/ui/components/storage/storage-image/public-image/amplify_outputs.js
@@ -1,0 +1,2 @@
+import amplifyOutputs from '@environments/storage/gen2/amplify_outputs';
+export default amplifyOutputs;

--- a/examples/next/pages/ui/components/storage/storage-image/public-image/aws-exports.js
+++ b/examples/next/pages/ui/components/storage/storage-image/public-image/aws-exports.js
@@ -1,2 +1,0 @@
-import awsExports from '@environments/storage/file-uploader/src/aws-exports';
-export default awsExports;

--- a/examples/next/pages/ui/components/storage/storage-image/public-image/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-image/public-image/index.page.tsx
@@ -4,9 +4,9 @@ import { Amplify } from 'aws-amplify';
 import { Text, Loader } from '@aws-amplify/ui-react';
 import { StorageImage } from '@aws-amplify/ui-react-storage';
 import '@aws-amplify/ui-react/styles.css';
-import awsExports from './aws-exports';
+import amplifyOutputs from './amplify_outputs';
 
-Amplify.configure(awsExports);
+Amplify.configure(amplifyOutputs);
 
 export function StorageImageExample() {
   const [isFirstImgLoaded, setIsFirstImgLoaded] = React.useState(false);

--- a/examples/next/pages/ui/components/storage/storage-manager/accept-all-file-types/amplify_outputs.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/accept-all-file-types/amplify_outputs.js
@@ -1,0 +1,2 @@
+import amplifyOutputs from '@environments/storage/gen2/amplify_outputs';
+export default amplifyOutputs;

--- a/examples/next/pages/ui/components/storage/storage-manager/accept-all-file-types/aws-exports.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/accept-all-file-types/aws-exports.js
@@ -1,2 +1,0 @@
-import awsExports from '@environments/storage/file-uploader/src/aws-exports';
-export default awsExports;

--- a/examples/next/pages/ui/components/storage/storage-manager/accept-all-file-types/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/accept-all-file-types/index.page.tsx
@@ -1,8 +1,8 @@
 import { Amplify } from 'aws-amplify';
 import { StorageManager } from '@aws-amplify/ui-react-storage';
 import '@aws-amplify/ui-react/styles.css';
-import awsExports from './aws-exports';
-Amplify.configure(awsExports);
+import amplifyOutputs from './amplify_outputs';
+Amplify.configure(amplifyOutputs);
 
 export function StorageManagerExample() {
   return (

--- a/examples/next/pages/ui/components/storage/storage-manager/authenticated-multipart/amplify_outputs.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/authenticated-multipart/amplify_outputs.js
@@ -1,0 +1,2 @@
+import amplifyOutputs from '@environments/storage/gen2/amplify_outputs';
+export default amplifyOutputs;

--- a/examples/next/pages/ui/components/storage/storage-manager/authenticated-multipart/aws-exports.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/authenticated-multipart/aws-exports.js
@@ -1,2 +1,0 @@
-import awsExports from '@environments/storage/file-uploader/src/aws-exports';
-export default awsExports;

--- a/examples/next/pages/ui/components/storage/storage-manager/authenticated-multipart/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/authenticated-multipart/index.page.tsx
@@ -7,8 +7,8 @@ import {
 import { StorageManager } from '@aws-amplify/ui-react-storage';
 
 import '@aws-amplify/ui-react/styles.css';
-import amplifyconfig from './aws-exports';
-Amplify.configure(amplifyconfig);
+import amplifyOutputs from './amplify_outputs';
+Amplify.configure(amplifyOutputs);
 
 export function StorageManagerExample() {
   const { signOut } = useAuthenticator((context) => [context.signOut]);

--- a/examples/next/pages/ui/components/storage/storage-manager/default-files/amplify_outputs.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/default-files/amplify_outputs.js
@@ -1,0 +1,2 @@
+import amplifyOutputs from '@environments/storage/gen2/amplify_outputs';
+export default amplifyOutputs;

--- a/examples/next/pages/ui/components/storage/storage-manager/default-files/aws-exports.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/default-files/aws-exports.js
@@ -1,2 +1,0 @@
-import awsExports from '@environments/storage/file-uploader/src/aws-exports';
-export default awsExports;

--- a/examples/next/pages/ui/components/storage/storage-manager/default-files/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/default-files/index.page.tsx
@@ -1,8 +1,8 @@
 import { Amplify } from 'aws-amplify';
 import { StorageManager } from '@aws-amplify/ui-react-storage';
 import '@aws-amplify/ui-react/styles.css';
-import awsExports from './aws-exports';
-Amplify.configure(awsExports);
+import amplifyOutputs from './amplify_outputs';
+Amplify.configure(amplifyOutputs);
 
 export function StorageManagerExample() {
   return (

--- a/examples/next/pages/ui/components/storage/storage-manager/guest-multipart/amplify_outputs.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/guest-multipart/amplify_outputs.js
@@ -1,0 +1,2 @@
+import amplifyOutputs from '@environments/storage/gen2/amplify_outputs';
+export default amplifyOutputs;

--- a/examples/next/pages/ui/components/storage/storage-manager/guest-multipart/aws-exports.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/guest-multipart/aws-exports.js
@@ -1,2 +1,0 @@
-import awsExports from '@environments/storage/file-uploader/src/aws-exports';
-export default awsExports;

--- a/examples/next/pages/ui/components/storage/storage-manager/guest-multipart/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/guest-multipart/index.page.tsx
@@ -1,8 +1,8 @@
 import { Amplify } from 'aws-amplify';
 import { StorageManager } from '@aws-amplify/ui-react-storage';
 import '@aws-amplify/ui-react/styles.css';
-import awsExports from './aws-exports';
-Amplify.configure(awsExports);
+import amplifyOutputs from './amplify_outputs';
+Amplify.configure(amplifyOutputs);
 
 export function StorageManagerExample() {
   return (

--- a/examples/next/pages/ui/components/storage/storage-manager/upload-actions/amplify_outputs.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/upload-actions/amplify_outputs.js
@@ -1,0 +1,2 @@
+import amplifyOutputs from '@environments/storage/gen2/amplify_outputs';
+export default amplifyOutputs;

--- a/examples/next/pages/ui/components/storage/storage-manager/upload-actions/aws-exports.js
+++ b/examples/next/pages/ui/components/storage/storage-manager/upload-actions/aws-exports.js
@@ -1,2 +1,0 @@
-import awsExports from '@environments/storage/file-uploader/src/aws-exports';
-export default awsExports;

--- a/examples/next/pages/ui/components/storage/storage-manager/upload-actions/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/upload-actions/index.page.tsx
@@ -1,8 +1,8 @@
 import { Amplify } from 'aws-amplify';
 import { StorageManager } from '@aws-amplify/ui-react-storage';
 import '@aws-amplify/ui-react/styles.css';
-import awsExports from './aws-exports';
-Amplify.configure(awsExports);
+import amplifyOutputs from './amplify_outputs';
+Amplify.configure(amplifyOutputs);
 
 export function StorageManagerExample() {
   return (


### PR DESCRIPTION
#### Description of changes

Add gen2 storage environment for e2e testing. The backend resource code is stored in the staging repo https://github.com/aws-amplify/amplify-ui-staging/tree/gen2-storage-backend

Note: new permission is required to be added to `AmplifyCLIPull` policy: `"cloudformation:GetTemplateSummary"`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
