### PR TITLE
fix(ui & ui-react): Resolves ratings height discrepancy in edge case 

### DIFF
--- a/.changeset/grumpy-crews-laugh.md
+++ b/.changeset/grumpy-crews-laugh.md
@@ -3,4 +3,4 @@
 '@aws-amplify/ui': patch
 ---
 
-This change removes an inconsistency in the heights of ratings between 0-1 (non-inclusive)
+This change removes an inconsistency in the heights of ratings between 0-1 (non-inclusive). This change was made per customer request via a raised issue. A customer would only need to update their code if they display ratings between 0-1 (non-inclusive).

--- a/.changeset/grumpy-crews-laugh.md
+++ b/.changeset/grumpy-crews-laugh.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui-react': patch
+'@aws-amplify/ui': patch
+---
+
+This change removes an inconsistency in the heights of ratings between 0-1 (non-inclusive)

--- a/packages/react/src/primitives/Rating/RatingIcon.tsx
+++ b/packages/react/src/primitives/Rating/RatingIcon.tsx
@@ -4,9 +4,10 @@ import { Property } from 'csstype';
 
 import { View } from '../View';
 import { StyleToken } from '../types/style';
+import { BaseComponentProps } from '../types';
 import { ComponentClassName } from '@aws-amplify/ui';
 
