### PR TITLE
chore(storage-browser): use ActionView when action is selected

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Controller.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Controller.tsx
@@ -48,9 +48,9 @@ export function Controller(): null {
     ({ bucket, permission, scope }: LocationData) =>
       handleListLocationItems({
         // uncomment to test managed auth config
-        prefix: '',
+        // prefix: '',
         // uncomment to test with amplify config with public access level
-        // prefix: 'public/'
+        prefix: 'public/',
         config: {
           bucket,
           credentialsProvider: async () =>

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/Controls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/Controls.tsx
@@ -4,14 +4,21 @@ import { StorageBrowserElements } from '../../context/elements';
 import { Controls } from '../Controls';
 import { CommonControl } from '../types';
 
-export interface LocationActionViewControls<T extends StorageBrowserElements>
-  extends Pick<Controls<T>, CommonControl | 'Summary'> {
+const { Title, Summary } = Controls;
+
+export interface LocationActionViewControls<
+  T extends StorageBrowserElements = StorageBrowserElements,
+> extends Pick<Controls<T>, CommonControl | 'Summary' | 'Title'> {
   (): React.JSX.Element;
 }
-
 // @ts-expect-error TODO: add Controls assignment
 export const LocationActionViewControls: LocationActionViewControls<
   StorageBrowserElements
 > = () => {
-  return <>Action View Controls</>;
+  return (
+    <>
+      <Title />
+      <Summary />
+    </>
+  );
 };

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/LocationActionView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/LocationActionView.tsx
@@ -16,7 +16,14 @@ export const LocationActionView: LocationActionView = () => {
   });
   const { actionType, items } = selected;
   const listItems = items
-    ? items?.map(({ key }) => <p key={key}>{key}</p>)
+    ? items.map(({ key, type }) => {
+        return (
+          <div key={key}>
+            <span>{key}</span>
+            <span>{type}</span>
+          </div>
+        );
+      })
     : 'No items selected.';
 
   return (

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/LocationActionView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/LocationActionView.tsx
@@ -3,28 +3,30 @@ import React from 'react';
 import { StorageBrowserElements } from '../../context/elements';
 
 import { ViewComponent } from '../types';
-import { Controls } from '../Controls';
 import { LocationActionViewControls } from './Controls';
 import { useControl } from '../../context/controls';
-const { Title } = Controls;
 
 export interface LocationActionView<
   T extends StorageBrowserElements = StorageBrowserElements,
 > extends ViewComponent<LocationActionViewControls<T>> {}
 
 export const LocationActionView: LocationActionView = () => {
-  const [{ selected }] = useControl({ type: 'ACTION_SELECT' });
-  console.log('selected: ', selected);
-  const { actionType, name, items } = selected;
+  const [{ selected }, handleUpdateState] = useControl({
+    type: 'ACTION_SELECT',
+  });
+  const { actionType, items } = selected;
   const listItems = items
     ? items?.map(({ key }) => <p key={key}>{key}</p>)
     : 'No items selected.';
 
   return (
     <>
-      <h2>
-        {name}: {actionType}
-      </h2>
+      <h2>{actionType}</h2>
+      <button
+        onClick={() => handleUpdateState({ type: 'DESELECT_ACTION_TYPE' })}
+      >
+        Cancel
+      </button>
       <LocationActionViewControls />
       {listItems}
     </>

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/LocationActionView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/LocationActionView.tsx
@@ -3,17 +3,30 @@ import React from 'react';
 import { StorageBrowserElements } from '../../context/elements';
 
 import { ViewComponent } from '../types';
+import { Controls } from '../Controls';
 import { LocationActionViewControls } from './Controls';
+import { useControl } from '../../context/controls';
+const { Title } = Controls;
 
 export interface LocationActionView<
   T extends StorageBrowserElements = StorageBrowserElements,
 > extends ViewComponent<LocationActionViewControls<T>> {}
 
 export const LocationActionView: LocationActionView = () => {
+  const [{ selected }] = useControl({ type: 'ACTION_SELECT' });
+  console.log('selected: ', selected);
+  const { actionType, name, items } = selected;
+  const listItems = items
+    ? items?.map(({ key }) => <p key={key}>{key}</p>)
+    : 'No items selected.';
+
   return (
     <>
-      <h1>LocationActionView</h1>;
+      <h2>
+        {name}: {actionType}
+      </h2>
       <LocationActionViewControls />
+      {listItems}
     </>
   );
 };

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/Controls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/Controls.tsx
@@ -10,15 +10,10 @@ export interface LocationDetailViewControls<
   T extends StorageBrowserElements = StorageBrowserElements,
 > extends Pick<
     Controls<T>,
-    CommonControl | 'ActionSelect' | 'Paginate' | 'Refresh' | 'Search'
+    CommonControl | 'Title' | 'ActionSelect' | 'Paginate' | 'Refresh' | 'Search'
   > {
   (): React.JSX.Element;
 }
-
-const TEMP_ACTIONS = [
-  { name: 'Upload File', type: 'UPLOAD_FILE' },
-  { name: 'Create Folder', type: 'CREATE_FOLDER' },
-];
 
 // @ts-expect-error TODO: add Controls assignment
 export const LocationDetailViewControls: LocationDetailViewControls = () => {

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/Controls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/Controls.tsx
@@ -4,8 +4,7 @@ import { StorageBrowserElements } from '../../context/elements';
 import { Controls } from '../Controls';
 import { CommonControl } from '../types';
 
-const { ActionSelect } = Controls;
-
+const { ActionSelect, Navigate } = Controls;
 export interface LocationDetailViewControls<
   T extends StorageBrowserElements = StorageBrowserElements,
 > extends Pick<
@@ -14,8 +13,6 @@ export interface LocationDetailViewControls<
   > {
   (): React.JSX.Element;
 }
-
-const { Navigate } = Controls;
 
 // @ts-expect-error TODO: add Controls assignment
 export const LocationDetailViewControls: LocationDetailViewControls = () => {

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/ActionSelect/ActionSelect.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/ActionSelect/ActionSelect.tsx
@@ -43,6 +43,9 @@ export function actionSelectReducer(
   state: ActionSelectState,
   _action: ActionSelectAction
 ): ActionSelectState {
+  if (_action.type === 'SELECT_ACTION_TYPE') {
+    return { ...state, selected: _action };
+  }
   return state;
 }
 
@@ -56,7 +59,6 @@ export function ActionSelectProvider({
   children?: React.ReactNode;
 }): React.JSX.Element {
   const value = React.useReducer(actionSelectReducer, INITIAL_STATE);
-
   return (
     <ActionSelectContext.Provider value={value}>
       {children}

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/ActionSelect/ActionSelect.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/ActionSelect/ActionSelect.tsx
@@ -29,7 +29,7 @@ export interface Action {
   type: ActionType;
 }
 
-interface ActionSelectState<T = ActionType> {
+export interface ActionSelectState<T = ActionType> {
   actions: Action[];
   selected: { actionType: T | undefined; items: LocationItem[] | undefined };
 }

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/ActionSelect/ActionSelect.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/ActionSelect/ActionSelect.tsx
@@ -44,7 +44,11 @@ export function actionSelectReducer(
   _action: ActionSelectAction
 ): ActionSelectState {
   if (_action.type === 'SELECT_ACTION_TYPE') {
+    // Update selected action with action passed from handleUpdateState
     return { ...state, selected: _action };
+  } else if (_action.type === 'DESELECT_ACTION_TYPE') {
+    // Clears selected action
+    return { ...state, selected: { actionType: undefined, items: undefined } };
   }
   return state;
 }

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/ActionSelect/__tests__/ActionSelect.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/ActionSelect/__tests__/ActionSelect.spec.tsx
@@ -1,6 +1,52 @@
+import {
+  actionSelectReducer,
+  ActionSelectState,
+  ActionSelectAction,
+} from '../ActionSelect';
+
 describe('actionSelectReducer', () => {
-  it.todo('handles a SELECT_ACTION_TYPE as expected');
-  it.todo('handles a DESELECT_ACTION_TYPE as expected');
+  it('handles a SELECT_ACTION_TYPE as expected', () => {
+    const initialState: ActionSelectState = {
+      actions: [],
+      selected: { actionType: undefined, items: undefined },
+    };
+    const action: ActionSelectAction = {
+      actionType: 'UPLOAD_FILES',
+      type: 'SELECT_ACTION_TYPE',
+      destination: 'public/',
+      name: 'Upload files',
+      items: [],
+    };
+    const newState = actionSelectReducer(initialState, action);
+    const expectedState = {
+      actions: [],
+      selected: {
+        ...action,
+      },
+    };
+    expect(newState).toEqual(expectedState);
+  });
+  it('handles a DESELECT_ACTION_TYPE as expected', () => {
+    const initialState: ActionSelectState = {
+      actions: [],
+      selected: {
+        actionType: 'UPLOAD_FILES',
+        items: [],
+      },
+    };
+    const action: ActionSelectAction = {
+      type: 'DESELECT_ACTION_TYPE',
+    };
+    const newState = actionSelectReducer(initialState, action);
+    const expectedState = {
+      actions: [],
+      selected: {
+        actionType: undefined,
+        items: undefined,
+      },
+    };
+    expect(newState).toEqual(expectedState);
+  });
   it.todo('handles a SET_UPLOAD_ITEMS as expected');
   it.todo('handles a SELECT_LOCATION_ITEM as expected');
   it.todo('handles a DESELECT_LOCATION_ITEM as expected');

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -4,7 +4,7 @@ import { MergeBaseElements } from '@aws-amplify/ui-react-core/elements';
 import { Permission } from './context/actions/types';
 import { StorageBrowserElements } from './context/elements';
 import createProvider, { CreateProviderInput } from './createProvider';
-import { LocationsView, LocationDetailView } from './Views';
+import { LocationsView, LocationDetailView, LocationActionView } from './Views';
 import { useControl } from './context/controls';
 
 export interface CreateStorageBrowserInput<T, K>
@@ -29,12 +29,16 @@ interface ResolvedStorageBrowserElements<
  */
 function DefaultStorageBrowser(): React.JSX.Element {
   const [{ location }] = useControl({ type: 'NAVIGATE' });
+  const [{ selected }] = useControl({ type: 'ACTION_SELECT' });
+
   const { current } = location;
-  // TODO: Check for ACTION_SELECT state to output Action view
-  if (current) {
+  const { actionType } = selected;
+
+  if (actionType) {
+    return <LocationActionView />;
+  } else if (current) {
     return <LocationDetailView />;
-  }
-  return <LocationsView />;
+  } else return <LocationsView />;
 }
 
 export function createStorageBrowser<


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- Displays ActionView when an action is selected from the ActionSelect menu
- Added a quick "cancel" button to this view to test the "DESELECT_ACTION" state

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
