### PR TITLE
chore(storage-browser): point aws-amplify deps at storage-browser tag

### DIFF
--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@angular/core": ">= 14.0.0",
-    "aws-amplify": "^6.3.2"
+    "aws-amplify": "storage-browser"
   },
   "dependencies": {
     "@aws-amplify/ui": "6.0.17",

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -49,7 +49,7 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },

--- a/packages/react-core-auth/package.json
+++ b/packages/react-core-auth/package.json
@@ -40,7 +40,7 @@
     "xstate": "^4.33.6"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "react": "^16.14.0 || ^17.0 || ^18.0"
   },
   "sideEffects": false

--- a/packages/react-core-notifications/package.json
+++ b/packages/react-core-notifications/package.json
@@ -39,7 +39,7 @@
     "@aws-amplify/ui-react-core": "3.0.17"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "react": "^16.14.0 || ^17.0 || ^18.0"
   },
   "sideEffects": false

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -47,7 +47,7 @@
     "xstate": "^4.33.6"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "react": "^16.14.0 || ^17.0 || ^18.0"
   },
   "sideEffects": false

--- a/packages/react-geo/package.json
+++ b/packages/react-geo/package.json
@@ -47,13 +47,13 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
-    "@aws-amplify/geo": "^3.0.31",
-    "aws-amplify": "^6.3.2",
+    "@aws-amplify/geo": "storage-browser",
+    "aws-amplify": "storage-browser",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },
   "devDependencies": {
-    "@aws-amplify/geo": "^3.0.31",
+    "@aws-amplify/geo": "storage-browser",
     "@types/mapbox__mapbox-gl-draw": "^1.3.3"
   },
   "sideEffects": [

--- a/packages/react-liveness/package.json
+++ b/packages/react-liveness/package.json
@@ -42,7 +42,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },

--- a/packages/react-native-auth/package.json
+++ b/packages/react-native-auth/package.json
@@ -34,7 +34,7 @@
     "qrcode": "1.5.0"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "react": "^18",
     "react-native": "^0.70 || ^0.71 || ^0.72"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -34,7 +34,7 @@
     "@aws-amplify/ui-react-core-notifications": "2.0.17"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "react-native": "^0.70 || ^0.71 || ^0.72 || ^0.73 || ^0.74",
     "react-native-safe-area-context": "^4.2.5"
   },

--- a/packages/react-notifications/package.json
+++ b/packages/react-notifications/package.json
@@ -45,7 +45,7 @@
     "tinycolor2": "1.4.2"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -48,7 +48,7 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,7 +60,7 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,7 +50,7 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "xstate": "^4.33.6"
   },
   "peerDependenciesMeta": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -65,7 +65,7 @@
     "vite-jest": "^0.1.4"
   },
   "peerDependencies": {
-    "aws-amplify": "^6.3.2",
+    "aws-amplify": "storage-browser",
     "vue": "^3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -528,10 +528,10 @@
     rxjs "^7.8.1"
     ulid "^2.3.0"
 
-"@aws-amplify/geo@^3.0.31":
-  version "3.0.40"
-  resolved "https://registry.npmjs.org/@aws-amplify/geo/-/geo-3.0.40.tgz#f5d350ba405ce58ca9c3e5583424a06eec593409"
-  integrity sha512-4iDTcO1rflawjKxkdZOEqcjxwfxcaBKON7za+0py6TxoB/sUMAVRyoJ+lW+SaU1nDnNrTrYhSYIdHJ1WKPeR0w==
+"@aws-amplify/geo@storage-browser":
+  version "3.0.40-storage-browser.08ef01b.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/geo/-/geo-3.0.40-storage-browser.08ef01b.0.tgz#ffd3f5b04c8de46c6b37d5932b887a28370c4aeb"
+  integrity sha512-PcHUtLfWAG6AHNxd/CLz6nkR/VMPMA4MYBrNJFpjpA+1ag7weJSY5cBmBJEqGNLw57PXrwDa9mVFb+RpD7axaw==
   dependencies:
     "@aws-sdk/client-location" "3.398.0"
     "@turf/boolean-clockwise" "6.5.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Point `aws-amplify` peerDeps to "storage-browser" to resolve dep conflicts during install of `@aws-amplify/ui-react-storage@storage-browser` tagged version
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
NA
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
