### PR TITLE
chore(storage-browser): add ACTIONS_DEFAULT unit tests

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/context/controls/locationActions/__tests__/__snapshots__/defaults.spec.ts.snap
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/locationActions/__tests__/__snapshots__/defaults.spec.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default actions contains the expected properties 1`] = `
+{
+  "CREATE_FOLDER": {
+    "handler": [Function],
+    "options": {
+      "disable": [Function],
+      "displayName": "Create Folder",
+      "hide": [Function],
+      "icon": <Icon
+        variant="create-folder"
+      />,
+    },
+  },
+  "UPLOAD_FILES": {
+    "handler": [Function],
+    "options": {
+      "disable": [Function],
+      "displayName": "Upload Files",
+      "hide": [Function],
+      "icon": <Icon
+        variant="upload-file"
+      />,
+      "selectionData": "file",
+    },
+  },
+  "UPLOAD_FOLDER": {
+    "handler": [Function],
+    "options": {
+      "disable": [Function],
+      "displayName": "Upload Folder",
+      "hide": [Function],
+      "icon": <Icon
+        variant="upload-folder"
+      />,
+      "selectionData": "folder",
+    },
+  },
+}
+`;

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/locationActions/__tests__/defaults.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/locationActions/__tests__/defaults.spec.ts
@@ -1,0 +1,29 @@
+import { ACTIONS_DEFAULT, OPTIONS_DEFAULT } from '../defaults';
+import { LocationActionOptions } from '../types';
+
+describe('default actions', () => {
+  it('contains the expected properties', () => {
+    expect(ACTIONS_DEFAULT).toMatchSnapshot();
+  });
+
+  it('has the expected behavior for the values of default options', () => {
+    const disable = OPTIONS_DEFAULT?.disable as Exclude<
+      LocationActionOptions['disable'],
+      undefined | boolean
+    >;
+
+    expect(typeof disable).toBe('function');
+    expect(disable([])).toBe(false);
+    expect(disable([{ type: 'FOLDER', key: 'something' }])).toBe(true);
+
+    const hide = OPTIONS_DEFAULT?.hide as Exclude<
+      LocationActionOptions['hide'],
+      undefined | boolean
+    >;
+
+    expect(typeof hide).toBe('function');
+    expect(hide('READWRITE')).toBe(false);
+    expect(hide('WRITE')).toBe(false);
+    expect(hide('READ')).toBe(true);
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/locationActions/defaults.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/locationActions/defaults.tsx
@@ -4,15 +4,19 @@ import { IconElement } from '../../elements/IconElement';
 import { TaskActionOutput, TaskActionInput } from '../../types';
 import { LocationAction } from './types';
 
+export const OPTIONS_DEFAULT: LocationAction['options'] = {
+  disable: (items) => !!items.length,
+  hide: (permission) => permission === 'READ',
+};
+
 const handler = (_: TaskActionInput): Promise<TaskActionOutput> =>
   Promise.resolve({ result: undefined });
 
 const CREATE_FOLDER: LocationAction = {
   handler,
   options: {
+    ...OPTIONS_DEFAULT,
     displayName: 'Create Folder',
-    disable: (items) => !!items.length,
-    hide: (permission) => permission === 'READ',
     icon: <IconElement variant="create-folder" />,
   },
 };
@@ -20,9 +24,8 @@ const CREATE_FOLDER: LocationAction = {
 const UPLOAD_FOLDER: LocationAction = {
   handler,
   options: {
-    disable: (items) => !!items.length,
+    ...OPTIONS_DEFAULT,
     displayName: 'Upload Folder',
-    hide: (permission) => permission === 'READ',
     icon: <IconElement variant="upload-folder" />,
     selectionData: 'folder',
   },
@@ -31,9 +34,8 @@ const UPLOAD_FOLDER: LocationAction = {
 const UPLOAD_FILES: LocationAction = {
   handler,
   options: {
-    disable: (items) => !!items.length,
+    ...OPTIONS_DEFAULT,
     displayName: 'Upload Files',
-    hide: (permission) => permission === 'READ',
     icon: <IconElement variant="upload-file" />,
     selectionData: 'file',
   },

--- a/packages/react-storage/src/components/StorageBrowser/context/controls/locationActions/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/controls/locationActions/types.ts
@@ -9,18 +9,20 @@ export type SelectionType =
   | ('file' | 'folder')
   | ['file' | 'folder', ...string[]];
 
+export interface LocationActionOptions<T = Permission> {
+  /**
+   * disable menu
+   */
+  disable?: boolean | ((selectedItems: LocationItem[]) => boolean);
+  displayName?: string;
+  hide?: boolean | ((permission: T) => boolean);
+  icon?: React.ReactNode | string;
+  selectionData?: SelectionType;
+}
+
 export interface LocationAction<T = Permission> {
   handler: PrefixTaskAction;
-  options?: {
-    /**
-     * disable menu
-     */
-    disable?: boolean | ((selectedItems: LocationItem[]) => boolean);
-    displayName?: string;
-    hide?: boolean | ((permission: T) => boolean);
-    icon?: React.ReactNode | string;
-    selectionData?: SelectionType;
-  };
+  options?: LocationActionOptions<T>;
 }
 
 export interface LocationActions<T = Permission> {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add unit tests for default `actions`
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
unit tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
