### PR TITLE
Add missing class to text cells

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/Controls/DataTable.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/Controls/DataTable.tsx
@@ -5,6 +5,7 @@ import { capitalize } from '@aws-amplify/ui';
 import {
   DataTable,
   TABLE_DATA_BUTTON_CLASS,
+  TABLE_DATA_TEXT_CLASS_NAME,
   TABLE_HEADER_BUTTON_CLASS_NAME,
   TABLE_HEADER_CLASS_NAME,
 } from '../../../components/DataTable';
@@ -12,7 +13,11 @@ import { useControl } from '../../../context/controls';
 import { useLocationsData } from '../../../context/actions';
 import { LocationAccess } from '../../../context/types';
 import { compareStrings } from '../../../context/controls/Table';
-import { ButtonElement, IconElement } from '../../../context/elements';
+import {
+  ButtonElement,
+  IconElement,
+  SpanElement,
+} from '../../../context/elements';
 
 export type SortDirection = 'ascending' | 'descending' | 'none';
 
@@ -113,8 +118,22 @@ const getLocationsData = ({
         </ButtonElement>
       ),
     },
-    { key: `td-type-${index}`, children: location.type },
-    { key: `td-permission-${index}`, children: location.permission },
+    {
+      key: `td-type-${index}`,
+      children: (
+        <SpanElement className={TABLE_DATA_TEXT_CLASS_NAME}>
+          {location.type}
+        </SpanElement>
+      ),
+    },
+    {
+      key: `td-permission-${index}`,
+      children: (
+        <SpanElement className={TABLE_DATA_TEXT_CLASS_NAME}>
+          {location.permission}
+        </SpanElement>
+      ),
+    },
   ]);
 
   return { columns, rows };

--- a/packages/react-storage/src/components/StorageBrowser/components/DataTable.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/components/DataTable.tsx
@@ -16,6 +16,7 @@ export const TABLE_HEADER_CLASS_NAME = `${TABLE_CLASS_NAME}__header`;
 export const TABLE_HEADER_BUTTON_CLASS_NAME = `${TABLE_CLASS_NAME}__header__button`;
 export const TABLE_ROW_CLASS_NAME = `${TABLE_CLASS_NAME}__row`;
 export const TABLE_DATA_CLASS_NAME = `${TABLE_CLASS_NAME}__data`;
+export const TABLE_DATA_TEXT_CLASS_NAME = `${TABLE_CLASS_NAME}__data__text`;
 export const TABLE_DATA_BUTTON_CLASS = `${TABLE_CLASS_NAME}__data__button`;
 
 export interface ColumnHeaderItemProps

--- a/packages/react-storage/src/components/StorageBrowser/context/elements/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/elements/index.ts
@@ -4,6 +4,7 @@ export {
   ButtonElementProps,
   MessageVariant,
   PaginateVariant,
+  SpanElement,
   StorageBrowserElements,
   TableBodyElement,
   TableDataElement,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds back the missing wrapper for text cells in LocationsView table

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
