### PR TITLE
fix(liveness): fix camera switching after ws connection established

### DIFF
--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
@@ -539,6 +539,10 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
       updateDeviceAndStream: assign({
         videoAssociatedParams: (context, event) => {
           setLastSelectedCameraId(event.data?.newDeviceId as string);
+          context.livenessStreamProvider?.setNewVideoStream(
+            event.data?.newStream as MediaStream
+          );
+
           return {
             ...context.videoAssociatedParams,
             selectedDeviceId: event.data

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/StreamRecorder/StreamRecorder.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/StreamRecorder/StreamRecorder.ts
@@ -35,7 +35,7 @@ export class StreamRecorder {
   setNewVideoStream(stream: MediaStream): void {
     this.#cleanUpEventListeners();
     this.#recorder = new MediaRecorder(stream, { bitsPerSecond: 1000000 });
-    this.#eventListeners = this.#createPassThroughRecorder();
+    this.#createPassThroughRecorder();
   }
 
   dispatchStreamEvent<T extends StreamResultType>(
@@ -137,7 +137,7 @@ export class StreamRecorder {
    * The startFaceLivenessSession API takes in a ReadableStream as its source of all websocket events
    * To allow for changing cameras we add new MediaRecorders which pass through events to the previously set MediaRecorder
    */
-  #createPassThroughRecorder(): { [key: string]: (args: any) => void } {
+  #createPassThroughRecorder(): void {
     const onDataAvailableHandler = ({ data }: { data: Blob }) => {
       this.#initialRecorder.dispatchEvent(
         new MessageEvent('dataavailable', { data })
@@ -173,7 +173,7 @@ export class StreamRecorder {
 
     this.#setupCallbacks();
 
-    return {
+    this.#eventListeners = {
       endStream: onEndStreamHandler,
       closeCode: onCloseCodeHandler,
       streamStop: onStreamStopHandler,

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/StreamRecorder/__tests__/StreamRecorder.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/StreamRecorder/__tests__/StreamRecorder.test.ts
@@ -238,4 +238,39 @@ describe('StreamRecorder', () => {
       expect(endStreamListener()).toBeUndefined();
     });
   });
+
+  describe('StreamRecorder.setNewVideoStream', () => {
+    it('creates a new video stream with event handling', () => {
+      const eventListeners: Record<string, (params?: any) => void> = {};
+      window.MediaRecorder = (jest.fn() as any).mockImplementation(() => ({
+        ...mockMediaRecorder,
+        addEventListener: jest.fn(
+          (name: string, cb: (params?: any) => void) => {
+            eventListeners[name] = cb;
+          }
+        ),
+      }));
+
+      const recorder = new StreamRecorder(stream);
+      const newStream = { id: 'new' } as MediaStream;
+      recorder.setNewVideoStream(newStream);
+
+      const sessionInfoListener = eventListeners['sessionInfo'];
+      const streamStopListener = eventListeners['streamStop'];
+      const closeCodeListener = eventListeners['closeCode'];
+      const endStreamListener = eventListeners['endStream'];
+
+      expect(sessionInfoListener).toBeDefined();
+      expect(sessionInfoListener({})).toBeUndefined();
+
+      expect(streamStopListener).toBeDefined();
+      expect(streamStopListener()).toBeUndefined();
+
+      expect(closeCodeListener).toBeDefined();
+      expect(closeCodeListener({ closeCode: 4003 })).toBeUndefined();
+
+      expect(endStreamListener).toBeDefined();
+      expect(endStreamListener()).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Issue: with no-light feature we decided to open the websocket connection on the camera check screen, the websocket connection takes in a readable stream derived from the MediaRecorder as an input, and we don't have a way to change that mid connection
- Potential solution: Now when users change camera we create a new MediaRecorder object and feed it's even stream into the originally set MediaRecorder that was used as an input to the websocket connection. Any events that are sent to the new camera / MediaRecorder are passed through to the original mediaRecorder which we maintain a reference to

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] `yarn test` passes and tests are updated/added
- [ ] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
