### PR TITLE
Feat(IdentityProviders): useIsSignedIn with data state

### DIFF
--- a/examples/next/pages/ui/components/authenticator/use-is-signed-in/aws-exports.js
+++ b/examples/next/pages/ui/components/authenticator/use-is-signed-in/aws-exports.js
@@ -1,0 +1,2 @@
+import awsExports from '@environments/auth/auth-with-email/src/aws-exports';
+export default awsExports;

--- a/examples/next/pages/ui/components/authenticator/use-is-signed-in/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/use-is-signed-in/index.page.tsx
@@ -1,0 +1,26 @@
+import { Amplify } from 'aws-amplify';
+import { useIsSignedIn } from '@aws-amplify/ui-react-core';
+import { signOut } from 'aws-amplify/auth';
+
+import { Authenticator } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+
+import awsExports from './aws-exports';
+Amplify.configure(awsExports);
+
+export default function AuthenticatorWithUseIsSignedIn() {
+  const signedInState = useIsSignedIn();
+  return signedInState.isLoading ? (
+    <p>loading</p>
+  ) : signedInState.data.isSignedIn ? (
+    <button
+      onClick={() => {
+        signOut();
+      }}
+    >
+      Sign out
+    </button>
+  ) : (
+    <Authenticator />
+  );
+}

--- a/packages/e2e/features/ui/components/authenticator/use-is-signed-in.feature
+++ b/packages/e2e/features/ui/components/authenticator/use-is-signed-in.feature
@@ -1,0 +1,16 @@
+Feature: UseIsSignedIn Hook
+
+  The UseIsSignedIn Hook uses hub events from Amplify JS that provides a method 
+  of conditionally rendering an authentication component.
+
+  Background:
+    Given I'm running the example "/ui/components/authenticator/use-is-signed-in"
+
+    @react
+    Scenario: Sign in with confirmed credentials and then sign out
+        When I type my "email" with status "CONFIRMED"
+        Then I type my password
+        Then I click the "Sign in" button
+        Then I see "Sign out"
+        Then I click the "Sign out" button
+        Then I see "Sign in"

