### PR TITLE
chore(raven): Add ability to pass in custom renderMessage function

### DIFF
--- a/packages/react-ai/src/components/AIConversation/views/Controls/MessagesControl.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/MessagesControl.tsx
@@ -29,10 +29,12 @@ const Timestamp = withBaseElementProps(Text, {
 
 export const MessageControl: MessageControl = ({ message }) => {
   return message.content.type === 'text' ? (
-    <TextContent data-testid={'message'}>{message.content.value}</TextContent>
+    <TextContent data-testid={'message-text'}>
+      {message.content.value}
+    </TextContent>
   ) : (
     <MediaContent
-      data-testid={'message'}
+      data-testid={'message-image'}
       // @ts-expect-error TODO fix type error
       src={convertBufferToBase64(
         message.content.value.bytes,
@@ -74,22 +76,27 @@ const Layout = withBaseElementProps(View, {
 });
 
 export const MessagesControl: MessagesControl = ({
+  renderMessage,
   variant = 'borderless',
 }) => {
   const messages = React.useContext(MessagesContext);
   return (
     <Layout>
-      {messages?.map((message, index) => (
-        <Container key={`message-${index}`} test-id={`message`}>
-          <HeaderContainer>
-            <AvatarControl message={message} />
-            <Separator />
-            <Timestamp>{formatDate(message.timestamp)}</Timestamp>
-          </HeaderContainer>
-          <MessageControl message={message} variant={variant} />
-          <ActionsBarControl message={message} />
-        </Container>
-      ))}
+      {messages?.map((message, index) =>
+        renderMessage ? (
+          renderMessage(message)
+        ) : (
+          <Container data-testid={`message`} key={`message-${index}`}>
+            <HeaderContainer>
+              <AvatarControl message={message} />
+              <Separator />
+              <Timestamp>{formatDate(message.timestamp)}</Timestamp>
+            </HeaderContainer>
+            <MessageControl message={message} variant={variant} />
+            <ActionsBarControl message={message} />
+          </Container>
+        )
+      )}
     </Layout>
   );
 };
@@ -105,7 +112,10 @@ MessagesControl.Separator = Separator;
 export interface MessagesControl<
   T extends Partial<AIConversationElements> = AIConversationElements,
 > {
-  (props: { variant?: MessageVariant }): JSX.Element;
+  (props: {
+    variant?: MessageVariant;
+    renderMessage?: (message: ConversationMessage) => React.ReactNode;
+  }): JSX.Element;
   ActionsBar: ActionsBarControl<T>;
   Avatar: AvatarControl<T>;
   Container: T['View'];

--- a/packages/react-ai/src/components/AIConversation/views/Controls/__tests__/MessagesControl.spec.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/__tests__/MessagesControl.spec.tsx
@@ -8,6 +8,8 @@ import { AvatarsProvider } from '../../../context/AvatarsContext';
 import { MessagesProvider } from '../../../context/MessagesContext';
 import { MessagesControl, MessageControl } from '../MessagesControl';
 
+import { convertBufferToBase64 } from '../../../utils';
+
 const messages: ConversationMessage[] = [
   {
     id: '1',
@@ -103,6 +105,37 @@ describe('MessagesControl', () => {
     const actionElements = screen.getAllByRole('button');
     expect(avatarElements).toHaveLength(3);
     expect(actionElements).toHaveLength(3);
+  });
+
+  it('renders a MessagesControl element with a custom renderMessage function', () => {
+    const customMessage = jest.fn((message: ConversationMessage) => (
+      <div key={message.id} data-testid="custom-message">
+        {message.content.type === 'text' ? (
+          message.content.value
+        ) : (
+          <img
+            src={convertBufferToBase64(
+              message.content.value.bytes,
+              message.content.value.format
+            )}
+          ></img>
+        )}
+      </div>
+    ));
+
+    render(
+      <MessagesProvider messages={messages}>
+        <MessagesControl renderMessage={customMessage} />
+      </MessagesProvider>
+    );
+
+    expect(customMessage).toHaveBeenCalledTimes(3);
+
+    const defaultMessageElements = screen.queryAllByTestId('message');
+    expect(defaultMessageElements).toHaveLength(0);
+
+    const customMessageElements = screen.queryAllByTestId('custom-message');
+    expect(customMessageElements).toHaveLength(3);
   });
 });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add `renderMessage` function to `MessagesControl` props, which optionally allows customer to override the way we render messages  

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
