### PR TITLE
fix(SearchField): accessibility - do not exclude clear button from tab order

### DIFF
--- a/.changeset/eighty-candles-complain.md
+++ b/.changeset/eighty-candles-complain.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix:(SearchField) accessibility - do not exclude clear button from tab order

--- a/packages/react/src/primitives/SearchField/SearchField.tsx
+++ b/packages/react/src/primitives/SearchField/SearchField.tsx
@@ -78,7 +78,6 @@ const SearchFieldPrimitive: Primitive<SearchFieldProps, 'input'> = (
       innerEndComponent={
         <FieldClearButton
           ariaLabel={clearButtonLabel}
-          excludeFromTabOrder
           isVisible={!isDisabled && strHasLength(composedValue)}
           onClick={onClearHandler}
           size={size}

--- a/packages/react/src/primitives/SearchField/__tests__/SearchField.test.tsx
+++ b/packages/react/src/primitives/SearchField/__tests__/SearchField.test.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ComponentClassName } from '@aws-amplify/ui';
@@ -212,6 +218,23 @@ describe('SearchField component', () => {
       });
       expect(searchField).toHaveValue('');
       expect(searchField).toHaveFocus();
+    });
+
+    it('should be focusable via keyboard', async () => {
+      const user = userEvent.setup();
+      render(<SearchField label={label} name="q" />);
+
+      const searchField = await screen.findByLabelText(label);
+
+      await user.type(searchField, searchQuery);
+
+      const clearButton = await screen.findByLabelText(clearButtonLabel);
+      expect(clearButton).not.toHaveFocus();
+
+      await user.tab();
+      await waitFor(() => {
+        expect(clearButton).toHaveFocus();
+      });
     });
 
     it('should clear text and refocus controlled input when clicked', async () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Accessibility review found that having the clear button excluded from the tab order does not meet accessibility standards for keyboard users.

This PR addresses this finding by removing the `excludeFromTabOrder` property on the clear button in the SearchField component

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
addresses #5375 

#### Description of how you validated changes
changes validated locally by building and verifying the updated behavior in local instance of the docs site

https://github.com/aws-amplify/amplify-ui/assets/100880084/153fec20-f408-4fa2-b047-a05a8e201f3d
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



