### PR TITLE
fix(storage-browser): max callstack error

### DIFF
--- a/examples/next/pages/ui/components/storage/storage-browser/composable-playground/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-browser/composable-playground/index.page.tsx
@@ -16,7 +16,7 @@ const { StorageBrowser } = createStorageBrowser({ elements });
 export default function Example() {
   return (
     <StorageBrowser.Provider>
-      {/* <StorageBrowser.Controls.Search /> */}
+      <StorageBrowser.Controls.Search />
     </StorageBrowser.Provider>
   );
 }

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Search.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Search.tsx
@@ -77,7 +77,7 @@ const FieldControl: FieldControl = () => (
 FieldControl.Container = FieldContainer;
 FieldControl.Icon = FieldIcon;
 FieldControl.Input = FieldInput;
-FieldControl.Label = Label;
+FieldControl.Label = FieldLabel;
 
 const ToggleContainer = withBaseElementProps(Span, {
   className: `${SEARCH_BLOCK}-${TOGGLE_BLOCK}__container`,

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -10,7 +10,7 @@ export default function createStorageBrowser<T extends StorageBrowserElements>({
 }: CreateStorageBrowserInput<Partial<T>> = {}): {
   StorageBrowser: StorageBrowser<T>;
 } {
-  const elements = { ..._elements, ...StorageBrowserElements };
+  const elements = { ..._elements, StorageBrowserElements };
   const Provider = createProvider({ elements });
 
   function StorageBrowser(): React.JSX.Element {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This fixes the below error when running the next-example and a minor fix to Search control that was referencing Label instead of FieldLabel

<img width="961" alt="Screenshot 2024-07-17 at 12 09 10 PM" src="https://github.com/user-attachments/assets/e3e42cd8-36f4-4b59-b7d7-642150f12572">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
