### PR TITLE
chore(storage-browser): use Icon variant in TableControl

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
@@ -48,31 +48,19 @@ const TableRow = withBaseElementProps(BaseTableRow, {
   className: `${BLOCK_NAME}__row`,
 });
 
-const iconAttributes = {
-  'aria-hidden': true,
-  width: '24',
-  height: '24',
-  viewBox: '0 -960 960 960',
-  fill: 'none',
-  xmlns: 'http://www.w3.org/2000/svg',
-};
-
 const SortIndeterminateIcon = withBaseElementProps(Icon, {
-  children: <path d="M240-440v-80h480v80H240Z" fill="currentColor" />,
   className: `${BLOCK_NAME}__sort-icon--indeterminate`,
-  ...iconAttributes,
+  variant: 'sort-indeterminate',
 });
 
 const SortAscendingIcon = withBaseElementProps(Icon, {
-  children: <path d="m280-400 200-200 200 200H280Z" fill="currentColor" />,
   className: `${BLOCK_NAME}__sort-icon--ascending`,
-  ...iconAttributes,
+  variant: 'sort-ascending',
 });
 
 const SortDescendingIcon = withBaseElementProps(Icon, {
-  children: <path d="M480-360 280-560h400L480-360Z" fill="currentColor" />,
   className: `${BLOCK_NAME}__sort-icon--descending`,
-  ...iconAttributes,
+  variant: 'sort-descending',
 });
 
 export interface Data {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Use the latest changes for `Icon` in order to use the `variant` property

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
