### PR TITLE
chore(storage-browser): Add file/folder icons to table, some css cleanup

### DIFF
--- a/examples/next/pages/ui/components/storage/storage-browser/default-auth/custom-elements.tsx
+++ b/examples/next/pages/ui/components/storage/storage-browser/default-auth/custom-elements.tsx
@@ -49,18 +49,26 @@ const Button = React.forwardRef<HTMLButtonElement>(function Button(props, ref) {
           ref={ref}
         />
       );
+    case 'navigate':
+      return (
+        <_Button
+          {...props}
+          size="small"
+          paddingInline="xs"
+          variation="link"
+          ref={ref}
+        />
+      );
     case 'action-select-toggle':
     case 'cancel':
     case 'download':
     case 'exit':
-    case 'navigate':
     case 'refresh':
     case 'sort':
-      return <_Button {...props} size="small" variation="link" ref={ref} />;
     case 'paginate-current':
     case 'paginate-next':
     case 'paginate-previous':
-      return <_Button {...props} size="small" ref={ref} />;
+      return <_Button {...props} size="small" variation="link" ref={ref} />;
     case 'table-data':
       return (
         <_Button
@@ -128,7 +136,7 @@ const TableHead = React.forwardRef<HTMLTableSectionElement>(
 
 const TableData = React.forwardRef<HTMLTableCellElement>(
   function TableData(props, ref) {
-    return <_TableCell {...props} ref={ref} />;
+    return <_TableCell padding="xxxs" {...props} ref={ref} />;
   }
 );
 
@@ -140,7 +148,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement>(
 
 const TableHeader = React.forwardRef<HTMLTableCellElement>(
   function TableHeader(props, ref) {
-    return <_TableCell as="th" {...props} ref={ref} />;
+    return <_TableCell padding="xxxs" as="th" {...props} ref={ref} />;
   }
 );
 

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
@@ -17,56 +17,74 @@ const {
   TableRow: BaseTableRow,
   Button,
   Icon,
+  View,
 } = StorageBrowserElements;
 
-const BLOCK_NAME = 'table';
+const BLOCK_NAME = `${CLASS_BASE}__table`;
 
 const Table = withBaseElementProps(BaseTable, {
-  className: `${CLASS_BASE}__${BLOCK_NAME}`,
+  className: `${BLOCK_NAME}`,
 });
 
 const TableBody = withBaseElementProps(BaseTableBody, {
-  className: `${CLASS_BASE}__${BLOCK_NAME}__body`,
+  className: `${BLOCK_NAME}__body`,
 });
 
 const TableHead = withBaseElementProps(BaseTableHead, {
-  className: `${CLASS_BASE}__${BLOCK_NAME}__head`,
+  className: `${BLOCK_NAME}__head`,
 });
 
 const TableHeader = withBaseElementProps(BaseTableHeader, {
-  className: `${CLASS_BASE}__${BLOCK_NAME}__header`,
+  className: `${BLOCK_NAME}__header`,
 });
 
 const TableHeaderButton = withBaseElementProps(Button, {
-  className: `${CLASS_BASE}__${BLOCK_NAME}__header-button`,
+  className: `${BLOCK_NAME}__header__button`,
   variant: 'sort',
 });
 
 const TableData = withBaseElementProps(BaseTableData, {
-  className: `${CLASS_BASE}__${BLOCK_NAME}__data`,
+  className: `${BLOCK_NAME}__data`,
 });
 
 const TableDataButton = withBaseElementProps(Button, {
-  className: `${CLASS_BASE}__${BLOCK_NAME}__data-button`,
+  className: `${BLOCK_NAME}__data__button`,
   variant: 'table-data',
 });
 
+const TableDataContainer = withBaseElementProps(View, {
+  className: `${BLOCK_NAME}__data__container`,
+});
+
+const TableDataIcon: typeof Icon = React.forwardRef(
+  function TableDataIcon(props, ref) {
+    const { variant } = props;
+    return variant ? (
+      <Icon
+        {...props}
+        className={props.className ?? `${BLOCK_NAME}__data__icon`}
+        variant={variant}
+        ref={ref}
+      />
+    ) : null;
+  }
+);
 const TableRow = withBaseElementProps(BaseTableRow, {
-  className: `${CLASS_BASE}__${BLOCK_NAME}__row`,
+  className: `${BLOCK_NAME}__row`,
 });
 
 const SortIndeterminateIcon = withBaseElementProps(Icon, {
-  className: `${CLASS_BASE}__${BLOCK_NAME}__sort-icon--indeterminate`,
+  className: `${BLOCK_NAME}__sort-icon--indeterminate`,
   variant: 'sort-indeterminate',
 });
 
 // const SortAscendingIcon = withBaseElementProps(Icon, {
-//   className: `${CLASS_BASE}__${BLOCK_NAME}__sort-icon--ascending`,
+//   className: `${BLOCK_NAME}__sort-icon--ascending`,
 //   variant: 'sort-ascending',
 // });
 
 // const SortDescendingIcon = withBaseElementProps(Icon, {
-//   className: `${CLASS_BASE}__${BLOCK_NAME}__sort-icon--descending`,
+//   className: `${BLOCK_NAME}__sort-icon--descending`,
 //   variant: 'sort-descending',
 // });
 
@@ -191,7 +209,7 @@ export const LocationsViewTable = (): JSX.Element => {
                     }}
                     type="button"
                   >
-                    {row.scope}
+                    <TableDataIcon variant="folder" /> {row.scope}
                   </TableDataButton>
                 ) : (
                   <>{row[column.key]}</>
@@ -258,7 +276,14 @@ export const LocationDetailViewTable = (): JSX.Element => {
         } else if (column.key === ('download' as keyof LocationItem)) {
           return <DownloadControl fileKey={row.key} />;
         } else {
-          return row[column.key];
+          return (
+            <>
+              {column.key === 'key' && row.type === 'FILE' ? (
+                <TableDataIcon variant="file" />
+              ) : null}
+              {row[column.key]}
+            </>
+          );
         }
       };
 
@@ -282,10 +307,12 @@ export const LocationDetailViewTable = (): JSX.Element => {
                     }}
                     key={`${index}-${row.key}`}
                   >
-                    {row.key}
+                    <TableDataIcon variant="folder" /> {row.key}
                   </TableDataButton>
                 ) : (
-                  <>{parseTableData(row, column)}</>
+                  <TableDataContainer>
+                    {parseTableData(row, column)}
+                  </TableDataContainer>
                 )}
               </TableData>
             );

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
@@ -21,6 +21,7 @@ const {
 } = StorageBrowserElements;
 
 const BLOCK_NAME = `${CLASS_BASE}__table`;
