### PR TITLE
chore(liveness): move starting of ws connection to beginning of state…

### DIFF
--- a/.changeset/slimy-items-deny.md
+++ b/.changeset/slimy-items-deny.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+chore(liveness): move ws connection start to beginning of liveness flow

--- a/packages/e2e/features/ui/components/liveness/disable-start-screen.feature
+++ b/packages/e2e/features/ui/components/liveness/disable-start-screen.feature
@@ -11,8 +11,8 @@ Feature: Disable Start Screen
 
   @react
   Scenario: See camera module and instructions
-      Then I see "liveness-detector" element
       Then I see "connecting"
+      Then I see "liveness-detector" element
       Then I see the "Face didn't fit inside oval in time limit." timeout error
       Then I click the "Try again" button
       Then I see "Loading"

--- a/packages/e2e/features/ui/components/liveness/liveness-detector.feature
+++ b/packages/e2e/features/ui/components/liveness/liveness-detector.feature
@@ -20,9 +20,9 @@ Feature: Liveness Detector
 
   @react
   Scenario: See camera module and instructions
+      Then I see "connecting"
       Then I click the "Start video check" button
       Then I see "liveness-detector" element
-      Then I see "connecting"
       Then I see "Move closer"
       Then I see the "Face didn't fit inside oval in time limit." timeout error
       Then I click the "Try again" button

--- a/packages/e2e/features/ui/components/liveness/with-credential-provider.feature
+++ b/packages/e2e/features/ui/components/liveness/with-credential-provider.feature
@@ -13,9 +13,9 @@ Liveness component supports using a custom credential provider.
 
   @react
   Scenario: See camera module and instructions
+      Then I see "connecting"
       Then I click the "Start video check" button
       Then I see "liveness-detector" element
-      Then I see "connecting"
       Then I see "Move closer"
       Then I see the "Face didn't fit inside oval in time limit." timeout error
       Then I click the "Try again" button

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -71,14 +71,6 @@ export interface LivenessCameraModuleProps {
   testId?: string;
 }
 
