### PR TITLE
chore(storage-browser): Add Navigate control to LocationDetailView

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Controller.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Controller.tsx
@@ -33,7 +33,6 @@ export function Controller(): null {
     type: 'LIST_LOCATION_ITEMS',
   });
   const [{ location }] = useControl({ type: 'NAVIGATE' });
-  const { current } = location;
 
   const loadLocations = shouldLoadLocations(locationsState);
 
@@ -63,11 +62,11 @@ export function Controller(): null {
 
   const loadLocationItems = shouldLoadLocationItems(locationItemsState);
   React.useEffect(() => {
-    if (current && loadLocationItems) {
+    if (location && loadLocationItems) {
       // TODO: update to exhaustive call
-      listLocationItems(current);
+      listLocationItems(location);
     }
-  }, [current, listLocationItems, loadLocationItems]);
+  }, [location, listLocationItems, loadLocationItems]);
 
   return null;
 }

--- a/packages/react-storage/src/components/StorageBrowser/Controller.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Controller.tsx
@@ -41,6 +41,7 @@ export function Controller(): null {
       // TODO: update to exhaustive call
       handleListLocations();
     } else if (location.shouldRefresh) {
+      // TODO: update to exhaustive call
       handleListLocations({ refresh: true });
     }
   }, [location.shouldRefresh, handleListLocations, loadLocations]);
@@ -69,6 +70,7 @@ export function Controller(): null {
       // TODO: update to exhaustive call
       listLocationItems(location.current);
     } else if (location.current && history.shouldRefresh) {
+      // TODO: update to exhaustive call
       listLocationItems(location.current, true);
     }
   }, [location, history.shouldRefresh, listLocationItems, loadLocationItems]);

--- a/packages/react-storage/src/components/StorageBrowser/Controller.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Controller.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
 
-import {
-  LocationData,
-  LocationItemsState,
-  LocationsDataState,
-  useAction,
-  useLocationsData,
-} from './context/actions';
-
-import { useControl } from './context/controls';
-import { useConfig } from './context/config';
+import { LocationsDataState, useLocationsData } from './context/actions';
 
 const shouldLoadLocations = ({
   data,
@@ -17,22 +8,11 @@ const shouldLoadLocations = ({
   isLoading,
 }: LocationsDataState[0]) => !data.locations.length && !isLoading && !hasError;
 
-const shouldLoadLocationItems = ({
-  // data,
-  hasError,
-  isLoading,
-}: LocationItemsState[0]) => !isLoading && !hasError;
-
 /**
  * Handles fetching of list data
  */
 export function Controller(): null {
-  const { getLocationCredentials, region } = useConfig();
   const [locationsState, handleListLocations] = useLocationsData();
-  const [locationItemsState, handleListLocationItems] = useAction({
-    type: 'LIST_LOCATION_ITEMS',
-  });
-  const [{ location, history }] = useControl({ type: 'NAVIGATE' });
 
   const loadLocations = shouldLoadLocations(locationsState);
 
@@ -46,59 +26,6 @@ export function Controller(): null {
     //   handleListLocations({ refresh: true });
     // }
   }, [handleListLocations, loadLocations]);
-
-  const { bucket, permission, scope, prefix } = location ?? {};
-
-  const listLocationItems = React.useCallback(
-    ({ prefix = '', scope }: { prefix: string | undefined; scope: string }) => {
-      // s3://SOME_STRING/*
-      // eslint-disable-next-line no-console
-      console.log('listLocationItems scope', scope);
-
-      return handleListLocationItems({
-        // uncomment to test managed auth config
-        // prefix: '',
-        // uncomment to test with amplify config with public access level
-
-        prefix,
-        config: {
-          bucket: bucket!,
-          credentialsProvider: async () =>
-            await getLocationCredentials({ permission: permission!, scope }),
-          region,
-        },
-        options: { refresh: true },
-      });
-    },
-    [
-      getLocationCredentials,
-      bucket,
-      permission,
-      handleListLocationItems,
-      region,
-    ]
-  );
-
-  React.useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log('location changed', location);
-  }, [location]);
-
-  const loadLocationItems = shouldLoadLocationItems(locationItemsState);
-
-  React.useEffect(() => {
-    if (scope && loadLocationItems) {
-      // TODO: update to exhaustive call
-      listLocationItems({ prefix, scope });
-    }
-    // if (location.current && loadLocationItems) {
-    //   // TODO: update to exhaustive call
-    //   listLocationItems(location.current);
-    // } else if (location.current && history.shouldRefresh) {
-    //   // TODO: update to exhaustive call
-    //   listLocationItems(location.current, true);
-    // }
-  }, [prefix, scope, listLocationItems, loadLocationItems]);
 
   return null;
 }

--- a/packages/react-storage/src/components/StorageBrowser/Controller.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Controller.tsx
@@ -21,10 +21,6 @@ export function Controller(): null {
       // TODO: update to exhaustive call
       handleListLocations();
     }
