### PR TITLE
fix(storage-browser): Message dismiss icon

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Message.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Message.tsx
@@ -27,7 +27,7 @@ const DismissButton = withBaseElementProps(Button, {
 const DismissIcon = withBaseElementProps(IconElement, {
   'aria-hidden': true,
   className: `${BLOCK_NAME}__dismiss__icon`,
-  variant: 'cancel',
+  variant: 'dismiss',
 });
 
 export const MessageDismissControl: MessageDismissControl = () => (

--- a/packages/react-storage/src/components/StorageBrowser/context/elements/IconElement.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/elements/IconElement.tsx
@@ -14,6 +14,7 @@ export type IconVariant =
   | 'action-error'
   | 'cancel'
   | 'create-folder'
+  | 'dismiss'
   | 'download'
   | 'error'
   | 'exit'
@@ -55,6 +56,9 @@ export const DEFAULT_ICON_PATHS: Record<IconVariant, string> = {
   // "Create New Folder"
   'create-folder':
     'M560-320h80v-80h80v-80h-80v-80h-80v80h-80v80h80v80ZM160-160q-33 0-56.5-23.5T80-240v-480q0-33 23.5-56.5T160-800h240l80 80h320q33 0 56.5 23.5T880-640v400q0 33-23.5 56.5T800-160H160Zm0-80h640v-400H447l-80-80H160v480Zm0 0v-480 480Z',
+  // "Close"
+  dismiss:
+    'm256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z',
   // "Download" icon
   download:
     'M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58-200 200ZM240-160q-33 0-56.5-23.5T160-240v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-160H240Z',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

The dismiss icon got lost in the shuffle when we switched the <- Back and Cancel icons around.

**before**
<img width="705" alt="Screenshot 2024-08-19 at 12 57 16 PM" src="https://github.com/user-attachments/assets/dead2948-96d7-4fe2-a0f5-a5d66ed3198c">

**after**
<img width="684" alt="Screenshot 2024-08-19 at 12 59 41 PM" src="https://github.com/user-attachments/assets/9ddf28e2-ae4e-42b3-bf28-66d3f056484c">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
