### PR TITLE
chore(storage-browser): use webkitrelativepath if it exists when creating cancelable task

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/useHandleUpload.ts
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/useHandleUpload.ts
@@ -73,7 +73,10 @@ export function useHandleUpload({
   React.useEffect(() => {
     const nextTasks = files.map((file) => ({
       cancel: () => setTasks((prev) => removeTask(prev, file.name)),
-      key: file.name,
+      key:
+        file.webkitRelativePath?.length > 0
+          ? file.webkitRelativePath
+          : file.name,
       data: file,
       size: file.size,
       status: 'INITIAL' as const,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Set file key as `webkitrelativepath` if it exists so that folders can be created based on the `/` delimeter

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
