### PR TITLE
deps(react-native): include 0.74.x in allowed peerDep range

### DIFF
--- a/.changeset/fifty-clouds-fry.md
+++ b/.changeset/fifty-clouds-fry.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-native": minor
+---
+
+deps(react-native): include 0.74.x in allowed peerDep range

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "aws-amplify": "^6.2.0",
-    "react-native": "^0.70 || ^0.71 || ^0.72 || ^0.73",
+    "react-native": "^0.70 || ^0.71 || ^0.72 || ^0.73 || ^0.74",
     "react-native-safe-area-context": "^4.2.5"
   },
   "files": [


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
[`react-native@0.74.1`](https://www.npmjs.com/package/react-native/v/0.74.1) was recently released and is above the maximum allowed peerDep of `@aws-amplify/ui-react-native`. This PR increases the allowed peerDep of `@aws-amplify/ui-react-native` to include `^0.74`
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested Authenticator flows in an `expo@latest` app using `react-native@0.74`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
