### PR TITLE
chore(liveness): Remove audit image processing from example app

### DIFF
--- a/examples/next/pages/ui/components/liveness/components/LivenessInlineResults.tsx
+++ b/examples/next/pages/ui/components/liveness/components/LivenessInlineResults.tsx
@@ -13,10 +13,6 @@ export default function LivenessInlineResults({
 }) {
   const { isLive, confidenceScore, auditImageBytes } = getLivenessResponse;
 
-  // Previously the rekognition backend passed the base64 string but from the api direclty you receive a byte array
-  var base64string = Buffer.from(
-    new Uint8Array(Object.values(auditImageBytes))
-  ).toString('base64');
   const displayScore = truncateNumber(confidenceScore, 4);
   return (
     <Flex direction="column" gap="medium">
@@ -58,7 +54,7 @@ export default function LivenessInlineResults({
       <Image
         width="100%"
         height="100%"
-        src={`data:image/jpeg;base64,${base64string}`}
+        src={`data:image/jpeg;base64,${auditImageBytes}`}
         alt="Audit image"
       />
     </Flex>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
The conversion to base 64 string happens in the lambda so removing from frontend so the audit image shows up.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran example app and verified audit image shows up

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
