### PR TITLE
fix(liveness): add a check to see if recording works before choosing …

### DIFF
--- a/.changeset/tall-stingrays-decide.md
+++ b/.changeset/tall-stingrays-decide.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+fix(liveness): add a check to see if recording works before choosing …

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
@@ -41,6 +41,7 @@ import {
   isCameraDeviceVirtual,
   FreshnessColorDisplay,
   drawStaticOval,
+  doesDefaultMimeTypeWork,
 } from '../utils';
 
 import { getStaticLivenessOvalDetails } from '../utils/liveness';
@@ -60,6 +61,7 @@ import { WS_CLOSURE_CODE } from '../utils/constants';
 
 const CAMERA_ID_KEY = 'AmplifyLivenessCameraId';
 const DEFAULT_FACE_FIT_TIMEOUT = 7000;
+const ALTERNATE_MIME_TYPE = 'video/x-matroska;codecs=vp8';
 
 let responseStream: Promise<AsyncIterable<LivenessResponseStream>>;
 const responseStreamActor = async (callback: StreamActorCallback) => {
@@ -1010,6 +1012,10 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
       },
       // eslint-disable-next-line @typescript-eslint/require-await
       async openLivenessStreamConnection(context) {
+        const shouldUseAlternateMimeType = !(await doesDefaultMimeTypeWork(
+          context.videoAssociatedParams!.videoMediaStream!
+        ));
+
         const { config } = context.componentProps!;
         const { credentialProvider, endpointOverride } = config!;
         const livenessStreamProvider = new LivenessStreamProvider({
@@ -1019,6 +1025,9 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
           videoEl: context.videoAssociatedParams!.videoEl!,
           credentialProvider: credentialProvider,
           endpointOverride: endpointOverride,
+          mimeType: shouldUseAlternateMimeType
+            ? ALTERNATE_MIME_TYPE
+            : undefined,
         });
 
         responseStream = livenessStreamProvider.getResponseStream();

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
@@ -24,6 +24,7 @@ interface StreamProviderArgs extends StartLivenessStreamInput {
   videoEl: HTMLVideoElement;
   credentialProvider?: AwsCredentialProvider;
   endpointOverride?: string;
+  mimeType?: string;
 }
 
 const TIME_SLICE = 1000;
@@ -68,12 +69,13 @@ export class LivenessStreamProvider {
     videoEl,
     credentialProvider,
     endpointOverride,
+    mimeType,
   }: StreamProviderArgs) {
     this.sessionId = sessionId;
     this.region = region;
     this._stream = stream;
     this.videoEl = videoEl;
-    this.videoRecorder = new VideoRecorder(stream);
+    this.videoRecorder = new VideoRecorder(stream, mimeType);
     this.credentialProvider = credentialProvider;
     this.endpointOverride = endpointOverride;
     this.initPromise = this.init();


### PR DESCRIPTION
…an encoding

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- There is a known bug on Chrome 125 where the the H264 encoder fails silently - https://issues.chromium.org/issues/343199623
- This has caused issues on certain devices where it will attempt to record video but nothing will be recorded in memory
- Added this solution where we attempt to do a small 200ms recording before hand to see if it can successfully create chunks
- If recording does not successfully add chunks we will use an alternate encoding type from the common default which appears to be `'video/x-matroska;codecs=avc1` (h264 === avc)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
