### PR TITLE
docs: CONTRIBUTING.md troubleshooting section addition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ You should open an issue to discuss your pull request, unless it's a trivial cha
 
 ### Troubleshooting
 
-**M1 Mac:**
+**Apple Silicon:**
 If using an M1 (or more recent) Macbook and you get the following error message regarding installation of `canvas`:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ You should open an issue to discuss your pull request, unless it's a trivial cha
 
 ### Troubleshooting
 
+**M1 Mac:**
 If using an M1 (or more recent) Macbook and you get the following error message regarding installation of `canvas`:
 
 ```bash
@@ -65,6 +66,7 @@ gyp: Call to 'pkg-config pixman-1 --libs' returned exit status 127 while in bind
 
 See the [canvas docs](https://github.com/Automattic/node-canvas#compiling) to install required dependencies for local docs development.
 
+**Python 3.12:**
 If you are using Python 3.12 or greater and you get the following error message regarding installation of `canvas`:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ gyp: Call to 'pkg-config pixman-1 --libs' returned exit status 127 while in bind
 
 See the [canvas docs](https://github.com/Automattic/node-canvas#compiling) to install required dependencies for local docs development.
 
-If you are using a Python3.12 or greater and you get the following error message regarding installation of `canvas`:
+If you are using Python 3.12 or greater and you get the following error message regarding installation of `canvas`:
 
 ```bash
 error /Users/USERNAME/amplify-ui/node_modules/canvas: Command failed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,17 @@ gyp: Call to 'pkg-config pixman-1 --libs' returned exit status 127 while in bind
 
 See the [canvas docs](https://github.com/Automattic/node-canvas#compiling) to install required dependencies for local docs development.
 
+If you are using a Python3.12 or greater and you get the following error message regarding installation of `canvas`:
+
+```bash
+error /Users/USERNAME/amplify-ui/node_modules/canvas: Command failed.
+Exit code: 1
+...
+ModuleNotFoundError: No module named 'distutils'
+```
+
+See the [setuptools](https://pypi.org/project/setuptools/) installation website. Setuptools serves as a [recommended](https://docs.python.org/3.10/library/distutils.html) alternative to distutils.
+
 ## Project Structure
 
 `amplify-ui` is a monorepo that contains the following workspaces:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ gyp: Call to 'pkg-config pixman-1 --libs' returned exit status 127 while in bind
 
 See the [canvas docs](https://github.com/Automattic/node-canvas#compiling) to install required dependencies for local docs development.
 
-**Python 3.12:**
+**Python >= 3.12:**
 If you are using Python 3.12 or greater and you get the following error message regarding installation of `canvas`:
 
 ```bash


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

I ran into an error when running ```yarn setup``` with an M3 Mac and Python 3.12. One of the required dependencies for canvas installation (distutils) is deprecated for Python 3.12. There is a recommended replacement package called python-setuptools that solves the issue when you download it. I believe that many people are likely to run into a similar issue if they use a recent Python version.

I modified the CONTRIBUTING.md document to include the error and the solution. For more trust, I also linked an article showing that this is Python’s recommended solution. I added bolded headers to the different troubleshooting steps for more organization.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Reviewed CONTRIBUTING.md code as a markdown file to ensure valid appearance.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
