### PR TITLE
fix(liveness): Fix photosensitivity text customization

### DIFF
--- a/packages/react-liveness/src/components/FaceLivenessDetector/utils/getDisplayText.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/utils/getDisplayText.ts
@@ -16,6 +16,48 @@ interface LivenessDisplayTextInterface {
   errorDisplayText: Required<ErrorDisplayText>;
 }
 
+function getMergedDisplayText(
+  overrideDisplayText: Partial<LivenessDisplayText>
+): Partial<LivenessDisplayText> {
+  const mergeField = (
+    correctKey: keyof InstructionDisplayText,
+    deprecatedKey: keyof InstructionDisplayText
+  ) => {
+    if (
+      overrideDisplayText[correctKey] &&
+      overrideDisplayText[correctKey] !== defaultLivenessDisplayText[correctKey]
+    ) {
+      return overrideDisplayText[correctKey];
+    } else if (
+      overrideDisplayText[deprecatedKey] &&
+      overrideDisplayText[deprecatedKey] !==
+        defaultLivenessDisplayText[correctKey]
+    ) {
+      return overrideDisplayText[deprecatedKey];
+    } else {
+      return defaultLivenessDisplayText[correctKey];
+    }
+  };
+
+  return {
+    photosensitivityWarningBodyText: mergeField(
+      'photosensitivityWarningBodyText',
+      'photosensitivyWarningBodyText'
+    ),
+    photosensitivityWarningHeadingText: mergeField(
+      'photosensitivityWarningHeadingText',
+      'photosensitivyWarningHeadingText'
+    ),
+    photosensitivityWarningInfoText: mergeField(
+      'photosensitivityWarningInfoText',
+      'photosensitivyWarningInfoText'
+    ),
+    photosensitivityWarningLabelText: mergeField(
+      'photosensitivityWarningLabelText',
+      'photosensitivyWarningLabelText'
+    ),
+  };
+}
 /**
  * Merges optional displayText prop with
  * defaultLivenessDisplayText and returns more bite size portions to pass
@@ -26,9 +68,12 @@ interface LivenessDisplayTextInterface {
 export function getDisplayText(
   overrideDisplayText: LivenessDisplayText | undefined
 ): LivenessDisplayTextInterface {
+  const mergedDisplayText = getMergedDisplayText(overrideDisplayText ?? {});
+
   const displayText = {
     ...defaultLivenessDisplayText,
     ...overrideDisplayText,
+    ...mergedDisplayText,
   };
 
   const {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
We have two versions of each photosensitivity display text, one with a typo (e.g. `photosensitivyWarningBodyText`), which is deprecated and will eventually be removed, and one with the correct spelling (e.g. `photosensitivityWarningBodyText`). 

Currently if you provide a customization to the incorrect spelled version it will not be applied; this fixes that issue by adding an additional util to "merge" the two versions depending on where the override was specified. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
