### PR TITLE
fix(storage-browser): set flag to specify when to download file so that it only happens on click

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Download.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Download.tsx
@@ -48,13 +48,16 @@ export const DownloadControl: DownloadControl = ({ fileKey }) => {
     signedUrl: '',
   });
 
+  const [shouldDownload, setShouldDownload] = React.useState(false);
+
   const { signedUrl } = data;
 
   useEffect(() => {
-    if (signedUrl && signedUrl !== '') {
+    if (shouldDownload && signedUrl && signedUrl !== '') {
       download(fileKey, signedUrl);
+      setShouldDownload(false);
     }
-  }, [signedUrl, fileKey]);
+  }, [signedUrl, fileKey, shouldDownload]);
 
   return (
     <DownloadButton
@@ -64,6 +67,7 @@ export const DownloadControl: DownloadControl = ({ fileKey }) => {
           config: getConfig,
           key: fileKey,
         });
+        setShouldDownload(true);
       }}
     >
       <DownloadIcon />


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Noticed a bug where a download would automatically happen when you navigate between prefixes. Added a flag to make sure that the download only happens on a click.


**Steps to reproduce bug**:
1. Navigate to a nested prefix with files to download
2. Download a file
3. Navigate up a prefix using the navigate breadcrumbs
4. Observe that the file that was just downloaded, gets downloaded again
   - I think this might be happening because of the `useEffect` in the `DownloadControl` component and how it will call the function to download if the`signedUrl` is valid. When we first download a file, it saves the `signedUrl` in its state and so navigating will cause each of the `DownloadControls` to re-render which causes it to download the file again since it has a valid `signedUrl`?
   
   
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
