### PR TITLE
fix(liveness): skip empty video events

### DIFF
--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createRequestStreamGenerator/__tests__/createRequestStreamGenerator.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createRequestStreamGenerator/__tests__/createRequestStreamGenerator.test.ts
@@ -12,6 +12,10 @@ import { createRequestStreamGenerator } from '../createRequestStreamGenerator';
 
 const streamStop: StreamResult<'streamStop'> = { type: 'streamStop' };
 const streamVideo: StreamResult<'streamVideo'> = {
+  data: new Blob([JSON.stringify({ hello: 'world' })]),
+  type: 'streamVideo',
+};
+const emptyStreamVideo: StreamResult<'streamVideo'> = {
   data: new Blob(),
   type: 'streamVideo',
 };
@@ -99,6 +103,27 @@ describe('createRequestStreamGenerator', () => {
     const yielded = await requestStream.next();
     const expected = await getExpectedResult(resultType as StreamResultType);
 
+    expect(yielded).toStrictEqual(expected);
+  });
+
+  it('handles an empty video event by skipping it', async () => {
+    mockRead.mockResolvedValueOnce({
+      value: emptyStreamVideo,
+      done: false,
+    });
+
+    mockRead.mockResolvedValueOnce({
+      value: streamVideo,
+      done: false,
+    });
+
+    const { getRequestStream } = createRequestStreamGenerator(videoStream);
+    const requestStream = getRequestStream();
+
+    const yielded = await requestStream.next();
+
+    expect(yielded.done).toBe(false);
+    const expected = await getExpectedResult('streamVideo');
     expect(yielded).toStrictEqual(expected);
   });
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createRequestStreamGenerator/createRequestStreamGenerator.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createRequestStreamGenerator/createRequestStreamGenerator.ts
@@ -28,6 +28,8 @@ export function createRequestStreamGenerator(stream: VideoStream): {
         if (value.type === 'sessionInfo') {
           yield { ClientSessionInformationEvent: value.data };
         } else {
+          // Unless value.type is closeCode we never want to send a 0 size video event as it signals end of stream
+          if (value.type === 'streamVideo' && value.data.size < 1) continue;
           yield { VideoEvent: await createVideoEvent(value) };
         }
       }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- We previously had this but it got lost in the refactor - https://github.com/aws-amplify/amplify-ui/blob/main/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts#L166
- Seems like some devices send an empty video event randomly so this helps fix that

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
