### PR TITLE
fix: add style-dictionary dependency to docs and react-native package

### DIFF
--- a/.changeset/tame-toys-agree.md
+++ b/.changeset/tame-toys-agree.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react-native': patch
+---
+
+adding style-dictionary to ui-react-native dependencies

--- a/docs/package.json
+++ b/docs/package.json
@@ -53,7 +53,8 @@
     "remark-mdx-images": "^1.0.2",
     "rimraf": "^3.0.2",
     "sass": "^1.43.4",
-    "slugify": "^1.6.3"
+    "slugify": "^1.6.3",
+    "style-dictionary": "3.9.1"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "@aws-amplify/ui": "6.1.0",
     "@aws-amplify/ui-react-core": "3.0.18",
-    "@aws-amplify/ui-react-core-notifications": "2.0.18"
+    "@aws-amplify/ui-react-core-notifications": "2.0.18",
+    "style-dictionary": "3.9.1"
   },
   "peerDependencies": {
     "aws-amplify": "^6.3.2",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

`style-dictionary` is a required dependency of docs/ and packages/react-native/

Previously, this dependency had been indirectly provided via ui/, which caused regression when `style-dictionary` was reclassified as a dev dependency in ui/

These changes seek to resolve the issue by adding `style-dictionary` as a dependency to docs/ and packages/react-native/

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/5590

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

This was confirmed by validating attached issue using latest version of `@aws-amplify/ui-react-native`, followed by validating the resolution of the issue by rolling back to a version of `@aws-amplify/ui-react-native` in which the dependency was provided.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
