### PR TITLE
fix(storage): fix looping calls to processFile

### DIFF
--- a/.changeset/four-apricots-compete.md
+++ b/.changeset/four-apricots-compete.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-storage": patch
+---
+
+fix(storage): fix looping calls to processFile

--- a/examples/next/pages/ui/components/storage/storage-manager/process-file-access-level/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-manager/process-file-access-level/index.page.tsx
@@ -28,7 +28,7 @@ export function StorageManagerExample() {
   return (
     <StorageManager
       acceptedFileTypes={['image/*']}
-      accessLevel="private"
+      path={({ identityId }) => `private/${identityId}/`}
       maxFileCount={3}
       showThumbnails={true}
       processFile={processFile}

--- a/packages/react-storage/src/components/StorageManager/utils/getInput.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/getInput.ts
@@ -44,25 +44,32 @@ export const getInput = ({
     // IMPORTANT: always pass `...rest` here for backwards compatibility
     const options = { contentType, onProgress, ...rest };
 
+    let inputResult: PathInput | UploadDataInput;
     if (hasKeyInput) {
       // legacy handling of `path` is to prefix to `fileKey`
       const resolvedKey = hasStringPath
         ? `${path}${processedKey}`
         : processedKey;
 
-      return { data, key: resolvedKey, options: { ...options, accessLevel } };
-    }
+      inputResult = {
+        data,
+        key: resolvedKey,
+        options: { ...options, accessLevel },
+      };
+    } else {
+      const { identityId } = await fetchAuthSession();
+      const resolvedPath = `${
+        hasCallbackPath ? path({ identityId }) : path
+      }${processedKey}`;
 
-    const { identityId } = await fetchAuthSession();
-    const resolvedPath = `${
-      hasCallbackPath ? path({ identityId }) : path
-    }${processedKey}`;
+      inputResult = { data: file, path: resolvedPath, options };
+    }
 
     if (processFile) {
       // provide post-processing value of target `key`
       onProcessFileSuccess({ processedKey });
     }
 
-    return { data: file, path: resolvedPath, options };
+    return inputResult;
   };
 };

--- a/packages/react-storage/src/components/StorageManager/utils/getInput.ts
+++ b/packages/react-storage/src/components/StorageManager/utils/getInput.ts
@@ -39,11 +39,6 @@ export const getInput = ({
       ...rest
     } = await resolveFile({ file, key, processFile });
 
-    if (processFile) {
-      // provide post-processing value of target `key`
-      onProcessFileSuccess({ processedKey });
-    }
-
     const contentType = file.type || 'binary/octet-stream';
 
     // IMPORTANT: always pass `...rest` here for backwards compatibility
@@ -62,6 +57,11 @@ export const getInput = ({
     const resolvedPath = `${
       hasCallbackPath ? path({ identityId }) : path
     }${processedKey}`;
+
+    if (processFile) {
+      // provide post-processing value of target `key`
+      onProcessFileSuccess({ processedKey });
+    }
 
     return { data: file, path: resolvedPath, options };
   };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Using a combination of `processFile` and `path` would cause the processFile to be called on loop
- Seems to be caused by the `setProcessKey` being called before the getting the `identityId` for use with the path callback
- Moved the call to setPRocessedKey` after the call to `fetchAuthSession` and that seems to resolve the issue
- Updated e2e test to use `path` with `processFile`
- fixes https://github.com/aws-amplify/amplify-ui/issues/5467

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
