### PR TITLE
 style: Added a missing period for Japanese translation (Email verification)

### DIFF
--- a/packages/ui/src/i18n/dictionaries/authenticator/ja.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/ja.ts
@@ -26,7 +26,7 @@ export const jaDict: AuthenticatorDictionary = {
   'Enter your Username': 'ユーザー名を入力 ',
   'Forgot your password?': 'パスワードを忘れましたか？ ',
   'Hide password': 'パスワードを非表示',
-  'It may take a minute to arrive': '到着するまでに 1 分かかることがあります。',
+  'It may take a minute to arrive.': '到着するまでに 1 分かかることがあります。',
   Loading: 'ロード中',
   'New password': '新しいパスワード',
   or: '又は',


### PR DESCRIPTION
There is a typo within email verification screen.

#### Description of changes

English message: Your code is on the way. To login, enter the code we email to email address. It may take a minute to arrive.

Current: ログインするには、メールに記載されたコードを入力してください。送信先: email address. 到着するまでに１分かかることがあります。.

Fix to: ログインするには、メールに記載されたコードを入力してください。送信先: email address. 到着するまでに１分かかることがあります。

#### Issue #, if available
NA

#### Description of how you validated changes


#### Checklist
- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
