### PR TITLE
fix(ui-react): Whitespace in Tab IDs

### DIFF
--- a/.changeset/tall-olives-beam.md
+++ b/.changeset/tall-olives-beam.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react': patch
+---
+
+fixes invalid tab IDs

--- a/docs/src/pages/[platform]/components/tabs/examples/ComposedTabsExample.tsx
+++ b/docs/src/pages/[platform]/components/tabs/examples/ComposedTabsExample.tsx
@@ -11,9 +11,9 @@ export const ComposedTabsExample = () => {
         </Tabs.Item>
       </Tabs.List>
       <Tabs.Panel value="Tab 1">Tab 1 content</Tabs.Panel>
-      <Tabs.Panel value="Tab 2">Tab 1 content</Tabs.Panel>
+      <Tabs.Panel value="Tab 2">Tab 2 content</Tabs.Panel>
       <Tabs.Panel value="Tab 3" isDisabled>
-        Tab 1 content
+        Tab 3 content
       </Tabs.Panel>
     </Tabs.Container>
   );

--- a/packages/react/src/primitives/Tabs/TabsContainer.tsx
+++ b/packages/react/src/primitives/Tabs/TabsContainer.tsx
@@ -7,6 +7,8 @@ import { primitiveWithForwardRef } from '../utils/primitiveWithForwardRef';
 import { BaseTabsProps, TabsProps } from './types';
 import { View } from '../View';
 import { TabsContext } from './TabsContext';
