### PR TITLE
chore(storage-browser): fix list markup for Navigate and use aria-current

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -59,13 +59,10 @@ const NavigateButton = withBaseElementProps(Button, {
 });
 
 export const NavigateItem = (props: NavigateItemProps): React.JSX.Element => {
-  const { isCurrent } = props;
+  const { isCurrent, ...rest } = props;
   return (
     <NavigateItemContainer>
-      <NavigateButton
-        {...props}
-        aria-current={isCurrent ? 'page' : undefined}
-      />
+      <NavigateButton {...rest} aria-current={isCurrent ? 'page' : undefined} />
       {isCurrent ? null : <Separator />}
     </NavigateItemContainer>
   );

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -25,6 +25,7 @@ export interface NavigateControl<
 
 interface NavigateItemProps {
   children?: React.ReactNode;
+  isCurrent?: boolean;
   onClick?: () => void;
 }
 
@@ -44,6 +45,7 @@ const HOME_NAVIGATE_ITEM = 'Home';
 
 const Separator = withBaseElementProps(Span, {
   className: `${BLOCK_NAME}__separator`,
+  'aria-hidden': true,
   children: '/',
 });
 
@@ -56,11 +58,18 @@ const NavigateButton = withBaseElementProps(Button, {
   variant: 'navigate',
 });
 
-export const NavigateItem = (props: NavigateItemProps): React.JSX.Element => (
-  <NavigateItemContainer>
-    <NavigateButton {...props} />
-  </NavigateItemContainer>
-);
+export const NavigateItem = (props: NavigateItemProps): React.JSX.Element => {
+  const { isCurrent } = props;
+  return (
+    <NavigateItemContainer>
+      <NavigateButton
+        {...props}
+        aria-current={isCurrent ? 'page' : undefined}
+      />
+      {isCurrent ? null : <Separator />}
+    </NavigateItemContainer>
+  );
+};
 
 NavigateItem.Button = NavigateButton;
 NavigateItem.Separator = Separator;
@@ -113,11 +122,11 @@ export const NavigateControl: NavigateControl = (_props) => {
 
         return (
           <React.Fragment key={entry}>
-            <Separator />
             <NavigateItem
               onClick={() => {
                 handleUpdateState({ type: 'NAVIGATE', prefix: entry });
               }}
+              isCurrent={i === history.length - 1}
             >
               {displayValue}
             </NavigateItem>

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Navigate.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Navigate.spec.tsx
@@ -100,4 +100,20 @@ describe('NavigateControl', () => {
     expect(separators).toHaveLength(4);
     expect(separators[0]).toBeInTheDocument();
   });
+
+  it('applies aria-current to last element in the control and does not contain a separator', async () => {
+    render(
+      <ControlProvider>
+        <NavigateControl />
+      </ControlProvider>
+    );
+    const items = await screen.findAllByRole('listitem');
+    const lastItem = items[items.length - 1];
+    const lastSeparator = lastItem.querySelector(
+      '.storage-browser__navigate__separator'
+    );
+    const currentButton = lastItem.querySelector('button');
+    expect(currentButton).toHaveAttribute('aria-current', 'page');
+    expect(lastSeparator).toBeNull();
+  });
 });

--- a/packages/react-storage/src/styles/storage-browser.css
+++ b/packages/react-storage/src/styles/storage-browser.css
@@ -39,6 +39,7 @@
 }
 .storage-browser__navigate__item {
   display: flex;
+  align-items: center;
   gap: var(--storage-browser-gap);
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->


#### Description of changes

- Nests the Separator inside of the `<li>` so there is valid list markup
- Passes down an `isCurrent` prop to the last NavigateItem to properly apply aria-current to the button and not show the separator for the last item

<img width="722" alt="Screenshot 2024-08-13 at 7 57 07 PM" src="https://github.com/user-attachments/assets/10e5a5d2-5342-433b-b1c3-9501986e6aaf">


```
<nav aria-label="Breadcrumbs" class="storage-browser__navigate">
  <ol class="storage-browser__navigate__list">
    <li class="storage-browser__navigate__item">
      <button class="storage-browser__navigate__button">Home</button>
      <span class="storage-browser__navigate__separator" aria-hidden="true">/</span>
    </li>
    <li class="storage-browser__navigate__item">
      <button class="storage-browser__navigate__button">fileuploaderbucket121216-dev/public</button>
      <span class="storage-browser__navigate__separator" aria-hidden="true">/</span>
    </li>
    <li class="storage-browser__navigate__item">
      <button class="storage-browser__navigate__button" aria-current="page">Blueberry/Banana</button>
    </li>
  </ol>
</nav>
```

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
