### PR TITLE
fix(storage-browser): update locations loading init to use refresh flag

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Controller.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Controller.tsx
@@ -10,7 +10,7 @@ export function Controller(): null {
   const [, handleListLocations] = useLocationsData();
 
   React.useEffect(() => {
-    handleListLocations({ options: { pageSize: 1000, reset: true } });
+    handleListLocations({ options: { pageSize: 1000, refresh: true } });
   }, [handleListLocations]);
 
   return null;

--- a/packages/react-storage/src/components/StorageBrowser/__tests__/Controller.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/__tests__/Controller.spec.tsx
@@ -97,7 +97,7 @@ describe('Controller', () => {
 
     expect(handleListLocations).toHaveBeenCalledTimes(1);
     expect(handleListLocations).toHaveBeenCalledWith({
-      options: { pageSize: 1000, reset: true },
+      options: { pageSize: 1000, refresh: true },
     });
     expect(updatedHandleListLocations).not.toHaveBeenCalled();
 
@@ -107,7 +107,7 @@ describe('Controller', () => {
     expect(handleListLocations).toHaveBeenCalledTimes(1);
     expect(updatedHandleListLocations).toHaveBeenCalledTimes(1);
     expect(updatedHandleListLocations).toHaveBeenCalledWith({
-      options: { pageSize: 1000, reset: true },
+      options: { pageSize: 1000, refresh: true },
     });
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fix issue with locations loading always resetting to the default state
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
