### PR TITLE
chore(liveness): add more granular timeout messages, remove disconnec…

### DIFF
--- a/.changeset/red-points-push.md
+++ b/.changeset/red-points-push.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+chore(liveness): add more granular timeout messages, remove disconnec…

--- a/.changeset/red-points-push.md
+++ b/.changeset/red-points-push.md
@@ -2,4 +2,4 @@
 "@aws-amplify/ui-react-liveness": patch
 ---
 
-chore(liveness): add more granular timeout messages, remove disconnec…
+chore(liveness): add more granular timeout messages, remove disconnect timeout

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/__tests__/machine.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/__tests__/machine.test.ts
@@ -418,8 +418,10 @@ describe('Liveness Machine', () => {
       expect(service.state.context.errorState).toBeUndefined();
 
       jest.advanceTimersToNextTimer();
-      expect(service.state.value).toEqual('timeout');
-      expect(service.state.context.errorState).toBe(LivenessErrorState.TIMEOUT);
+      expect(service.state.value).toEqual('error');
+      expect(service.state.context.errorState).toBe(
+        LivenessErrorState.RUNTIME_ERROR
+      );
       await flushPromises();
       expect(mockcomponentProps.onError).toHaveBeenCalledTimes(1);
     });
@@ -712,8 +714,10 @@ describe('Liveness Machine', () => {
       jest.advanceTimersToNextTimer(); // checkFaceDetected
       jest.advanceTimersToNextTimer(); // cancelOvalDrawingTimeout
       jest.advanceTimersToNextTimer(6000);
-      expect(service.state.value).toEqual('timeout');
-      expect(service.state.context.errorState).toBe(LivenessErrorState.TIMEOUT);
+      expect(service.state.value).toEqual('error');
+      expect(service.state.context.errorState).toBe(
+        LivenessErrorState.RUNTIME_ERROR
+      );
       expect(mockcomponentProps.onError).toHaveBeenCalled();
     });
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/__tests__/machine.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/__tests__/machine.test.ts
@@ -127,6 +127,7 @@ describe('Liveness Machine', () => {
     await transitionToRecording(service);
     await flushPromises(); // detectInitialFaceAndDrawOval
     jest.advanceTimersToNextTimer(); // checkFaceDetected
+    jest.advanceTimersToNextTimer(); // cancelOvalDrawingTimeout
     jest.advanceTimersToNextTimer(); // checkRecordingStarted
     await advanceMinFaceMatches(); // detectFaceAndMatchOval
     jest.advanceTimersToNextTimer(); // delayBeforeFlash
@@ -429,6 +430,7 @@ describe('Liveness Machine', () => {
       expect(service.state.value).toEqual({ recording: 'checkFaceDetected' });
 
       jest.advanceTimersToNextTimer(); // checkFaceDetected
+      jest.advanceTimersToNextTimer(); // cancelOvalDrawingTimeout
       jest.advanceTimersToNextTimer(); // checkRecordingStarted
       expect(service.state.value).toEqual({
         recording: 'ovalMatching',
@@ -443,7 +445,7 @@ describe('Liveness Machine', () => {
         mockFace
       );
 
-      jest.advanceTimersToNextTimer();
+      jest.advanceTimersToNextTimer(12000);
       expect(service.state.value).toEqual('timeout');
       expect(service.state.context.errorState).toBe(LivenessErrorState.TIMEOUT);
       await flushPromises();
@@ -541,6 +543,7 @@ describe('Liveness Machine', () => {
       await transitionToRecording(service);
       await flushPromises();
       jest.advanceTimersToNextTimer(); // checkFaceDetected
+      jest.advanceTimersToNextTimer(); // cancelOvalDrawingTimeout
       jest.advanceTimersToNextTimer(); // checkRecordingStarted
       expect(service.state.value).toEqual({ recording: 'ovalMatching' });
       expect(
@@ -570,6 +573,7 @@ describe('Liveness Machine', () => {
       await transitionToRecording(service);
       await flushPromises(); // detectInitialFaceAndDrawOval
       jest.advanceTimersToNextTimer(); // checkFaceDetected
+      jest.advanceTimersToNextTimer(); // cancelOvalDrawingTimeout
       jest.advanceTimersToNextTimer(); // checkRecordingStarted
 
       await advanceMinFaceMatches(); // detectFaceAndMatchOval
@@ -589,6 +593,7 @@ describe('Liveness Machine', () => {
       await transitionToRecording(service);
       await flushPromises(); // detectInitialFaceAndDrawOval
       jest.advanceTimersToNextTimer(); // checkFaceDetected
+      jest.advanceTimersToNextTimer(); // cancelOvalDrawingTimeout
       jest.advanceTimersToNextTimer(); // checkRecordingStarted
 
       await advanceMinFaceMatches(); // detectFaceAndMatchOval
@@ -609,6 +614,7 @@ describe('Liveness Machine', () => {
       await transitionToRecording(service);
       await flushPromises(); // detectInitialFaceAndDrawOval
       jest.advanceTimersToNextTimer(); // checkFaceDetected
+      jest.advanceTimersToNextTimer(); // cancelOvalDrawingTimeout
       jest.advanceTimersToNextTimer(); // checkRecordingStarted
       await advanceMinFaceMatches(); // detectFaceAndMatchOval
       jest.advanceTimersToNextTimer(); // delayBeforeFlash
@@ -641,6 +647,7 @@ describe('Liveness Machine', () => {
       await transitionToRecording(service);
       await flushPromises(); // detectInitialFaceAndDrawOval
       jest.advanceTimersToNextTimer(); // checkFaceDetected
+      jest.advanceTimersToNextTimer(); // cancelOvalDrawingTimeout
       jest.advanceTimersToNextTimer(); // checkRecordingStarted
 
       await flushPromises();
@@ -693,18 +700,6 @@ describe('Liveness Machine', () => {
       expect(mockLivenessStreamProvider.sendClientInfo).toHaveBeenCalledTimes(
         2
       );
-    });
-
-    it('should reach timeout state if disconnect event never arrives', async () => {
-      await transitionToUploading(service);
-      await flushPromises(); // stopVideo
-      jest.advanceTimersToNextTimer(30000); // waitForDisconnect
-      expect(service.state.value).toEqual('timeout');
-      expect(service.state.context.errorState).toBe(
-        LivenessErrorState.SERVER_ERROR
-      );
-      await flushPromises();
-      expect(mockcomponentProps.onError).toHaveBeenCalledTimes(1);
     });
 
     it('should reach error state after getLiveness returns error', async () => {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
@@ -822,9 +822,7 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
         context.componentProps!.onUserCancel?.();
       },
       callUserTimeoutCallback: (context) => {
-        const error = new Error(
-          (context.errorMessage as string) ?? 'Client Timeout'
-        );
+        const error = new Error(context.errorMessage ?? 'Client Timeout');
         error.name = context.errorState!;
         const livenessError: LivenessError = {
           state: context.errorState!,

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
@@ -200,6 +200,7 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
       },
       RUNTIME_ERROR: {
         target: 'error',
+        actions: 'updateErrorStateForRuntime',
       },
       MOBILE_LANDSCAPE_WARNING: {
         target: 'mobileLandscapeWarning',
@@ -747,9 +748,9 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
       // timeouts
       sendTimeoutAfterOvalDrawingDelay: actions.send(
         {
-          type: 'TIMEOUT',
+          type: 'RUNTIME_ERROR',
           data: {
-            message: 'Client timed out waiting to draw oval.',
+            message: 'Client failed to draw oval.',
           },
         },
         {
@@ -760,9 +761,9 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
       cancelOvalDrawingTimeout: actions.cancel('ovalDrawingTimeout'),
       sendTimeoutAfterRecordingDelay: actions.send(
         {
-          type: 'TIMEOUT',
+          type: 'RUNTIME_ERROR',
           data: {
-            message: 'Client timed out waiting to start recording.',
+            message: 'Client failed to start recording.',
           },
         },
         {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/types/machine.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/types/machine.ts
@@ -60,6 +60,7 @@ export interface LivenessContext {
   challengeId?: string;
   componentProps?: FaceLivenessDetectorCoreProps;
   errorState?: ErrorState;
+  errorMessage?: string;
   faceMatchAssociatedParams?: FaceMatchAssociatedParams;
   faceMatchStateBeforeStart?: FaceMatchState;
   failedAttempts?: number;


### PR DESCRIPTION
…t timeout

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Added more granular timeout messaging for timeouts caused by recording delay, oval drawing delay, and failure to match oval. This is only for the error message callback function which the dev can log
- Removed the wait for disconnect timeout since the service will disconnect after 60 seconds

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
