### PR TITLE
Feat storage browser/fix download managed auth

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Download.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Download.tsx
@@ -5,6 +5,7 @@ import { downloadAction } from '../../context/actions';
 import { StorageBrowserElements } from '../../context/elements';
 import { CLASS_BASE } from '../constants';
 import { useDataState } from '@aws-amplify/ui-react-core';
+import { useGetLocationConfig } from '../../context/config';
 
 const { Button, Icon } = StorageBrowserElements;
 
@@ -42,6 +43,9 @@ function download(fileName: string, url: string) {
 }
 
 export const DownloadControl: DownloadControl = ({ fileKey }) => {
+  const getConfig = useGetLocationConfig();
+  const { bucket: bucketName, credentialsProvider, region } = getConfig();
+
   const [{ data }, handleDownload] = useDataState(downloadAction, {
     signedUrl: '',
   });
@@ -59,6 +63,7 @@ export const DownloadControl: DownloadControl = ({ fileKey }) => {
       aria-label={`Download ${fileKey}`}
       onClick={() => {
         handleDownload({
+          config: { bucket: bucketName, credentialsProvider, region },
           key: fileKey,
         });
       }}

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Download.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Download.tsx
@@ -44,8 +44,6 @@ function download(fileName: string, url: string) {
 
 export const DownloadControl: DownloadControl = ({ fileKey }) => {
   const getConfig = useGetLocationConfig();
-  const { bucket: bucketName, credentialsProvider, region } = getConfig();
-
   const [{ data }, handleDownload] = useDataState(downloadAction, {
     signedUrl: '',
   });
@@ -63,7 +61,7 @@ export const DownloadControl: DownloadControl = ({ fileKey }) => {
       aria-label={`Download ${fileKey}`}
       onClick={() => {
         handleDownload({
-          config: { bucket: bucketName, credentialsProvider, region },
+          config: getConfig,
           key: fileKey,
         });
       }}

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Download.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Download.spec.tsx
@@ -4,9 +4,16 @@ import userEvent from '@testing-library/user-event';
 import * as StorageModule from 'aws-amplify/storage';
 
 import createProvider from '../../../createProvider';
+import * as ConfigModule from '../../../context/config';
+
 import { DownloadControl } from '../Download';
 
 const getUrlSpy = jest.spyOn(StorageModule, 'getUrl');
+
+const useGetLocationConfigSpy = jest.spyOn(
+  ConfigModule,
+  'useGetLocationConfig'
+);
 
 const listLocations = jest.fn(() =>
   Promise.resolve({ locations: [], nextToken: undefined })
@@ -22,6 +29,14 @@ const config = {
 const Provider = createProvider({ config });
 
 describe('DownloadControl', () => {
+  beforeEach(() => {
+    useGetLocationConfigSpy.mockReturnValue(() => ({
+      bucket: 'myBucket',
+      credentialsProvider: jest.fn(),
+      region: 'region',
+    }));
+  });
+
   it('renders the DownloadControl', async () => {
     const fileKey = 'test.jpg';
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Add `useGetLocationConfig` to `DownloadControl` so that config can be passed to `handleDownload` call to create the `getUrl` API call

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
