### PR TITLE
chore(storage-browser): add sorting to locations view table

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
@@ -7,6 +7,14 @@ import { CLASS_BASE } from '../constants';
 import { useControl } from '../../context/controls';
 import { LocationAccess, LocationItem, Permission } from '../../context/types';
 import { useAction, useLocationsData } from '../../context/actions';
+import { compareStrings } from '../../context/controls/Table';
+
+export type SortDirection = 'ascending' | 'descending' | 'none';
+
+export type SortState<T> = {
+  selection: keyof T;
+  sortDirection: SortDirection;
+};
 
 const {
   Table: BaseTable,
@@ -93,21 +101,6 @@ const TableRow = withBaseElementProps(BaseTableRow, {
   className: `${BLOCK_NAME}__row`,
 });
 
-const SortIndeterminateIcon = withBaseElementProps(Icon, {
-  className: `${BLOCK_NAME}__sort-icon--indeterminate`,
-  variant: 'sort-indeterminate',
-});
-
-// const SortAscendingIcon = withBaseElementProps(Icon, {
-//   className: `${BLOCK_NAME}__sort-icon--ascending`,
-//   variant: 'sort-ascending',
-// });
-
-// const SortDescendingIcon = withBaseElementProps(Icon, {
-//   className: `${BLOCK_NAME}__sort-icon--descending`,
-//   variant: 'sort-descending',
-// });
-
 const LOCATION_VIEW_COLUMNS: Column<LocationAccess<Permission>>[] = [
   {
     header: 'Name',
@@ -157,17 +150,21 @@ export interface TableControl<
   <U>(props: TableControlProps<U>): React.JSX.Element;
 }
 
+export type RenderHeaderItem<T> = (column: Column<T>) => JSX.Element;
+
 export type RenderRowItem<T> = (row: T, index: number) => JSX.Element;
 
 interface TableControlProps<T> {
   data: T[];
   columns: Column<T>[];
+  renderHeaderItem: RenderHeaderItem<T>;
   renderRowItem: RenderRowItem<T>;
 }
 
 export const TableControl: TableControl = <U,>({
   data,
   columns,
+  renderHeaderItem,
   renderRowItem,
 }: TableControlProps<U>) => {
   const ariaLabel = 'Table';
@@ -175,34 +172,7 @@ export const TableControl: TableControl = <U,>({
   return (
     <Table aria-label={ariaLabel}>
       <TableHead>
-        <TableRow>
-          {columns?.map((column) =>
-            column.key === 'download' || column.key === 'cancel' ? (
-              <TableHeader
-                key={column.header}
-                aria-label={column.header}
-                variant={column.key}
-              ></TableHeader>
-            ) : (
-              <TableHeader
-                key={column.header}
-                variant={column.key as string}
-                aria-sort="none"
-              >
-                {/* Should all columns be sortable? */}
-
-                <TableHeaderButton
-                  onClick={() => {
-                    /* no op for now */
-                  }}
-                >
-                  {column.header}
-                  <SortIndeterminateIcon />
-                </TableHeaderButton>
-              </TableHeader>
-            )
-          )}
-        </TableRow>
+        <TableRow>{columns.map((column) => renderHeaderItem(column))}</TableRow>
       </TableHead>
 
       <TableBody>
@@ -215,12 +185,76 @@ export const TableControl: TableControl = <U,>({
 TableControl.TableRow = TableRow;
 TableControl.TableData = TableData;
 
+const LocationsViewColumnSortMap = {
+  scope: compareStrings,
+  type: compareStrings,
+  permission: compareStrings,
+};
+
 export const LocationsViewTable = (): JSX.Element => {
   const [{ data, isLoading }] = useLocationsData();
   const [, handleUpdateState] = useControl({ type: 'NAVIGATE' });
 
   const hasLocations = !!data.result?.length;
   const shouldRenderLocations = !hasLocations || isLoading;
+
+  const [compareFn, setCompareFn] = React.useState(() => compareStrings);
+  const [sortState, setSortState] = React.useState<
+    SortState<LocationAccess<Permission>>
+  >({
+    selection: 'scope',
+    sortDirection: 'ascending',
+  });
+
+  const { sortDirection, selection } = sortState;
+
+  const tableData =
+    sortDirection === 'ascending'
+      ? data.result.sort((a, b) => compareFn(a[selection], b[selection]))
+      : data.result.sort((a, b) => compareFn(b[selection], a[selection]));
+
+  const renderHeaderItem = React.useCallback(
+    (column: Column<LocationAccess<Permission>>) => {
+      // Defining this function inside the `LocationsViewTable` to get access
+      // to the current sort state
+      const { header, key } = column;
+
+      return (
+        <TableHeader
+          key={header}
+          aria-sort={selection === key ? sortDirection : 'none'}
+        >
+          <TableHeaderButton
+            onClick={() => {
+              setCompareFn(() => LocationsViewColumnSortMap[column.key]);
+
+              setSortState((prevState) => ({
+                selection: column.key,
+                sortDirection:
+                  prevState.sortDirection === 'ascending'
+                    ? 'descending'
+                    : 'ascending',
+              }));
+            }}
+          >
+            {column.header}
+            {selection === column.key ? (
+              <Icon
+                variant={
+                  sortDirection === 'none'
+                    ? 'sort-indeterminate'
+                    : `sort-${sortDirection}`
+                }
+              />
+            ) : (
+              <Icon variant="sort-indeterminate" />
+            )}
+          </TableHeaderButton>
+        </TableHeader>
+      );
+    },
+    [sortDirection, selection]
+  );
 
   // @TODO: This should be it's own component instead of using `useCallback`
   const renderRowItem: RenderRowItem<LocationAccess<Permission>> =
@@ -260,7 +294,8 @@ export const LocationsViewTable = (): JSX.Element => {
   ) : (
     <TableControl
       columns={LOCATION_VIEW_COLUMNS}
-      data={data.result}
+      data={tableData}
+      renderHeaderItem={renderHeaderItem}
       renderRowItem={renderRowItem}
     />
   );
@@ -364,6 +399,7 @@ export const LocationDetailViewTable = (): JSX.Element => {
     <TableControl
       columns={LOCATION_DETAIL_VIEW_COLUMNS}
       data={data.result}
+      renderHeaderItem={() => <div></div>} // temporary
       renderRowItem={renderRowItem}
     />
   );

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
@@ -13,7 +13,7 @@ export type SortDirection = 'ascending' | 'descending' | 'none';
 
 export type SortState<T> = {
   selection: keyof T;
-  sortDirection: SortDirection;
+  direction: SortDirection;
 };
 
 const {
@@ -203,10 +203,10 @@ export const LocationsViewTable = (): JSX.Element => {
     SortState<LocationAccess<Permission>>
   >({
     selection: 'scope',
-    sortDirection: 'ascending',
+    direction: 'ascending',
   });
 
-  const { sortDirection, selection } = sortState;
+  const { direction: sortDirection, selection } = sortState;
 
   const tableData =
     sortDirection === 'ascending'
@@ -230,8 +230,8 @@ export const LocationsViewTable = (): JSX.Element => {
 
               setSortState((prevState) => ({
                 selection: column.key,
-                sortDirection:
-                  prevState.sortDirection === 'ascending'
+                direction:
+                  prevState.direction === 'ascending'
                     ? 'descending'
                     : 'ascending',
               }));

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Table.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Table.spec.tsx
@@ -99,14 +99,12 @@ describe('TableControl', () => {
     ];
 
     render(
-      <Provider>
-        <TableControl
-          data={locationItems}
-          columns={columns}
-          renderHeaderItem={renderHeaderItemSpy}
-          renderRowItem={renderRowItemSpy}
-        />
-      </Provider>
+      <TableControl
+        data={locationItems}
+        columns={columns}
+        renderHeaderItem={renderHeaderItemSpy}
+        renderRowItem={renderRowItemSpy}
+      />
     );
 
     expect(renderHeaderItemSpy).toHaveBeenCalled();

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Table.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Table.spec.tsx
@@ -6,7 +6,12 @@ import * as ControlsModule from '../../../context/controls/';
 import * as ActionsModule from '../../../context/actions';
 import { LocationItem } from '../../../context/actions';
 
-import { LocationDetailViewTable, LocationsViewTable } from '../Table';
+import {
+  Column,
+  LocationDetailViewTable,
+  LocationsViewTable,
+  TableControl,
+} from '../Table';
 
 const useControlSpy = jest.spyOn(ControlsModule, 'useControl');
 const useActionSpy = jest.spyOn(ActionsModule, 'useAction');
@@ -78,6 +83,46 @@ describe('TableControl', () => {
     handleUpdateControlState.mockClear();
   });
 
+  it('calls renderHeaderItem and renderRowItem to render the TableControl', () => {
+    const renderHeaderItemSpy = jest.fn();
+    const renderRowItemSpy = jest.fn();
+
+    const columns: Column<LocationItem>[] = [
+      {
+        header: 'Name',
+        key: 'key',
+      },
+      {
+        header: 'Type',
+        key: 'type',
+      },
+    ];
+
+    render(
+      <Provider>
+        <TableControl
+          data={locationItems}
+          columns={columns}
+          renderHeaderItem={renderHeaderItemSpy}
+          renderRowItem={renderRowItemSpy}
+        />
+      </Provider>
+    );
+
+    expect(renderHeaderItemSpy).toHaveBeenCalled();
+    expect(renderRowItemSpy).toHaveBeenCalled();
+  });
+});
+
+describe('LocationsViewTable', () => {
+  beforeEach(() => {
+    useActionSpy.mockClear();
+    useControlSpy.mockClear();
+
+    handleUpdateActionState.mockClear();
+    handleUpdateControlState.mockClear();
+  });
+
   it('renders a Locations View table', async () => {
     await waitFor(() =>
       expect(
@@ -110,6 +155,16 @@ describe('TableControl', () => {
     await waitFor(() => {
       expect(handleUpdateActionState).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('LocationDetailViewTable', () => {
+  beforeEach(() => {
+    useActionSpy.mockClear();
+    useControlSpy.mockClear();
+
+    handleUpdateActionState.mockClear();
+    handleUpdateControlState.mockClear();
   });
 
   it('loads initial location items for a BUCKET location as expected', async () => {

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/UploadControls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/UploadControls.tsx
@@ -128,6 +128,7 @@ export const UploadControls = (): JSX.Element => {
       <Table
         data={tasks}
         columns={LOCATION_ACTION_VIEW_COLUMNS}
+        renderHeaderItem={() => <div></div>} // temporary
         renderRowItem={renderRowItem}
       />
     </>

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/__tests__/LocationsView.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/__tests__/LocationsView.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 import createProvider from '../../../createProvider';
+import * as ActionsModule from '../../../context/actions';
 
 import { LocationsView } from '..';
 
@@ -16,7 +17,16 @@ const config = {
 };
 const Provider = createProvider({ config });
 
+const useLocationsDataSpy = jest.spyOn(ActionsModule, 'useLocationsData');
+
+const handleListLocations = jest.fn();
+
 describe('LocationsListView', () => {
+  beforeEach(() => {
+    handleListLocations.mockClear();
+    useLocationsDataSpy.mockClear();
+  });
+
   it('renders a `LocationsListView`', async () => {
     await waitFor(() => {
       expect(
@@ -27,5 +37,36 @@ describe('LocationsListView', () => {
         ).container
       ).toBeDefined();
     });
+  });
+
+  it('renders a Locations View table', () => {
+    useLocationsDataSpy.mockReturnValue([
+      {
+        data: {
+          result: [
+            {
+              permission: 'READWRITE',
+              scope: 's3://test-bucket/*',
+              type: 'BUCKET',
+            },
+          ],
+          nextToken: undefined,
+        },
+        hasError: false,
+        isLoading: false,
+        message: undefined,
+      },
+      handleListLocations,
+    ]);
+
+    render(
+      <Provider>
+        <LocationsView />
+      </Provider>
+    );
+
+    const table = screen.getByRole('table');
+
+    expect(table).toBeDefined();
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Table/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Table/index.ts
@@ -1,1 +1,2 @@
 export { TableProvider, TableContext, TableStateContext } from './Table';
+export * from './sortCompareUtils';

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/Table/sortCompareUtils.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/Table/sortCompareUtils.ts
@@ -1,0 +1,17 @@
+export const compareStrings = (a: string, b: string): number => {
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  return a.localeCompare(b);
+};
+
+export const compareNumbers = (a: number, b: number): number => {
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  return a - b;
+};
+
+export const compareDates = (a: Date, b: Date): number => {
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  return a.getTime() - b.getTime();
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Splitting this up from https://github.com/aws-amplify/amplify-ui/pull/5583

- Add `sortCompareUtils.ts` to hold compare functions for sorting
- Update `LocationsViewTable` to have columns that sort the table
- Update `TableControl` to have `renderHeaderItem` to render the table header items

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
