### PR TITLE
chore(storage-browser): update composability of Navigate

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { withBaseElementProps } from '@aws-amplify/ui-react-core/elements';
 
+import type { OmitElements } from '../types';
 import { StorageBrowserElements } from '../../context/elements';
 import { CLASS_BASE } from '../constants';
 
@@ -58,30 +59,37 @@ NavigateItem.Separator = Separator;
 NavigateItem.ListItem = ListItem;
 
 /* <NavigateContainer /> */
-const NavigateContainer: NavigateControl['Container'] = React.forwardRef(
-  function Container({ children, ...props }, ref) {
-    return (
-      <Nav
-        {...props}
-        aria-label={props['aria-label'] ?? 'Breadcrumbs'}
-        className={props.className ?? `${BLOCK_NAME}__container`}
-        ref={ref}
-      >
-        <OrderedList className={`${props.className ?? BLOCK_NAME}__list`}>
-          {children}
-        </OrderedList>
-      </Nav>
-    );
-  }
-);
+const NavigateContainer: typeof Nav = React.forwardRef(function Container(
+  { children, ...props },
+  ref
+) {
+  return (
+    <Nav
+      {...props}
+      aria-label={props['aria-label'] ?? 'Breadcrumbs'}
+      className={props.className ?? `${BLOCK_NAME}__container`}
+      ref={ref}
+    >
+      <OrderedList className={`${props.className ?? BLOCK_NAME}__list`}>
+        {children}
+      </OrderedList>
+    </Nav>
+  );
+});
 
 /* <NavigateControl /> */
-export interface NavigateControl<
+export interface _NavigateControl<
   T extends StorageBrowserElements = StorageBrowserElements,
 > {
   (props: { renderNavigateItem?: RenderNavigateItem }): React.JSX.Element;
   Container: T['Nav'];
   NavigateItem: NavigateItem<T>;
+}
+
+export interface NavigateControl<
+  T extends StorageBrowserElements = StorageBrowserElements,
+> extends OmitElements<_NavigateControl<T>, 'Container' | 'NavigateItem'> {
+  (props: { renderNavigateItem?: RenderNavigateItem }): React.JSX.Element;
 }
 
 export const NavigateControl: NavigateControl = (_props) => {
@@ -105,5 +113,3 @@ export const NavigateControl: NavigateControl = (_props) => {
     </NavigateContainer>
   );
 };
-NavigateControl.Container = NavigateContainer;
-NavigateControl.NavigateItem = NavigateItem;

--- a/packages/react-storage/src/components/StorageBrowser/Views/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/Views/types.ts
@@ -4,6 +4,11 @@ import { Controls } from './Controls';
 
 export type CommonControl = 'Message' | 'Navigate' | 'Title';
 
+export type OmitElements<T, K extends string = never> = Omit<
+  T,
+  keyof StorageBrowserElements | K
+>;
+
 export interface ViewComponent<T extends StorageBrowserElements, C> {
   (): React.JSX.Element;
   Controls: C;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Removes composability of Navigate

**Output**

<img width="175" alt="Screenshot 2024-07-25 at 4 41 04 PM" src="https://github.com/user-attachments/assets/06460fab-9eb5-4169-8851-50113644079d">

**Verifying subcontrols aren't accessible**

<img width="887" alt="Screenshot 2024-07-25 at 4 39 24 PM" src="https://github.com/user-attachments/assets/e11c0090-5685-49f2-8308-c473ee129f37">



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