--- a/packages/react-core/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/react-core/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -16,6 +16,7 @@ exports[`@aws-amplify/ui-react-core exports should match snapshot 1`] = `
   "useForm",
   "useGetUrl",
   "useHasValueUpdated",
+  "useIsSignedIn",
   "usePreviousValue",
   "useSetUserAgent",
   "useTimeout",

--- a/packages/react-core/src/hooks/__tests__/useIsSignedIn.test.ts
+++ b/packages/react-core/src/hooks/__tests__/useIsSignedIn.test.ts
@@ -7,8 +7,8 @@ import { Hub } from 'aws-amplify/utils';
 
 const getCurrentUserSpy = jest.spyOn(AuthModule, 'getCurrentUser');
 
-const mockError = new Error('Authorization error');
-const mockSuccess: GetCurrentUserOutput = {
+const errorResult = new Error('Authorization error');
+const successResult: GetCurrentUserOutput = {
   username: 'username',
   userId: '123',
 };
@@ -42,7 +42,7 @@ describe('useIsSignedIn', () => {
     getCurrentUserSpy.mockImplementationOnce(async () => {
       return new Promise((_, reject) => {
         setTimeout(() => {
-          reject(mockError);
+          reject(errorResult);
         }, 10);
       });
     });
@@ -60,7 +60,7 @@ describe('useIsSignedIn', () => {
     getCurrentUserSpy.mockImplementationOnce(() => {
       return new Promise((resolve) => {
         setTimeout(() => {
-          resolve(mockSuccess);
+          resolve(successResult);
         }, 10);
       });
     });
@@ -75,7 +75,7 @@ describe('useIsSignedIn', () => {
   });
 
   it('should be true if receiving a signedIn event', async () => {
-    getCurrentUserSpy.mockRejectedValueOnce(mockError);
+    getCurrentUserSpy.mockRejectedValueOnce(errorResult);
 
     const { result } = renderHook(() => useIsSignedIn());
     expect(result.current).toEqual(expectedLoadingState);
@@ -92,7 +92,7 @@ describe('useIsSignedIn', () => {
   });
 
   it('should be false if receiving a signedOut event', async () => {
-    getCurrentUserSpy.mockResolvedValueOnce(mockSuccess);
+    getCurrentUserSpy.mockResolvedValueOnce(successResult);
 
     const { result } = renderHook(() => useIsSignedIn());
 
@@ -108,7 +108,7 @@ describe('useIsSignedIn', () => {
   });
 
   it('should be able to listen to multiple events after one call', () => {
-    getCurrentUserSpy.mockRejectedValueOnce(mockError);
+    getCurrentUserSpy.mockRejectedValueOnce(errorResult);
 
     const { result } = renderHook(() => useIsSignedIn());
 

--- a/packages/react-core/src/hooks/__tests__/useIsSignedIn.test.ts
+++ b/packages/react-core/src/hooks/__tests__/useIsSignedIn.test.ts
@@ -4,25 +4,15 @@ import { waitFor } from '@testing-library/react';
 import * as AuthModule from 'aws-amplify/auth';
 import { GetCurrentUserOutput } from 'aws-amplify/auth';
 import { Hub } from 'aws-amplify/utils';
-import { AuthError } from 'aws-amplify/auth';
 
 const getCurrentUserSpy = jest.spyOn(AuthModule, 'getCurrentUser');
 
-const USER_UNAUTHENTICATED_EXCEPTION = 'UserUnAuthenticatedException';
-
-const authErrorResult = new AuthError({
-  name: USER_UNAUTHENTICATED_EXCEPTION,
-  message: 'User needs to be authenticated to call this API.',
-  recoverySuggestion: 'Sign in before calling this API again.',
-});
-
-const nonAuthErrorResule = new Error('Non-Authorization error');
-
-const successResult: GetCurrentUserOutput = {
+const mockError = new Error('Authorization error');
+const mockSuccess: GetCurrentUserOutput = {
   username: 'username',
   userId: '123',
 };
-const expectedSignedOutState = {
+const expectedDefaultState = {
   data: { isSignedIn: false },
   hasError: false,
   isLoading: false,
@@ -38,9 +28,9 @@ const expectedErrorState = {
   data: { isSignedIn: false },
   hasError: true,
   isLoading: false,
-  message: 'Non-Authorization error',
+  message: 'Authorization error',
 };
-const expectedSignedInState = {
+const expectedAcceptedState = {
   data: { isSignedIn: true },
   hasError: false,
   isLoading: false,
@@ -52,100 +42,7 @@ describe('useIsSignedIn', () => {
     getCurrentUserSpy.mockImplementationOnce(async () => {
       return new Promise((_, reject) => {
         setTimeout(() => {
-          reject(authErrorResult);
-        }, 10);
-      });
-    });
-
-    const { result } = renderHook(() => useIsSignedIn());
-
-    expect(result.current).toEqual(expectedLoadingState);
-
-    await waitFor(() => {
-      expect(result.current).toEqual(expectedSignedOutState);
-    });
-  });
-
-  it('should have an intermediate loading state before receiving true', async () => {
-    getCurrentUserSpy.mockImplementationOnce(() => {
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve(successResult);
-        }, 10);
-      });
-    });
-
-    const { result } = renderHook(() => useIsSignedIn());
-
-    expect(result.current).toEqual(expectedLoadingState);
-
-    await waitFor(() => {
-      expect(result.current).toEqual(expectedSignedInState);
-    });
-  });
-
-  it('should be true if receiving a signedIn event', async () => {
-    getCurrentUserSpy.mockRejectedValueOnce(authErrorResult);
-
-    const { result } = renderHook(() => useIsSignedIn());
-    expect(result.current).toEqual(expectedLoadingState);
-
-    await waitFor(() => {
-      expect(result.current).toEqual(expectedSignedOutState);
-    });
-
-    act(() => {
-      Hub.dispatch('auth', { event: 'signedIn' });
-    });
-
-    expect(result.current).toEqual(expectedSignedInState);
-  });
-
-  it('should be false if receiving a signedOut event', async () => {
-    getCurrentUserSpy.mockResolvedValueOnce(successResult);
-
-    const { result } = renderHook(() => useIsSignedIn());
-
-    await waitFor(() => {
-      expect(result.current).toEqual(expectedSignedInState);
-    });
-
-    act(() => {
-      Hub.dispatch('auth', { event: 'signedOut' });
-    });
-
-    expect(result.current).toEqual(expectedSignedOutState);
-  });
-
-  it('should be able to listen to multiple events after one call', () => {
-    getCurrentUserSpy.mockRejectedValueOnce(authErrorResult);
-
-    const { result } = renderHook(() => useIsSignedIn());
-
-    act(() => {
-      Hub.dispatch('auth', { event: 'signedIn' });
-    });
-
-    expect(result.current).toEqual(expectedSignedInState);
-
-    act(() => {
-      Hub.dispatch('auth', { event: 'signedOut' });
-    });
-
-    expect(result.current).toEqual(expectedSignedOutState);
-
-    act(() => {
-      Hub.dispatch('auth', { event: 'signedIn' });
-    });
-
-    expect(result.current).toEqual(expectedSignedInState);
-  });
-
-  it('should have an error in state if there is a non-authorization error', async () => {
-    getCurrentUserSpy.mockImplementationOnce(async () => {
-      return new Promise((_, reject) => {
-        setTimeout(() => {
-          reject(nonAuthErrorResule);
+          reject(mockError);
         }, 10);
       });
     });
@@ -157,5 +54,80 @@ describe('useIsSignedIn', () => {
     await waitFor(() => {
       expect(result.current).toEqual(expectedErrorState);
     });
+  });
+
+  it('should have an intermediate loading state before receiving true', async () => {
+    getCurrentUserSpy.mockImplementationOnce(() => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(mockSuccess);
+        }, 10);
+      });
+    });
+
+    const { result } = renderHook(() => useIsSignedIn());
+
+    expect(result.current).toEqual(expectedLoadingState);
+
+    await waitFor(() => {
+      expect(result.current).toEqual(expectedAcceptedState);
+    });
+  });
+
+  it('should be true if receiving a signedIn event', async () => {
+    getCurrentUserSpy.mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useIsSignedIn());
+    expect(result.current).toEqual(expectedLoadingState);
+
+    await waitFor(() => {
+      expect(result.current).toEqual(expectedErrorState);
+    });
+
+    act(() => {
+      Hub.dispatch('auth', { event: 'signedIn' });
+    });
+
+    expect(result.current).toEqual(expectedAcceptedState);
+  });
+
+  it('should be false if receiving a signedOut event', async () => {
+    getCurrentUserSpy.mockResolvedValueOnce(mockSuccess);
+
+    const { result } = renderHook(() => useIsSignedIn());
+
+    await waitFor(() => {
+      expect(result.current).toEqual(expectedAcceptedState);
+    });
+
+    act(() => {
+      Hub.dispatch('auth', { event: 'signedOut' });
+    });
+
+    expect(result.current).toEqual(expectedDefaultState);
+  });
+
+  it('should be able to listen to multiple events after one call', () => {
+    getCurrentUserSpy.mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useIsSignedIn());
+
+    act(() => {
+      Hub.dispatch('auth', { event: 'signedIn' });
+    });
+
+    expect(result.current).toEqual(expectedAcceptedState);
+
+    act(() => {
+      Hub.dispatch('auth', { event: 'signedOut' });
+    });
+
+    expect(result.current).toEqual(expectedDefaultState);
+
+    act(() => {
+      Hub.dispatch('auth', { event: 'signedIn' });
+    });
+
+    expect(result.current).toEqual(expectedAcceptedState);
   });
 });

--- a/packages/react-core/src/hooks/__tests__/useIsSignedIn.test.ts
+++ b/packages/react-core/src/hooks/__tests__/useIsSignedIn.test.ts
@@ -7,24 +7,24 @@ import { Hub } from 'aws-amplify/utils';
 
 const getCurrentUserSpy = jest.spyOn(AuthModule, 'getCurrentUser');
 
-const mockError = new Error('Authorization error');
-const mockSuccess: GetCurrentUserOutput = {
+const MOCK_ERROR = new Error('Authorization error');
+const MOCK_SUCCESS: GetCurrentUserOutput = {
   username: 'username',
   userId: '123',
 };
-const expectedLoadingState = {
+const EXPECTED_LOADING_STATE = {
   data: { isSignedIn: false },
   hasError: false,
   isLoading: true,
   message: undefined,
 };
-const expectedErrorState = {
+const EXPECTED_ERROR_STATE = {
   data: { isSignedIn: false },
   hasError: true,
   isLoading: false,
   message: 'Authorization error',
 };
-const expectedAcceptedState = {
+const EXPECTED_ACCEPTED_STATE = {
   data: { isSignedIn: true },
   hasError: false,
   isLoading: false,
@@ -36,17 +36,17 @@ describe('useIsSignedIn', () => {
     getCurrentUserSpy.mockImplementationOnce(async () => {
       return new Promise((_, reject) => {
         setTimeout(() => {
-          reject(mockError);
+          reject(MOCK_ERROR);
         }, 10);
       });
     });
 
     const { result } = renderHook(() => useIsSignedIn());
 
-    expect(result.current).toEqual(expectedLoadingState);
+    expect(result.current).toEqual(EXPECTED_LOADING_STATE);
 
     await waitFor(() => {
-      expect(result.current).toEqual(expectedErrorState);
+      expect(result.current).toEqual(EXPECTED_ERROR_STATE);
     });
   });
 
@@ -54,29 +54,29 @@ describe('useIsSignedIn', () => {
     getCurrentUserSpy.mockImplementationOnce(() => {
       return new Promise((resolve) => {
         setTimeout(() => {
-          resolve(mockSuccess);
+          resolve(MOCK_SUCCESS);
         }, 10);
       });
     });
 
     const { result } = renderHook(() => useIsSignedIn());
 
-    expect(result.current).toEqual(expectedLoadingState);
+    expect(result.current).toEqual(EXPECTED_LOADING_STATE);
 
     await waitFor(() => {
-      expect(result.current).toEqual(expectedAcceptedState);
+      expect(result.current).toEqual(EXPECTED_ACCEPTED_STATE);
     });
   });
 
   it('should be true if receiving a signedIn event', async () => {
-    getCurrentUserSpy.mockRejectedValueOnce(mockError);
-    getCurrentUserSpy.mockResolvedValueOnce(mockSuccess);
+    getCurrentUserSpy.mockRejectedValueOnce(MOCK_ERROR);
+    getCurrentUserSpy.mockResolvedValueOnce(MOCK_SUCCESS);
 
     const { result } = renderHook(() => useIsSignedIn());
-    expect(result.current).toEqual(expectedLoadingState);
+    expect(result.current).toEqual(EXPECTED_LOADING_STATE);
 
     await waitFor(() => {
-      expect(result.current).toEqual(expectedErrorState);
+      expect(result.current).toEqual(EXPECTED_ERROR_STATE);
     });
 
     act(() => {
@@ -84,19 +84,19 @@ describe('useIsSignedIn', () => {
     });
 
     await waitFor(() => {
-      expect(result.current).toEqual(expectedAcceptedState);
+      expect(result.current).toEqual(EXPECTED_ACCEPTED_STATE);
     });
   });
 
   it('should be false if receiving a signedOut event', async () => {
-    getCurrentUserSpy.mockResolvedValueOnce(mockSuccess);
-    getCurrentUserSpy.mockRejectedValueOnce(mockError);
-    getCurrentUserSpy.mockRejectedValueOnce(mockError);
+    getCurrentUserSpy.mockResolvedValueOnce(MOCK_SUCCESS);
+    getCurrentUserSpy.mockRejectedValueOnce(MOCK_ERROR);
+    getCurrentUserSpy.mockRejectedValueOnce(MOCK_ERROR);
 
     const { result } = renderHook(() => useIsSignedIn());
 
     await waitFor(() => {
-      expect(result.current).toEqual(expectedAcceptedState);
+      expect(result.current).toEqual(EXPECTED_ACCEPTED_STATE);
     });
 
     act(() => {
@@ -104,21 +104,21 @@ describe('useIsSignedIn', () => {
     });
 
     await waitFor(() => {
-      expect(result.current).toEqual(expectedErrorState);
+      expect(result.current).toEqual(EXPECTED_ERROR_STATE);
     });
   });
 
   it('should be able to listen to multiple events after one call', async () => {
-    getCurrentUserSpy.mockRejectedValueOnce(mockError);
-    getCurrentUserSpy.mockResolvedValueOnce(mockSuccess);
-    getCurrentUserSpy.mockRejectedValueOnce(mockError);
-    getCurrentUserSpy.mockRejectedValueOnce(mockError);
-    getCurrentUserSpy.mockResolvedValueOnce(mockSuccess);
+    getCurrentUserSpy.mockRejectedValueOnce(MOCK_ERROR);
+    getCurrentUserSpy.mockResolvedValueOnce(MOCK_SUCCESS);
+    getCurrentUserSpy.mockRejectedValueOnce(MOCK_ERROR);
+    getCurrentUserSpy.mockRejectedValueOnce(MOCK_ERROR);
+    getCurrentUserSpy.mockResolvedValueOnce(MOCK_SUCCESS);
 
     const { result } = renderHook(() => useIsSignedIn());
 
     await waitFor(() => {
-      expect(result.current).toEqual(expectedErrorState);
+      expect(result.current).toEqual(EXPECTED_ERROR_STATE);
     });
 
     act(() => {
@@ -126,7 +126,7 @@ describe('useIsSignedIn', () => {
     });
 
     await waitFor(() => {
-      expect(result.current).toEqual(expectedAcceptedState);
+      expect(result.current).toEqual(EXPECTED_ACCEPTED_STATE);
     });
 
     act(() => {
@@ -134,7 +134,7 @@ describe('useIsSignedIn', () => {
     });
 
     await waitFor(() => {
-      expect(result.current).toEqual(expectedErrorState);
+      expect(result.current).toEqual(EXPECTED_ERROR_STATE);
     });
 
     act(() => {
@@ -142,7 +142,7 @@ describe('useIsSignedIn', () => {
     });
 
     await waitFor(() => {
-      expect(result.current).toEqual(expectedAcceptedState);
+      expect(result.current).toEqual(EXPECTED_ACCEPTED_STATE);
     });
   });
 });

--- a/packages/react-core/src/hooks/__tests__/useIsSignedIn.test.ts
+++ b/packages/react-core/src/hooks/__tests__/useIsSignedIn.test.ts
@@ -1,0 +1,133 @@
+import useIsSignedIn from '../useIsSignedIn';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
+import * as AuthModule from 'aws-amplify/auth';
+import { GetCurrentUserOutput } from 'aws-amplify/auth';
+import { Hub } from 'aws-amplify/utils';
+
+const getCurrentUserSpy = jest.spyOn(AuthModule, 'getCurrentUser');
+
+const mockError = new Error('Authorization error');
+const mockSuccess: GetCurrentUserOutput = {
+  username: 'username',
+  userId: '123',
+};
+const expectedDefaultState = {
+  data: { isSignedIn: false },
+  hasError: false,
+  isLoading: false,
+  message: undefined,
+};
+const expectedLoadingState = {
+  data: { isSignedIn: false },
+  hasError: false,
+  isLoading: true,
+  message: undefined,
+};
+const expectedErrorState = {
+  data: { isSignedIn: false },
+  hasError: true,
+  isLoading: false,
+  message: 'Authorization error',
+};
+const expectedAcceptedState = {
+  data: { isSignedIn: true },
+  hasError: false,
+  isLoading: false,
+  message: undefined,
+};
+
+describe('useIsSignedIn', () => {
+  it('should have an intermediate loading state before receiving false and error', async () => {
+    getCurrentUserSpy.mockImplementationOnce(async () => {
+      return new Promise((_, reject) => {
+        setTimeout(() => {
+          reject(mockError);
+        }, 10);
+      });
+    });
+
+    const { result } = renderHook(() => useIsSignedIn());
+
+    expect(result.current).toEqual(expectedLoadingState);
+
+    await waitFor(() => {
+      expect(result.current).toEqual(expectedErrorState);
+    });
+  });
+
+  it('should have an intermediate loading state before receiving true', async () => {
+    getCurrentUserSpy.mockImplementationOnce(() => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(mockSuccess);
+        }, 10);
+      });
+    });
+
+    const { result } = renderHook(() => useIsSignedIn());
+
+    expect(result.current).toEqual(expectedLoadingState);
+
+    await waitFor(() => {
+      expect(result.current).toEqual(expectedAcceptedState);
+    });
+  });
+
+  it('should be true if receiving a signedIn event', async () => {
+    getCurrentUserSpy.mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useIsSignedIn());
+    expect(result.current).toEqual(expectedLoadingState);
+
+    await waitFor(() => {
+      expect(result.current).toEqual(expectedErrorState);
+    });
+
+    act(() => {
+      Hub.dispatch('auth', { event: 'signedIn' });
+    });
+
+    expect(result.current).toEqual(expectedAcceptedState);
+  });
+
+  it('should be false if receiving a signedOut event', async () => {
+    getCurrentUserSpy.mockResolvedValueOnce(mockSuccess);
+
+    const { result } = renderHook(() => useIsSignedIn());
+
+    await waitFor(() => {
+      expect(result.current).toEqual(expectedAcceptedState);
+    });
+
+    act(() => {
+      Hub.dispatch('auth', { event: 'signedOut' });
+    });
+
+    expect(result.current).toEqual(expectedDefaultState);
+  });
+
+  it('should be able to listen to multiple events after one call', () => {
+    getCurrentUserSpy.mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useIsSignedIn());
+
+    act(() => {
+      Hub.dispatch('auth', { event: 'signedIn' });
+    });
+
+    expect(result.current).toEqual(expectedAcceptedState);
+
+    act(() => {
+      Hub.dispatch('auth', { event: 'signedOut' });
+    });
+
+    expect(result.current).toEqual(expectedDefaultState);
+
+    act(() => {
+      Hub.dispatch('auth', { event: 'signedIn' });
+    });
+
+    expect(result.current).toEqual(expectedAcceptedState);
+  });
+});

--- a/packages/react-core/src/hooks/index.ts
+++ b/packages/react-core/src/hooks/index.ts
@@ -9,3 +9,4 @@ export { default as useHasValueUpdated } from './useHasValueUpdated';
 export { default as usePreviousValue } from './usePreviousValue';
 export { default as useSetUserAgent } from './useSetUserAgent';
 export { default as useTimeout } from './useTimeout';
+export { default as useIsSignedIn } from './useIsSignedIn';

--- a/packages/react-core/src/hooks/useIsSignedIn.ts
+++ b/packages/react-core/src/hooks/useIsSignedIn.ts
@@ -2,10 +2,23 @@ import { getCurrentUser } from 'aws-amplify/auth';
 import { Hub, HubCallback } from '@aws-amplify/core';
 import { useEffect, useState } from 'react';
 import useDataState, { DataState } from './useDataState';
+import { AuthError } from 'aws-amplify/auth';
+
+const USER_UNAUTHENTICATED_EXCEPTION = 'UserUnAuthenticatedException';
 
 const action = async (_: { isSignedIn: boolean }, __: undefined) => {
-  await getCurrentUser();
-  return { isSignedIn: true };
+  try {
+    await getCurrentUser();
+    return { isSignedIn: true };
+  } catch (error) {
+    if (
+      error instanceof AuthError &&
+      error.name === USER_UNAUTHENTICATED_EXCEPTION
+    ) {
+      return { isSignedIn: false };
+    }
+    throw error;
+  }
 };
 
 const defaultState: DataState<{ isSignedIn: boolean }> = {

--- a/packages/react-core/src/hooks/useIsSignedIn.ts
+++ b/packages/react-core/src/hooks/useIsSignedIn.ts
@@ -1,50 +1,35 @@
 import { getCurrentUser } from 'aws-amplify/auth';
 import { Hub, HubCallback } from '@aws-amplify/core';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import useDataState, { DataState } from './useDataState';
-import { AuthError } from 'aws-amplify/auth';
 
-const USER_UNAUTHENTICATED_EXCEPTION = 'UserUnAuthenticatedException';
-
-const action = async (_: { isSignedIn: boolean }, __: undefined) => {
+const action = async (
+  _: { isSignedIn: boolean },
+  input: { setState?: boolean }
+) => {
   try {
     await getCurrentUser();
     return { isSignedIn: true };
   } catch (error) {
-    if (
-      error instanceof AuthError &&
-      error.name === USER_UNAUTHENTICATED_EXCEPTION
-    ) {
+    if (input?.setState) {
       return { isSignedIn: false };
     }
     throw error;
   }
 };
 
-const defaultState: DataState<{ isSignedIn: boolean }> = {
-  hasError: false,
-  isLoading: false,
-  message: undefined,
-  data: { isSignedIn: false },
-};
-
 export default function useIsSignedIn(): DataState<{ isSignedIn: boolean }> {
   const [state, handler] = useDataState(action, { isSignedIn: false });
-  const [effectState, setEffectState] =
-    useState<DataState<{ isSignedIn: boolean }>>(state);
-
-  useEffect(() => {
-    setEffectState(state);
-  }, [state]);
 
   useEffect(() => {
     handler();
 
     const listener: HubCallback = ({ payload }) => {
       if (payload.event === 'signedIn') {
-        setEffectState({ ...defaultState, data: { isSignedIn: true } });
+        handler();
       } else if (payload.event === 'signedOut') {
-        setEffectState(defaultState);
+        handler({ setState: true });
+        handler();
       }
     };
 
@@ -55,5 +40,5 @@ export default function useIsSignedIn(): DataState<{ isSignedIn: boolean }> {
     };
   }, [handler]);
 
-  return effectState;
+  return state;
 }

--- a/packages/react-core/src/hooks/useIsSignedIn.ts
+++ b/packages/react-core/src/hooks/useIsSignedIn.ts
@@ -1,0 +1,46 @@
+import { getCurrentUser } from 'aws-amplify/auth';
+import { Hub, HubCallback } from '@aws-amplify/core';
+import { useEffect, useState } from 'react';
+import useDataState, { DataState } from './useDataState';
+
+const action = async (_: { isSignedIn: boolean }, __: undefined) => {
+  await getCurrentUser();
+  return { isSignedIn: true };
+};
+
+const defaultState: DataState<{ isSignedIn: boolean }> = {
+  hasError: false,
+  isLoading: false,
+  message: undefined,
+  data: { isSignedIn: false },
+};
+
+export default function useIsSignedIn(): DataState<{ isSignedIn: boolean }> {
+  const [state, handler] = useDataState(action, { isSignedIn: false });
+  const [effectState, setEffectState] =
+    useState<DataState<{ isSignedIn: boolean }>>(state);
+
+  useEffect(() => {
+    setEffectState(state);
+  }, [state]);
+
+  useEffect(() => {
+    handler();
+
+    const listener: HubCallback = ({ payload }) => {
+      if (payload.event === 'signedIn') {
+        setEffectState({ ...defaultState, data: { isSignedIn: true } });
+      } else if (payload.event === 'signedOut') {
+        setEffectState(defaultState);
+      }
+    };
+
+    const unmount = Hub.listen('auth', listener);
+
+    return () => {
+      unmount();
+    };
+  }, [handler]);
+
+  return effectState;
+}

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -39,6 +39,7 @@ export {
   UseDeprecationWarning,
   useGetUrl,
   useHasValueUpdated,
+  useIsSignedIn,
   usePreviousValue,
   useSetUserAgent,
   useTimeout,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Updated the useIsSignedIn hook to use the data state hook. This allows for an isLoading field in the state, as well as an error message.
This hook uses the useDataState hook in a unique way, since the action function (getCurrentUser) is not returned to the customer. On top of this, signedIn state needs to use hub events to update state. Therefore, I decided to call getCurrentUser after each hub event update. Also, since the false state throws an error, I needed to add a condition to the action that allowed for setting the data state vs setting the error state, and made 2 calls to the action to update each.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I created a test file to go over possible cases and ran yarn test.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
