### PR TITLE
chore(storage-browser): fix various default styles

### DIFF
--- a/packages/react-storage/src/styles/storage-browser.css
+++ b/packages/react-storage/src/styles/storage-browser.css
@@ -145,6 +145,7 @@
   grid-row-start: 5;
   grid-column: 1 / -1;
   table-layout: fixed;
+  width: 100%;
 }
 
 .storage-browser__table__header--type,
@@ -180,6 +181,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  text-align: start;
 }
 
 .storage-browser__table__data__icon,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes some table styling when just using the default styles.

**before (stretched and weird buttons)**

<img width="1084" alt="Screenshot 2024-08-20 at 4 28 21 PM" src="https://github.com/user-attachments/assets/11014638-06e0-4f82-ad95-83e437208a10">

**after**
<img width="1081" alt="Screenshot 2024-08-20 at 4 28 57 PM" src="https://github.com/user-attachments/assets/c9c0f9e2-5dcf-4db7-a70a-e4051769f2d8">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
