### PR TITLE
chore(FileSelect): add useFileSelect

### DIFF
--- a/packages/react/__tests__/__snapshots__/exports.ts.snap
+++ b/packages/react/__tests__/__snapshots__/exports.ts.snap
@@ -82,6 +82,7 @@ exports[`@aws-amplify/ui-react/internal exports should match snapshot 1`] = `
 [
   "AlertIcon",
   "Field",
+  "FileSelect",
   "FilterChildren",
   "IconAdd",
   "IconCheck",
@@ -109,6 +110,7 @@ exports[`@aws-amplify/ui-react/internal exports should match snapshot 1`] = `
   "useColorMode",
   "useDeprecationWarning",
   "useDropZone",
+  "useFileSelect",
   "useIcons",
   "useStorageURL",
   "useThemeBreakpoint",

--- a/packages/react/src/components/FileSelect/FileSelect.tsx
+++ b/packages/react/src/components/FileSelect/FileSelect.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+
+/**
+ * @internal @unstable
+ */
+export interface FileSelectProps {
+  accept?: string;
+  multiple?: boolean;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  type?: 'file' | 'folder';
+}
+
+/**
+ * @internal @unstable
+ */
+export interface FileSelectOptions
+  extends Omit<FileSelectProps, 'onChange' | 'type'> {}
+
+type HandleSelect = (
+  type: 'file' | 'folder',
+  options?: FileSelectOptions
+) => void;
+
+/**
+ * @internal @unstable
+ */
+export type UseFileSelect = [
+  fileSelect: React.ReactNode,
+  handleSelect: HandleSelect,
+];
+
+const TEST_ID = 'amplify-file-select';
+export const DEFAULT_PROPS = {
+  style: { display: 'none' },
+  type: 'file',
+  'data-testid': TEST_ID,
+};
+
+/**
+ * @internal @unstable
+ */
+export const FileSelect = React.forwardRef<HTMLInputElement, FileSelectProps>(
+  function FileSelect({ multiple = true, type = 'file', ...props }, ref) {
+    return (
+      <input
+        {...DEFAULT_PROPS}
+        {...(type === 'folder' ? { webkitdirectory: '' } : undefined)}
+        {...props}
+        multiple={multiple}
+        ref={ref}
+      />
+    );
+  }
+);
+
+/**
+ * @internal @unstable
+ *
+ * @usage
+ * ```tsx
+ *  function MyUploadButton() {
+ *    const [files, setFiles] = React.useState<File[]>([]);
+ *    const [fileSelect, handleSelect] = useFileSelect(setFiles);
+ *    return (
+ *      <>
+ *        {fileSelect}
+ *        <Button
+ *          onClick={() => {
+ *            handleSelect('file');
+ *          }}
+ *        />
+ *      </>
+ *    );
+ *  }
+ * ```
+ */
+export const useFileSelect = (
+  onSelect?: (files: File[]) => void
+): UseFileSelect => {
+  const [inputProps, setInputProps] = React.useState<
+    FileSelectProps | undefined
+  >(undefined);
+
+  const ref = React.useRef<HTMLInputElement>(null);
+  const handleSelect = React.useRef<HandleSelect>((type, options) => {
+    setInputProps({ type, ...options });
+  }).current;
+
+  React.useEffect(() => {
+    if (inputProps) {
+      ref.current?.click();
+    }
+
+    return () => {
+      setInputProps(undefined);
+    };
+  }, [inputProps]);
+
+  const fileSelect = (
+    <FileSelect
+      {...inputProps}
+      onChange={({ target }) => {
+        onSelect?.([...(target.files ?? [])]);
+      }}
+      ref={ref}
+    />
+  );
+
+  return [fileSelect, handleSelect];
+};

--- a/packages/react/src/components/FileSelect/__tests__/FileSelect.spec.tsx
+++ b/packages/react/src/components/FileSelect/__tests__/FileSelect.spec.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import { useFileSelect } from '../FileSelect';
+
+const TestComponent = ({
+  onSelect,
+  type,
+}: {
+  onSelect: (files: File[]) => void;
+  type: 'file' | 'folder';
+}) => {
+  const [fileSelect, handleSelect] = useFileSelect(onSelect);
+
+  return (
+    <>
+      {fileSelect}
+      <button
+        onClick={() => {
+          handleSelect(type);
+        }}
+      />
+    </>
+  );
+};
+
+describe('useFileSelect', () => {
+  it.each(['file', 'folder'] as const)(
+    'behaves as expected with a %s type as expected',
+    async (type) => {
+      const user = userEvent.setup();
+      const onSelect = jest.fn();
+
+      render(<TestComponent onSelect={onSelect} type={type} />);
+
+      const button = screen.getByRole('button');
+
+      await act(async () => {
+        await user.click(button);
+      });
+
+      const input: HTMLInputElement | null = screen.queryByTestId(
+        'amplify-file-select'
+      );
+
+      expect(input).toBeDefined();
+      expect(input).not.toBeNull();
+
+      const file = new File([], 'file one');
+      await user.upload(input!, file);
+
+      expect(input?.files?.[0]).toStrictEqual(file);
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+      expect(onSelect).toHaveBeenCalledWith([file]);
+    }
+  );
+});

--- a/packages/react/src/components/FileSelect/index.ts
+++ b/packages/react/src/components/FileSelect/index.ts
@@ -1,0 +1,7 @@
+export {
+  FileSelect,
+  FileSelectOptions,
+  FileSelectProps,
+  useFileSelect,
+  UseFileSelect,
+} from './FileSelect';

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -9,6 +9,14 @@ export { AlertIcon } from './primitives/Alert/AlertIcon';
 export * from './primitives/Icon/internal';
 export { useDropZone } from './primitives/DropZone/useDropZone';
 
+export {
+  FileSelect,
+  FileSelectOptions,
+  FileSelectProps,
+  useFileSelect,
+  UseFileSelect,
+} from './components/FileSelect';
+
 export { Field } from './primitives/Field';
 
 export { PrimitiveCatalog } from './PrimitiveCatalog';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add `FileSelect` component and `useFileSelect` utility

 ```tsx
  function MyUploadButton() {
    const [files, setFiles] = React.useState<File[]>([]);
    const [fileSelect, handleSelect] = useFileSelect(setFiles);
    return (
      <>
        {fileSelect}
        <Button
          onClick={() => {
            handleSelect('file');
          }}
        />
      </>
    );
  }
 ```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual testing
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
