### PR TITLE
fix(liveness): target android chrome 125 to use alternate mime type

### DIFF
--- a/.changeset/odd-bats-smile.md
+++ b/.changeset/odd-bats-smile.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+fix(liveness): target android chrome 125 to use alternate mime type

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/videoRecorder.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/videoRecorder.ts
@@ -1,3 +1,7 @@
+import { isAndroidChromeWithBrokenH264 } from '../../utils/device';
+
+const ALTERNATE_MIME_TYPE = 'video/x-matroska;codecs=vp8';
+
 /**
  * Helper wrapper class over the native MediaRecorder.
  */
@@ -24,7 +28,12 @@ export class VideoRecorder {
 
     this._stream = stream;
     this._chunks = [];
-    this._recorder = new MediaRecorder(stream, { bitsPerSecond: 1000000 });
+    this._recorder = new MediaRecorder(stream, {
+      bitsPerSecond: 1000000,
+      mimeType: isAndroidChromeWithBrokenH264()
+        ? ALTERNATE_MIME_TYPE
+        : undefined,
+    });
 
     this._setupCallbacks();
   }

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/videoRecorder.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/videoRecorder.ts
@@ -1,6 +1,7 @@
 import { isAndroidChromeWithBrokenH264 } from '../../utils/device';
 
-const ALTERNATE_MIME_TYPE = 'video/x-matroska;codecs=vp8';
+// Only to be used with Chrome for the Android Chrome H264 Bug - https://issues.chromium.org/issues/343199623
+const ALTERNATE_CHROME_MIME_TYPE = 'video/x-matroska;codecs=vp8';
 
 /**
  * Helper wrapper class over the native MediaRecorder.
@@ -31,7 +32,7 @@ export class VideoRecorder {
     this._recorder = new MediaRecorder(stream, {
       bitsPerSecond: 1000000,
       mimeType: isAndroidChromeWithBrokenH264()
-        ? ALTERNATE_MIME_TYPE
+        ? ALTERNATE_CHROME_MIME_TYPE
         : undefined,
     });
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/utils/__tests__/device.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/utils/__tests__/device.test.ts
@@ -97,7 +97,7 @@ describe('device', () => {
         'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.146 Mobile Safari/537.36';
       expect(isAndroidChromeWithBrokenH264()).toBe(false);
     });
-    it('false on android version older than 124', () => {
+    it('false on chrome version older than 124', () => {
       (global.navigator as any).userAgent = GOOGLE_PIXEL_CHROME;
       expect(isAndroidChromeWithBrokenH264()).toBe(false);
     });

--- a/packages/react-liveness/src/components/FaceLivenessDetector/utils/__tests__/device.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/utils/__tests__/device.test.ts
@@ -3,6 +3,7 @@ import {
   isMobileScreen,
   isPortrait,
   getLandscapeMediaQuery,
+  isAndroidChromeWithBrokenH264,
 } from '../device';
 import { mockMatchMedia } from '../../__mocks__/utils';
 
@@ -79,6 +80,27 @@ describe('device', () => {
 
     (global.navigator as any).userAgent = GOOGLE_PIXEL_CHROME;
     expect(isIOS()).toBe(false);
+  });
+
+  describe('isAndroidChromeWithBrokenH264', () => {
+    it('true on android chrome 125.0.0.0', () => {
+      (global.navigator as any).userAgent =
+        'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36';
+      expect(isAndroidChromeWithBrokenH264()).toBe(true);
+    });
+    it('false on non android device', () => {
+      (global.navigator as any).userAgent = NEW_IPAD;
+      expect(isAndroidChromeWithBrokenH264()).toBe(false);
+    });
+    it('false on android with version newer or equal to 125.0.6422.146', () => {
+      (global.navigator as any).userAgent =
+        'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.146 Mobile Safari/537.36';
+      expect(isAndroidChromeWithBrokenH264()).toBe(false);
+    });
+    it('false on android version older than 124', () => {
+      (global.navigator as any).userAgent = GOOGLE_PIXEL_CHROME;
+      expect(isAndroidChromeWithBrokenH264()).toBe(false);
+    });
   });
 });
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/utils/device.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/utils/device.ts
@@ -33,3 +33,22 @@ export function isPortrait(): boolean {
 export function getLandscapeMediaQuery(): MediaQueryList {
   return window.matchMedia('(orientation: landscape)');
 }
+
+// minor version 146+ is confirmed to have the fix https://issues.chromium.org/issues/343199623#comment34
+export function isAndroidChromeWithBrokenH264(): boolean {
+  const groups = /Chrome\/125\.[0-9]+\.[0-9]+\.([0-9]+)/i.exec(
+    navigator.userAgent
+  );
+
+  if (!groups) {
+    return false;
+  }
+
+  const minorVersion = groups[1];
+
+  return (
+    /Android/i.test(navigator.userAgent) &&
+    /Chrome\/125/i.test(navigator.userAgent) &&
+    parseInt(minorVersion) < 146
+  );
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- There is a known bug on Chrome 125 where the the H264 encoder fails silently - https://issues.chromium.org/issues/343199623
- This has caused issues on certain devices where it will attempt to record video but nothing will be recorded in memory
- Added a solution where we choose an alternate mimetype for Android devices running the known chrome affected version

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
