### PR TITLE
chore(storage-browser): use getUrl to download

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Download.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Download.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
-import { useAction } from '../../context/actions';
+import { downloadAction } from '../../context/actions';
 import { StorageBrowserElements } from '../../context/elements';
 import { CLASS_BASE } from '../constants';
+import { useDataState } from '@aws-amplify/ui-react-core';
 
 const { Button: ButtonElement, Icon: IconElement } = StorageBrowserElements;
 
@@ -11,7 +12,7 @@ const BLOCK_NAME = `${CLASS_BASE}__download`;
 export interface DownloadControl<
   T extends StorageBrowserElements = StorageBrowserElements,
 > {
-  (props: { key: string }): React.JSX.Element;
+  (props: { fileKey: string }): React.JSX.Element;
   Button: T['Button'];
   Icon: T['Icon'];
 }
@@ -42,18 +43,39 @@ const DownloadButton: typeof ButtonElement = React.forwardRef(
   }
 );
 
-export const DownloadControl: DownloadControl = ({ key }) => {
-  const [, handleDownload] = useAction({
-    type: 'DOWNLOAD',
+function download(fileName: string, url: string) {
+  const a = document.createElement('a');
+
+  a.href = url;
+  a.download = fileName;
+
+  document.body.appendChild(a);
+
+  a.click();
+
+  document.body.removeChild(a);
+}
+
+export const DownloadControl: DownloadControl = ({ fileKey }) => {
+  const [{ data }, handleDownload] = useDataState(downloadAction, {
+    signedUrl: '',
   });
+
+  const { signedUrl } = data;
+
+  useEffect(() => {
+    if (signedUrl && signedUrl !== '') {
+      download(fileKey, signedUrl);
+    }
+  }, [signedUrl, fileKey]);
 
   return (
     <DownloadButton
-      onClick={() =>
+      onClick={() => {
         handleDownload({
-          key: key,
-        })
-      }
+          key: fileKey,
+        });
+      }}
     >
       <DownloadIcon />
     </DownloadButton>

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
@@ -279,7 +279,12 @@ export const LocationDetailViewTable = (): JSX.Element => {
         ) {
           return new Date(row[column.key]).toLocaleString();
         } else if (column.key === ('download' as keyof LocationItem)) {
-          return <DownloadControl key={row.key} />;
+          return (
+            <DownloadControl
+              key={`${index}-${column.key}-${row.key}`}
+              fileKey={row.key}
+            />
+          );
         } else {
           return row[column.key];
         }

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
@@ -279,12 +279,7 @@ export const LocationDetailViewTable = (): JSX.Element => {
         ) {
           return new Date(row[column.key]).toLocaleString();
         } else if (column.key === ('download' as keyof LocationItem)) {
-          return (
-            <DownloadControl
-              key={`${index}-${column.key}-${row.key}`}
-              fileKey={row.key}
-            />
-          );
+          return <DownloadControl fileKey={row.key} />;
         } else {
           return row[column.key];
         }

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Download.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Download.spec.tsx
@@ -21,18 +21,6 @@ const config = {
 
 const Provider = createProvider({ config });
 
-const mockResponse = jest.fn();
-Object.defineProperty(window, 'location', {
-  value: {
-    hash: {
-      endsWith: mockResponse,
-      includes: mockResponse,
-    },
-    assign: mockResponse,
-  },
-  writable: true,
-});
-
 describe('DownloadControl', () => {
   it('renders the DownloadControl', async () => {
     await waitFor(() => {

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Download.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Download.spec.tsx
@@ -45,6 +45,8 @@ describe('DownloadControl', () => {
   });
 
   it('calls getUrl onClick', async () => {
+    // @TODO: mock location correctly so when the
+    // click for the link to download happens, it doesn't console.error
     const user = userEvent.setup();
 
     getUrlSpy.mockResolvedValueOnce({

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Download.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Download.spec.tsx
@@ -1,23 +1,12 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as StorageModule from 'aws-amplify/storage';
-import * as ControlsModule from '../../../context/controls/';
 
 import createProvider from '../../../createProvider';
 import { DownloadControl } from '../Download';
 
-const useControlSpy = jest.spyOn(ControlsModule, 'useControl');
-const downloadSpy = jest.spyOn(StorageModule, 'downloadData');
-
-const handleUpdateControlState = jest.fn();
-const controlState = {
-  location: {
-    scope: 's3://test-bucket/*',
-    permission: 'READ',
-    type: 'BUCKET',
-  },
-  history: ['test-bucket'],
-};
+const getUrlSpy = jest.spyOn(StorageModule, 'getUrl');
 
 const listLocations = jest.fn(() =>
   Promise.resolve({ locations: [], nextToken: undefined })
@@ -30,23 +19,27 @@ const config = {
   registerAuthListener: jest.fn(),
 };
 
-useControlSpy.mockReturnValue([controlState, handleUpdateControlState]);
-
 const Provider = createProvider({ config });
 
-describe('DownloadControl', () => {
-  beforeEach(() => {
-    useControlSpy.mockClear();
-    downloadSpy.mockClear();
-    handleUpdateControlState.mockClear();
-  });
+const mockResponse = jest.fn();
+Object.defineProperty(window, 'location', {
+  value: {
+    hash: {
+      endsWith: mockResponse,
+      includes: mockResponse,
+    },
+    assign: mockResponse,
+  },
+  writable: true,
+});
 
+describe('DownloadControl', () => {
   it('renders the DownloadControl', async () => {
     await waitFor(() => {
       expect(
         render(
           <Provider>
-            <DownloadControl key="" />
+            <DownloadControl fileKey="" />
           </Provider>
         ).container
       ).toBeDefined();
@@ -63,22 +56,30 @@ describe('DownloadControl', () => {
     expect(icon).toHaveAttribute('aria-hidden', 'true');
   });
 
-  it('calls downloadData onClick', async () => {
-    // @ts-expect-error
-    downloadSpy.mockResolvedValueOnce({ key: 'a_key' });
+  it('calls getUrl onClick', async () => {
+    const user = userEvent.setup();
 
-    await waitFor(() => {
-      render(
-        <Provider>
-          <DownloadControl key="" />
-        </Provider>
-      );
-      const button = screen.getByRole('button', {
-        name: 'Download item',
-      });
-      fireEvent.click(button);
+    getUrlSpy.mockResolvedValueOnce({
+      url: new URL('https://docs.amplify.aws/'),
+      expiresAt: new Date(),
     });
 
-    expect(downloadSpy).toHaveBeenCalled();
+    render(
+      <Provider>
+        <DownloadControl fileKey="" />
+      </Provider>
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Download item',
+    });
+
+    act(() => {
+      user.click(button);
+    });
+
+    await waitFor(() => {
+      expect(getUrlSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/__tests__/downloadAction.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/__tests__/downloadAction.spec.tsx
@@ -1,28 +1,30 @@
 import * as StorageModule from 'aws-amplify/storage';
 import { downloadAction } from '../downloadAction';
 
-const downloadSpy = jest.spyOn(StorageModule, 'downloadData');
+const getUrlSpy = jest.spyOn(StorageModule, 'getUrl');
 const config = {
   bucket: 'bucket',
   credentialsProvider: jest.fn(),
   region: 'region',
 };
-const initialValue = { key: '' };
+const initialValue = { signedUrl: '' };
 
 describe('downloadAction', () => {
   beforeEach(() => {
-    downloadSpy.mockClear();
+    getUrlSpy.mockClear();
   });
 
   it('returns the expected output in the happy path', async () => {
-    // @ts-expect-error
-    downloadSpy.mockResolvedValueOnce({ key: 'a_key' });
+    getUrlSpy.mockResolvedValueOnce({
+      url: new URL('https://docs.amplify.aws/'),
+      expiresAt: new Date(),
+    });
 
-    const { key } = await downloadAction(initialValue, {
+    const { signedUrl } = await downloadAction(initialValue, {
       config,
       key: 'a_prefix',
     });
 
-    expect(key).toEqual('a_prefix');
+    expect(signedUrl).toEqual('https://docs.amplify.aws/');
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/actions.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/actions.tsx
@@ -9,7 +9,6 @@ import {
   ActionState,
   createActionStateContext,
 } from './createActionStateContext';
-import { downloadAction } from './downloadAction';
 
 import { createFolderAction } from './createFolderAction';
 import { listLocationItemsAction } from './listLocationItemsAction';
@@ -34,14 +33,12 @@ export const ERROR_MESSAGE =
 
 export const DEFAULT_ACTIONS = {
   CREATE_FOLDER: createFolderAction,
-  DOWNLOAD: downloadAction,
   LIST_LOCATION_ITEMS: listLocationItemsAction,
 };
 
 export const INITIAL_VALUE = {
   CREATE_FOLDER: { result: undefined },
   LIST_LOCATION_ITEMS: { result: [], nextToken: undefined },
-  DOWNLOAD: { key: '' },
 };
 
 const [ActionStateProvider, useActionState] = createActionStateContext(

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/downloadAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/downloadAction.ts
@@ -27,6 +27,7 @@ export async function downloadAction(
 
     return { signedUrl: signedUrl.url.toString() };
   } catch (e) {
+    // @TODO: update UI to let user know that the file no longer exists?
     return Promise.reject(e);
   }
 }

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/downloadAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/downloadAction.ts
@@ -1,8 +1,8 @@
-import { downloadData } from 'aws-amplify/storage';
+import { getUrl } from 'aws-amplify/storage';
 
 import { DownloadActionInput, DownloadActionOutput } from '../types';
 
-export function downloadAction(
+export async function downloadAction(
   _: DownloadActionOutput,
   input: DownloadActionInput
 ): Promise<DownloadActionOutput> {
@@ -15,12 +15,18 @@ export function downloadAction(
 
   const bucket = bucketName && region ? { bucketName, region } : undefined;
 
-  downloadData({
-    path,
-    options: {
-      bucket,
-      locationCredentialsProvider: credentialsProvider,
-    },
-  });
-  return Promise.resolve({ key: path });
+  try {
+    const signedUrl = await getUrl({
+      path,
+      options: {
+        bucket,
+        locationCredentialsProvider: credentialsProvider,
+        validateObjectExistence: true,
+      },
+    });
+
+    return { signedUrl: signedUrl.url.toString() };
+  } catch (e) {
+    return Promise.reject(e);
+  }
 }

--- a/packages/react-storage/src/components/StorageBrowser/context/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/types.ts
@@ -113,5 +113,5 @@ export interface DownloadActionInput {
 }
 
 export interface DownloadActionOutput {
-  key: string;
+  signedUrl: string;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Use `getUrl` to create a signed url and download the file when clicked

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