-const centeredLoader = (
-  <Loader
-    size="large"
-    className={LivenessClassNames.Loader}
-    data-testid="centered-loader"
-  />
-);
-
 const showMatchIndicatorStates = [
   FaceMatchState.TOO_FAR,
   FaceMatchState.CANT_IDENTIFY,
@@ -136,8 +128,12 @@ export const LivenessCameraModule = (
   const freshnessColorRef = useRef<HTMLCanvasElement | null>(null);
 
   const [isCameraReady, setIsCameraReady] = useState<boolean>(false);
-  const isCheckingCamera = state.matches('cameraCheck');
-  const isWaitingForCamera = state.matches('waitForDOMAndCameraDetails');
+  const isInitCamera = state.matches('initCamera');
+  const isInitWebsocket = state.matches('initWebsocket');
+  const isCheckingCamera = state.matches({ initCamera: 'cameraCheck' });
+  const isWaitingForCamera = state.matches({
+    initCamera: 'waitForDOMAndCameraDetails',
+  });
   const isStartView = state.matches('start') || state.matches('userCancel');
   const isDetectFaceBeforeStart = state.matches('detectFaceBeforeStart');
   const isRecording = state.matches('recording');
@@ -274,7 +270,7 @@ export const LivenessCameraModule = (
       >
         <Loader
           size="large"
-          className={LivenessClassNames.Loader}
+          className={LivenessClassNames.CenteredLoader}
           data-testid="centered-loader"
           position="unset"
         />
@@ -290,13 +286,31 @@ export const LivenessCameraModule = (
     );
   }
 
+  const shouldShowCenteredLoader = isInitCamera || isInitWebsocket;
+
   // We don't show full screen camera on the pre check screen (isStartView/isWaitingForCamera)
   const shouldShowFullScreenCamera =
-    isMobileScreen && !isStartView && !isWaitingForCamera;
+    isMobileScreen &&
+    !isStartView &&
+    !isWaitingForCamera &&
+    !shouldShowCenteredLoader;
 
   return (
     <>
       {photoSensitivityWarning}
+
+      {shouldShowCenteredLoader && (
+        <Flex className={LivenessClassNames.ConnectingLoader}>
+          <Loader
+            size="large"
+            className={LivenessClassNames.Loader}
+            data-testid="centered-loader"
+          />
+          <Text className={LivenessClassNames.LandscapeErrorModalHeader}>
+            {hintDisplayText.hintConnectingText}
+          </Text>
+        </Flex>
+      )}
 
       <Flex
         className={classNames(
@@ -307,8 +321,6 @@ export const LivenessCameraModule = (
         data-testid={testId}
         gap="zero"
       >
-        {!isCameraReady && centeredLoader}
-
         <Overlay
           horizontal="center"
           vertical={

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -292,7 +292,6 @@ export const LivenessCameraModule = (
   const shouldShowFullScreenCamera =
     isMobileScreen &&
     !isStartView &&
-    !isWaitingForCamera &&
     !shouldShowCenteredLoader;
 
   return (

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
@@ -202,6 +202,12 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
     states: {
       initCamera: {
         initial: 'cameraCheck',
+        on: {
+          SET_DOM_AND_CAMERA_DETAILS: {
+            actions: 'setDOMAndCameraDetails',
+            target: '#livenessMachine.initWebsocket',
+          },
+        },
         states: {
           cameraCheck: {
             entry: 'resetErrorState',
@@ -216,15 +222,7 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
               },
             },
           },
-          waitForDOMAndCameraDetails: {
-            after: {
-              0: {
-                target: '#livenessMachine.initWebsocket',
-                cond: 'hasDOMAndCameraDetails',
-              },
-              10: { target: 'waitForDOMAndCameraDetails' },
-            },
-          },
+          waitForDOMAndCameraDetails: {},
         },
       },
       initWebsocket: {
@@ -568,11 +566,6 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
       }),
       startRecording: assign({
         videoAssociatedParams: (context) => {
-          if (!context.serverSessionInformation) {
-            throw new Error(
-              'Session information was not received from response stream'
-            );
-          }
           if (
             context.livenessStreamProvider &&
             !context.livenessStreamProvider.isRecording()

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/__tests__/liveness.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/__tests__/liveness.test.ts
@@ -1,5 +1,6 @@
 import 'jest-canvas-mock';
 import {
+  clearOvalCanvas,
   drawLivenessOvalInCanvas,
   estimateIllumination,
   fillOverlayCanvasFractional,
@@ -106,6 +107,41 @@ describe('Liveness Helper', () => {
       expect(ovalParameters.centerY).toBe(4);
       expect(ovalParameters.width).toBe(1);
       expect(ovalParameters.height).toBe(2);
+    });
+
+    it('should throw an error if some oval parameters are not defined', () => {
+      const badSessionInfo = {
+        Challenge: {
+          FaceMovementAndLightChallenge: {
+            ChallengeConfig: {
+              BlazeFaceDetectionThreshold: 0.75,
+              FaceDistanceThreshold: 0.4000000059604645,
+              FaceDistanceThresholdMax: 0,
+              FaceDistanceThresholdMin: 0.4000000059604645,
+              FaceIouHeightThreshold: 0.15000000596046448,
+              FaceIouWidthThreshold: 0.15000000596046448,
+              OvalHeightWidthRatio: 1.6180000305175781,
+              OvalIouHeightThreshold: 0.25,
+              OvalIouThreshold: 0.6,
+              OvalIouWidthThreshold: 0.25,
+            },
+            OvalParameters: {
+              Width: undefined,
+              Height: undefined,
+              CenterX: undefined,
+              CenterY: undefined,
+            },
+            LightChallengeType: 'SEQUENTIAL',
+            ColorSequences: [],
+          },
+        },
+      };
+      expect(() => {
+        getOvalDetailsFromSessionInformation({
+          sessionInformation: badSessionInfo,
+          videoWidth: 1,
+        });
+      }).toThrow();
     });
   });
 
@@ -468,6 +504,29 @@ describe('Liveness Helper', () => {
       Object.defineProperty(videoEl, 'videoWidth', { value: 100 });
       Object.defineProperty(videoEl, 'videoHeight', { value: 100 });
       expect(estimateIllumination(videoEl)).toBe(IlluminationState.DARK);
+    });
+  });
+
+  describe('clearOvalCanvas', () => {
+    it('should attempt to clear the oval canvas', () => {
+      const canvas = getMockContext().videoAssociatedParams?.canvasEl!;
+
+      clearOvalCanvas({ canvas });
+
+      const canvasContext = canvas.getContext('2d');
+
+      expect(canvasContext!.restore).toBeCalled();
+      expect(canvasContext!.clearRect).toBeCalled();
+    });
+
+    it('should fail if no context is found', () => {
+      const mockGetContext = jest.fn().mockReturnValue(undefined);
+      const canvas = context.videoAssociatedParams?.canvasEl!;
+      (canvas as any).getContext = mockGetContext;
+
+      expect(() => {
+        clearOvalCanvas({ canvas });
+      }).toThrow();
     });
   });
 });

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/Hint.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/Hint.tsx
@@ -71,7 +71,6 @@ export const Hint: React.FC<HintProps> = ({ hintDisplayText }) => {
     state.matches('detectFaceDistanceBeforeRecording');
   const isStartView = state.matches('start') || state.matches('userCancel');
   const isRecording = state.matches('recording');
-  const isNotRecording = state.matches('notRecording');
   const isUploading = state.matches('uploading');
   const isCheckSuccessful = state.matches('checkSucceeded');
   const isCheckFailed = state.matches('checkFailed');
@@ -125,12 +124,6 @@ export const Hint: React.FC<HintProps> = ({ hintDisplayText }) => {
       isFaceFarEnoughBeforeRecordingState === false
     ) {
       return <DefaultToast text={hintDisplayText.hintTooCloseText} />;
-    }
-
-    if (isNotRecording) {
-      return (
-        <ToastWithLoader displayText={hintDisplayText.hintConnectingText} />
-      );
     }
 
     if (isUploading) {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/shared/__tests__/Hint.test.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/shared/__tests__/Hint.test.tsx
@@ -177,17 +177,6 @@ describe('Hint', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render not recording state if present', () => {
-    isNotRecording = true;
-    mockStateMatchesAndSelectors();
-
-    renderWithLivenessProvider(<Hint hintDisplayText={hintDisplayText} />);
-
-    expect(
-      screen.getByText(hintDisplayText.hintConnectingText)
-    ).toBeInTheDocument();
-  });
-
   it('should render uploading state if present', () => {
     isUploading = true;
     mockStateMatchesAndSelectors();

--- a/packages/react-liveness/src/components/FaceLivenessDetector/types/classNames.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/types/classNames.ts
@@ -2,6 +2,8 @@ export enum LivenessClassNames {
   CameraModule = 'amplify-liveness-camera-module',
   CancelContainer = 'amplify-liveness-cancel-container',
   CancelButton = 'amplify-liveness-cancel-button',
+  CenteredLoader = 'amplify-liveness-centered-loader',
+  ConnectingLoader = 'amplify-liveness-connecting-loader',
   CountdownContainer = 'amplify-liveness-countdown-container',
   DescriptionBullet = 'amplify-liveness-description-bullet',
   DescriptionBulletIndex = 'amplify-liveness-description-bullet__index',

--- a/packages/ui/src/theme/css/component/liveness.scss
+++ b/packages/ui/src/theme/css/component/liveness.scss
@@ -72,11 +72,26 @@
   z-index: 1;
 }
 
-.amplify-liveness-loader {
+.amplify-liveness-loader .amplify-liveness-centered-loader {
+  transform: translate(-50%, -50%);
+}
+
+.amplify-liveness-centered-loader {
   position: absolute;
   left: 50%;
   top: 50%;
-  transform: translate(-50%, -50%);
+}
+
+.amplify-liveness-connecting-loader {
+  display: flex;
+  position: absolute;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 3;
+  width: 100%;
+  height: 100%;
+  background-color: var(--amplify-colors-background-primary);
 }
 
 .amplify-liveness-oval-canvas {


### PR DESCRIPTION
… machine

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Moved ws connection opening to right after camera initialization at the start of the machine
- Adding a loading screen per the figma designs

<img width="723" alt="Screenshot 2024-05-09 at 12 53 58 PM" src="https://github.com/aws-amplify/amplify-ui/assets/68032955/01a27c21-7b81-47f6-a566-1f3617711e60">


<img width="484" alt="Screenshot 2024-05-09 at 12 54 06 PM" src="https://github.com/aws-amplify/amplify-ui/assets/68032955/1236c4bb-de75-4c5c-bedf-6fd342ef4b6d">

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
