### PR TITLE
fix: Use consistent spelling for E-Mail in german

### DIFF
--- a/packages/ui/src/i18n/dictionaries/authenticator/de.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/de.ts
@@ -21,7 +21,7 @@ export const deDict: AuthenticatorDictionary = {
   'Create Account': 'Account erstellen',
   'Creating Account': 'Account wird erstellt',
   'Dismiss alert': 'Warnung verwerfen',
-  Email: 'Email',
+  Email: 'E-Mail',
   'Enter your Birthdate': 'Geben Sie Ihr Geburtsdatum ein',
   'Enter your code': 'Geben Sie Ihren Code ein',
   'Enter your Confirmation Code': 'Geben Sie Ihren Bestätigungs-Code ein',
@@ -33,7 +33,7 @@ export const deDict: AuthenticatorDictionary = {
   'Enter your Nickname': 'Geben Sie Ihren Spitznamen ein',
   'Enter your Password': 'Geben Sie Ihr Passwort ein',
   'Enter your password': 'Geben Sie Ihr Passwort ein',
-  'Enter your email': 'Geben Sie Ihre e-mail ein',
+  'Enter your email': 'Geben Sie Ihre E-Mail ein',
   'Enter your phone number': 'Geben Sie Ihre Telefonnummer ein',
   'Enter your Preferred Username': 'Geben Sie Ihren bevorzugten Benutzernamen ein',
   'Enter your username': 'Geben Sie Ihren Benutzernamen ein',
@@ -68,7 +68,7 @@ export const deDict: AuthenticatorDictionary = {
   Username: 'Benutzername',
   'Verify Contact': 'Kontakt verifizieren',
   Verify: 'Verifizieren',
-  'We Emailed You': 'Email wurde versendet',
+  'We Emailed You': 'E-Mail wurde versendet',
   'We Sent A Code': 'Wir haben einen Code gesendet',
   'We Texted You': 'Wir haben Ihnen eine SMS gesendet',
   'Your code is on the way. To log in, enter the code we emailed to':
@@ -80,7 +80,7 @@ export const deDict: AuthenticatorDictionary = {
 
   // Additional translations provided by customers
   'An account with the given email already exists.':
-    'Ein Account mit dieser Email existiert bereits.',
+    'Ein Account mit dieser E-Mail existiert bereits.',
   'Confirm a Code': 'Code bestätigen',
   'Confirm Sign In': 'Anmeldung bestätigen',
   'Create account': 'Hier registrieren',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Use consistent spelling for E-Mail in the german translation.  Before the change, it was sometimes EMail, Email or e-mail, but only "E-Mail" is correct.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
