### PR TITLE
chore(storage-browser): scaffold TargetControl

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Controls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Controls.tsx
@@ -7,6 +7,7 @@ import { RefreshControl } from './Refresh';
 import { SearchControl } from './Search';
 import { SummaryControl } from './Summary';
 import { TableControl } from './Table';
+import { TargetControl } from './Target';
 import { TitleControl } from './Title';
 
 export interface Controls<
@@ -20,6 +21,7 @@ export interface Controls<
   Navigate: NavigateControl<T>;
   Summary: SummaryControl<T>;
   Table: TableControl<T>;
+  Target: TargetControl<T>;
   Title: TitleControl<T>;
 }
 
@@ -32,5 +34,6 @@ export const Controls: Controls = {
   Navigate: NavigateControl,
   Summary: SummaryControl,
   Table: TableControl,
+  Target: TargetControl,
   Title: TitleControl,
 };

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Target.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Target.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { withBaseElementProps } from '@aws-amplify/ui-react-core/elements';
+
+import { StorageBrowserElements } from '../../context/elements';
+import { CLASS_BASE } from '../constants';
+
+const { Span, View, Input, Label, Button } = StorageBrowserElements;
+const BLOCK_NAME = `${CLASS_BASE}__target`;
+
+const DestinationContainer = withBaseElementProps(View, {
+  className: `${BLOCK_NAME}__destination`,
+});
+
+const DestinationLabel = withBaseElementProps(Span, {
+  className: `${BLOCK_NAME}__destination__label`,
+});
+
+const DestinationValue = withBaseElementProps(Span, {
+  className: `${BLOCK_NAME}__destination__value`,
+});
+
+export interface DestinationControl<
+  T extends StorageBrowserElements = StorageBrowserElements,
+> {
+  (): React.JSX.Element;
+  Container: T['View'];
+  Label: T['Span'];
+  Value: T['Span'];
+}
+
+export const DestinationControl: DestinationControl = () => (
+  <DestinationContainer>
+    <DestinationLabel />
+    <DestinationValue />
+  </DestinationContainer>
+);
+
+DestinationControl.Container = DestinationContainer;
+DestinationControl.Label = DestinationLabel;
+DestinationControl.Value = DestinationValue;
+
+const FieldContainer = withBaseElementProps(View, {
+  className: `${CLASS_BASE}__target__field`,
+});
+
+const FieldLabel = withBaseElementProps(Label, {
+  className: `${CLASS_BASE}__target__label`,
+});
+
+const FieldInput = withBaseElementProps(Input, {
+  className: `${CLASS_BASE}__target__input`,
+  type: 'text',
+});
+
+const FieldSubmit = withBaseElementProps(Button, {
+  className: `${CLASS_BASE}__target__submit`,
+  children: 'Submit',
+  type: 'submit',
+});
+
+interface FieldControl<
+  T extends StorageBrowserElements = StorageBrowserElements,
+> {
+  (): React.JSX.Element;
+  Container: T['View'];
+  Label: T['Label'];
+  Input: T['Input'];
+  Submit: T['Button'];
+}
+
+const FieldControl: FieldControl = () => {
+  return (
+    <FieldContainer>
+      <FieldLabel />
+      <FieldInput />
+      <FieldSubmit />
+    </FieldContainer>
+  );
+};
+
+FieldControl.Container = FieldContainer;
+FieldControl.Label = FieldLabel;
+FieldControl.Input = FieldInput;
+FieldControl.Submit = FieldSubmit;
+
+const Container = withBaseElementProps(View, {
+  className: BLOCK_NAME,
+});
+
+export interface TargetControl<
+  T extends StorageBrowserElements = StorageBrowserElements,
+> {
+  (): React.JSX.Element;
+  Container: T['View'];
+  Field: FieldControl<T>;
+  Destination: DestinationControl<T>;
+}
+
+export const TargetControl: TargetControl = () => {
+  return (
+    <Container>
+      <FieldControl />
+      <DestinationControl />
+    </Container>
+  );
+};
+
+TargetControl.Container = Container;
+TargetControl.Field = FieldControl;
+TargetControl.Destination = DestinationControl;

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Target.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Target.spec.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TargetControl } from '../Target';
+
+describe('TargetControl', () => {
+  it('renders a `TargetControl`', () => {
+    expect(render(<TargetControl />).container).toBeDefined();
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/index.ts
@@ -4,6 +4,7 @@ export { NavigateControl } from './Navigate';
 export { PaginateControl } from './Paginate';
 export { RefreshControl } from './Refresh';
 export { SearchControl } from './Search';
+export { TargetControl } from './Target';
 export { TitleControl } from './Title';
 export { TableControl } from './Table';
 export { Controls } from './Controls';

--- a/packages/react-storage/src/styles/storage-browser.css
+++ b/packages/react-storage/src/styles/storage-browser.css
@@ -51,9 +51,29 @@
   display: block;
 }
 
-.storage-browser__divider {
-  border: 0 0 0 var(--storage-browser-divider-border-width);
-  border-style: var(--storage-browser-divider-border-style);
-  border-color: var(--storage-browser-divider-border-color);
-  height: var(--storage-browser-divider-height);
+.storage-browser__target__field {
+  display: inline-grid;
+  gap: var(--storage-browser-gap);
+  grid-template-rows: auto auto;
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    'label label'
+    'input submit';
+}
+
+.storage-browser__target__label {
+  grid-area: label;
+}
+.storage-browser__target__input {
+  grid-area: input;
+}
+.storage-browser__target__submit {
+  grid-area: submit;
+}
+.storage-browser__target__destination {
+  display: flex;
+  gap: var(--storage-browser-gap);
+}
+.storage-browser__target__destination__value {
+  word-break: break-word;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Currently, the two sub controls are output together.

**Field**
<img width="270" alt="Screenshot 2024-07-24 at 6 07 38 PM" src="https://github.com/user-attachments/assets/1b0cff63-0302-4db1-a29c-415dea37ad3d">

**Destination**
<img width="218" alt="Screenshot 2024-07-24 at 6 07 48 PM" src="https://github.com/user-attachments/assets/e5645d99-485b-41ce-8f30-b59f930c6839">

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
