### PR TITLE
fix(storage-browser): export additional types to prevent portability …

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -25,7 +25,7 @@ export interface StorageBrowser<T extends StorageBrowserElements> {
   Provider: (props: { children?: React.ReactNode }) => React.JSX.Element;
 }
 
-interface ResolvedStorageBrowserElements<
+export interface ResolvedStorageBrowserElements<
   T extends Partial<StorageBrowserElements>,
 > extends MergeBaseElements<StorageBrowserElements, T> {}
 

--- a/packages/react-storage/src/components/StorageBrowser/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/index.ts
@@ -1,6 +1,9 @@
+export { StorageBrowserElements } from './context/elements';
 export {
   createStorageBrowser,
   CreateStorageBrowserInput,
+  StorageBrowser,
+  ResolvedStorageBrowserElements,
 } from './createStorageBrowser';
 export {
   createAmplifyAuthAdapter,

--- a/packages/react-storage/src/components/index.ts
+++ b/packages/react-storage/src/components/index.ts
@@ -6,7 +6,10 @@ export {
   CreateManagedAuthAdapterInput,
   createStorageBrowser,
   CreateStorageBrowserInput,
+  ResolvedStorageBrowserElements,
+  StorageBrowser,
   StorageBrowserAuthAdapter,
+  StorageBrowserElements,
 } from './StorageBrowser';
 export { StorageImage, StorageImageProps } from './StorageImage';
 export {

--- a/packages/react-storage/src/index.ts
+++ b/packages/react-storage/src/index.ts
@@ -11,10 +11,13 @@ export {
   FileListFooterProps,
   // @TODO: temporary exports, should be exported from
   // '@aws-amplify/ui-react-storage/create-storage-browser'
-  createStorageBrowser,
-  CreateStorageBrowserInput,
   createAmplifyAuthAdapter,
   createManagedAuthAdapter,
   CreateManagedAuthAdapterInput,
+  createStorageBrowser,
+  CreateStorageBrowserInput,
+  ResolvedStorageBrowserElements,
+  StorageBrowser,
   StorageBrowserAuthAdapter,
+  StorageBrowserElements,
 } from './components';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Expose `createStorageBrowser` and `StorageBrowser` related interfaces to fix type portability issues in consuming projects
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`npm pack` and install in test app
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
