### PR TITLE
bug(liveness): handle empty video events

### DIFF
--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/StreamRecorder/__tests__/StreamRecorder.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/StreamRecorder/__tests__/StreamRecorder.test.ts
@@ -95,8 +95,23 @@ describe('StreamRecorder', () => {
       streamRecorder.startRecording();
       // force run `this.#recorded.onstart`
       mockMediaRecorder.onstart();
+      const chunk = new Blob([JSON.stringify({ hello: 'world' })]);
+      mockMediaRecorder.ondataavailable({ data: chunk });
 
       expect(streamRecorder.hasRecordingStarted()).toBe(true);
+    });
+
+    it('returns false if recording has started but no chunks have been made available', () => {
+      const streamRecorder = new StreamRecorder(stream);
+      expect(streamRecorder.hasRecordingStarted()).toBe(false);
+
+      streamRecorder.startRecording();
+      // force run `this.#recorded.onstart`
+      mockMediaRecorder.onstart();
+      const chunk = new Blob();
+      mockMediaRecorder.ondataavailable({ data: chunk });
+
+      expect(streamRecorder.hasRecordingStarted()).toBe(false);
     });
   });
 
@@ -170,10 +185,19 @@ describe('StreamRecorder', () => {
     it('returns the length of recorded chunks from data available events', () => {
       const streamRecorder = new StreamRecorder(stream);
       expect(streamRecorder.getChunksLength()).toBe(0);
-      const chunk = new Blob();
+      const chunk = new Blob([JSON.stringify({ hello: 'world' })]);
       mockMediaRecorder.ondataavailable({ data: chunk });
 
       expect(streamRecorder.getChunksLength()).toBe(1);
+    });
+
+    it('doesnt add empty chunks', () => {
+      const streamRecorder = new StreamRecorder(stream);
+      expect(streamRecorder.getChunksLength()).toBe(0);
+      const chunk = new Blob();
+      mockMediaRecorder.ondataavailable({ data: chunk });
+
+      expect(streamRecorder.getChunksLength()).toBe(0);
     });
   });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Mimics more of what we have in `main` to handle empty video events and recording starts

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