+import { useStableId } from '../utils/useStableId';
+import { WHITESPACE_VALUE } from './constants';
 
 const TabsContainerPrimitive: Primitive<TabsProps, 'div'> = (
   {
@@ -20,7 +22,11 @@ const TabsContainerPrimitive: Primitive<TabsProps, 'div'> = (
   }: BaseTabsProps,
   ref
 ) => {
+  const groupId = useStableId(); // groupId is used to ensure uniqueness between Tab Groups in IDs
   const isControlled = controlledValue !== undefined;
+  if (defaultValue && typeof defaultValue === 'string') {
+    defaultValue = defaultValue.replace(' ', WHITESPACE_VALUE); // remove whitespace from defaultValue
+  }
   const [localValue, setLocalValue] = React.useState(() =>
     isControlled ? controlledValue : defaultValue
   );
@@ -44,8 +50,9 @@ const TabsContainerPrimitive: Primitive<TabsProps, 'div'> = (
       activeTab,
       isLazy,
       setActiveTab,
+      groupId,
     };
-  }, [activeTab, setActiveTab, isLazy]);
+  }, [activeTab, setActiveTab, isLazy, groupId]);
 
   return (
     <TabsContext.Provider value={_value}>

--- a/packages/react/src/primitives/Tabs/TabsContainer.tsx
+++ b/packages/react/src/primitives/Tabs/TabsContainer.tsx
@@ -24,9 +24,6 @@ const TabsContainerPrimitive: Primitive<TabsProps, 'div'> = (
 ) => {
   const groupId = useStableId(); // groupId is used to ensure uniqueness between Tab Groups in IDs
   const isControlled = controlledValue !== undefined;
-  if (defaultValue && typeof defaultValue === 'string') {
-    defaultValue = defaultValue.replace(' ', WHITESPACE_VALUE); // remove whitespace from defaultValue
-  }
   const [localValue, setLocalValue] = React.useState(() =>
     isControlled ? controlledValue : defaultValue
   );

--- a/packages/react/src/primitives/Tabs/TabsContainer.tsx
+++ b/packages/react/src/primitives/Tabs/TabsContainer.tsx
@@ -8,7 +8,6 @@ import { BaseTabsProps, TabsProps } from './types';
 import { View } from '../View';
 import { TabsContext } from './TabsContext';
 import { useStableId } from '../utils/useStableId';
-import { WHITESPACE_VALUE } from './constants';
 
 const TabsContainerPrimitive: Primitive<TabsProps, 'div'> = (
   {

--- a/packages/react/src/primitives/Tabs/TabsContext.tsx
+++ b/packages/react/src/primitives/Tabs/TabsContext.tsx
@@ -3,10 +3,12 @@ import * as React from 'react';
 export interface TabsContextInterface {
   activeTab: string;
   isLazy?: boolean;
+  groupId: string;
   setActiveTab: (tab: string) => void;
 }
 
 export const TabsContext = React.createContext<TabsContextInterface>({
+  groupId: '',
   activeTab: '',
   setActiveTab: () => {},
 });

--- a/packages/react/src/primitives/Tabs/TabsItem.tsx
+++ b/packages/react/src/primitives/Tabs/TabsItem.tsx
@@ -19,9 +19,7 @@ const TabsItemPrimitive: Primitive<TabsItemProps, 'button'> = (
   ref
 ) => {
   const { activeTab, setActiveTab, groupId } = React.useContext(TabsContext);
-  if (value && typeof value === 'string') {
-    value = value.replace(' ', WHITESPACE_VALUE);
-  }
+  const idValue = value.replace(' ', WHITESPACE_VALUE);
   const isActive = activeTab === value;
   const handleOnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (isTypedFunction(onClick)) {
@@ -34,9 +32,9 @@ const TabsItemPrimitive: Primitive<TabsItemProps, 'button'> = (
       {...rest}
       role={role}
       as={as}
-      id={`${groupId}-tab-${value}`}
+      id={`${groupId}-tab-${idValue}`}
       aria-selected={isActive}
-      aria-controls={`${groupId}-panel-${value}`}
+      aria-controls={`${groupId}-panel-${idValue}`}
       tabIndex={!isActive ? -1 : undefined}
       className={classNames(
         ComponentClassName.TabsItem,

--- a/packages/react/src/primitives/Tabs/TabsItem.tsx
+++ b/packages/react/src/primitives/Tabs/TabsItem.tsx
@@ -12,12 +12,16 @@ import { View } from '../View';
 import { primitiveWithForwardRef } from '../utils/primitiveWithForwardRef';
 import { BaseTabsItemProps, TabsItemProps } from './types';
 import { TabsContext } from './TabsContext';
+import { WHITESPACE_VALUE } from './constants';
 
 const TabsItemPrimitive: Primitive<TabsItemProps, 'button'> = (
   { className, value, children, onClick, as = 'button', role = 'tab', ...rest },
   ref
 ) => {
-  const { activeTab, setActiveTab } = React.useContext(TabsContext);
+  const { activeTab, setActiveTab, groupId } = React.useContext(TabsContext);
+  if (value && typeof value === 'string') {
+    value = value.replace(' ', WHITESPACE_VALUE);
+  }
   const isActive = activeTab === value;
   const handleOnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (isTypedFunction(onClick)) {
@@ -25,15 +29,14 @@ const TabsItemPrimitive: Primitive<TabsItemProps, 'button'> = (
     }
     setActiveTab(value);
   };
-
   return (
     <View
       {...rest}
       role={role}
       as={as}
-      id={`${value}-tab`}
+      id={`${groupId}-tab-${value}`}
       aria-selected={isActive}
-      aria-controls={`${value}-panel`}
+      aria-controls={`${groupId}-panel-${value}`}
       tabIndex={!isActive ? -1 : undefined}
       className={classNames(
         ComponentClassName.TabsItem,

--- a/packages/react/src/primitives/Tabs/TabsItem.tsx
+++ b/packages/react/src/primitives/Tabs/TabsItem.tsx
@@ -19,7 +19,10 @@ const TabsItemPrimitive: Primitive<TabsItemProps, 'button'> = (
   ref
 ) => {
   const { activeTab, setActiveTab, groupId } = React.useContext(TabsContext);
-  const idValue = value.replace(' ', WHITESPACE_VALUE);
+  let idValue = value;
+  if (typeof idValue === 'string') {
+    idValue = idValue.replace(' ', WHITESPACE_VALUE);
+  }
   const isActive = activeTab === value;
   const handleOnClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (isTypedFunction(onClick)) {

--- a/packages/react/src/primitives/Tabs/TabsPanel.tsx
+++ b/packages/react/src/primitives/Tabs/TabsPanel.tsx
@@ -18,7 +18,10 @@ const TabPanelPrimitive: Primitive<TabsPanelProps, 'div'> = (
 
   if (isLazy && activeTab !== value) return null;
 
-  const idValue = value.replace(' ', WHITESPACE_VALUE);
+  let idValue = value;
+  if (typeof idValue === 'string') {
+    idValue = idValue.replace(' ', WHITESPACE_VALUE);
+  }
 
   return (
     <View

--- a/packages/react/src/primitives/Tabs/TabsPanel.tsx
+++ b/packages/react/src/primitives/Tabs/TabsPanel.tsx
@@ -17,15 +17,15 @@ const TabPanelPrimitive: Primitive<TabsPanelProps, 'div'> = (
   const { activeTab, isLazy, groupId } = React.useContext(TabsContext);
 
   if (isLazy && activeTab !== value) return null;
-  if (value && typeof value === 'string') {
-    value = value.replace(' ', WHITESPACE_VALUE);
-  }
+
+  const idValue = value.replace(' ', WHITESPACE_VALUE);
+
   return (
     <View
       {...rest}
       role={role}
-      id={`${groupId}-panel-${value}`}
-      aria-labelledby={`${groupId}-tab-${value}`}
+      id={`${groupId}-panel-${idValue}`}
+      aria-labelledby={`${groupId}-tab-${idValue}`}
       className={classNames(
         ComponentClassName.TabsPanel,
         classNameModifierByFlag(

--- a/packages/react/src/primitives/Tabs/TabsPanel.tsx
+++ b/packages/react/src/primitives/Tabs/TabsPanel.tsx
@@ -8,21 +8,24 @@ import { View } from '../View';
 import { BaseTabsPanelProps, TabsPanelProps } from './types';
 import { primitiveWithForwardRef } from '../utils/primitiveWithForwardRef';
 import { TabsContext } from './TabsContext';
+import { WHITESPACE_VALUE } from './constants';
 
 const TabPanelPrimitive: Primitive<TabsPanelProps, 'div'> = (
   { className, value, children, role = 'tabpanel', ...rest },
   ref
 ) => {
-  const { activeTab, isLazy } = React.useContext(TabsContext);
+  const { activeTab, isLazy, groupId } = React.useContext(TabsContext);
 
   if (isLazy && activeTab !== value) return null;
-
+  if (value && typeof value === 'string') {
+    value = value.replace(' ', WHITESPACE_VALUE);
+  }
   return (
     <View
       {...rest}
       role={role}
-      id={`${value}-panel`}
-      aria-labelledby={`${value}-tab`}
+      id={`${groupId}-panel-${value}`}
+      aria-labelledby={`${groupId}-tab-${value}`}
       className={classNames(
         ComponentClassName.TabsPanel,
         classNameModifierByFlag(

--- a/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
@@ -119,8 +119,8 @@ describe('Tabs', () => {
       </Tabs.Container>
     );
     const tabs = await screen.findAllByRole('tab');
-    expect(tabs[0].id === tabs[1].id).toBeFalsy;
-    expect(tabs[0].id === tabs[2].id).toBeFalsy;
+    expect(tabs[0].id === tabs[1].id).toBeFalsy();
+    expect(tabs[0].id === tabs[2].id).toBeFalsy();
   });
 
   it('creates the same ids tabs with the same value in the same group', async () => {
@@ -137,8 +137,8 @@ describe('Tabs', () => {
       </Tabs.Container>
     );
     const tabs = await screen.findAllByRole('tab');
-    expect(tabs[0].id === tabs[1].id).toBeTruthy;
-    expect(tabs[0].id === tabs[2].id).toBeTruthy;
+    expect(tabs[0].id === tabs[1].id).toBeTruthy();
+    expect(tabs[0].id === tabs[2].id).toBeTruthy();
   });
 
   describe('TabItem', () => {

--- a/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/primitives/Tabs/__tests__/Tabs.test.tsx
@@ -86,6 +86,61 @@ describe('Tabs', () => {
     expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('creates unique IDs for two tabs with same value in different tab groups"', async () => {
+    render(
+      <Tabs.Container>
+        <Tabs.List>
+          <Tabs.Item value="Tab 1">Tab 1</Tabs.Item>
+        </Tabs.List>
+      </Tabs.Container>
+    );
+    render(
+      <Tabs.Container>
+        <Tabs.List>
+          <Tabs.Item value="Tab 1">Tab 1</Tabs.Item>
+        </Tabs.List>
+      </Tabs.Container>
+    );
+    const tabs = await screen.findAllByRole('tab');
+    expect(tabs[0].id === tabs[1].id).toBeFalsy();
+  });
+
+  it('creates unique ids for each tab with a unique value', async () => {
+    render(
+      <Tabs.Container testId="tabsTest">
+        <Tabs.List>
+          <Tabs.Item value="1">Tab 1</Tabs.Item>
+          <Tabs.Item value="2">Tab 2</Tabs.Item>
+          <Tabs.Item value="3">Tab 3</Tabs.Item>
+        </Tabs.List>
+        <Tabs.Panel value="1">Tab 1</Tabs.Panel>
+        <Tabs.Panel value="2">Tab 2</Tabs.Panel>
+        <Tabs.Panel value="3">Tab 3</Tabs.Panel>
+      </Tabs.Container>
+    );
+    const tabs = await screen.findAllByRole('tab');
+    expect(tabs[0].id === tabs[1].id).toBeFalsy;
+    expect(tabs[0].id === tabs[2].id).toBeFalsy;
+  });
+
+  it('creates the same ids tabs with the same value in the same group', async () => {
+    render(
+      <Tabs.Container testId="tabsTest">
+        <Tabs.List>
+          <Tabs.Item value="1">Tab 1</Tabs.Item>
+          <Tabs.Item value="1">Tab 2</Tabs.Item>
+          <Tabs.Item value="1">Tab 3</Tabs.Item>
+        </Tabs.List>
+        <Tabs.Panel value="1">Tab 1</Tabs.Panel>
+        <Tabs.Panel value="1">Tab 2</Tabs.Panel>
+        <Tabs.Panel value="1">Tab 3</Tabs.Panel>
+      </Tabs.Container>
+    );
+    const tabs = await screen.findAllByRole('tab');
+    expect(tabs[0].id === tabs[1].id).toBeTruthy;
+    expect(tabs[0].id === tabs[2].id).toBeTruthy;
+  });
+
   describe('TabItem', () => {
     it('can render custom classnames', async () => {
       render(

--- a/packages/react/src/primitives/Tabs/constants.ts
+++ b/packages/react/src/primitives/Tabs/constants.ts
@@ -1,0 +1,2 @@
+/* WHITESPACE_VALUE is used to fill whitespace present in user-inputed `value` when creating id for TabsItem and TabsPanel */
+export const WHITESPACE_VALUE = '-';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

Adds `groupId` to TabsContext such that unique IDs can be created for each tab group. IDs are of the form `${groupId}-tab-${idValue}` for tabs, and`${groupId}-panel-${idValue}` for panels. `idValue` is the given `value` stripped of its whitespace using the added constant `WHITESPACE_VALUE`. `idValue` is created in TabsPanel and TabsItem, so assuming the developer enters the same values for these two elements the functionality works. `defaultValue` and controlled tab functionality still works because the actual `value` of the tabs is not altered in any way, but it is highly recommended to not assign `value` to a string containing whitespace. 

Outer html output for a tablist with given values: ['Tab 1', 'Tab 2', 'Tab 3']: `<div role="tablist" class="amplify-tabs__list" style="justify-content: flex-start;"><button role="tab" id="amplify-id-:rl:-tab-Tab-1" aria-selected="true" aria-controls="amplify-id-:rl:-panel-Tab-1" class="amplify-tabs__item amplify-tabs__item--active">Tab 1</button><button role="tab" id="amplify-id-:rl:-tab-Tab-2" aria-selected="false" aria-controls="amplify-id-:rl:-panel-Tab-2" tabindex="-1" class="amplify-tabs__item">Tab 2</button><button disabled="" role="tab" id="amplify-id-:rl:-tab-Tab-3" aria-selected="false" aria-controls="amplify-id-:rl:-panel-Tab-3" tabindex="-1" class="amplify-tabs__item">Disabled tab</button></div>`

Also updated the ComposedTabsExample.tsx file such that each Tab has unique content (previously each was "Tab 1 Content"). 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#5220 

<!-- Also, please reference any associated PRs for documentation updates. -->

#5302 is an old version of this PR that had errors

#### Description of how you validated changes
Added tests to confirm IDs are the same for tabs in the same tab group with the same given value (should be avoided in practice), IDs are different for tabs in different groups with the same value (fine to do in practice). Also confirms that tabs in same group with different values yield unique IDs. Passes all yarn tests.

Also, edited the Amplify UI Docs examples to explore cases where `value` and `defaultValue` are passed with whitespace to ensure composability, control, and disable still work as intended. User experience perfectly matches the production version of Amplify UI Docs. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [] Relevant documentation is changed or added (and PR referenced)
- [x] `yarn test` passes and tests are updated/added
- [x] No side effects or [`sideEffects`](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react/CONTRIBUTING.md#code-standards) field updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