-    // else if (location.shouldRefresh) {
-    //   // TODO: update to exhaustive call
-    //   handleListLocations({ refresh: true });
-    // }
   }, [handleListLocations, loadLocations]);
 
   return null;

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -100,7 +100,7 @@ export const NavigateControl: NavigateControl = (_props) => {
         </NavigateButton>
         {state.location ? <Separator /> : null}
       </NavigateItemContainer>
-      {state.location.current && (
+      {/* {state.location.current && (
         <NavigateItemContainer>
           <NavigateButton
             onClick={() => {
@@ -118,8 +118,8 @@ export const NavigateControl: NavigateControl = (_props) => {
             <Separator />
           ) : null}
         </NavigateItemContainer>
-      )}
-      {state.history &&
+      )} */}
+      {/* {state.history &&
         state.history.list?.map((folder, index) => (
           <NavigateItem
             key={index}
@@ -134,7 +134,7 @@ export const NavigateControl: NavigateControl = (_props) => {
               });
             }}
           />
-        ))}
+        ))} */}
     </NavigateContainer>
   );
 };

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -100,29 +100,33 @@ export const NavigateControl: NavigateControl = (_props) => {
         </NavigateButton>
         {state.location ? <Separator /> : null}
       </NavigateItemContainer>
-      {state.location && (
+      {state.location.current && (
         <NavigateItemContainer>
           <NavigateButton
             onClick={() => {
-              if (state?.location) {
+              if (state?.location.current) {
                 handleUpdateState({
                   type: 'SELECT_LOCATION',
-                  location: state.location,
+                  location: state.location.current,
                 });
               }
             }}
           >
-            {state.location.bucket}
+            {state.location.current.bucket}
           </NavigateButton>
-          {state.location ? <Separator /> : null}
+          {state.history.list && state.history.list.length > 0 ? (
+            <Separator />
+          ) : null}
         </NavigateItemContainer>
       )}
       {state.history &&
-        state.history.map((folder, index) => (
+        state.history.list?.map((folder, index) => (
           <NavigateItem
             key={index}
             item={folder}
-            current={folder === state.history?.[state.history.length - 1]}
+            current={
+              folder === state.history.list?.[state.history.list.length - 1]
+            }
             onClick={() => {
               handleUpdateState({
                 type: 'EXIT_FOLDER',

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -4,7 +4,6 @@ import { withBaseElementProps } from '@aws-amplify/ui-react-core/elements';
 import type { OmitElements } from '../types';
 import { StorageBrowserElements } from '../../context/elements';
 import { CLASS_BASE } from '../constants';
-import { FolderName } from '../../context/actions';
 import { useControl } from '../../context/controls';
 
 const { Span, Button, Nav, OrderedList, ListItem } = StorageBrowserElements;
@@ -18,7 +17,7 @@ const Separator = withBaseElementProps(Span, {
 });
 
 type RenderNavigateItemProps = {
-  item: FolderName;
+  item: string;
   current?: boolean;
   onClick?: () => void;
 };
@@ -104,12 +103,14 @@ export const NavigateControl: NavigateControl = (_props) => {
       {state.location && (
         <NavigateItemContainer>
           <NavigateButton
-            onClick={() =>
-              handleUpdateState({
-                type: 'SELECT_LOCATION',
-                location: state.location!, // TODO: Remove '!'; not sure why state.location is possibly undefined
-              })
-            }
+            onClick={() => {
+              if (state?.location) {
+                handleUpdateState({
+                  type: 'SELECT_LOCATION',
+                  location: state.location,
+                });
+              }
+            }}
           >
             {state.location.bucket}
           </NavigateButton>

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -4,17 +4,11 @@ import { withBaseElementProps } from '@aws-amplify/ui-react-core/elements';
 import type { OmitElements } from '../types';
 import { StorageBrowserElements } from '../../context/elements';
 import { CLASS_BASE } from '../constants';
+import { FolderName } from '../../context/actions';
+import { useControl } from '../../context/controls';
 
 const { Span, Button, Nav, OrderedList, ListItem } = StorageBrowserElements;
 const BLOCK_NAME = `${CLASS_BASE}__navigate`;
-
-type PermissionType = 'READ' | 'READWRITE' | 'WRITE';
-type LocationType = 'OBJECT' | 'PREFIX' | 'BUCKET';
-interface LocationData {
-  name: string;
-  permissionType: PermissionType;
-  locationType: LocationType;
-}
 
 /* <Separator /> */
 
@@ -23,11 +17,14 @@ const Separator = withBaseElementProps(Span, {
   children: '/',
 });
 
-/* <NavigateItem /> */
-type RenderNavigateItem = (props: {
-  item: LocationData;
+type RenderNavigateItemProps = {
+  item: FolderName;
   current?: boolean;
-}) => React.JSX.Element;
+  onClick?: () => void;
+};
+
+/* <NavigateItem /> */
+type RenderNavigateItem = (props: RenderNavigateItemProps) => React.JSX.Element;
 
 interface NavigateItem<
   T extends StorageBrowserElements = StorageBrowserElements,
@@ -44,11 +41,10 @@ const NavigateButton = withBaseElementProps(Button, {
   className: `${BLOCK_NAME}__button`,
 });
 
-const NavigateItem: NavigateItem = ({ item, current }) => {
-  const { name } = item;
+const NavigateItem: NavigateItem = ({ item: name, current, onClick }) => {
   return (
     <NavigateItemContainer>
-      <NavigateButton>{name}</NavigateButton>
+      <NavigateButton onClick={onClick}>{name}</NavigateButton>
       {current ? null : <Separator />}
     </NavigateItemContainer>
   );
@@ -93,23 +89,47 @@ export interface NavigateControl<
 }
 
 export const NavigateControl: NavigateControl = (_props) => {
+  const [state, handleUpdateState] = useControl({ type: 'NAVIGATE' });
+
   return (
     <NavigateContainer>
-      <NavigateItem
-        item={{
-          name: 'Home',
-          permissionType: 'READ',
-          locationType: 'OBJECT',
-        }}
-      />
-      <NavigateItem
-        item={{
-          name: 'Location01',
-          permissionType: 'READ',
-          locationType: 'OBJECT',
-        }}
-        current
-      />
+      <NavigateItemContainer>
+        <NavigateButton
+          onClick={() => handleUpdateState({ type: 'DESELECT_LOCATION' })}
+        >
+          Home
+        </NavigateButton>
+        {state.location ? <Separator /> : null}
+      </NavigateItemContainer>
+      {state.location && (
+        <NavigateItemContainer>
+          <NavigateButton
+            onClick={() =>
+              handleUpdateState({
+                type: 'SELECT_LOCATION',
+                location: state.location!, // TODO: Remove '!'; not sure why state.location is possibly undefined
+              })
+            }
+          >
+            {state.location.bucket}
+          </NavigateButton>
+          {state.location ? <Separator /> : null}
+        </NavigateItemContainer>
+      )}
+      {state.history &&
+        state.history.map((folder, index) => (
+          <NavigateItem
+            key={index}
+            item={folder}
+            current={folder === state.history?.[state.history.length - 1]}
+            onClick={() => {
+              handleUpdateState({
+                type: 'EXIT_FOLDER',
+                index,
+              });
+            }}
+          />
+        ))}
     </NavigateContainer>
   );
 };

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -101,34 +101,36 @@ export const NavigateControl: NavigateControl = (_props) => {
         onClick={() => handleUpdateState({ type: 'DESELECT_LOCATION' })}
       />
       {state.location && (
-        <NavigateItem
-          item={state.location.bucket}
-          current={!state.history || state.history.length === 0}
-          onClick={() => {
-            if (state?.location) {
-              handleUpdateState({
-                type: 'SELECT_LOCATION',
-                location: state.location,
-              });
-            }
-          }}
-        />
+        <>
+          <NavigateItem
+            item={state.location.bucket}
+            current={!state.history || state.history.length === 0}
+            onClick={() => {
+              if (state?.location) {
+                handleUpdateState({
+                  type: 'SELECT_LOCATION',
+                  location: state.location,
+                });
+              }
+            }}
+          />
+          {state.history?.map((folder, index) => (
+            <NavigateItem
+              key={index}
+              item={folder}
+              current={folder === state.history?.[state.history.length - 1]}
+              onClick={() => {
+                if (isFolderName(folder)) {
+                  handleUpdateState({
+                    type: 'EXIT_FOLDER',
+                    name: folder,
+                  });
+                }
+              }}
+            />
+          ))}
+        </>
       )}
-      {state.history?.map((folder, index) => (
-        <NavigateItem
-          key={index}
-          item={folder}
-          current={folder === state.history?.[state.history.length - 1]}
-          onClick={() => {
-            if (isFolderName(folder)) {
-              handleUpdateState({
-                type: 'EXIT_FOLDER',
-                name: folder,
-              });
-            }
-          }}
-        />
-      ))}
     </NavigateContainer>
   );
 };

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -106,7 +106,7 @@ export const NavigateControl: NavigateControl = (_props) => {
             item={state.location.bucket}
             current={!state.history || state.history.length === 0}
             onClick={() => {
-              if (state?.location) {
+              if (state.location) {
                 handleUpdateState({
                   type: 'SELECT_LOCATION',
                   location: state.location,

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -5,9 +5,12 @@ import type { OmitElements } from '../types';
 import { StorageBrowserElements } from '../../context/elements';
 import { CLASS_BASE } from '../constants';
 import { useControl } from '../../context/controls';
+import { isFolderName } from '../../context/actions/types';
 
 const { Span, Button, Nav, OrderedList, ListItem } = StorageBrowserElements;
 const BLOCK_NAME = `${CLASS_BASE}__navigate`;
+
+const HOME_NAVIGATE_ITEM = 'Home';
 
 /* <Separator /> */
 
@@ -92,45 +95,40 @@ export const NavigateControl: NavigateControl = (_props) => {
 
   return (
     <NavigateContainer>
-      <NavigateItemContainer>
-        <NavigateButton
-          onClick={() => handleUpdateState({ type: 'DESELECT_LOCATION' })}
-        >
-          Home
-        </NavigateButton>
-        {state.location ? <Separator /> : null}
-      </NavigateItemContainer>
+      <NavigateItem
+        item={HOME_NAVIGATE_ITEM}
+        current={!state.location}
+        onClick={() => handleUpdateState({ type: 'DESELECT_LOCATION' })}
+      />
       {state.location && (
-        <NavigateItemContainer>
-          <NavigateButton
-            onClick={() => {
-              if (state?.location) {
-                handleUpdateState({
-                  type: 'SELECT_LOCATION',
-                  location: state.location,
-                });
-              }
-            }}
-          >
-            {state.location.bucket}
-          </NavigateButton>
-          {state.history && state.history.length > 0 ? <Separator /> : null}
-        </NavigateItemContainer>
+        <NavigateItem
+          item={state.location.bucket}
+          current={!state.history || state.history.length === 0}
+          onClick={() => {
+            if (state?.location) {
+              handleUpdateState({
+                type: 'SELECT_LOCATION',
+                location: state.location,
+              });
+            }
+          }}
+        />
       )}
-      {state.history &&
-        state.history?.map((folder, index) => (
-          <NavigateItem
-            key={index}
-            item={folder}
-            current={folder === state.history?.[state.history.length - 1]}
-            onClick={() => {
+      {state.history?.map((folder, index) => (
+        <NavigateItem
+          key={index}
+          item={folder}
+          current={folder === state.history?.[state.history.length - 1]}
+          onClick={() => {
+            if (isFolderName(folder)) {
               handleUpdateState({
                 type: 'EXIT_FOLDER',
-                index,
+                name: folder,
               });
-            }}
-          />
-        ))}
+            }
+          }}
+        />
+      ))}
     </NavigateContainer>
   );
 };

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -100,33 +100,29 @@ export const NavigateControl: NavigateControl = (_props) => {
         </NavigateButton>
         {state.location ? <Separator /> : null}
       </NavigateItemContainer>
-      {/* {state.location.current && (
+      {state.location && (
         <NavigateItemContainer>
           <NavigateButton
             onClick={() => {
-              if (state?.location.current) {
+              if (state?.location) {
                 handleUpdateState({
                   type: 'SELECT_LOCATION',
-                  location: state.location.current,
+                  location: state.location,
                 });
               }
             }}
           >
-            {state.location.current.bucket}
+            {state.location.bucket}
           </NavigateButton>
-          {state.history.list && state.history.list.length > 0 ? (
-            <Separator />
-          ) : null}
+          {state.history && state.history.length > 0 ? <Separator /> : null}
         </NavigateItemContainer>
-      )} */}
-      {/* {state.history &&
-        state.history.list?.map((folder, index) => (
+      )}
+      {state.history &&
+        state.history?.map((folder, index) => (
           <NavigateItem
             key={index}
             item={folder}
-            current={
-              folder === state.history.list?.[state.history.list.length - 1]
-            }
+            current={folder === state.history?.[state.history.length - 1]}
             onClick={() => {
               handleUpdateState({
                 type: 'EXIT_FOLDER',
@@ -134,7 +130,7 @@ export const NavigateControl: NavigateControl = (_props) => {
               });
             }}
           />
-        ))} */}
+        ))}
     </NavigateContainer>
   );
 };

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Navigate.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Navigate.spec.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ControlProvider } from '../../../context/controls';
 
 import { NavigateControl } from '../Navigate';
+import * as useControlObject from '../../../context/controls';
 
 describe('NavigateControl', () => {
+  const user = userEvent.setup();
+
   it('renders the NavigateControl', () => {
     render(
       <ControlProvider>
@@ -21,5 +25,89 @@ describe('NavigateControl', () => {
 
     expect(nav).toBeInTheDocument();
     expect(list).toBeInTheDocument();
+    expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+
+  it('handles selecting "home" navigate item', async () => {
+    const mockHandleUpdateState = jest.fn();
+    const mockState = {
+      location: { current: { bucket: 'test-bucket' }, shouldRefresh: false },
+      history: {
+        list: ['folder1/', 'folder2/', 'folder3/'],
+        shouldRefresh: false,
+      },
+    };
+
+    jest
+      .spyOn(useControlObject, 'useControl')
+      .mockImplementation(() => [mockState, mockHandleUpdateState]);
+
+    render(
+      <ControlProvider>
+        <NavigateControl />
+      </ControlProvider>
+    );
+
+    await user.click(screen.getByText('Home'));
+
+    expect(mockHandleUpdateState).toHaveBeenCalledWith({
+      type: 'DESELECT_LOCATION',
+    });
+  });
+
+  it('handles selecting location navigate item', async () => {
+    const mockHandleUpdateState = jest.fn();
+    const mockState = {
+      location: { current: { bucket: 'test-bucket' }, shouldRefresh: false },
+      history: {
+        list: ['folder1/', 'folder2/', 'folder3/'],
+        shouldRefresh: false,
+      },
+    };
+
+    jest
+      .spyOn(useControlObject, 'useControl')
+      .mockImplementation(() => [mockState, mockHandleUpdateState]);
+
+    render(
+      <ControlProvider>
+        <NavigateControl />
+      </ControlProvider>
+    );
+
+    await user.click(screen.getByText('test-bucket'));
+
+    expect(mockHandleUpdateState).toHaveBeenCalledWith({
+      type: 'SELECT_LOCATION',
+      location: { bucket: 'test-bucket' },
+    });
+  });
+
+  it('handles selecting a folder navigate item', async () => {
+    const mockHandleUpdateState = jest.fn();
+    const mockState = {
+      location: { current: { bucket: 'test-bucket' }, shouldRefresh: false },
+      history: {
+        list: ['folder1/', 'folder2/', 'folder3/'],
+        shouldRefresh: false,
+      },
+    };
+
+    jest
+      .spyOn(useControlObject, 'useControl')
+      .mockImplementation(() => [mockState, mockHandleUpdateState]);
+
+    render(
+      <ControlProvider>
+        <NavigateControl />
+      </ControlProvider>
+    );
+
+    await user.click(screen.getByText('folder1/'));
+
+    expect(mockHandleUpdateState).toHaveBeenCalledWith({
+      type: 'EXIT_FOLDER',
+      index: 0,
+    });
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Navigate.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Navigate.spec.tsx
@@ -31,14 +31,8 @@ describe('NavigateControl', () => {
   it('handles selecting "home" navigate item', async () => {
     const mockHandleUpdateState = jest.fn();
     const mockState = {
-      location: {
-        current: { bucket: 'test-bucket' },
-        shouldRefresh: false,
-      },
-      history: {
-        list: ['folder1/', 'folder2/', 'folder3/'],
-        shouldRefresh: false,
-      },
+      location: { bucket: 'test-bucket' },
+      history: ['folder1/', 'folder2/', 'folder3/'],
     };
 
     jest
@@ -61,14 +55,8 @@ describe('NavigateControl', () => {
   it('handles selecting location navigate item', async () => {
     const mockHandleUpdateState = jest.fn();
     const mockState = {
-      location: {
-        current: { bucket: 'test-bucket' },
-        shouldRefresh: false,
-      },
-      history: {
-        list: ['folder1/', 'folder2/', 'folder3/'],
-        shouldRefresh: false,
-      },
+      location: { bucket: 'test-bucket' },
+      history: ['folder1/', 'folder2/', 'folder3/'],
     };
 
     jest
@@ -92,14 +80,8 @@ describe('NavigateControl', () => {
   it('handles selecting a folder navigate item', async () => {
     const mockHandleUpdateState = jest.fn();
     const mockState = {
-      location: {
-        current: { bucket: 'test-bucket' },
-        shouldRefresh: false,
-      },
-      history: {
-        list: ['folder1/', 'folder2/', 'folder3/'],
-        shouldRefresh: false,
-      },
+      location: { bucket: 'test-bucket' },
+      history: ['folder1/', 'folder2/', 'folder3/'],
     };
 
     jest
@@ -116,21 +98,15 @@ describe('NavigateControl', () => {
 
     expect(mockHandleUpdateState).toHaveBeenCalledWith({
       type: 'EXIT_FOLDER',
-      index: 0,
+      name: 'folder1/',
     });
   });
 
   it('creates a separator between home and the loction', () => {
     const mockHandleUpdateState = jest.fn();
     const mockState = {
-      location: {
-        current: { bucket: 'test-bucket' },
-        shouldRefresh: false,
-      },
-      history: {
-        list: undefined,
-        shouldRefresh: false,
-      },
+      location: { bucket: 'test-bucket' },
+      history: undefined,
     };
 
     jest

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Navigate.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Navigate.spec.tsx
@@ -31,7 +31,10 @@ describe('NavigateControl', () => {
   it('handles selecting "home" navigate item', async () => {
     const mockHandleUpdateState = jest.fn();
     const mockState = {
-      location: { current: { bucket: 'test-bucket' }, shouldRefresh: false },
+      location: {
+        current: { bucket: 'test-bucket' },
+        shouldRefresh: false,
+      },
       history: {
         list: ['folder1/', 'folder2/', 'folder3/'],
         shouldRefresh: false,
@@ -58,7 +61,10 @@ describe('NavigateControl', () => {
   it('handles selecting location navigate item', async () => {
     const mockHandleUpdateState = jest.fn();
     const mockState = {
-      location: { current: { bucket: 'test-bucket' }, shouldRefresh: false },
+      location: {
+        current: { bucket: 'test-bucket' },
+        shouldRefresh: false,
+      },
       history: {
         list: ['folder1/', 'folder2/', 'folder3/'],
         shouldRefresh: false,
@@ -86,7 +92,10 @@ describe('NavigateControl', () => {
   it('handles selecting a folder navigate item', async () => {
     const mockHandleUpdateState = jest.fn();
     const mockState = {
-      location: { current: { bucket: 'test-bucket' }, shouldRefresh: false },
+      location: {
+        current: { bucket: 'test-bucket' },
+        shouldRefresh: false,
+      },
       history: {
         list: ['folder1/', 'folder2/', 'folder3/'],
         shouldRefresh: false,
@@ -109,5 +118,36 @@ describe('NavigateControl', () => {
       type: 'EXIT_FOLDER',
       index: 0,
     });
+  });
+
+  it('creates a separator between home and the loction', () => {
+    const mockHandleUpdateState = jest.fn();
+    const mockState = {
+      location: {
+        current: { bucket: 'test-bucket' },
+        shouldRefresh: false,
+      },
+      history: {
+        list: undefined,
+        shouldRefresh: false,
+      },
+    };
+
+    jest
+      .spyOn(useControlObject, 'useControl')
+      .mockImplementation(() => [mockState, mockHandleUpdateState]);
+
+    const { container } = render(
+      <ControlProvider>
+        <NavigateControl />
+      </ControlProvider>
+    );
+
+    const separators = container.getElementsByClassName(
+      'storage-browser__navigate__separator'
+    );
+
+    expect(separators).toHaveLength(1);
+    expect(separators[0]).toBeInTheDocument();
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/Controls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/Controls.tsx
@@ -18,6 +18,8 @@ const TEMP_ACTIONS = [
   { name: 'Create Folder', type: 'CREATE_FOLDER' },
 ];
 
+const { Navigate } = Controls;
+
 // @ts-expect-error TODO: add Controls assignment
 export const LocationDetailViewControls: LocationDetailViewControls = () => {
   const handleActionSelect = (type: string) => {
@@ -27,6 +29,7 @@ export const LocationDetailViewControls: LocationDetailViewControls = () => {
 
   return (
     <>
+      <Navigate />
       {TEMP_ACTIONS.map(({ name, type }) => (
         <button
           key={name}

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
@@ -40,10 +40,6 @@ export const LocationDetailView: LocationDetailView = () => {
       scope: string;
     }) =>
       handleListLocationItems({
-        // uncomment to test managed auth config
-        // prefix: '',
-        // uncomment to test with amplify config with public access level
-
         prefix,
         config: {
           bucket,

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
@@ -13,9 +13,12 @@ export interface LocationDetailView<
 export const LocationDetailView: LocationDetailView = () => {
   const [_, handleUpdateState] = useControl({ type: 'NAVIGATE' });
 
-  const [{ data, isLoading }] = useAction({
+  const [{ data, isLoading, message }] = useAction({
     type: 'LIST_LOCATION_ITEMS',
   });
+
+  // eslint-disable-next-line no-console
+  console.log('message', message);
 
   const hasItems = !!data.items.length;
 
@@ -26,6 +29,9 @@ export const LocationDetailView: LocationDetailView = () => {
           return (
             <button
               onClick={() => {
+                // eslint-disable-next-line no-console
+                console.log('clcik', item.key);
+
                 if (item.key.endsWith('/')) {
                   handleUpdateState({
                     type: 'ENTER_FOLDER',

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
@@ -7,6 +7,7 @@ import { LocationDetailViewControls } from './Controls';
 import { useControl } from '../../context/controls';
 import { useConfig } from '../../context/config';
 import { useHasValueUpdated } from '@aws-amplify/ui-react-core';
+import { isFolderName } from '../../context/actions/types';
 
 export interface LocationDetailView<
   T extends StorageBrowserElements = StorageBrowserElements,
@@ -66,26 +67,25 @@ export const LocationDetailView: LocationDetailView = () => {
 
   const listItems = !hasItems
     ? null
-    : data.items.map((item) => {
-        if (item.type === 'FOLDER') {
+    : data.items.map(({ key, type }) => {
+        if (type === 'FOLDER') {
           return (
             <button
               onClick={() => {
-                if (item.key.endsWith('/')) {
+                if (isFolderName(key)) {
                   handleUpdateState({
                     type: 'ENTER_FOLDER',
-                    // @ts-expect-error Type 'string' is not assignable to type '${string}/'
-                    name: item.key, // TODO: fix this type error
+                    name: key,
                   });
                 }
               }}
-              key={item.key}
+              key={key}
             >
-              {item.key}
+              {key}
             </button>
           );
         } else {
-          return <p key={item.key}>{item.key}</p>;
+          return <p key={key}>{key}</p>;
         }
       });
 

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 
-import { useAction } from '../../context/actions';
+import { FolderName, useAction } from '../../context/actions';
 import { StorageBrowserElements } from '../../context/elements';
 import { ViewComponent } from '../types';
 import { LocationDetailViewControls } from './Controls';
+import { useControl } from '../../context/controls';
 
 export interface LocationDetailView<
   T extends StorageBrowserElements = StorageBrowserElements,
 > extends ViewComponent<LocationDetailViewControls<T>> {}
 
 export const LocationDetailView: LocationDetailView = () => {
+  const [_, handleUpdateState] = useControl({ type: 'NAVIGATE' });
+
   const [{ data, isLoading }] = useAction({
     type: 'LIST_LOCATION_ITEMS',
   });
@@ -18,7 +21,25 @@ export const LocationDetailView: LocationDetailView = () => {
 
   const listItems = !hasItems
     ? null
-    : data.items.map(({ key }) => <p key={key}>{key}</p>);
+    : data.items.map((item) => {
+        if (item.type === 'FOLDER') {
+          return (
+            <button
+              onClick={() => {
+                handleUpdateState({
+                  type: 'ENTER_FOLDER',
+                  name: item.key as FolderName, //TODO: remove this, just testing for now
+                });
+              }}
+              key={item.key}
+            >
+              {item.key}
+            </button>
+          );
+        } else {
+          return <p key={item.key}>{item.key}</p>;
+        }
+      });
 
   return (
     <>

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FolderName, useAction } from '../../context/actions';
+import { useAction } from '../../context/actions';
 import { StorageBrowserElements } from '../../context/elements';
 import { ViewComponent } from '../types';
 import { LocationDetailViewControls } from './Controls';
@@ -26,10 +26,13 @@ export const LocationDetailView: LocationDetailView = () => {
           return (
             <button
               onClick={() => {
-                handleUpdateState({
-                  type: 'ENTER_FOLDER',
-                  name: item.key as FolderName, //TODO: remove this, just testing for now
-                });
+                if (item.key.endsWith('/')) {
+                  handleUpdateState({
+                    type: 'ENTER_FOLDER',
+                    // @ts-expect-error Type 'string' is not assignable to type '${string}/'
+                    name: item.key, // TODO: fix this type error
+                  });
+                }
               }}
               key={item.key}
             >

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
@@ -1,21 +1,16 @@
 import React from 'react';
 
-import { useAction, LocationItemsState } from '../../context/actions';
+import { useAction } from '../../context/actions';
 import { StorageBrowserElements } from '../../context/elements';
 import { ViewComponent } from '../types';
 import { LocationDetailViewControls } from './Controls';
 import { useControl } from '../../context/controls';
 import { useConfig } from '../../context/config';
+import { useHasValueUpdated } from '@aws-amplify/ui-react-core';
 
 export interface LocationDetailView<
   T extends StorageBrowserElements = StorageBrowserElements,
 > extends ViewComponent<LocationDetailViewControls<T>> {}
-
-const shouldLoadLocationItems = ({
-  // data,
-  hasError,
-  isLoading,
-}: LocationItemsState[0]) => !isLoading && !hasError;
 
 export const LocationDetailView: LocationDetailView = () => {
   const { getLocationCredentials, region } = useConfig();
@@ -26,40 +21,46 @@ export const LocationDetailView: LocationDetailView = () => {
   });
 
   const { bucket, permission, scope, prefix } = location ?? {};
-  const { data, message, isLoading } = locationItemsState;
+  const { data, isLoading } = locationItemsState;
 
-  // eslint-disable-next-line no-console
-  console.log('message', message);
+  const hasScopeChanged = useHasValueUpdated(scope);
 
   const listLocationItems = React.useCallback(
-    ({ prefix = '', scope }: { prefix: string | undefined; scope: string }) => {
-      // s3://SOME_STRING/*
-      // eslint-disable-next-line no-console
-      console.log('listLocationItems scope', scope);
-
-      return handleListLocationItems({
+    ({
+      bucket,
+      // uncomment for testing Amplify buckets
+      prefix = 'public/',
+      // uncomment for testing managed auth buckets
+      // prefix = '',
+      scope,
+    }: {
+      bucket: string;
+      prefix: string | undefined;
+      scope: string;
+    }) =>
+      handleListLocationItems({
         // uncomment to test managed auth config
         // prefix: '',
         // uncomment to test with amplify config with public access level
 
         prefix,
         config: {
-          bucket: bucket!,
+          bucket,
           credentialsProvider: async () =>
             await getLocationCredentials({ permission: permission!, scope }),
           region,
         },
         options: { refresh: true },
-      });
-    },
-    [
-      getLocationCredentials,
-      bucket,
-      permission,
-      handleListLocationItems,
-      region,
-    ]
+      }),
+    [getLocationCredentials, permission, handleListLocationItems, region]
   );
+
+  React.useEffect(() => {
+    if (bucket && scope && hasScopeChanged) {
+      // TODO: update to exhaustive call
+      listLocationItems({ bucket, prefix, scope });
+    }
+  }, [bucket, hasScopeChanged, prefix, scope, listLocationItems]);
 
   const hasItems = !!data.items.length;
 
@@ -70,9 +71,6 @@ export const LocationDetailView: LocationDetailView = () => {
           return (
             <button
               onClick={() => {
-                // eslint-disable-next-line no-console
-                console.log('clcik', item.key);
-
                 if (item.key.endsWith('/')) {
                   handleUpdateState({
                     type: 'ENTER_FOLDER',
@@ -90,24 +88,6 @@ export const LocationDetailView: LocationDetailView = () => {
           return <p key={item.key}>{item.key}</p>;
         }
       });
-
-  const loadLocationItems = shouldLoadLocationItems(locationItemsState);
-  // eslint-disable-next-line no-console
-  console.log('loadLocationItems', loadLocationItems);
-
-  React.useEffect(() => {
-    if (scope && loadLocationItems) {
-      // TODO: update to exhaustive call
-      listLocationItems({ prefix, scope });
-    }
-    // if (location.current && loadLocationItems) {
-    //   // TODO: update to exhaustive call
-    //   listLocationItems(location.current);
-    // } else if (location.current && history.shouldRefresh) {
-    //   // TODO: update to exhaustive call
-    //   listLocationItems(location.current, true);
-    // }
-  }, [prefix, scope, listLocationItems, loadLocationItems]);
 
   return (
     <>

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/LocationDetailView.tsx
@@ -1,24 +1,65 @@
 import React from 'react';
 
-import { useAction } from '../../context/actions';
+import { useAction, LocationItemsState } from '../../context/actions';
 import { StorageBrowserElements } from '../../context/elements';
 import { ViewComponent } from '../types';
 import { LocationDetailViewControls } from './Controls';
 import { useControl } from '../../context/controls';
+import { useConfig } from '../../context/config';
 
 export interface LocationDetailView<
   T extends StorageBrowserElements = StorageBrowserElements,
 > extends ViewComponent<LocationDetailViewControls<T>> {}
 
-export const LocationDetailView: LocationDetailView = () => {
-  const [_, handleUpdateState] = useControl({ type: 'NAVIGATE' });
+const shouldLoadLocationItems = ({
+  // data,
+  hasError,
+  isLoading,
+}: LocationItemsState[0]) => !isLoading && !hasError;
 
-  const [{ data, isLoading, message }] = useAction({
+export const LocationDetailView: LocationDetailView = () => {
+  const { getLocationCredentials, region } = useConfig();
+  const [{ location }, handleUpdateState] = useControl({ type: 'NAVIGATE' });
+
+  const [locationItemsState, handleListLocationItems] = useAction({
     type: 'LIST_LOCATION_ITEMS',
   });
 
+  const { bucket, permission, scope, prefix } = location ?? {};
+  const { data, message, isLoading } = locationItemsState;
+
   // eslint-disable-next-line no-console
   console.log('message', message);
+
+  const listLocationItems = React.useCallback(
+    ({ prefix = '', scope }: { prefix: string | undefined; scope: string }) => {
+      // s3://SOME_STRING/*
+      // eslint-disable-next-line no-console
+      console.log('listLocationItems scope', scope);
+
+      return handleListLocationItems({
+        // uncomment to test managed auth config
+        // prefix: '',
+        // uncomment to test with amplify config with public access level
+
+        prefix,
+        config: {
+          bucket: bucket!,
+          credentialsProvider: async () =>
+            await getLocationCredentials({ permission: permission!, scope }),
+          region,
+        },
+        options: { refresh: true },
+      });
+    },
+    [
+      getLocationCredentials,
+      bucket,
+      permission,
+      handleListLocationItems,
+      region,
+    ]
+  );
 
   const hasItems = !!data.items.length;
 
@@ -49,6 +90,24 @@ export const LocationDetailView: LocationDetailView = () => {
           return <p key={item.key}>{item.key}</p>;
         }
       });
+
+  const loadLocationItems = shouldLoadLocationItems(locationItemsState);
+  // eslint-disable-next-line no-console
+  console.log('loadLocationItems', loadLocationItems);
+
+  React.useEffect(() => {
+    if (scope && loadLocationItems) {
+      // TODO: update to exhaustive call
+      listLocationItems({ prefix, scope });
+    }
+    // if (location.current && loadLocationItems) {
+    //   // TODO: update to exhaustive call
+    //   listLocationItems(location.current);
+    // } else if (location.current && history.shouldRefresh) {
+    //   // TODO: update to exhaustive call
+    //   listLocationItems(location.current, true);
+    // }
+  }, [prefix, scope, listLocationItems, loadLocationItems]);
 
   return (
     <>

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/LocationsView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/LocationsView.tsx
@@ -53,23 +53,26 @@ export const LocationsView: LocationsView = () => {
       </div>
       {!hasLocations || isLoading
         ? '...loading'
-        : data.locations.map(
-            ({ bucket, prefix = 'public/', scope, ...rest }) =>
-              bucket ? (
-                <button
-                  key={scope}
-                  onClick={() => {
-                    handleUpdateState({
-                      type: 'SELECT_LOCATION',
-                      location: { bucket, prefix, scope, ...rest },
-                    });
-                  }}
-                  type="button"
-                >
-                  {bucket}
-                </button>
-              ) : null
-          )}
+        : data.locations.map(({ bucket, prefix, scope, ...rest }) => {
+            return bucket ? (
+              <button
+                key={scope}
+                onClick={() => {
+                  const location = { bucket, prefix, scope, ...rest };
+                  // eslint-disable-next-line no-console
+                  console.log('loca', location);
+
+                  handleUpdateState({
+                    type: 'SELECT_LOCATION',
+                    location: { bucket, prefix, scope, ...rest },
+                  });
+                }}
+                type="button"
+              >
+                {bucket}
+              </button>
+            ) : null;
+          })}
     </div>
   );
 };

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/LocationsView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/LocationsView.tsx
@@ -58,10 +58,6 @@ export const LocationsView: LocationsView = () => {
               <button
                 key={scope}
                 onClick={() => {
-                  const location = { bucket, prefix, scope, ...rest };
-                  // eslint-disable-next-line no-console
-                  console.log('loca', location);
-
                   handleUpdateState({
                     type: 'SELECT_LOCATION',
                     location: { bucket, prefix, scope, ...rest },

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/LocationsView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/LocationsView.tsx
@@ -53,21 +53,22 @@ export const LocationsView: LocationsView = () => {
       </div>
       {!hasLocations || isLoading
         ? '...loading'
-        : data.locations.map(({ bucket, scope, ...rest }) =>
-            bucket ? (
-              <button
-                key={scope}
-                onClick={() => {
-                  handleUpdateState({
-                    type: 'SELECT_LOCATION',
-                    location: { bucket, scope, ...rest },
-                  });
-                }}
-                type="button"
-              >
-                {bucket}
-              </button>
-            ) : null
+        : data.locations.map(
+            ({ bucket, prefix = 'public/', scope, ...rest }) =>
+              bucket ? (
+                <button
+                  key={scope}
+                  onClick={() => {
+                    handleUpdateState({
+                      type: 'SELECT_LOCATION',
+                      location: { bucket, prefix, scope, ...rest },
+                    });
+                  }}
+                  type="button"
+                >
+                  {bucket}
+                </button>
+              ) : null
           )}
     </div>
   );

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/index.ts
@@ -6,4 +6,5 @@ export {
   LocationItem,
   Permission,
   UploadItemData,
+  FolderName,
 } from './types';

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/index.ts
@@ -6,5 +6,4 @@ export {
   LocationItem,
   Permission,
   UploadItemData,
-  FolderName,
 } from './types';

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
@@ -41,23 +41,11 @@ export interface ListLocationItemsActionOutput {
 
 const parseResultItems = (items: ListOutputItem[]): LocationItem[] =>
   items.map(({ path: key, lastModified, size }) => {
-    if (size === 0) {
+    if (size === 0 && key.endsWith('/')) {
       return { key, type: 'FOLDER' };
     }
-    // eslint-disable-next-line no-console
-    // console.log('key', key);
-    // // eslint-disable-next-line no-console
-    // console.log('lastModified', lastModified);
-
-    // // eslint-disable-next-line no-console
-    // console.log('size', size);
 
     return { key, lastModified: lastModified!, size: size!, type: 'FILE' };
-    // return lastModified
-    //   ? // `size` is marked as potentially `undefined` in `ListOutputItem`
-    //     // but is populated when the item is a file
-    //     { key, lastModified, size: size!, type: 'FILE' }
-    //   : { key, type: 'FOLDER' };
   });
 
 export async function listLocationItemsAction(

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
@@ -40,13 +40,25 @@ export interface ListLocationItemsActionOutput {
 }
 
 const parseResultItems = (items: ListOutputItem[]): LocationItem[] =>
-  items.map(({ path: key, lastModified, size }) =>
-    lastModified
-      ? // `size` is marked as potentially `undefined` in `ListOutputItem`
-        // but is populated when the item is a file
-        { key, lastModified, size: size!, type: 'FILE' }
-      : { key, type: 'FOLDER' }
-  );
+  items.map(({ path: key, lastModified, size }) => {
+    if (size === 0) {
+      return { key, type: 'FOLDER' };
+    }
+    // eslint-disable-next-line no-console
+    // console.log('key', key);
+    // // eslint-disable-next-line no-console
+    // console.log('lastModified', lastModified);
+
+    // // eslint-disable-next-line no-console
+    // console.log('size', size);
+
+    return { key, lastModified: lastModified!, size: size!, type: 'FILE' };
+    // return lastModified
+    //   ? // `size` is marked as potentially `undefined` in `ListOutputItem`
+    //     // but is populated when the item is a file
+    //     { key, lastModified, size: size!, type: 'FILE' }
+    //   : { key, type: 'FOLDER' };
+  });
 
 export async function listLocationItemsAction(
   prevState: ListLocationItemsActionOutput,
@@ -73,6 +85,8 @@ export async function listLocationItemsAction(
   };
 
   const { items, nextToken } = await list(listInput);
+  // eslint-disable-next-line no-console
+  console.log('items', items);
 
   return {
     items: [...(refresh ? [] : prevState.items), ...parseResultItems(items)],

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
@@ -40,10 +40,8 @@ export interface ListLocationItemsActionOutput {
 }
 
 const parseResultItems = (items: ListOutputItem[]): LocationItem[] =>
-  // @ts-expect-error this is complaining about wrong types, just setting this up for testing
-  // will remove for pr
   items.map(({ path: key, lastModified, size }) =>
-    !key.endsWith('/')
+    lastModified
       ? // `size` is marked as potentially `undefined` in `ListOutputItem`
         // but is populated when the item is a file
         { key, lastModified, size: size!, type: 'FILE' }

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
@@ -40,8 +40,10 @@ export interface ListLocationItemsActionOutput {
 }
 
 const parseResultItems = (items: ListOutputItem[]): LocationItem[] =>
+  // @ts-expect-error this is complaining about wrong types, just setting this up for testing
+  // will remove for pr
   items.map(({ path: key, lastModified, size }) =>
-    lastModified
+    !key.endsWith('/')
       ? // `size` is marked as potentially `undefined` in `ListOutputItem`
         // but is populated when the item is a file
         { key, lastModified, size: size!, type: 'FILE' }

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
@@ -73,8 +73,6 @@ export async function listLocationItemsAction(
   };
 
   const { items, nextToken } = await list(listInput);
-  // eslint-disable-next-line no-console
-  console.log('items', items);
 
   return {
     items: [...(refresh ? [] : prevState.items), ...parseResultItems(items)],

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationsAction.ts
@@ -72,7 +72,16 @@ export const createListLocationsAction = (
       (acc, { scope, permission, type }) =>
         shouldExclude(permission, exclude)
           ? acc
-          : [...acc, { bucket: getBucket(scope), scope, permission, type }],
+          : [
+              ...acc,
+              {
+                bucket: getBucket(scope),
+                prefix: undefined,
+                scope,
+                permission,
+                type,
+              },
+            ],
       [] as LocationData[]
     );
 

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/testUtils.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/testUtils.ts
@@ -124,6 +124,7 @@ const generateBucketData = (count: number): LocationData[] => {
   const scope = `s3://${bucketName}/*`;
   result.push({
     bucket: bucketName,
+    prefix: undefined,
     permission: getRandomPermission(),
     scope,
     type: 'BUCKET',
@@ -134,6 +135,7 @@ const generateBucketData = (count: number): LocationData[] => {
       // object: <bucket>/<prefix-with-path>/<object>
       result.push({
         bucket: bucketName,
+        prefix: undefined,
         scope: `${scope}${generateString(randomNumberInRange(6, 20))}.${
           EXTENSIONS[randomNumberInRange(0, EXTENSIONS.length)]
         }`,
@@ -158,6 +160,7 @@ const generateBucketData = (count: number): LocationData[] => {
 
       result.push({
         bucket: bucketName,
+        prefix: undefined,
         scope,
         permission: getRandomPermission(),
         type,

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/types.ts
@@ -3,6 +3,10 @@ export interface FolderItem {
   type: 'FOLDER';
 }
 
+export type FolderName = `${string}/`;
+export const isFolderName = (key: string): key is FolderName =>
+  key.endsWith('/');
+
 export interface FileItem {
   key: string;
   lastModified: Date;

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/types.ts
@@ -17,6 +17,7 @@ export type LocationType = 'OBJECT' | 'PREFIX' | 'BUCKET';
 
 export interface LocationData<T = Permission> {
   bucket: string;
+  prefix: string | undefined;
   scope: string;
   permission: T;
   type: LocationType;

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/types.ts
@@ -3,8 +3,6 @@ export interface FolderItem {
   type: 'FOLDER';
 }
 
-export type FolderName = `${string}/`;
-
 export interface FileItem {
   key: string;
   lastModified: Date;

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/types.ts
@@ -3,6 +3,8 @@ export interface FolderItem {
   type: 'FOLDER';
 }
 
+export type FolderName = `${string}/`;
+
 export interface FileItem {
   key: string;
   lastModified: Date;

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
@@ -5,14 +5,9 @@ import { LocationData } from '../../actions/types';
 type FolderName = `${string}/`;
 
 const INITIAL_STATE: NavigateState = {
-  location: {
-    current: undefined,
-    shouldRefresh: false,
-  },
-  history: {
-    list: undefined,
-    shouldRefresh: false,
-  },
+  location: undefined,
+
+  history: undefined,
 };
 
 export type NavigateAction =
@@ -22,14 +17,8 @@ export type NavigateAction =
   | { type: 'EXIT_FOLDER'; index: number };
 
 export interface NavigateState {
-  location: {
-    current: LocationData | undefined;
-    shouldRefresh: boolean;
-  };
-  history: {
-    list: string[] | undefined;
-    shouldRefresh: boolean;
-  };
+  location: LocationData | undefined;
+  history: string[] | undefined;
 }
 
 export type NavigateStateContext = [
@@ -42,50 +31,42 @@ export function navigateReducer(
   action: NavigateAction
 ): NavigateState {
   switch (action.type) {
-    case 'SELECT_LOCATION':
-      return {
-        location: {
-          current: action.location,
-          shouldRefresh: false,
-        },
-        history: {
-          list: undefined,
-          shouldRefresh: true,
-        },
-      };
-    case 'DESELECT_LOCATION':
-      return {
-        location: {
-          current: undefined,
-          shouldRefresh: true,
-        },
-        history: {
-          list: undefined,
-          shouldRefresh: false,
-        },
-      };
+    case 'SELECT_LOCATION': {
+      const { location } = action;
+      return { ...state, location };
+    }
+    case 'DESELECT_LOCATION': {
+      return state;
+    }
     case 'ENTER_FOLDER': {
       const { name } = action;
+      const { location } = state;
+      const { bucket, prefix, permission, type } = location!;
+
+      // eslint-disable-next-line no-console
+      console.log('ENTER_FOLDER prefix', prefix);
+
+      const scope = `s3://${bucket}/${name}*`;
+      // eslint-disable-next-line no-console
+      console.log('new scope', scope);
 
       return {
         ...state,
-        history: {
-          list: [...(state.history.list ?? []), name],
-          shouldRefresh: true,
-        },
+        location: { bucket, prefix: name, permission, scope, type },
       };
     }
     case 'EXIT_FOLDER': {
-      const { index } = action;
-      const updatedHistory = state.history.list?.slice(0, index + 1);
+      return state;
+      // const { index } = action;
+      // const updatedHistory = state.history.list?.slice(0, index + 1);
 
-      return {
-        ...state,
-        history: {
-          list: updatedHistory,
-          shouldRefresh: true,
-        },
-      };
+      // return {
+      //   ...state,
+      //   history: {
+      //     list: updatedHistory,
+      //     shouldRefresh: true,
+      //   },
+      // };
     }
   }
 }

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
@@ -29,13 +29,11 @@ export function navigateReducer(
 ): NavigateState {
   switch (action.type) {
     case 'SELECT_LOCATION': {
-      /** 
-        This action comes from the navigate item specifying the location
-        It uses the current state location and so this has the "old" scope
-        which could include the previous folder we were at
-        We'll need to update the scope here
-        We need to update the prefix too?
-      */
+        // This action comes from the navigate item specifying the location
+        // It uses the current state location and so this has the "old" scope
+        // which could include the previous folder we were at
+        // We'll need to update the scope here
+        // We need to update the prefix too?
 
       const { location } = action;
       const { bucket } = location;

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
@@ -44,7 +44,6 @@ export function navigateReducer(
   switch (action.type) {
     case 'SELECT_LOCATION':
       return {
-        ...state,
         location: {
           current: action.location,
           shouldRefresh: false,

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
@@ -29,11 +29,11 @@ export function navigateReducer(
 ): NavigateState {
   switch (action.type) {
     case 'SELECT_LOCATION': {
-        // This action comes from the navigate item specifying the location
-        // It uses the current state location and so this has the "old" scope
-        // which could include the previous folder we were at
-        // We'll need to update the scope here
-        // We need to update the prefix too?
+      // This action comes from the navigate item specifying the location
+      // It uses the current state location and so this has the "old" scope
+      // which could include the previous folder we were at
+      // We'll need to update the scope here
+      // We need to update the prefix too?
 
       const { location } = action;
       const { bucket } = location;
@@ -55,9 +55,11 @@ export function navigateReducer(
       const { name } = action;
       const { location, history } = state;
 
+      // TODO: Look into why listLocationsItems returns the current folder as a result
+      // Clicking on it in the list locations items view would add it to the history if
+      // we didn't  have this check
       if (name === history?.[history.length - 1]) {
         // Don't add the same folder into history again
-        // For some reason listLocationItems also returns the current folder again
         return state;
       }
 

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
@@ -5,8 +5,14 @@ import { LocationData } from '../../actions/types';
 type FolderName = `${string}/`;
 
 const INITIAL_STATE: NavigateState = {
-  location: undefined,
-  history: undefined,
+  location: {
+    current: undefined,
+    shouldRefresh: false,
+  },
+  history: {
+    list: undefined,
+    shouldRefresh: false,
+  },
 };
 
 export type NavigateAction =
@@ -16,8 +22,14 @@ export type NavigateAction =
   | { type: 'EXIT_FOLDER'; index: number };
 
 export interface NavigateState {
-  location: LocationData | undefined;
-  history: string[] | undefined;
+  location: {
+    current: LocationData | undefined;
+    shouldRefresh: boolean;
+  };
+  history: {
+    list: string[] | undefined;
+    shouldRefresh: boolean;
+  };
 }
 
 export type NavigateStateContext = [
@@ -32,29 +44,48 @@ export function navigateReducer(
   switch (action.type) {
     case 'SELECT_LOCATION':
       return {
-        location: action.location,
-        history: undefined,
+        ...state,
+        location: {
+          current: action.location,
+          shouldRefresh: false,
+        },
+        history: {
+          list: undefined,
+          shouldRefresh: true,
+        },
       };
     case 'DESELECT_LOCATION':
       return {
-        location: undefined,
-        history: undefined,
+        location: {
+          current: undefined,
+          shouldRefresh: true,
+        },
+        history: {
+          list: undefined,
+          shouldRefresh: false,
+        },
       };
     case 'ENTER_FOLDER': {
       const { name } = action;
 
       return {
         ...state,
-        history: [...(state.history ?? []), name],
+        history: {
+          list: [...(state.history.list ?? []), name],
+          shouldRefresh: true,
+        },
       };
     }
     case 'EXIT_FOLDER': {
       const { index } = action;
-      const updatedHistory = state.history?.slice(0, index + 1);
+      const updatedHistory = state.history.list?.slice(0, index + 1);
 
       return {
         ...state,
-        history: updatedHistory,
+        history: {
+          list: updatedHistory,
+          shouldRefresh: true,
+        },
       };
     }
   }

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
@@ -1,34 +1,21 @@
 import React from 'react';
 
-import { LocationData } from '../../actions/types';
+import { LocationData, FolderName } from '../../actions/types';
 
 const INITIAL_STATE: NavigateState = {
-  initial: 'Home',
-  location: {
-    current: undefined,
-    isLoadingInitialData: false,
-    previousLocations: undefined,
-  },
-  locations: {
-    isLoadingInitialData: false,
-  },
+  location: undefined,
+  history: undefined,
 };
 
 export type NavigateAction =
   | { type: 'SELECT_LOCATION'; location: LocationData }
   | { type: 'DESELECT_LOCATION' }
-  | { type: 'ENTER_LOCATION'; location: LocationData }
-  | { type: 'EXIT_LOCATION' };
+  | { type: 'ENTER_FOLDER'; name: FolderName }
+  | { type: 'EXIT_FOLDER'; index: number };
 
 export interface NavigateState {
-  location: {
-    current: LocationData | undefined;
-    isLoadingInitialData: boolean;
-    previousLocations: LocationData[] | undefined;
-  };
-  locations: { isLoadingInitialData: boolean };
-  // entrypoint name, e.g. "home"
-  readonly initial: string;
+  location: LocationData | undefined;
+  history: FolderName[] | undefined;
 }
 
 export type NavigateStateContext = [
@@ -40,13 +27,35 @@ export function navigateReducer(
   state: NavigateState,
   action: NavigateAction
 ): NavigateState {
-  if (action.type === 'SELECT_LOCATION') {
-    return {
-      ...state,
-      location: { ...state.location, current: action.location },
-    };
+  switch (action.type) {
+    case 'SELECT_LOCATION':
+      return {
+        location: action.location,
+        history: undefined,
+      };
+    case 'DESELECT_LOCATION':
+      return {
+        location: undefined,
+        history: undefined,
+      };
+    case 'ENTER_FOLDER': {
+      const { name } = action;
+
+      return {
+        ...state,
+        history: [...(state.history ?? []), name],
+      };
+    }
+    case 'EXIT_FOLDER': {
+      const { index } = action;
+      const updatedHistory = state.history?.slice(0, index + 1);
+
+      return {
+        ...state,
+        history: updatedHistory,
+      };
+    }
   }
-  return state;
 }
 
 export const NavigateContext = React.createContext<

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/Navigate.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { LocationData, FolderName } from '../../actions/types';
+import { LocationData } from '../../actions/types';
+
+type FolderName = `${string}/`;
 
 const INITIAL_STATE: NavigateState = {
   location: undefined,
@@ -15,7 +17,7 @@ export type NavigateAction =
 
 export interface NavigateState {
   location: LocationData | undefined;
-  history: FolderName[] | undefined;
+  history: string[] | undefined;
 }
 
 export type NavigateStateContext = [

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/__tests__/Navigate.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/__tests__/Navigate.spec.tsx
@@ -11,15 +11,27 @@ describe('navigateReducer', () => {
 
   it('handles a SELECT_LOCATION as expected', () => {
     const initialState: NavigateState = {
-      location: undefined,
-      history: undefined,
+      location: {
+        current: undefined,
+        shouldRefresh: false,
+      },
+      history: {
+        list: undefined,
+        shouldRefresh: false,
+      },
     };
 
     const action: NavigateAction = { type: 'SELECT_LOCATION', location };
 
     const expectedState: NavigateState = {
-      location,
-      history: undefined,
+      location: {
+        current: location,
+        shouldRefresh: false,
+      },
+      history: {
+        list: undefined,
+        shouldRefresh: true,
+      },
     };
 
     const newState = navigateReducer(initialState, action);
@@ -29,15 +41,27 @@ describe('navigateReducer', () => {
 
   it('handles a DESELECT_LOCATION as expected', () => {
     const state: NavigateState = {
-      location,
-      history: ['folder1/', 'folder2/'],
+      location: {
+        current: location,
+        shouldRefresh: false,
+      },
+      history: {
+        list: ['folder1/', 'folder2/'],
+        shouldRefresh: true,
+      },
     };
 
     const action: NavigateAction = { type: 'DESELECT_LOCATION' };
 
     const expectedState: NavigateState = {
-      location: undefined,
-      history: undefined,
+      location: {
+        current: undefined,
+        shouldRefresh: true,
+      },
+      history: {
+        list: undefined,
+        shouldRefresh: false,
+      },
     };
 
     const newState = navigateReducer(state, action);
@@ -47,18 +71,30 @@ describe('navigateReducer', () => {
 
   it('handles a ENTER_FOLDER as expected', () => {
     const state: NavigateState = {
-      location,
-      history: ['folder1/'],
+      location: {
+        current: location,
+        shouldRefresh: false,
+      },
+      history: {
+        list: ['folder1/'],
+        shouldRefresh: false,
+      },
     };
 
     const action: NavigateAction = {
       type: 'ENTER_FOLDER',
-      name: 'folder2/' as `${string}/`,
+      name: 'folder2/',
     };
 
     const expectedState: NavigateState = {
-      location,
-      history: ['folder1/', 'folder2/'],
+      location: {
+        current: location,
+        shouldRefresh: false,
+      },
+      history: {
+        list: ['folder1/', 'folder2/'],
+        shouldRefresh: true,
+      },
     };
 
     const newState = navigateReducer(state, action);
@@ -68,15 +104,27 @@ describe('navigateReducer', () => {
 
   it('should handle ENTER_FOLDER with undefined history', () => {
     const state: NavigateState = {
-      location,
-      history: undefined,
+      location: {
+        current: location,
+        shouldRefresh: false,
+      },
+      history: {
+        list: undefined,
+        shouldRefresh: false,
+      },
     };
 
     const action: NavigateAction = { type: 'ENTER_FOLDER', name: 'folder1/' };
 
     const expectedState: NavigateState = {
-      location,
-      history: ['folder1/'],
+      location: {
+        current: location,
+        shouldRefresh: false,
+      },
+      history: {
+        list: ['folder1/'],
+        shouldRefresh: true,
+      },
     };
 
     const newState = navigateReducer(state, action);
@@ -86,33 +134,27 @@ describe('navigateReducer', () => {
 
   it('handles a EXIT_FOLDER as expected', () => {
     const state: NavigateState = {
-      location,
-      history: ['folder1/', 'folder2/', 'folder3/'],
+      location: {
+        current: location,
+        shouldRefresh: false,
+      },
+      history: {
+        list: ['folder1/', 'folder2/', 'folder3/'],
+        shouldRefresh: false,
+      },
     };
 
     const action: NavigateAction = { type: 'EXIT_FOLDER', index: 1 };
 
     const expectedState: NavigateState = {
-      location,
-      history: ['folder1/', 'folder2/'],
-    };
-
-    const newState = navigateReducer(state, action);
-
-    expect(newState).toEqual(expectedState);
-  });
-
-  it('should handle EXIT_FOLDER with index out of bounds', () => {
-    const state: NavigateState = {
-      location,
-      history: ['folder1/', 'folder2/', 'folder3/'],
-    };
-
-    const action: NavigateAction = { type: 'EXIT_FOLDER', index: 5 };
-
-    const expectedState: NavigateState = {
-      location,
-      history: ['folder1/', 'folder2/', 'folder3/'],
+      location: {
+        current: location,
+        shouldRefresh: false,
+      },
+      history: {
+        list: ['folder1/', 'folder2/'],
+        shouldRefresh: true,
+      },
     };
 
     const newState = navigateReducer(state, action);

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/__tests__/Navigate.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/__tests__/Navigate.spec.tsx
@@ -7,31 +7,26 @@ describe('navigateReducer', () => {
     scope: 's3://',
     permission: 'READ',
     type: 'OBJECT',
+    prefix: undefined,
   };
 
   it('handles a SELECT_LOCATION as expected', () => {
     const initialState: NavigateState = {
-      location: {
-        current: undefined,
-        shouldRefresh: false,
-      },
-      history: {
-        list: undefined,
-        shouldRefresh: false,
-      },
+      location: undefined,
+      history: undefined,
     };
 
     const action: NavigateAction = { type: 'SELECT_LOCATION', location };
 
     const expectedState: NavigateState = {
       location: {
-        current: location,
-        shouldRefresh: false,
+        bucket: location.bucket,
+        permission: location.permission,
+        scope: `s3://${location.bucket}/*`,
+        type: location.type,
+        prefix: location.prefix,
       },
-      history: {
-        list: undefined,
-        shouldRefresh: true,
-      },
+      history: undefined,
     };
 
     const newState = navigateReducer(initialState, action);
@@ -41,27 +36,15 @@ describe('navigateReducer', () => {
 
   it('handles a DESELECT_LOCATION as expected', () => {
     const state: NavigateState = {
-      location: {
-        current: location,
-        shouldRefresh: false,
-      },
-      history: {
-        list: ['folder1/', 'folder2/'],
-        shouldRefresh: true,
-      },
+      location,
+      history: ['folder1/', 'folder2/'],
     };
 
     const action: NavigateAction = { type: 'DESELECT_LOCATION' };
 
     const expectedState: NavigateState = {
-      location: {
-        current: undefined,
-        shouldRefresh: true,
-      },
-      history: {
-        list: undefined,
-        shouldRefresh: false,
-      },
+      location: undefined,
+      history: undefined,
     };
 
     const newState = navigateReducer(state, action);
@@ -71,14 +54,8 @@ describe('navigateReducer', () => {
 
   it('handles a ENTER_FOLDER as expected', () => {
     const state: NavigateState = {
-      location: {
-        current: location,
-        shouldRefresh: false,
-      },
-      history: {
-        list: ['folder1/'],
-        shouldRefresh: false,
-      },
+      location,
+      history: ['folder1/'],
     };
 
     const action: NavigateAction = {
@@ -88,13 +65,13 @@ describe('navigateReducer', () => {
 
     const expectedState: NavigateState = {
       location: {
-        current: location,
-        shouldRefresh: false,
+        bucket: location.bucket,
+        permission: location.permission,
+        scope: `s3://${location.bucket}/${action.name}*`,
+        type: location.type,
+        prefix: action.name,
       },
-      history: {
-        list: ['folder1/', 'folder2/'],
-        shouldRefresh: true,
-      },
+      history: ['folder1/', 'folder2/'],
     };
 
     const newState = navigateReducer(state, action);
@@ -104,27 +81,21 @@ describe('navigateReducer', () => {
 
   it('should handle ENTER_FOLDER with undefined history', () => {
     const state: NavigateState = {
-      location: {
-        current: location,
-        shouldRefresh: false,
-      },
-      history: {
-        list: undefined,
-        shouldRefresh: false,
-      },
+      location,
+      history: undefined,
     };
 
     const action: NavigateAction = { type: 'ENTER_FOLDER', name: 'folder1/' };
 
     const expectedState: NavigateState = {
       location: {
-        current: location,
-        shouldRefresh: false,
+        bucket: location.bucket,
+        permission: location.permission,
+        scope: `s3://${location.bucket}/${action.name}*`,
+        type: location.type,
+        prefix: action.name,
       },
-      history: {
-        list: ['folder1/'],
-        shouldRefresh: true,
-      },
+      history: ['folder1/'],
     };
 
     const newState = navigateReducer(state, action);
@@ -134,27 +105,21 @@ describe('navigateReducer', () => {
 
   it('handles a EXIT_FOLDER as expected', () => {
     const state: NavigateState = {
-      location: {
-        current: location,
-        shouldRefresh: false,
-      },
-      history: {
-        list: ['folder1/', 'folder2/', 'folder3/'],
-        shouldRefresh: false,
-      },
+      location,
+      history: ['folder1/', 'folder2/', 'folder3/'],
     };
 
-    const action: NavigateAction = { type: 'EXIT_FOLDER', index: 1 };
+    const action: NavigateAction = { type: 'EXIT_FOLDER', name: 'folder2/' };
 
     const expectedState: NavigateState = {
       location: {
-        current: location,
-        shouldRefresh: false,
+        bucket: location.bucket,
+        permission: location.permission,
+        scope: `s3://${location.bucket}/${action.name}*`,
+        type: location.type,
+        prefix: action.name,
       },
-      history: {
-        list: ['folder1/', 'folder2/'],
-        shouldRefresh: true,
-      },
+      history: ['folder1/', 'folder2/'],
     };
 
     const newState = navigateReducer(state, action);

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/__tests__/Navigate.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/__tests__/Navigate.spec.tsx
@@ -1,6 +1,122 @@
+import { LocationData } from '../../../actions';
+import { NavigateAction, navigateReducer, NavigateState } from '../Navigate';
+
 describe('navigateReducer', () => {
-  it.todo('handles a SELECT_LOCATION as expected');
-  it.todo('handles a DESELECT_LOCATION as expected');
-  it.todo('handles a ENTER_LOCATION as expected');
-  it.todo('handles a EXIT_LOCATION as expected');
+  const location: LocationData = {
+    bucket: 'bucket-name',
+    scope: 's3://',
+    permission: 'READ',
+    type: 'OBJECT',
+  };
+
+  it('handles a SELECT_LOCATION as expected', () => {
+    const initialState: NavigateState = {
+      location: undefined,
+      history: undefined,
+    };
+
+    const action: NavigateAction = { type: 'SELECT_LOCATION', location };
+
+    const expectedState: NavigateState = {
+      location,
+      history: undefined,
+    };
+
+    const newState = navigateReducer(initialState, action);
+
+    expect(newState).toEqual(expectedState);
+  });
+
+  it('handles a DESELECT_LOCATION as expected', () => {
+    const state: NavigateState = {
+      location,
+      history: ['folder1/', 'folder2/'],
+    };
+
+    const action: NavigateAction = { type: 'DESELECT_LOCATION' };
+
+    const expectedState: NavigateState = {
+      location: undefined,
+      history: undefined,
+    };
+
+    const newState = navigateReducer(state, action);
+
+    expect(newState).toEqual(expectedState);
+  });
+
+  it('handles a ENTER_FOLDER as expected', () => {
+    const state: NavigateState = {
+      location,
+      history: ['folder1/'],
+    };
+
+    const action: NavigateAction = {
+      type: 'ENTER_FOLDER',
+      name: 'folder2/' as `${string}/`,
+    };
+
+    const expectedState: NavigateState = {
+      location,
+      history: ['folder1/', 'folder2/'],
+    };
+
+    const newState = navigateReducer(state, action);
+
+    expect(newState).toEqual(expectedState);
+  });
+
+  it('should handle ENTER_FOLDER with undefined history', () => {
+    const state: NavigateState = {
+      location,
+      history: undefined,
+    };
+
+    const action: NavigateAction = { type: 'ENTER_FOLDER', name: 'folder1/' };
+
+    const expectedState: NavigateState = {
+      location,
+      history: ['folder1/'],
+    };
+
+    const newState = navigateReducer(state, action);
+
+    expect(newState).toEqual(expectedState);
+  });
+
+  it('handles a EXIT_FOLDER as expected', () => {
+    const state: NavigateState = {
+      location,
+      history: ['folder1/', 'folder2/', 'folder3/'],
+    };
+
+    const action: NavigateAction = { type: 'EXIT_FOLDER', index: 1 };
+
+    const expectedState: NavigateState = {
+      location,
+      history: ['folder1/', 'folder2/'],
+    };
+
+    const newState = navigateReducer(state, action);
+
+    expect(newState).toEqual(expectedState);
+  });
+
+  it('should handle EXIT_FOLDER with index out of bounds', () => {
+    const state: NavigateState = {
+      location,
+      history: ['folder1/', 'folder2/', 'folder3/'],
+    };
+
+    const action: NavigateAction = { type: 'EXIT_FOLDER', index: 5 };
+
+    const expectedState: NavigateState = {
+      location,
+      history: ['folder1/', 'folder2/', 'folder3/'],
+    };
+
+    const newState = navigateReducer(state, action);
+
+    expect(newState).toEqual(expectedState);
+  });
 });

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/__tests__/Navigate.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Navigate/__tests__/Navigate.spec.tsx
@@ -103,7 +103,22 @@ describe('navigateReducer', () => {
     expect(newState).toEqual(expectedState);
   });
 
-  it('handles a EXIT_FOLDER as expected', () => {
+  it('handles ENTER_FOLDER when the same folder is selected', () => {
+    const state: NavigateState = {
+      location,
+      history: ['folder1/'],
+    };
+
+    const action: NavigateAction = { type: 'ENTER_FOLDER', name: 'folder1/' };
+
+    const expectedState: NavigateState = state;
+
+    const newState = navigateReducer(state, action);
+
+    expect(newState).toEqual(expectedState);
+  });
+
+  it('handles an EXIT_FOLDER as expected', () => {
     const state: NavigateState = {
       location,
       history: ['folder1/', 'folder2/', 'folder3/'],
@@ -121,6 +136,21 @@ describe('navigateReducer', () => {
       },
       history: ['folder1/', 'folder2/'],
     };
+
+    const newState = navigateReducer(state, action);
+
+    expect(newState).toEqual(expectedState);
+  });
+
+  it('handles an EXIT_FOLDER out of bounds as expected', () => {
+    const state: NavigateState = {
+      location,
+      history: ['folder1/', 'folder2/', 'folder3/'],
+    };
+
+    const action: NavigateAction = { type: 'EXIT_FOLDER', name: 'folder4/' };
+
+    const expectedState: NavigateState = state;
 
     const newState = navigateReducer(state, action);
 

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -29,9 +29,6 @@ interface ResolvedStorageBrowserElements<
  */
 function DefaultStorageBrowser(): React.JSX.Element {
   const [{ location }] = useControl({ type: 'NAVIGATE' });
-  // const { current } = location;
-  // eslint-disable-next-line no-console
-  console.log('HUH');
 
   if (location) {
     // if (current) {

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -29,8 +29,9 @@ interface ResolvedStorageBrowserElements<
  */
 function DefaultStorageBrowser(): React.JSX.Element {
   const [{ location }] = useControl({ type: 'NAVIGATE' });
+  const { current } = location;
 
-  if (location) {
+  if (current) {
     return <LocationDetailView />;
   }
   return <LocationsView />;

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -29,9 +29,10 @@ interface ResolvedStorageBrowserElements<
  */
 function DefaultStorageBrowser(): React.JSX.Element {
   const [{ location }] = useControl({ type: 'NAVIGATE' });
-  const { current } = location;
+  // const { current } = location;
 
-  if (current) {
+  if (location) {
+    // if (current) {
     return <LocationDetailView />;
   }
   return <LocationsView />;

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -31,7 +31,6 @@ function DefaultStorageBrowser(): React.JSX.Element {
   const [{ location }] = useControl({ type: 'NAVIGATE' });
 
   if (location) {
-    // if (current) {
     return <LocationDetailView />;
   }
   return <LocationsView />;

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -29,9 +29,8 @@ interface ResolvedStorageBrowserElements<
  */
 function DefaultStorageBrowser(): React.JSX.Element {
   const [{ location }] = useControl({ type: 'NAVIGATE' });
-  const { current } = location;
 
-  if (current) {
+  if (location) {
     return <LocationDetailView />;
   }
   return <LocationsView />;

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -30,6 +30,8 @@ interface ResolvedStorageBrowserElements<
 function DefaultStorageBrowser(): React.JSX.Element {
   const [{ location }] = useControl({ type: 'NAVIGATE' });
   // const { current } = location;
+  // eslint-disable-next-line no-console
+  console.log('HUH');
 
   if (location) {
     // if (current) {

--- a/packages/react-storage/src/styles/storage-browser.css
+++ b/packages/react-storage/src/styles/storage-browser.css
@@ -155,3 +155,7 @@
   gap: var(--storage-browser-gap-small);
   align-items: center;
 }
+
+.storage-browser__navigate__container {
+  grid-column: 1 / -1;
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Updated `NavigateState` 
   - to have `history`, which is a string array of the folder names we are navigating through
- Updated `Navigate` control to use the navigate context to create the `NavigateItems` 
- Moved `listLocationItems` loading logic out of `Controller.tsx` to `LocationDetailView`


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
