### PR TITLE
chore(docs): Add a note about re-declaring defaults on form fields

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/form-fields.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/formfields/form-fields.web.mdx
@@ -221,10 +221,12 @@ You can customize any label, placeholder, set a field as required or not require
 To use this feature create a `formFields` prop and include the component name as a key.
 Inside that object you can list all the inputs you'd like to change by their name. Inputs can have additional client side validation by following [HTML form validation standards](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation).
 
+**Note:** Specifying `formFields` for a given field will overwrite any default attributes. To include defaults, you must re-specify them as shown below.
+
 The following example customizes the Sign In page by:
 
 - Updating the placeholder with `placeholder`.
-- Setting required to true with `isRequired`, which is also the default for this field.
+- Setting required to true with `isRequired`. `username` is required by default, but as mentioned above, default attributes will be overwritten and must be re-declared when using `formFields`.
 - Updating the label text with `label`.
 - Show the label using `labelHidden` set to `false`.
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add a note to make it clear you need to re-declare defaults when using form fields, per https://github.com/aws-amplify/amplify-ui/issues/5225

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