-interface RatingIconProps {
+interface RatingIconProps extends BaseComponentProps {
   icon: React.ReactNode;
   fill?: StyleToken<Property.Color>;
   className: string;
@@ -23,14 +24,12 @@ export const RatingIcon: React.FC<RatingIconProps> = ({
       className={ComponentClassName.RatingItem}
       aria-hidden="true"
     >
-      <View 
-        as="span" 
-        className={classNames(
-          ComponentClassName.RatingIcon, 
-          className
-        )} 
-        color={fill}>
-          {icon}
+      <View
+        as="span"
+        className={classNames(ComponentClassName.RatingIcon, className)}
+        color={fill}
+      >
+        {icon}
       </View>
     </View>
   );

--- a/packages/react/src/primitives/Rating/RatingIcon.tsx
+++ b/packages/react/src/primitives/Rating/RatingIcon.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { classNames } from '@aws-amplify/ui';
+import { classNames, ComponentClassName } from '@aws-amplify/ui';
 import { Property } from 'csstype';
 
-import { View } from '../View';
-import { StyleToken } from '../types/style';
 import { BaseComponentProps } from '../types';
-import { ComponentClassName } from '@aws-amplify/ui';
+import { StyleToken } from '../types/style';
+import { View } from '../View';
 
 interface RatingIconProps extends BaseComponentProps {
   icon: React.ReactNode;

--- a/packages/react/src/primitives/Rating/RatingIcon.tsx
+++ b/packages/react/src/primitives/Rating/RatingIcon.tsx
@@ -23,8 +23,14 @@ export const RatingIcon: React.FC<RatingIconProps> = ({
       className={ComponentClassName.RatingItem}
       aria-hidden="true"
     >
-      <View as="span" className={classNames(className)} color={fill}>
-        {icon}
+      <View 
+        as="span" 
+        className={classNames(
+          ComponentClassName.RatingIcon, 
+          className
+        )} 
+        color={fill}>
+          {icon}
       </View>
     </View>
   );

--- a/packages/react/src/primitives/Rating/RatingIcon.tsx
+++ b/packages/react/src/primitives/Rating/RatingIcon.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 import { classNames, ComponentClassName } from '@aws-amplify/ui';
 import { Property } from 'csstype';
 
-import { BaseComponentProps } from '../types';
 import { StyleToken } from '../types/style';
 import { View } from '../View';
 
-interface RatingIconProps extends BaseComponentProps {
+interface RatingIconProps {
   icon: React.ReactNode;
   fill?: StyleToken<Property.Color>;
   className: string;

--- a/packages/react/src/primitives/Rating/__tests__/RatingIcon.test.tsx
+++ b/packages/react/src/primitives/Rating/__tests__/RatingIcon.test.tsx
@@ -9,7 +9,7 @@ const CustomIcon = ({ className }: { className: string }) => (
 );
 
 describe('RatingIcon', () => {
-  it('should render rating icon class', async () => {
+  it('should render rating icon class', () => {
     const { container } = render(
       <div data-testid="custom-element">
         <RatingIcon

--- a/packages/react/src/primitives/Rating/__tests__/RatingIcon.test.tsx
+++ b/packages/react/src/primitives/Rating/__tests__/RatingIcon.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
-import { RatingIcon } from '../RatingIcon';
 import { ComponentClassName } from '@aws-amplify/ui';
+import { RatingIcon } from '../RatingIcon';
 
 const CustomIcon = ({ className }: { className: string }) => (
   <svg className={className}></svg>
@@ -11,13 +11,12 @@ const CustomIcon = ({ className }: { className: string }) => (
 describe('RatingIcon', () => {
   it('should render rating icon class', () => {
     const { container } = render(
-      <div data-testid="custom-element">
-        <RatingIcon
-          icon={<CustomIcon className="my-custom-component" />}
-          className="test-class"
-        ></RatingIcon>
-      </div>
+      <RatingIcon
+        className="test-class"
+        icon={<CustomIcon className="dummy-icon" />}
+      />
     );
+
     const iconSpan = container.getElementsByClassName(
       'test-class'
     )[0] as HTMLElement;

--- a/packages/react/src/primitives/Rating/__tests__/RatingIcon.test.tsx
+++ b/packages/react/src/primitives/Rating/__tests__/RatingIcon.test.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { RatingIcon } from '../RatingIcon';
+import { ComponentClassName } from '@aws-amplify/ui';
+
+const CustomIcon = ({ className }: { className: string }) => (
+  <svg className={className}></svg>
+);
+
+describe('RatingIcon', () => {
+  it('should render rating icon class', async () => {
+    const { container } = render(
+      <div data-testid="custom-element">
+        <RatingIcon
+          icon={<CustomIcon className="my-custom-component" />}
+          className="test-class"
+        ></RatingIcon>
+      </div>
+    );
+    const iconSpan = container.getElementsByClassName(
+      'test-class'
+    )[0] as HTMLElement;
+    expect(iconSpan).toHaveClass(ComponentClassName['RatingIcon']);
+  });
+});

--- a/packages/ui/src/theme/css/component/rating.scss
+++ b/packages/ui/src/theme/css/component/rating.scss
@@ -1,5 +1,5 @@
 .amplify-rating {
-  display: inline-flex;
+  display: flex;
   position: relative;
   text-align: left;
   font-size: var(--amplify-components-rating-default-size);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Currently, icons that are completely filled and completely unfilled have classes amplify-rating__icon–filled and amplify-rating__icon–empty, respectively. The mixed icons act as an overlaid combination of the 2 icons, and have an additional class: amplify-rating__icon. This gives the mixed icons absolute position to ensure an accurate overlay. The problem arises due to the fact that the absolute position (combined with inline-flex display of the flex container) resulted in the icon having bottom space, pushing down the text. Note that this space still exists in the filled and empty icons – just on top, which was not noted in the bug report.

To fix the misalignment, I passed in the amplify-rating__icon class into the empty and filled icons to give all an absolute position. To fix the additional resulting bottom space, I changed the display of the amplify-rating class to flex instead of inline-flex.

I wrote a single unit test to ensure that RatingIcon instances had the additional class.

I extended the RatingIconProps interface with the BaseComponentProps interface to allow for id assignment and simpler unit testing. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

This resolves [issue #4100 ](https://github.com/aws-amplify/amplify-ui/issues/4100)

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I validated changes in an example environment by looking at the alignment and additional space of the new ratings.

I ran the automated snapshot test with ```yarn ui test```.

I created a new test in Jest to check for the new class assignment.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
