### PR TITLE
chore(storage-browser): remove composability of Message

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Message.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Message.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { withBaseElementProps } from '@aws-amplify/ui-react-core/elements';
 
+import type { OmitElements } from '../types';
 import { MessageVariant, StorageBrowserElements } from '../../context/elements';
 import { CLASS_BASE } from '../constants';
 
@@ -86,15 +87,17 @@ const MessageContent = withBaseElementProps(
 interface MessageControlProps {
   variant?: MessageVariant;
 }
-export interface MessageControl<
+interface _MessageControl<
   T extends StorageBrowserElements = StorageBrowserElements,
-> extends Pick<T, 'Icon'> {
+> extends Pick<T, 'Icon' | 'View'> {
   ({ variant }: MessageControlProps): React.JSX.Element;
-  Container: T['View'];
-  Content: T['View'];
-  Dismiss: MessageDismissControl<T>;
 }
 
+export interface MessageControl<
+  T extends StorageBrowserElements = StorageBrowserElements,
+> extends OmitElements<_MessageControl<T>, 'Container'> {
+  ({ variant }: MessageControlProps): React.JSX.Element;
+}
 export const MessageControl: MessageControl = ({ variant }) => {
   return (
     <Container>
@@ -108,8 +111,3 @@ export const MessageControl: MessageControl = ({ variant }) => {
     </Container>
   );
 };
-
-MessageControl.Container = Container;
-MessageControl.Icon = MessageIcon;
-MessageControl.Content = MessageContent;
-MessageControl.Dismiss = MessageDismissControl;

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Paginate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Paginate.tsx
@@ -6,6 +6,7 @@ import {
   PaginateVariant,
   StorageBrowserElements,
 } from '../../context/elements';
+import type { OmitElements } from '../types';
 import { CLASS_BASE } from '../constants';
 import { PaginateStateContext, useControl } from '../../context/controls';
 
@@ -24,11 +25,6 @@ const PAGINATE_VARIANTS = [
   { variant: 'paginate-current' },
   { variant: 'paginate-next' },
 ] as const;
-
-type OmitElements<T, K extends string = never> = Omit<
-  T,
-  keyof StorageBrowserElements | K
->;
 
 interface PaginateItemProps extends Pick<ButtonElementProps, 'onClick'> {
   variant?: PaginateVariant;

--- a/packages/react-storage/src/components/StorageBrowser/Views/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/Views/types.ts
@@ -4,6 +4,11 @@ import { Controls } from './Controls';
 
 export type CommonControl = 'Message' | 'Navigate' | 'Title';
 
+export type OmitElements<T, K extends string = never> = Omit<
+  T,
+  keyof StorageBrowserElements | K
+>;
+
 export interface ViewComponent<T extends StorageBrowserElements, C> {
   (): React.JSX.Element;
   Controls: C;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- Removes composability of Message
- Moves `OmitElements` to /types.ts so it can be shared

Tested that variants still work, and you can no longer access subcontrols.

**Message with error variant**
<img width="493" alt="Screenshot 2024-07-25 at 4 26 13 PM" src="https://github.com/user-attachments/assets/fd5ddd4e-1f5d-4bed-840b-00bebd94c5c2">

**Just double checking autocomplete for subcontrols (none)**
<img width="877" alt="Screenshot 2024-07-25 at 4 25 56 PM" src="https://github.com/user-attachments/assets/3829ddeb-538d-4472-8cc7-18fa108c0712">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
