### PR TITLE
style: Added a missing period for Japanese translation (Email verification)

### DIFF
--- a/packages/ui/src/i18n/dictionaries/authenticator/ja.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/ja.ts
@@ -26,7 +26,7 @@ export const jaDict: AuthenticatorDictionary = {
   'Enter your Username': 'ユーザー名を入力 ',
   'Forgot your password?': 'パスワードを忘れましたか？ ',
   'Hide password': 'パスワードを非表示',
-  'It may take a minute to arrive': '到着するまでに 1 分かかることがあります。',
+  'It may take a minute to arrive.': '到着するまでに 1 分かかることがあります',
   Loading: 'ロード中',
   'New password': '新しいパスワード',
   or: '又は',
@@ -74,8 +74,6 @@ export const jaDict: AuthenticatorDictionary = {
   'Invalid password format': 'パスワードの形式が無効です ',
   'Invalid phone number format':
     '不正な電話番号の形式です。\n+12345678900 の形式で入力してください',
-  'It may take a minute to arrive.':
-    'コードを受信するまで数分かかる場合があります。',
   'Lost your code? ': 'コードを失くしましたか？',
   'New Password': '新しいパスワード',
   'No account? ': 'アカウントが無いとき ',

--- a/packages/ui/src/i18n/dictionaries/authenticator/ja.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/ja.ts
@@ -26,7 +26,7 @@ export const jaDict: AuthenticatorDictionary = {
   'Enter your Username': 'ユーザー名を入力 ',
   'Forgot your password?': 'パスワードを忘れましたか？ ',
   'Hide password': 'パスワードを非表示',
-  'It may take a minute to arrive.': '到着するまでに 1 分かかることがあります',
+  'It may take a minute to arrive.': '到着するまでに 1 分かかることがあります。',
   Loading: 'ロード中',
   'New password': '新しいパスワード',
   or: '又は',


### PR DESCRIPTION
There is a typo within email verification screen.
Also there is another translation with the same line. (It may take a minute to arrive.)

Description of changes
Change 1:
English message: Your code is on the way. To login, enter the code we email to email address. It may take a minute to arrive.

Current: ログインするには、メールに記載されたコードを入力してください。送信先: email address. 到着するまでに１分かかることがあります。.

Fix to: ログインするには、メールに記載されたコードを入力してください。送信先: email address. 到着するまでに１分かかることがあります。

Change 2:
Removed following line (77-78)
````
 'It may take a minute to arrive.':
    'コードを受信するまで数分かかる場合があります。',
````

Issue #, if available
NA

Description of how you validated changes
Checklist
 Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
 PR description included
 PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
 If this change should result in a version bump, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to docs, e2e, examples, or other private packages.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.