### PR TITLE
chore(ai): add keyboard navigation for conversation

### DIFF
--- a/packages/react-ai/src/ai-conversation-styles.css
+++ b/packages/react-ai/src/ai-conversation-styles.css
@@ -119,6 +119,7 @@
   width: 800px;
   overflow: hidden;
   resize: none;
+  outline: none;
 }
 
 .ai-field__button {

--- a/packages/react-ai/src/ai-conversation-styles.css
+++ b/packages/react-ai/src/ai-conversation-styles.css
@@ -166,7 +166,6 @@
   align-self: stretch;
   overflow: hidden;
   resize: none;
-  outline: none;
 }
 
 .ai-field__button {

--- a/packages/react-ai/src/components/AIConversation/context/elements/definitions.ts
+++ b/packages/react-ai/src/components/AIConversation/context/elements/definitions.ts
@@ -54,7 +54,7 @@ export const InputElement = defineBaseElement<'input', 'type'>({
   displayName: 'Input',
 });
 
-type ButtonElementProps = 'disabled' | 'onClick' | 'type';
+type ButtonElementProps = 'disabled' | 'onClick' | 'type' | 'tabIndex';
 type ButtonElementVariant = 'attach' | 'remove' | 'send-message';
 
 export const ButtonElement = defineBaseElement<

--- a/packages/react-ai/src/components/AIConversation/context/elements/definitions.ts
+++ b/packages/react-ai/src/components/AIConversation/context/elements/definitions.ts
@@ -57,7 +57,9 @@ export const ButtonElement = defineBaseElement<
   ButtonElementVariant
 >({ type: 'button', displayName: 'Button' });
 
-export const ViewElement = defineBaseElement({
+type ViewElementProps = 'onFocus' | 'tabIndex' | 'onKeyDown';
+
+export const ViewElement = defineBaseElement<'div', ViewElementProps>({
   type: 'div',
   displayName: 'View',
 });
@@ -67,7 +69,7 @@ export const SpanElement = defineBaseElement({
   displayName: 'Span',
 });
 
-type TextAreaElementProps = 'onChange' | 'placeholder';
+type TextAreaElementProps = 'onChange' | 'placeholder' | 'autoFocus';
 
 export const TextAreaElement = defineBaseElement<
   'textarea',

--- a/packages/react-ai/src/components/AIConversation/views/Controls/ActionsBarControl.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/ActionsBarControl.tsx
@@ -29,7 +29,10 @@ const Container = withBaseElementProps(View, {
   className: `${ACTIONS_BAR_BLOCK}__container`,
 });
 
-export const ActionsBarControl: ActionsBarControl = ({ message }) => {
+export const ActionsBarControl: ActionsBarControl = ({
+  message,
+  focusable,
+}) => {
   const actions = React.useContext(ActionsContext);
   return (
     <Container>
@@ -38,6 +41,7 @@ export const ActionsBarControl: ActionsBarControl = ({ message }) => {
           aria-label={action.displayName}
           key={index}
           onClick={() => action.handler(message)}
+          tabIndex={focusable ? 0 : -1}
         >
           <ActionIcon data-testid={`action-icon-${action.displayName}`}>
             {action.icon}
@@ -55,7 +59,10 @@ ActionsBarControl.Icon = ActionIcon;
 export interface ActionsBarControl<
   T extends Partial<AIConversationElements> = AIConversationElements,
 > {
-  (props: { message: ConversationMessage }): React.JSX.Element;
+  (props: {
+    message: ConversationMessage;
+    focusable?: boolean;
+  }): React.JSX.Element;
   Button: T['Button'];
   Container: T['View'];
   Icon: T['Span'];

--- a/packages/react-ai/src/components/AIConversation/views/Controls/FieldControl.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/FieldControl.tsx
@@ -66,6 +66,8 @@ const TextInput: typeof TextAreaBase = React.forwardRef(
   function TextInput(props, ref) {
     const { setInput } = React.useContext(InputContext);
     const messages = React.useContext(MessagesContext);
+    const textAreaRef = React.useRef<HTMLTextAreaElement | null>(null);
+
     const isFirstMessage = !messages || messages.length === 0;
 
     React.useEffect(() => {
@@ -91,12 +93,10 @@ const TextInput: typeof TextAreaBase = React.forwardRef(
     });
 
     React.useEffect(() => {
-      const textarea = document.getElementById(`text-input`);
-
-      if (textarea) {
-        textarea.focus();
+      if (textAreaRef && textAreaRef.current) {
+        textAreaRef.current.focus();
       }
-    }, []);
+    }, [textAreaRef]);
 
     return (
       <TextAreaBase
@@ -113,7 +113,14 @@ const TextInput: typeof TextAreaBase = React.forwardRef(
             ? 'Ask anything...'
             : 'Message Raven'
         }
-        ref={ref}
+        ref={(node) => {
+          textAreaRef.current = node;
+          if (typeof ref === 'function') {
+            ref(node);
+          } else if (ref) {
+            ref.current = node;
+          }
+        }}
         autoFocus
       />
     );

--- a/packages/react-ai/src/components/AIConversation/views/Controls/FieldControl.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/FieldControl.tsx
@@ -91,7 +91,7 @@ const TextInput: typeof TextAreaBase = React.forwardRef(
     });
 
     React.useEffect(() => {
-      const textarea = document.getElementById(`${FIELD_BLOCK}-text-input`);
+      const textarea = document.getElementById(`text-input`);
 
       if (textarea) {
         textarea.focus();

--- a/packages/react-ai/src/components/AIConversation/views/Controls/FieldControl.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/FieldControl.tsx
@@ -67,12 +67,21 @@ const TextInput: typeof TextAreaBase = React.forwardRef(
       };
     });
 
+    React.useEffect(() => {
+      const textarea = document.getElementById(`${FIELD_BLOCK}-text-input`);
+
+      if (textarea) {
+        textarea.focus();
+      }
+    }, []);
+
     return (
       <TextAreaBase
         {...props}
         data-testid="text-input"
         placeholder={isFirstMessage ? 'Ask anything...' : 'Message Raven'}
         ref={ref}
+        autoFocus
       />
     );
   }

--- a/packages/react-ai/src/components/AIConversation/views/Controls/MessagesControl.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/MessagesControl.tsx
@@ -148,7 +148,7 @@ export const MessagesControl: MessagesControl = ({ renderMessage }) => {
 
   const onKeyDown = React.useCallback(
     (index: number, { key }: React.KeyboardEvent<HTMLDivElement>) => {
-      let newIndex = focusedItemIndex;
+      let newIndex;
       switch (key) {
         case 'ArrowUp':
           newIndex = Math.max(0, index - 1);
@@ -177,7 +177,7 @@ export const MessagesControl: MessagesControl = ({ renderMessage }) => {
 
       return;
     },
-    [messages, focusedItemIndex]
+    [messages]
   );
 
   return (

--- a/packages/react-ai/src/components/AIConversation/views/Controls/MessagesControl.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/MessagesControl.tsx
@@ -153,25 +153,28 @@ export const MessagesControl: MessagesControl = ({ renderMessage }) => {
         case 'ArrowUp':
           newIndex = Math.max(0, index - 1);
           setFocusedItemIndex(newIndex);
+          messagesRef.current[newIndex]?.focus();
           break;
         case 'ArrowDown':
           newIndex = Math.min(index + 1, messages!.length - 1);
           setFocusedItemIndex(newIndex);
+          messagesRef.current[newIndex]?.focus();
           break;
         case 'Home':
           newIndex = 0;
           setFocusedItemIndex(newIndex);
+          messagesRef.current[newIndex]?.focus();
           break;
         case 'End':
           newIndex = messages!.length - 1;
           setFocusedItemIndex(newIndex);
+          messagesRef.current[newIndex]?.focus();
           break;
         default: {
           break;
         }
       }
 
-      messagesRef.current[newIndex]?.focus();
       return;
     },
     [messages, focusedItemIndex]
@@ -198,7 +201,12 @@ export const MessagesControl: MessagesControl = ({ renderMessage }) => {
                 <Timestamp>{formatDate(message.timestamp)}</Timestamp>
               </HeaderContainer>
               <MessageControl message={message} />
-              <ActionsBarControl message={message} />
+              {message.role === 'assistant' ? (
+                <ActionsBarControl
+                  message={message}
+                  focusable={focusedItemIndex === index}
+                />
+              ) : null}
             </MessageContainer>
           </RoleContext.Provider>
         )

--- a/packages/react-ai/src/components/AIConversation/views/Controls/MessagesControl.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/MessagesControl.tsx
@@ -79,13 +79,58 @@ export const MessagesControl: MessagesControl = ({
   variant = 'borderless',
 }) => {
   const messages = React.useContext(MessagesContext);
+  const messagesRef = React.useRef<(HTMLDivElement | null)[]>([]);
+
+  const [focusedItemIndex, setFocusedItemIndex] = React.useState(
+    messages ? messages.length - 1 : 0
+  );
+  const handleFocus = (index: number) => setFocusedItemIndex(index);
+
+  const onKeyDown = React.useCallback(
+    (index: number, { key }: React.KeyboardEvent<HTMLDivElement>) => {
+      let newIndex = focusedItemIndex;
+      switch (key) {
+        case 'ArrowUp':
+          newIndex = Math.max(0, index - 1);
+          setFocusedItemIndex(newIndex);
+          break;
+        case 'ArrowDown':
+          newIndex = Math.min(index + 1, messages!.length - 1);
+          setFocusedItemIndex(newIndex);
+          break;
+        case 'Home':
+          newIndex = 0;
+          setFocusedItemIndex(newIndex);
+          break;
+        case 'End':
+          newIndex = messages!.length - 1;
+          setFocusedItemIndex(newIndex);
+          break;
+        default: {
+          break;
+        }
+      }
+
+      messagesRef.current[newIndex]?.focus();
+      return;
+    },
+    [messages, focusedItemIndex]
+  );
+
   return (
     <Layout>
       {messages?.map((message, index) =>
         renderMessage ? (
           renderMessage(message)
         ) : (
-          <Container data-testid={`message`} key={`message-${index}`}>
+          <Container
+            data-testid={`message`}
+            key={`message-${index}`}
+            tabIndex={focusedItemIndex === index ? 0 : -1}
+            onFocus={() => handleFocus(index)}
+            onKeyDown={(event) => onKeyDown(index, event)}
+            ref={(el) => (messagesRef.current[index] = el)}
+          >
             <HeaderContainer>
               <AvatarControl message={message} />
               <Separator />

--- a/packages/react-ai/src/components/AIConversation/views/Controls/__tests__/MessagesControl.spec.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/__tests__/MessagesControl.spec.tsx
@@ -134,7 +134,7 @@ describe('MessagesControl', () => {
     const avatarElements = screen.getAllByTestId('avatar');
     const actionElements = screen.getAllByRole('button');
     expect(avatarElements).toHaveLength(3);
-    expect(actionElements).toHaveLength(3);
+    expect(actionElements).toHaveLength(2);
   });
 
   it('renders a MessagesControl element with a custom renderMessage function', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Added keyboard navigation to mimic Facebook Messenger and other chat applications
- Tabbing through the component only hits the most recent message and it's action buttons
- Once focused on a message, arrow navigation up and down goes to other messages
- Also set autofocus to the input area

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
