### PR TITLE
fix(ui-react): add aria-hidden to Select expand icon

### DIFF
--- a/.changeset/chilly-penguins-relate.md
+++ b/.changeset/chilly-penguins-relate.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(ui-react): add aria-hidden to Select expand icon

--- a/packages/react/src/primitives/Select/Select.tsx
+++ b/packages/react/src/primitives/Select/Select.tsx
@@ -81,6 +81,7 @@ const SelectPrimitive: Primitive<SelectProps, 'select'> = (
             classNameModifier(ComponentClassName.SelectIcon, size)
           )}
           color={iconColor}
+          aria-hidden="true"
         >
           {icon ?? icons?.expand ?? <IconExpandMore />}
         </Flex>


### PR DESCRIPTION
#### Description of changes

Add `aria-hidden="true"` to the Select drop-down icon to remove it from the accessibility tree.

#### Issue #, if available

fix https://github.com/aws-amplify/amplify-ui/issues/5253

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
