### PR TITLE
docs: StorageManager prop corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,8 @@ You should open an issue to discuss your pull request, unless it's a trivial cha
 
 1. Fork & Clone this repo (Make sure to disable associated GitHub Actions. In fork go to Settings > Actions > General > Disable actions > save)
 1. [`nvm install`](https://github.com/nvm-sh/nvm)
-1. [`nvm use`](https://github.com/nvm-sh/nvm)
+1. [`nvm use`](https://github.com/nvm-sh/nvm) (uses `.nvmrc` to use supported Node version)
+1. `yarn install`
 1. `yarn setup`
 1. Within your fork, create a new branch based on the issue you're addressing, e.g. `git checkout -b angular/remove-browser-module`
 1. Commit your code using [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/#summary), e.g. `git commit -m "chore: remove browser module"`.

--- a/docs/src/pages/[platform]/connected-components/storage/storagemanager/props.ts
+++ b/docs/src/pages/[platform]/connected-components/storage/storagemanager/props.ts
@@ -83,7 +83,7 @@ export const STORAGE_MANAGER = [
     name: `processFile?`,
     description:
       'Called immediately before uploading a file to allow you to edit the key or the file itself. The function can return synchronously or return a promise.',
-    type: `(params: {key: string, file: Blob}) => Promise<{key: string, file: Blob} & Record<string, any>> | {key: string, file: Blob} & Record<string, string>;`,
+    type: `(params: {key: string, file: File}) => Promise<{key: string, file: File} & Record<string, any>> | {key: string, file: File} & Record<string, string>;`,
   },
   {
     name: `defaultFiles?`,


### PR DESCRIPTION
#### Description of changes

Corrected the type of the `file` argument of tthe `processFile` callback in `StorageManager`: it was listed as `Blob`, and should be `File`.

Also updated `CONTRIBUTING.md` to add the necessary `yarn install` step and explained why `nvm use` is valuable.

#### Description of how you validated changes

I was not actually able to build or run the docs; the instructions in the [Local Development Guides](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md#local-development-guides) are insufficient.  I waded through many issues, but finally had to give up for now...I'll take a look at that another time and if I fix it, I'll submit a PR for that doc update.

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
