### PR TITLE
Feat(react-core): Updates useIsSignedIn data 

### DIFF
--- a/examples/next/pages/ui/components/authenticator/use-is-signed-in/index.page.tsx
+++ b/examples/next/pages/ui/components/authenticator/use-is-signed-in/index.page.tsx
@@ -12,7 +12,7 @@ export default function AuthenticatorWithUseIsSignedIn() {
   const signedInState = useIsSignedIn();
   return signedInState.isLoading ? (
     <p>loading</p>
-  ) : signedInState.data.isSignedIn ? (
+  ) : signedInState.data ? (
     <button
       onClick={() => {
         signOut();

--- a/packages/react-core/src/hooks/__tests__/useIsSignedIn.test.ts
+++ b/packages/react-core/src/hooks/__tests__/useIsSignedIn.test.ts
@@ -13,19 +13,19 @@ const MOCK_SUCCESS: GetCurrentUserOutput = {
   userId: '123',
 };
 const EXPECTED_LOADING_STATE = {
-  data: { isSignedIn: false },
+  data: false,
   hasError: false,
   isLoading: true,
   message: undefined,
 };
 const EXPECTED_ERROR_STATE = {
-  data: { isSignedIn: false },
+  data: false,
   hasError: true,
   isLoading: false,
   message: 'Authorization error',
 };
 const EXPECTED_ACCEPTED_STATE = {
-  data: { isSignedIn: true },
+  data: true,
   hasError: false,
   isLoading: false,
   message: undefined,

--- a/packages/react-core/src/hooks/useIsSignedIn.ts
+++ b/packages/react-core/src/hooks/useIsSignedIn.ts
@@ -3,23 +3,20 @@ import { Hub, HubCallback } from '@aws-amplify/core';
 import { useEffect } from 'react';
 import useDataState, { DataState } from './useDataState';
 
-const action = async (
-  _: { isSignedIn: boolean },
-  input: { setState?: boolean }
-) => {
+const action = async (_: boolean, input: { setState?: boolean }) => {
   try {
     await getCurrentUser();
-    return { isSignedIn: true };
+    return true;
   } catch (error) {
     if (input?.setState) {
-      return { isSignedIn: false };
+      return false;
     }
     throw error;
   }
 };
 
-export default function useIsSignedIn(): DataState<{ isSignedIn: boolean }> {
-  const [state, handler] = useDataState(action, { isSignedIn: false });
+export default function useIsSignedIn(): DataState<boolean> {
+  const [state, handler] = useDataState(action, false);
 
   useEffect(() => {
     handler();

--- a/packages/react/src/components/Authenticator/FederatedIdentities/context/elements/IconElement.tsx
+++ b/packages/react/src/components/Authenticator/FederatedIdentities/context/elements/IconElement.tsx
@@ -1,7 +1,7 @@
 import {
   defineBaseElement,
   withBaseElementProps,
-} from '@aws-amplify/ui-react-core/dist/types/elements';
+} from '@aws-amplify/ui-react-core/elements';
 import React from 'react';
 import { FederatedProvider } from '@aws-amplify/ui';
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This is a simple PR that changes the type of useIsSignedIn's data from {isSignedIn: boolean} to just a boolean.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Used example app with new data state and re-ran unit test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