+const ICON_CLASS = `${CLASS_BASE}__table__data__icon`;
 
 const Table = withBaseElementProps(BaseTable, {
   className: `${BLOCK_NAME}`,
@@ -56,19 +57,6 @@ const TableDataContainer = withBaseElementProps(View, {
   className: `${BLOCK_NAME}__data__container`,
 });
 
-const TableDataIcon: typeof Icon = React.forwardRef(
-  function TableDataIcon(props, ref) {
-    const { variant } = props;
-    return variant ? (
-      <Icon
-        {...props}
-        className={props.className ?? `${BLOCK_NAME}__data__icon`}
-        variant={variant}
-        ref={ref}
-      />
-    ) : null;
-  }
-);
 const TableRow = withBaseElementProps(BaseTableRow, {
   className: `${BLOCK_NAME}__row`,
 });
@@ -209,10 +197,10 @@ export const LocationsViewTable = (): JSX.Element => {
                     }}
                     type="button"
                   >
-                    <TableDataIcon variant="folder" /> {row.scope}
+                    <Icon className={ICON_CLASS} variant="folder" /> {row.scope}
                   </TableDataButton>
                 ) : (
-                  <>{row[column.key]}</>
+                  <TableDataContainer>{row[column.key]}</TableDataContainer>
                 )}
               </TableData>
             ))}
