### PR TITLE
fix(react-native): bump rn peerDep range

### DIFF
--- a/.changeset/few-geese-exist.md
+++ b/.changeset/few-geese-exist.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-native": patch
+---
+
+fix(react-native): bump rn peerDep range

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "aws-amplify": "^6.3.2",
-    "react-native": "^0.70 || ^0.71 || ^0.72 || ^0.73 || ^0.74",
+    "react-native": "^0.70 || ^0.71 || ^0.72 || ^0.73 || ^0.74 || ^0.75",
     "react-native-safe-area-context": "^4.2.5"
   },
   "files": [


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update _@aws-amplify/ui-react-native_ peerDeps to support `react-native@^0.75`
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Verified Authenticator federated sign in on iOS using a vanilla RN example app
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
