### PR TITLE
fix(storage-manager): update file processedKey on process file complete

### DIFF
--- a/.changeset/short-doors-flash.md
+++ b/.changeset/short-doors-flash.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-storage": patch
+---
+
+fix(storage-manager): update file processedKey on process file complete

--- a/packages/react-storage/jest.config.ts
+++ b/packages/react-storage/jest.config.ts
@@ -11,10 +11,10 @@ const config: Config = {
   ],
   coverageThreshold: {
     global: {
-      branches: 86,
-      functions: 87,
-      lines: 93,
-      statements: 93,
+      branches: 87,
+      functions: 90,
+      lines: 95,
+      statements: 95,
     },
   },
   moduleNameMapper: { '^uuid$': '<rootDir>/../../node_modules/uuid' },

--- a/packages/react-storage/src/components/StorageManager/StorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/StorageManager.tsx
@@ -110,6 +110,7 @@ const StorageManagerBase = React.forwardRef(function StorageManager(
     files,
     removeUpload,
     queueFiles,
+    setProcessedKey,
     setUploadingFile,
     setUploadPaused,
     setUploadProgress,
@@ -147,6 +148,7 @@ const StorageManagerBase = React.forwardRef(function StorageManager(
     onUploadError,
     onUploadSuccess,
     onUploadStart,
+    onProcessFileSuccess: setProcessedKey,
     setUploadingFile,
     setUploadProgress,
     setUploadSuccess,
@@ -201,7 +203,9 @@ const StorageManagerBase = React.forwardRef(function StorageManager(
     if (typeof onFileRemove === 'function') {
       const file = files.find((file) => file.id === id);
       if (file) {
-        onFileRemove({ key: file.key });
+        // return `processedKey` if available and `processFile` is provided
+        const key = (processFile && file?.processedKey) ?? file.key;
+        onFileRemove({ key });
       }
     }
   };

--- a/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
+++ b/packages/react-storage/src/components/StorageManager/__tests__/StorageManager.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { fireEvent, render, waitFor, act } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  waitFor,
+  act,
+  getByTestId,
+} from '@testing-library/react';
 import * as Storage from 'aws-amplify/storage';
 
 import { ComponentClassName } from '@aws-amplify/ui';
@@ -33,6 +39,7 @@ const storeManagerProps: StorageManagerProps = {
   accessLevel: 'guest',
   maxFileCount: 100,
 };
+
 describe('StorageManager', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -253,6 +260,117 @@ describe('StorageManager', () => {
         },
       });
       expect(onUploadStart).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('provides the correct file key on a remove file event before upload', () => {
+    const onFileRemove = jest.fn();
+
+    const { container } = render(
+      <StorageManager
+        {...storeManagerProps}
+        autoUpload={false}
+        onFileRemove={onFileRemove}
+      />
+    );
+
+    const hiddenInput: HTMLInputElement = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+
+    expect(hiddenInput).toBeInTheDocument();
+
+    const file = new File(['file content'], 'file.txt', { type: 'text/plain' });
+
+    fireEvent.change(hiddenInput, { target: { files: [file] } });
+
+    expect(uploadDataSpy).not.toHaveBeenCalled();
+
+    const removeButton = getByTestId(
+      container,
+      'storage-manager-remove-button'
+    );
+    expect(removeButton).toBeDefined();
+
+    fireEvent.click(removeButton);
+
+    expect(onFileRemove).toHaveBeenCalledTimes(1);
+    expect(onFileRemove).toHaveBeenCalledWith({ key: file.name });
+  });
+
+  it('provides the correct file key on a remove file event after upload', async () => {
+    const onFileRemove = jest.fn();
+
+    const { container } = render(
+      <StorageManager {...storeManagerProps} onFileRemove={onFileRemove} />
+    );
+    const hiddenInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+
+    expect(hiddenInput).toBeInTheDocument();
+    const file = new File(['file content'], 'file.txt', { type: 'text/plain' });
+    fireEvent.change(hiddenInput, {
+      target: { files: [file] },
+    });
+
+    // Wait for the file to be uploaded
+    await waitFor(() => {
+      expect(uploadDataSpy).toHaveBeenCalled();
+
+      const removeButton = getByTestId(
+        container,
+        'storage-manager-remove-button'
+      );
+      expect(removeButton).toBeDefined();
+
+      fireEvent.click(removeButton);
+
+      expect(onFileRemove).toHaveBeenCalledTimes(1);
+      expect(onFileRemove).toHaveBeenCalledWith({ key: file.name });
+    });
+  });
+
+  it('provides the processed file key on a remove file event after upload when processFile is provided', async () => {
+    const onFileRemove = jest.fn();
+
+    const processedKey = 'processedKey';
+    const processFile: StorageManagerProps['processFile'] = (input) => ({
+      ...input,
+      key: processedKey,
+    });
+
+    const { container } = render(
+      <StorageManager
+        {...storeManagerProps}
+        onFileRemove={onFileRemove}
+        processFile={processFile}
+      />
+    );
+
+    const hiddenInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+
+    expect(hiddenInput).toBeInTheDocument();
+    const file = new File(['file content'], 'file.txt', { type: 'text/plain' });
+
+    fireEvent.change(hiddenInput, { target: { files: [file] } });
+
+    // Wait for the file to be uploaded
+    await waitFor(() => {
+      expect(uploadDataSpy).toHaveBeenCalled();
+
+      const removeButton = getByTestId(
+        container,
+        'storage-manager-remove-button'
+      );
+      expect(removeButton).toBeDefined();
+
+      fireEvent.click(removeButton);
+
+      expect(onFileRemove).toHaveBeenCalledTimes(1);
+      expect(onFileRemove).toHaveBeenCalledWith({ key: processedKey });
     });
   });
 

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/__tests__/reducer.test.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/__tests__/reducer.test.ts
@@ -310,6 +310,38 @@ describe('storageManagerStateReducer', () => {
     expect(result.current.state.files).toEqual([file]);
   });
 
+  it('updates the key of a target file on SET_PROCESSED_FILE_KEY', () => {
+    const file: StorageFile = {
+      id: imageFile.name,
+      file: imageFile,
+      error: '',
+      key: imageFile.name,
+      status: FileStatus.QUEUED,
+      isImage: true,
+      progress: -1,
+    };
+
+    const { result } = renderHook(() => {
+      const [state, dispatch] = useReducer(storageManagerStateReducer, {
+        files: [file],
+      });
+      return { state, dispatch };
+    });
+
+    const processedKey = `processed-${imageFile.name}`;
+    const action: Action = {
+      type: StorageManagerActionTypes.SET_PROCESSED_FILE_KEY,
+      id: imageFile.name,
+      processedKey,
+    };
+
+    expect(result.current.state.files[0].processedKey).toBeUndefined();
+
+    act(() => result.current.dispatch(action));
+
+    expect(result.current.state.files[0].processedKey).toBe(processedKey);
+  });
+
   it('should only change added files to queued in QUEUE_FILES action', () => {
     const { result } = renderHook(() => {
       const [state, dispatch] = useReducer(storageManagerStateReducer, {

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/__tests__/useStorageManager.test.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/__tests__/useStorageManager.test.ts
@@ -166,6 +166,18 @@ describe('useUploadFiles', () => {
     expect(result.current.files.length).toBe(1);
   });
 
+  it('should update a target file key', () => {
+    const { result } = renderHook(() => useStorageManager(defaultFiles));
+
+    const processedKey = 'processedKey';
+
+    expect(result.current.files[0].processedKey).toBeUndefined();
+
+    act(() => result.current.setProcessedKey({ id: 'file1', processedKey }));
+
+    expect(result.current.files[0].processedKey).toBe(processedKey);
+  });
+
   describe('defaultFiles', () => {
     it('should handle good defaultFiles', () => {
       const { result } = renderHook(() =>

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/actions.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/actions.ts
@@ -26,6 +26,14 @@ export const queueFilesAction = (): Action => ({
   type: StorageManagerActionTypes.QUEUE_FILES,
 });
 
+export const setProcessedKeyAction = (input: {
+  id: string;
+  processedKey: string;
+}): Action => ({
+  ...input,
+  type: StorageManagerActionTypes.SET_PROCESSED_FILE_KEY,
+});
+
 export const setUploadingFileAction = ({
   id,
   uploadTask,

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/reducer.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/reducer.ts
@@ -1,9 +1,20 @@
-import { FileStatus, StorageFiles } from '../../types';
+import { FileStatus, StorageFile, StorageFiles } from '../../types';
 import {
   Action,
   StorageManagerActionTypes,
   UseStorageManagerState,
 } from './types';
+
+const updateFiles = (
+  files: StorageFiles,
+  nextFileData: Pick<StorageFile, 'id'> & Partial<StorageFile>
+) =>
+  files.reduce<StorageFiles>((files, currentFile) => {
+    if (currentFile.id === nextFileData.id) {
+      return [...files, { ...currentFile, ...nextFileData }];
+    }
+    return [...files, currentFile];
+  }, []);
 
 export function storageManagerStateReducer(
   state: UseStorageManagerState,
@@ -31,16 +42,10 @@ export function storageManagerStateReducer(
 
       const newFiles: StorageFiles = [...state.files, ...newUploads];
 
-      return {
-        ...state,
-        files: newFiles,
-      };
+      return { ...state, files: newFiles };
     }
     case StorageManagerActionTypes.CLEAR_FILES: {
-      return {
-        ...state,
-        files: [],
-      };
+      return { ...state, files: [] };
     }
     case StorageManagerActionTypes.QUEUE_FILES: {
       const { files } = state;
@@ -63,68 +68,31 @@ export function storageManagerStateReducer(
     }
     case StorageManagerActionTypes.SET_STATUS_UPLOADING: {
       const { id, uploadTask } = action;
-      const { files } = state;
+      const status = FileStatus.UPLOADING;
+      const progress = 0;
+      const nextFileData = { status, progress, id, uploadTask };
 
-      const newFiles = files.reduce<StorageFiles>((files, currentFile) => {
-        if (currentFile.id === id) {
-          return [
-            ...files,
-            {
-              ...currentFile,
-              status: FileStatus.UPLOADING,
-              progress: 0,
-              uploadTask,
-            },
-          ];
-        }
-        return [...files, currentFile];
-      }, []);
-      return {
-        ...state,
-        files: newFiles,
-      };
+      const files = updateFiles(state.files, nextFileData);
+
+      return { ...state, files };
+    }
+    case StorageManagerActionTypes.SET_PROCESSED_FILE_KEY: {
+      const { processedKey, id } = action;
+      const files = updateFiles(state.files, { processedKey, id });
+
+      return { files };
     }
     case StorageManagerActionTypes.SET_UPLOAD_PROGRESS: {
       const { id, progress } = action;
-      const { files } = state;
+      const files = updateFiles(state.files, { id, progress });
 
-      const newFiles = files.reduce<StorageFiles>((files, currentFile) => {
-        if (currentFile.id === id) {
-          return [
-            ...files,
-            {
-              ...currentFile,
-              progress,
-            },
-          ];
-        }
-        return [...files, currentFile];
-      }, []);
-      return {
-        ...state,
-        files: newFiles,
-      };
+      return { ...state, files };
     }
     case StorageManagerActionTypes.SET_STATUS: {
       const { id, status } = action;
-      const { files } = state;
+      const files = updateFiles(state.files, { id, status });
 
-      const newFiles = files.reduce<StorageFiles>((files, currentFile) => {
-        if (currentFile.id === id) {
-          return [
-            ...files,
-            {
-              ...currentFile,
-              status,
-            },
-          ];
-        }
-        return [...files, currentFile];
-      }, []);
-      return {
-        ...state,
-        files: newFiles,
-      };
+      return { ...state, files };
     }
     case StorageManagerActionTypes.REMOVE_UPLOAD: {
       const { id } = action;

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/types.ts
@@ -10,6 +10,7 @@ export enum StorageManagerActionTypes {
   CLEAR_FILES = 'CLEAR_FILES',
   QUEUE_FILES = 'QUEUE_FILES',
   SET_STATUS = 'SET_STATUS',
+  SET_PROCESSED_FILE_KEY = 'SET_PROCESSED_FILE_KEY',
   SET_STATUS_UPLOADING = 'SET_STATUS_UPLOADING',
   SET_UPLOAD_PROGRESS = 'SET_UPLOAD_PROGRESS',
   REMOVE_UPLOAD = 'REMOVE_UPLOAD',
@@ -44,6 +45,11 @@ export type Action =
       type: StorageManagerActionTypes.SET_UPLOAD_PROGRESS;
       id: string;
       progress: number;
+    }
+  | {
+      type: StorageManagerActionTypes.SET_PROCESSED_FILE_KEY;
+      id: string;
+      processedKey: string;
     }
   | {
       type: StorageManagerActionTypes.REMOVE_UPLOAD;

--- a/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/useStorageManager.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useStorageManager/useStorageManager.ts
@@ -10,6 +10,7 @@ import {
   clearFilesAction,
   queueFilesAction,
   removeUploadAction,
+  setProcessedKeyAction,
   setUploadingFileAction,
   setUploadProgressAction,
   setUploadStatusAction,
@@ -25,6 +26,7 @@ export interface UseStorageManager {
   clearFiles: () => void;
   queueFiles: () => void;
   setUploadingFile: TaskHandler;
+  setProcessedKey: (params: { id: string; processedKey: string }) => void;
   setUploadProgress: (params: { id: string; progress: number }) => void;
   setUploadSuccess: (params: { id: string }) => void;
   setUploadResumed: (params: { id: string }) => void;
@@ -78,6 +80,10 @@ export function useStorageManager(
     dispatch(setUploadingFileAction({ id, uploadTask }));
   };
 
+  const setProcessedKey: UseStorageManager['setProcessedKey'] = (input) => {
+    dispatch(setProcessedKeyAction(input));
+  };
+
   const setUploadProgress: UseStorageManager['setUploadProgress'] = ({
     progress,
     id,
@@ -103,6 +109,7 @@ export function useStorageManager(
 
   return {
     removeUpload,
+    setProcessedKey,
     setUploadPaused,
     setUploadProgress,
     setUploadResumed,

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/__tests__/useUploadFiles.spec.ts
@@ -39,19 +39,21 @@ const mockQueuedFile: StorageFile = {
   file: imageFile,
 };
 
+const mockOnProcessFileSuccess = jest.fn();
+const mockOnUploadError = jest.fn();
+const mockOnUploadStart = jest.fn();
 const mockSetUploadingFile = jest.fn();
 const mockSetUploadProgress = jest.fn();
 const mockSetUploadSuccess = jest.fn();
-const mockOnUploadError = jest.fn();
-const mockOnUploadStart = jest.fn();
 const props: Omit<UseUploadFilesProps, 'files'> = {
   accessLevel: 'guest',
   maxFileCount: 2,
+  onProcessFileSuccess: mockOnProcessFileSuccess,
+  onUploadError: mockOnUploadError,
+  onUploadStart: mockOnUploadStart,
   setUploadingFile: mockSetUploadingFile,
   setUploadProgress: mockSetUploadProgress,
   setUploadSuccess: mockSetUploadSuccess,
-  onUploadError: mockOnUploadError,
-  onUploadStart: mockOnUploadStart,
 };
 
 describe('useUploadFiles', () => {

--- a/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/useUploadFiles.ts
+++ b/packages/react-storage/src/components/StorageManager/hooks/useUploadFiles/useUploadFiles.ts
@@ -24,22 +24,24 @@ export interface UseUploadFilesProps
       'setUploadingFile' | 'setUploadProgress' | 'setUploadSuccess' | 'files'
     > {
   accessLevel?: StorageManagerProps['accessLevel'];
+  onProcessFileSuccess: (input: { id: string; processedKey: string }) => void;
   path?: string | PathCallback;
 }
 
 export function useUploadFiles({
-  files,
   accessLevel,
+  files,
   isResumable,
-  setUploadProgress,
-  setUploadingFile,
-  setUploadSuccess,
-  onUploadError,
-  onUploadSuccess,
-  onUploadStart,
   maxFileCount,
-  processFile,
+  onProcessFileSuccess,
+  onUploadError,
+  onUploadStart,
+  onUploadSuccess,
   path,
+  processFile,
+  setUploadingFile,
+  setUploadProgress,
+  setUploadSuccess,
 }: UseUploadFilesProps): void {
   React.useEffect(() => {
     const filesReadyToUpload = files.filter(
@@ -64,10 +66,14 @@ export function useUploadFiles({
       };
 
       if (file) {
+        const handleProcessFileSuccess = (input: { processedKey: string }) =>
+          onProcessFileSuccess({ id, ...input });
+
         const input = getInput({
           accessLevel,
           file,
           key,
+          onProcessFileSuccess: handleProcessFileSuccess,
           onProgress,
           path,
           processFile,
@@ -106,6 +112,7 @@ export function useUploadFiles({
     setUploadProgress,
     setUploadingFile,
     onUploadError,
+    onProcessFileSuccess,
     onUploadSuccess,
     onUploadStart,
     maxFileCount,

--- a/packages/react-storage/src/components/StorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/types.ts
@@ -26,6 +26,8 @@ export interface StorageFile {
   file?: File;
   status: FileStatus;
   progress: number;
+  // only present after `processFile` complete
+  processedKey?: string;
   uploadTask?: UploadTask;
   key: string;
   error: string;

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/FileRemoveButton.tsx
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/FileRemoveButton.tsx
@@ -9,7 +9,11 @@ export const FileRemoveButton = ({
 }: FileRemoveButtonProps): JSX.Element => {
   const icons = useIcons('storageManager');
   return (
-    <Button size="small" onClick={onClick}>
+    <Button
+      size="small"
+      onClick={onClick}
+      testId="storage-manager-remove-button"
+    >
       <VisuallyHidden>{altText}</VisuallyHidden>
       <View as="span" aria-hidden fontSize="medium">
         {icons?.remove ?? <IconClose />}

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileControl.test.tsx.snap
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileControl.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`FileControl renders as expected when file is uploading 1`] = `
       </svg>
       <button
         class="amplify-button amplify-field-group__control amplify-button--small"
+        data-testid="storage-manager-remove-button"
         type="button"
       >
         <span
@@ -105,6 +106,7 @@ exports[`FileControl renders as expected when uploading is paused 1`] = `
       />
       <button
         class="amplify-button amplify-field-group__control amplify-button--small"
+        data-testid="storage-manager-remove-button"
         type="button"
       >
         <span
@@ -209,6 +211,7 @@ exports[`FileControl renders thumbnails 1`] = `
       </svg>
       <button
         class="amplify-button amplify-field-group__control amplify-button--small"
+        data-testid="storage-manager-remove-button"
         type="button"
       >
         <span

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileList.test.tsx.snap
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileList.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`FileList renders an alert in case of error 1`] = `
         </svg>
         <button
           class="amplify-button amplify-field-group__control amplify-button--small"
+          data-testid="storage-manager-remove-button"
           type="button"
         >
           <span
@@ -187,6 +188,7 @@ exports[`FileList renders as expected 1`] = `
         </svg>
         <button
           class="amplify-button amplify-field-group__control amplify-button--small"
+          data-testid="storage-manager-remove-button"
           type="button"
         >
           <span
@@ -278,6 +280,7 @@ exports[`FileList renders as expected when upload is resumable 1`] = `
         </button>
         <button
           class="amplify-button amplify-field-group__control amplify-button--small"
+          data-testid="storage-manager-remove-button"
           type="button"
         >
           <span

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileRemoveButton.test.tsx.snap
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileRemoveButton.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`FileRemoveButton renders as expected 1`] = `
 <div>
   <button
     class="amplify-button amplify-field-group__control amplify-button--small"
+    data-testid="storage-manager-remove-button"
     type="button"
   >
     <span
@@ -40,6 +41,7 @@ exports[`FileRemoveButton renders custom icons from IconProvider 1`] = `
 <div>
   <button
     class="amplify-button amplify-field-group__control amplify-button--small"
+    data-testid="storage-manager-remove-button"
     type="button"
   >
     <span


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Prefer `processedKey` as `key` parameter to provided `onRemoveUpload` callback
- add `processedKey` to `StorageFile` interface
- add `setProcessedFileKey` action
- provide value of `processedKey` to `onRemoveUpload` callback if provided alongside `processFile`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-ui/issues/5327

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual tests, add unit tests

File                                    | % Stmts | % Branch | % Funcs | % Lines |
------------------------|-----------|----------|-----------|-------|
Before: All files                              |   93.86 |    86.34 |   87.91 |   93.76 |
After: All files                               |   95.33 |     87.5 |   90.32 |   95.07 |


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