@@ -279,7 +267,7 @@ export const LocationDetailViewTable = (): JSX.Element => {
           return (
             <>
               {column.key === 'key' && row.type === 'FILE' ? (
-                <TableDataIcon variant="file" />
+                <Icon className={ICON_CLASS} variant="file" />
               ) : null}
               {row[column.key]}
             </>
@@ -307,7 +295,7 @@ export const LocationDetailViewTable = (): JSX.Element => {
                     }}
                     key={`${index}-${row.key}`}
                   >
-                    <TableDataIcon variant="folder" /> {row.key}
+                    <Icon className={ICON_CLASS} variant="folder" /> {row.key}
                   </TableDataButton>
                 ) : (
                   <TableDataContainer>

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
@@ -21,7 +21,7 @@ const {
 } = StorageBrowserElements;
 
 const BLOCK_NAME = `${CLASS_BASE}__table`;
-const ICON_CLASS = `${CLASS_BASE}__table__data__icon`;
+const ICON_CLASS = `${BLOCK_NAME}__data__icon`;
 
 const Table = withBaseElementProps(BaseTable, {
   className: `${BLOCK_NAME}`,
@@ -53,8 +53,8 @@ const TableDataButton = withBaseElementProps(Button, {
   variant: 'table-data',
 });
 
-const TableDataContainer = withBaseElementProps(View, {
-  className: `${BLOCK_NAME}__data__container`,
+const TableDataText = withBaseElementProps(View, {
+  className: `${BLOCK_NAME}__data__text`,
 });
 
 const TableRow = withBaseElementProps(BaseTableRow, {
@@ -200,7 +200,7 @@ export const LocationsViewTable = (): JSX.Element => {
                     <Icon className={ICON_CLASS} variant="folder" /> {row.scope}
                   </TableDataButton>
                 ) : (
-                  <TableDataContainer>{row[column.key]}</TableDataContainer>
+                  <TableDataText>{row[column.key]}</TableDataText>
                 )}
               </TableData>
             ))}
@@ -298,9 +298,7 @@ export const LocationDetailViewTable = (): JSX.Element => {
                     <Icon className={ICON_CLASS} variant="folder" /> {row.key}
                   </TableDataButton>
                 ) : (
-                  <TableDataContainer>
-                    {parseTableData(row, column)}
-                  </TableDataContainer>
+                  <TableDataText>{parseTableData(row, column)}</TableDataText>
                 )}
               </TableData>
             );

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
@@ -17,7 +17,7 @@ const {
   TableRow: BaseTableRow,
   Button,
   Icon,
-  View,
+  Span,
 } = StorageBrowserElements;
 
 const BLOCK_NAME = `${CLASS_BASE}__table`;
@@ -53,7 +53,7 @@ const TableDataButton = withBaseElementProps(Button, {
   variant: 'table-data',
 });
 
-const TableDataText = withBaseElementProps(View, {
+const TableDataText = withBaseElementProps(Span, {
   className: `${BLOCK_NAME}__data__text`,
 });
 

--- a/packages/react-storage/src/styles/storage-browser.css
+++ b/packages/react-storage/src/styles/storage-browser.css
@@ -1,4 +1,5 @@
 .storage-browser {
+  --storage-browser-gap-small: 0.375rem;
   --storage-browser-gap: 0.6rem;
   display: grid;
   gap: var(--storage-browser-gap);
@@ -28,6 +29,10 @@
   justify-self: flex-end;
 }
 
+.storage-browser__paginate__list {
+  gap: var(--storage-browser-gap);
+}
+
 .storage-browser__navigate__list,
 .storage-browser__paginate__list {
   list-style: none;
@@ -35,12 +40,14 @@
   padding: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: var(--storage-browser-gap);
+}
+.storage-browser__navigate__list {
+  gap: var(--storage-browser-gap-small);
 }
 .storage-browser__navigate__item {
   display: flex;
   align-items: center;
-  gap: var(--storage-browser-gap);
+  gap: var(--storage-browser-gap-small);
 }
 
 .storage-browser__paginate__item {
@@ -134,9 +141,17 @@
   text-align: start;
 }
 
-.storage-browser__table__header-button {
+.storage-browser__table__header__button,
+.storage-browser__table__data__button,
+.storage-browser__table__data__container {
+  padding: var(--storage-browser-gap-small);
   display: flex;
-  justify-content: center;
+  align-items: center;
+  gap: var(--storage-browser-gap-small);
+}
+
+.storage-browser__table__data__icon {
+  flex: 0 0 auto;
 }
 
 .storage-browser__action-menu {

--- a/packages/react-storage/src/styles/storage-browser.css
+++ b/packages/react-storage/src/styles/storage-browser.css
@@ -143,7 +143,7 @@
 
 .storage-browser__table__header__button,
 .storage-browser__table__data__button,
-.storage-browser__table__data__container {
+.storage-browser__table__data__text {
   padding: var(--storage-browser-gap-small);
   display: flex;
   align-items: center;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- Adds File/Folder icons depending on the key/row type to LocationsView and LocationDetailView tables
- Adds a container for table cells. Since buttons inside of the table have padding, developers can use this to make a consistent padding around cells that don't have a button (so now the icons can line up)
- Added var(--storage-browser-gap-small) to use in cases like the Navigate item gap, and smaller gaps between text and icons.
- Some adjustments to the next-example custom UI

**LocationsView**
<img width="1587" alt="Screenshot 2024-08-14 at 12 48 22 PM" src="https://github.com/user-attachments/assets/32677baa-9206-4339-8deb-77f606d6ce4f">

**LocationDetailView**
<img width="1586" alt="Screenshot 2024-08-14 at 12 48 41 PM" src="https://github.com/user-attachments/assets/1dce7f30-4711-44db-9c86-5d3fbf7975ec">



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
