### PR TITLE
(Fix): Whitespace in Tab Labels

### DIFF
--- a/packages/react/src/primitives/Tabs/TabsItem.tsx
+++ b/packages/react/src/primitives/Tabs/TabsItem.tsx
@@ -12,6 +12,7 @@ import { View } from '../View';
 import { primitiveWithForwardRef } from '../utils/primitiveWithForwardRef';
 import { BaseTabsItemProps, TabsItemProps } from './types';
 import { TabsContext } from './TabsContext';
+import { useStableId } from '../utils/useStableId';
 
 const TabsItemPrimitive: Primitive<TabsItemProps, 'button'> = (
   { className, value, children, onClick, as = 'button', role = 'tab', ...rest },
@@ -25,15 +26,16 @@ const TabsItemPrimitive: Primitive<TabsItemProps, 'button'> = (
     }
     setActiveTab(value);
   };
+  const idValue = useStableId();
 
   return (
     <View
       {...rest}
       role={role}
       as={as}
-      id={`${value}-tab`}
+      id={`${idValue}-tab`}
       aria-selected={isActive}
-      aria-controls={`${value}-panel`}
+      aria-controls={`${idValue}-panel`}
       tabIndex={!isActive ? -1 : undefined}
       className={classNames(
         ComponentClassName.TabsItem,

--- a/packages/react/src/primitives/Tabs/TabsItem.tsx
+++ b/packages/react/src/primitives/Tabs/TabsItem.tsx
@@ -12,7 +12,6 @@ import { View } from '../View';
 import { primitiveWithForwardRef } from '../utils/primitiveWithForwardRef';
 import { BaseTabsItemProps, TabsItemProps } from './types';
 import { TabsContext } from './TabsContext';
-import { useStableId } from '../utils/useStableId';
 
 const TabsItemPrimitive: Primitive<TabsItemProps, 'button'> = (
   { className, value, children, onClick, as = 'button', role = 'tab', ...rest },
@@ -26,7 +25,7 @@ const TabsItemPrimitive: Primitive<TabsItemProps, 'button'> = (
     }
     setActiveTab(value);
   };
-  const idValue = useStableId();
+  const idValue = value.replace(' ', '-');
 
   return (
     <View

--- a/packages/react/src/primitives/Tabs/TabsPanel.tsx
+++ b/packages/react/src/primitives/Tabs/TabsPanel.tsx
@@ -8,14 +8,13 @@ import { View } from '../View';
 import { BaseTabsPanelProps, TabsPanelProps } from './types';
 import { primitiveWithForwardRef } from '../utils/primitiveWithForwardRef';
 import { TabsContext } from './TabsContext';
-import { useStableId } from '../utils/useStableId';
 
 const TabPanelPrimitive: Primitive<TabsPanelProps, 'div'> = (
   { className, value, children, role = 'tabpanel', ...rest },
   ref
 ) => {
   const { activeTab, isLazy } = React.useContext(TabsContext);
-  const idValue = useStableId();
+  const idValue = value.replace(' ', '-');
 
   if (isLazy && activeTab !== value) return null;
 

--- a/packages/react/src/primitives/Tabs/TabsPanel.tsx
+++ b/packages/react/src/primitives/Tabs/TabsPanel.tsx
@@ -8,12 +8,14 @@ import { View } from '../View';
 import { BaseTabsPanelProps, TabsPanelProps } from './types';
 import { primitiveWithForwardRef } from '../utils/primitiveWithForwardRef';
 import { TabsContext } from './TabsContext';
+import { useStableId } from '../utils/useStableId';
 
 const TabPanelPrimitive: Primitive<TabsPanelProps, 'div'> = (
   { className, value, children, role = 'tabpanel', ...rest },
   ref
 ) => {
   const { activeTab, isLazy } = React.useContext(TabsContext);
+  const idValue = useStableId();
 
   if (isLazy && activeTab !== value) return null;
 
@@ -21,8 +23,8 @@ const TabPanelPrimitive: Primitive<TabsPanelProps, 'div'> = (
     <View
       {...rest}
       role={role}
-      id={`${value}-panel`}
-      aria-labelledby={`${value}-tab`}
+      id={`${idValue}-panel`}
+      aria-labelledby={`${idValue}-tab`}
       className={classNames(
         ComponentClassName.TabsPanel,
         classNameModifierByFlag(

--- a/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
@@ -86,6 +86,36 @@ describe('Tabs', () => {
     expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('creates an id ending in "-tab"', async () => {
+    render(
+      <Tabs.Container>
+        <Tabs.List>
+          <Tabs.Item value="Tab 1">Tab 1</Tabs.Item>
+        </Tabs.List>
+      </Tabs.Container>
+    );
+    const tab = await screen.findByRole('tab');
+    expect(tab.id.endsWith('-tab')).toBeTruthy();
+  });
+
+  it('creates unique ids for each tab', async () => {
+    render(
+      <Tabs.Container testId="tabsTest">
+        <Tabs.List>
+          <Tabs.Item value="1">Tab 1</Tabs.Item>
+          <Tabs.Item value="1">Tab 2</Tabs.Item>
+          <Tabs.Item value="1">Tab 3</Tabs.Item>
+        </Tabs.List>
+        <Tabs.Panel value="1">Tab 1</Tabs.Panel>
+        <Tabs.Panel value="1">Tab 2</Tabs.Panel>
+        <Tabs.Panel value="1">Tab 3</Tabs.Panel>
+      </Tabs.Container>
+    );
+    const tabs = await screen.findAllByRole('tab');
+    expect(tabs[0].id === tabs[1].id).toBeFalsy;
+    expect(tabs[0].id === tabs[2].id).toBeFalsy;
+  });
+
   describe('TabItem', () => {
     it('can render custom classnames', async () => {
       render(

--- a/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
@@ -98,17 +98,17 @@ describe('Tabs', () => {
     expect(tab.id.endsWith('-tab')).toBeTruthy();
   });
 
-  it('creates unique ids for each tab', async () => {
+  it('creates unique ids for each tab with a unique value', async () => {
     render(
       <Tabs.Container testId="tabsTest">
         <Tabs.List>
           <Tabs.Item value="1">Tab 1</Tabs.Item>
-          <Tabs.Item value="1">Tab 2</Tabs.Item>
-          <Tabs.Item value="1">Tab 3</Tabs.Item>
+          <Tabs.Item value="2">Tab 2</Tabs.Item>
+          <Tabs.Item value="2">Tab 3</Tabs.Item>
         </Tabs.List>
         <Tabs.Panel value="1">Tab 1</Tabs.Panel>
-        <Tabs.Panel value="1">Tab 2</Tabs.Panel>
-        <Tabs.Panel value="1">Tab 3</Tabs.Panel>
+        <Tabs.Panel value="2">Tab 2</Tabs.Panel>
+        <Tabs.Panel value="2">Tab 3</Tabs.Panel>
       </Tabs.Container>
     );
     const tabs = await screen.findAllByRole('tab');

--- a/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
@@ -104,11 +104,11 @@ describe('Tabs', () => {
         <Tabs.List>
           <Tabs.Item value="1">Tab 1</Tabs.Item>
           <Tabs.Item value="2">Tab 2</Tabs.Item>
-          <Tabs.Item value="2">Tab 3</Tabs.Item>
+          <Tabs.Item value="3">Tab 3</Tabs.Item>
         </Tabs.List>
         <Tabs.Panel value="1">Tab 1</Tabs.Panel>
         <Tabs.Panel value="2">Tab 2</Tabs.Panel>
-        <Tabs.Panel value="2">Tab 3</Tabs.Panel>
+        <Tabs.Panel value="3">Tab 3</Tabs.Panel>
       </Tabs.Container>
     );
     const tabs = await screen.findAllByRole('tab');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Generates ID without whitespace for each tab component. 

Example: A tab declared with `value="Tab 1"` produces the following HTML output `<button role="tab" id="Tab-1-tab" aria-selected="true" aria-controls="Tab-1-panel" class="amplify-tabs__item amplify-tabs__item--active">Tab 1</button>`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes #5220

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Inspected elements in Tabs Docs, IDs now contain no whitespace and are unique.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
