### PR TITLE
chore(storage-browser): remove old locations view table

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Table.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Table.spec.tsx
@@ -1,22 +1,15 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 import createProvider from '../../../createProvider';
 import * as ControlsModule from '../../../context/controls/';
 import * as ActionsModule from '../../../context/actions';
-import { LocationItem, Permission } from '../../../context/actions';
+import { LocationItem } from '../../../context/actions';
 
-import {
-  Column,
-  LocationDetailViewTable,
-  LocationsViewTable,
-  TableControl,
-} from '../Table';
-import { LocationAccess } from '../../../context/types';
+import { Column, LocationDetailViewTable, TableControl } from '../Table';
 
 const useControlSpy = jest.spyOn(ControlsModule, 'useControl');
 const useActionSpy = jest.spyOn(ActionsModule, 'useAction');
-const useLocations = jest.spyOn(ActionsModule, 'useLocationsData');
 
 const handleUpdateControlState = jest.fn();
 const controlState = {
@@ -112,101 +105,6 @@ describe('TableControl', () => {
 
     expect(renderHeaderItemSpy).toHaveBeenCalled();
     expect(renderRowItemSpy).toHaveBeenCalled();
-  });
-});
-
-describe('LocationsViewTable', () => {
-  beforeEach(() => {
-    useActionSpy.mockClear();
-    useControlSpy.mockClear();
-
-    handleUpdateActionState.mockClear();
-    handleUpdateControlState.mockClear();
-  });
-
-  it('renders a Locations View table', async () => {
-    await waitFor(() =>
-      expect(
-        render(
-          <Provider>
-            <LocationsViewTable />
-          </Provider>
-        ).container
-      ).toBeDefined()
-    );
-  });
-
-  it('does not load location items when location is not set', async () => {
-    useControlSpy.mockReturnValue([
-      { location: undefined, history: [], path: '' },
-      handleUpdateControlState,
-    ]);
-
-    useActionSpy.mockReturnValue([
-      { ...locationItemsState, data: { result: [], nextToken: undefined } },
-      handleUpdateActionState,
-    ]);
-
-    await waitFor(() => {
-      render(
-        <Provider>
-          <LocationDetailViewTable />
-        </Provider>
-      );
-    });
-
-    expect(handleUpdateActionState).not.toHaveBeenCalled();
-  });
-
-  it('sorts descending when sortDirection is descending', async () => {
-    const mockData: LocationAccess<Permission>[] = [
-      {
-        type: 'PREFIX',
-        permission: 'READWRITE',
-        scope: 's3://filebucket-dev/public/*',
-      },
-      {
-        type: 'PREFIX',
-        permission: 'READWRITE',
-        scope: 's3://filebucket-dev/private/*',
-      },
-      {
-        type: 'PREFIX',
-        permission: 'READWRITE',
-        scope: 's3://filebucket-dev/protected/*',
-      },
-    ];
-
-    const sortSpy = jest.spyOn(Array.prototype, 'sort');
-
-    useLocations.mockReturnValue([
-      {
-        data: {
-          result: mockData,
-          nextToken: undefined,
-        },
-        hasError: false,
-        isLoading: false,
-        message: undefined,
-      },
-      jest.fn(),
-    ]);
-
-    await waitFor(() => {
-      render(
-        <Provider>
-          <LocationsViewTable />
-        </Provider>
-      );
-    });
-
-    const nameColumn = screen.getByRole('button', { name: 'Name' });
-
-    expect(nameColumn).toBeDefined();
-
-    fireEvent.click(nameColumn);
-
-    expect(sortSpy).toHaveBeenCalled();
   });
 });
 

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/index.ts
@@ -10,9 +10,5 @@ export { RefreshControl } from './Refresh';
 export { SearchControl } from './Search';
 export { TargetControl } from './Target';
 export { TitleControl } from './Title';
-export {
-  TableControl,
-  LocationsViewTable,
-  LocationDetailViewTable,
-} from './Table';
+export { TableControl, LocationDetailViewTable } from './Table';
 export { Controls } from './Controls';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Remove old `LocationsVIewTable` component

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
