### PR TITLE
chore(storage-browser): adds theme-able Cancel button

### DIFF
--- a/examples/next/pages/ui/components/storage/storage-browser/default-auth/custom-elements.tsx
+++ b/examples/next/pages/ui/components/storage/storage-browser/default-auth/custom-elements.tsx
@@ -39,8 +39,6 @@ const Button = React.forwardRef<HTMLButtonElement>(function Button(props, ref) {
           ref={ref}
         />
       );
-    case 'action-select-toggle':
-    case 'exit':
     case 'message-dismiss':
       return (
         <_Button
@@ -51,7 +49,10 @@ const Button = React.forwardRef<HTMLButtonElement>(function Button(props, ref) {
           ref={ref}
         />
       );
+    case 'action-select-toggle':
+    case 'cancel':
     case 'download':
+    case 'exit':
     case 'navigate':
     case 'refresh':
     case 'sort':

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Cancel.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Cancel.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { withBaseElementProps } from '@aws-amplify/ui-react-core/elements';
+
+import type { OmitElements } from '../types';
+import { StorageBrowserElements } from '../../context/elements';
+import { CLASS_BASE } from '../constants';
+
+const { Button, Icon } = StorageBrowserElements;
+
+const BLOCK_NAME = `${CLASS_BASE}__cancel`;
+
+export interface _CancelControl<
+  T extends StorageBrowserElements = StorageBrowserElements,
+> {
+  (): React.JSX.Element;
+  Button: T['Button'];
+  Icon: T['Icon'];
+}
+
+export interface CancelControl<
+  T extends StorageBrowserElements = StorageBrowserElements,
+> extends OmitElements<_CancelControl<T>, 'Button'> {
+  (props: { onClick?: () => void; ariaLabel?: string }): React.JSX.Element;
+}
+
+const CancelIcon = withBaseElementProps(Icon, {
+  className: `${BLOCK_NAME}__icon`,
+  variant: 'cancel',
+});
+
+const CancelButton = withBaseElementProps(Button, {
+  className: `${BLOCK_NAME}`,
+  variant: 'cancel',
+});
+
+export const CancelControl: CancelControl = ({ onClick, ariaLabel }) => (
+  <CancelButton onClick={onClick} aria-label={ariaLabel}>
+    <CancelIcon />
+  </CancelButton>
+);

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Controls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Controls.tsx
@@ -1,6 +1,7 @@
 import { StorageBrowserElements } from '../../context/elements';
 
 import { ActionSelectControl } from './ActionSelect';
+import { CancelControl } from './Cancel';
 import { DownloadControl } from './Download';
 import { ExitControl } from './Exit';
 import { MessageControl } from './Message';
@@ -18,6 +19,7 @@ export interface Controls<
   T extends StorageBrowserElements = StorageBrowserElements,
 > {
   ActionSelect: ActionSelectControl<T>;
+  Cancel: CancelControl<T>;
   Download: DownloadControl<T>;
   Exit: ExitControl<T>;
   Message: MessageControl<T>;
@@ -35,6 +37,7 @@ export interface Controls<
 export const Controls: Controls = {
   Exit: ExitControl,
   ActionSelect: ActionSelectControl,
+  Cancel: CancelControl,
   Download: DownloadControl,
   Message: MessageControl,
   Paginate: PaginateControl,

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Cancel.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Cancel.spec.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CancelControl } from '../Cancel';
+
+describe('CancelControl', () => {
+  it('renders the CancelControl', () => {
+    const ariaLabel = 'Cancel file upload';
+
+    render(<CancelControl ariaLabel={ariaLabel} />);
+
+    const button = screen.getByRole('button', {
+      name: ariaLabel,
+    });
+
+    const icon = button.querySelector('svg');
+
+    expect(button).toBeInTheDocument();
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/index.ts
@@ -1,5 +1,6 @@
 export { ExitControl } from './Exit';
 export { ActionSelectControl } from './ActionSelect';
+export { CancelControl } from './Cancel';
 export { DownloadControl } from './Download';
 export { MessageControl } from './Message';
 export { NavigateControl, NavigateItem } from './Navigate';

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/UploadControls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/UploadControls.tsx
@@ -9,7 +9,7 @@ import { Column, RenderRowItem } from '../Controls/Table';
 
 import { CancelableTask, useHandleUpload } from './useHandleUpload';
 
-const { Exit, Primary, Summary, Table } = Controls;
+const { Cancel, Exit, Primary, Summary, Table } = Controls;
 
 const LOCATION_ACTION_VIEW_COLUMNS: Column<CancelableTask>[] = [
   {
@@ -43,7 +43,10 @@ const renderRowItem: RenderRowItem<CancelableTask> = (row, index) => {
             ) : column.key === 'progress' ? (
               <>{row.progress}</>
             ) : column.key === 'cancel' ? (
-              <button onClick={row.cancel}>Cancel</button>
+              <Cancel
+                onClick={row.cancel}
+                ariaLabel={`Cancel upload for ${row.key}`}
+              />
             ) : null}
           </Table.TableData>
         );

--- a/packages/react-storage/src/components/StorageBrowser/context/elements/definitions.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/elements/definitions.ts
@@ -35,6 +35,7 @@ type ButtonElementVariant =
   | 'action-select-item'
   | 'action-select-toggle'
   | 'action-submit'
+  | 'cancel'
   | 'download'
   | 'exit'
   | 'message-dismiss'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

This is used in the Upload controls table for cancelling an item you've selected to download. 

```
<button
  class="storage-browser__cancel"
  aria-label="Cancel upload for Screenshot 2024-08-13 at 3.36.21 PM.png"
>
  <svg
    aria-hidden="true"
    width="24"
    height="24"
    viewBox="0 -960 960 960"
    fill="none"
    xmlns="http://www.w3.org/2000/svg"
    class="storage-browser__cancel__icon"
  >
    <path
      d="m256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z"
      fill="currentColor"
    ></path>
  </svg>
</button>
```

<img width="872" alt="Screenshot 2024-08-13 at 5 23 01 PM" src="https://github.com/user-attachments/assets/4dc462d6-8e77-4bf5-8009-90d90af2647e">



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
