### PR TITLE
chore(storage-browser): use elementsDefault for managed-auth example

### DIFF
--- a/examples/next/pages/ui/components/storage/storage-browser/managed-auth/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-browser/managed-auth/index.page.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 
-import { createStorageBrowser } from '@aws-amplify/ui-react-storage/browser';
+import {
+  elementsDefault,
+  createStorageBrowser,
+} from '@aws-amplify/ui-react-storage/browser';
 
 import { auth, managedAuthAdapter } from '../managedAuthAdapter';
 
 import { Button, Flex } from '@aws-amplify/ui-react';
 
-import '@aws-amplify/ui-react-storage/storage-browser-styles.css';
 import '@aws-amplify/ui-react-storage/styles.css';
+import '@aws-amplify/ui-react-storage/storage-browser-styles.css';
 
 const { StorageBrowser } = createStorageBrowser({
+  elements: elementsDefault,
   actions: {},
   config: managedAuthAdapter,
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds the default Amplify UI elements to the managed-auth example

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
