### PR TITLE
chore(storage-browser): move list location items fetch into controller

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Controller.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Controller.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { useLocationsData } from './context/actions';
+import { useAction, useLocationsData } from './context/actions';
+import { useControl } from './context/controls';
 
 /**
  * Defines and provides default `StorageBrowser`
@@ -12,6 +13,30 @@ export function Controller(): null {
   React.useEffect(() => {
     handleListLocations({ options: { pageSize: 1000, refresh: true } });
   }, [handleListLocations]);
+
+  const [{ selected }] = useControl({ type: 'ACTION_SELECT' });
+  const [{ history, path }] = useControl({
+    type: 'NAVIGATE',
+  });
+  const [, handleListLocationItems] = useAction({
+    type: 'LIST_LOCATION_ITEMS',
+  });
+
+  const currentPosition = history.length;
+  const hasHistory = !!currentPosition;
+
+  React.useEffect(() => {
+    if (!hasHistory) return;
+
+    // Check to make sure that we're not in an action view
+    // This makes it so that the list locations refreshes when we go back from an action view
+    if (!selected.type) {
+      handleListLocationItems({
+        prefix: path,
+        options: { pageSize: 1000, refresh: true, delimiter: '/' },
+      });
+    }
+  }, [handleListLocationItems, hasHistory, history, path, selected.type]);
 
   return null;
 }

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Table.tsx
@@ -188,12 +188,11 @@ export const LocationDetailViewTable = (): JSX.Element | null => {
     type: 'NAVIGATE',
   });
 
-  const [{ data, isLoading }, handleList] = useAction({
+  const [{ data, isLoading }] = useAction({
     type: 'LIST_LOCATION_ITEMS',
   });
 
   const currentPosition = history.length;
-  const hasHistory = !!currentPosition;
   const hasItems = !!data.result?.length;
 
   const [compareFn, setCompareFn] = React.useState(() => compareStrings);
@@ -208,15 +207,6 @@ export const LocationDetailViewTable = (): JSX.Element | null => {
     direction === 'ascending'
       ? data.result.sort((a, b) => compareFn(a[selection], b[selection]))
       : data.result.sort((a, b) => compareFn(b[selection], a[selection]));
-
-  React.useEffect(() => {
-    if (!hasHistory) return;
-
-    handleList({
-      prefix: path,
-      options: { pageSize: 1000, refresh: true, delimiter: '/' },
-    });
-  }, [handleList, hasHistory, history, path]);
 
   const renderHeaderItem = React.useCallback(
     (column: Column<LocationItem>) => {

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Table.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Table.spec.tsx
@@ -1,26 +1,9 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
-import createProvider from '../../../createProvider';
-import * as ControlsModule from '../../../context/controls/';
-import * as ActionsModule from '../../../context/actions';
-import { LocationItem } from '../../../context/actions';
+import { LocationItem } from '../../../context/types';
 
-import { Column, LocationDetailViewTable, TableControl } from '../Table';
-
-const useControlSpy = jest.spyOn(ControlsModule, 'useControl');
-const useActionSpy = jest.spyOn(ActionsModule, 'useAction');
-
-const handleUpdateControlState = jest.fn();
-const controlState = {
-  location: {
-    scope: 's3://test-bucket/*',
-    permission: 'READ',
-    type: 'BUCKET',
-  },
-  history: [{ prefix: '', position: 0 }],
-  path: '',
-};
+import { Column, TableControl } from '../Table';
 
 const locationItems: LocationItem[] = [
   {
@@ -47,38 +30,7 @@ const locationItems: LocationItem[] = [
   },
 ];
 
-const locationItemsState = {
-  data: { result: locationItems, nextToken: undefined },
-  hasError: false,
-  isLoading: false,
-  message: undefined,
-};
-const handleUpdateActionState = jest.fn();
-
-useActionSpy.mockReturnValue([locationItemsState, handleUpdateActionState]);
-
-const listLocations = jest.fn(() =>
-  Promise.resolve({ locations: [], nextToken: undefined })
-);
-
-const config = {
-  getLocationCredentials: jest.fn(),
-  listLocations,
-  region: 'region',
-  registerAuthListener: jest.fn(),
-};
-
-const Provider = createProvider({ actions: {}, config });
-
 describe('TableControl', () => {
-  beforeEach(() => {
-    useActionSpy.mockClear();
-    useControlSpy.mockClear();
-
-    handleUpdateActionState.mockClear();
-    handleUpdateControlState.mockClear();
-  });
-
   it('calls renderHeaderItem and renderRowItem to render the TableControl', () => {
     const renderHeaderItemSpy = jest.fn();
     const renderRowItemSpy = jest.fn();
@@ -105,66 +57,5 @@ describe('TableControl', () => {
 
     expect(renderHeaderItemSpy).toHaveBeenCalled();
     expect(renderRowItemSpy).toHaveBeenCalled();
-  });
-});
-
-describe('LocationDetailViewTable', () => {
-  beforeEach(() => {
-    useActionSpy.mockClear();
-    useControlSpy.mockClear();
-
-    handleUpdateActionState.mockClear();
-    handleUpdateControlState.mockClear();
-  });
-
-  it('loads initial location items for a BUCKET location as expected', async () => {
-    useControlSpy.mockReturnValue([controlState, handleUpdateControlState]);
-
-    useActionSpy.mockReturnValue([locationItemsState, handleUpdateActionState]);
-
-    await waitFor(() => {
-      render(
-        <Provider>
-          <LocationDetailViewTable />
-        </Provider>
-      );
-    });
-
-    expect(handleUpdateActionState).toHaveBeenCalledTimes(1);
-    expect(handleUpdateActionState).toHaveBeenCalledWith({
-      prefix: '',
-      options: { delimiter: '/', pageSize: 1000, refresh: true },
-    });
-  });
-
-  it('loads initial location items for a PREFIX location as expected', async () => {
-    const prefixControlState = {
-      location: {
-        scope: 's3://test-bucket/test-prefix/*',
-        permission: 'READ',
-        type: 'PREFIX',
-      },
-      history: [{ prefix: 'test-prefix/', position: 0 }],
-      path: 'test-prefix/',
-    };
-
-    useControlSpy.mockReturnValue([
-      prefixControlState,
-      handleUpdateControlState,
-    ]);
-
-    await waitFor(() => {
-      render(
-        <Provider>
-          <LocationDetailViewTable />
-        </Provider>
-      );
-    });
-
-    expect(handleUpdateActionState).toHaveBeenCalledTimes(1);
-    expect(handleUpdateActionState).toHaveBeenCalledWith({
-      prefix: 'test-prefix/',
-      options: { delimiter: '/', pageSize: 1000, refresh: true },
-    });
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/Controls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/Controls.tsx
@@ -45,7 +45,10 @@ const RefreshControl = () => {
     <Refresh
       disabled={isLoading || data.result.length <= 0}
       onClick={() =>
-        handleList({ prefix: path, options: { refresh: true, pageSize: 1000 } })
+        handleList({
+          prefix: path,
+          options: { refresh: true, pageSize: 1000, delimiter: '/' },
+        })
       }
     />
   );

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/Controls/__tests__/DataTable.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/Controls/__tests__/DataTable.spec.tsx
@@ -32,9 +32,38 @@ const config = {
 
 const Provider = createProvider({ actions: {}, config });
 
+const INITIAL_PAGINATE_STATE = [
+  {
+    hasNext: false,
+    hasPrevious: false,
+    isLoadingNextPage: false,
+    current: 0,
+  },
+  jest.fn(),
+];
+
+const mockNavigateUpdateState = jest.fn();
+const INITIAL_NAVIGATE_STATE = [
+  { location: undefined, history: [], path: '' },
+  mockNavigateUpdateState,
+];
+
+const mockActionSelectUpdateState = jest.fn();
+const INITIAL_ACTION_STATE = [
+  { selected: { type: undefined, items: undefined }, actions: {} },
+  mockActionSelectUpdateState,
+];
+
 describe('LocationsViewTableControl', () => {
   beforeEach(() => {
-    useControlModuleSpy.mockReturnValue([{}, jest.fn()]);
+    useControlModuleSpy.mockImplementation(
+      ({ type }) =>
+        ({
+          ACTION_SELECT: INITIAL_ACTION_STATE,
+          NAVIGATE: INITIAL_NAVIGATE_STATE,
+          PAGINATE: INITIAL_PAGINATE_STATE,
+        })[type]
+    );
     useLocationsDataSpy.mockReturnValue([
       {
         data: { result: mockData, nextToken: undefined },
@@ -77,9 +106,6 @@ describe('LocationsViewTableControl', () => {
   });
 
   it('triggers location click handler when a row is clicked', () => {
-    const mockHandleUpdateState = jest.fn();
-    useControlModuleSpy.mockReturnValue([{}, mockHandleUpdateState]);
-
     render(
       <Provider>
         <DataTableControl />
@@ -89,7 +115,7 @@ describe('LocationsViewTableControl', () => {
     const firstRowButton = screen.getByRole('button', { name: 'Location A' });
     fireEvent.click(firstRowButton);
 
-    expect(mockHandleUpdateState).toHaveBeenCalledWith({
+    expect(mockNavigateUpdateState).toHaveBeenCalledWith({
       type: 'ACCESS_LOCATION',
       location: mockData[0],
     });

--- a/packages/react-storage/src/components/StorageBrowser/__tests__/Controller.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/__tests__/Controller.spec.tsx
@@ -1,12 +1,27 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
+import { LocationItem } from './../context/actions';
+import * as ControlsModule from './../context/controls/';
 import * as ActionsModule from './../context/actions';
-import { Controller } from '../Controller';
+import createProvider from '../createProvider';
 
 const useLocationsDataSpy = jest.spyOn(ActionsModule, 'useLocationsData');
+const useControlSpy = jest.spyOn(ControlsModule, 'useControl');
+const useActionSpy = jest.spyOn(ActionsModule, 'useAction');
 
-const handleListLocations = jest.fn();
+const handleListLocations = jest.fn(() =>
+  Promise.resolve({ locations: [], nextToken: undefined })
+);
+
+const config = {
+  getLocationCredentials: jest.fn(),
+  listLocations: handleListLocations,
+  region: 'region',
+  registerAuthListener: jest.fn(),
+};
+
+const Provider = createProvider({ actions: {}, config });
 
 const initialState: ActionsModule.LocationsDataState = [
   {
@@ -45,8 +60,51 @@ const resolvedState: ActionsModule.LocationsDataState = [
   handleListLocations,
 ];
 
+const locationItems: LocationItem[] = [
+  {
+    key: 'test-key-1',
+    lastModified: new Date(),
+    size: 1000,
+    type: 'FILE',
+  },
+];
+
+const locationItemsState = {
+  data: { result: locationItems, nextToken: undefined },
+  hasError: false,
+  isLoading: false,
+  message: undefined,
+};
+
+const INITIAL_PAGINATE_STATE = [
+  {
+    hasNext: false,
+    hasPrevious: false,
+    isLoadingNextPage: false,
+    current: 0,
+  },
+  jest.fn(),
+];
+const INITIAL_NAVIGATE_STATE = [
+  { location: undefined, history: [], path: '' },
+  jest.fn(),
+];
+const INITIAL_ACTION_STATE = [
+  { selected: { type: undefined, items: undefined }, actions: {} },
+  jest.fn(),
+];
+
 describe('Controller', () => {
   beforeEach(() => {
+    useControlSpy.mockImplementation(
+      ({ type }) =>
+        ({
+          ACTION_SELECT: INITIAL_ACTION_STATE,
+          NAVIGATE: INITIAL_NAVIGATE_STATE,
+          PAGINATE: INITIAL_PAGINATE_STATE,
+        })[type]
+    );
+
     handleListLocations.mockClear();
     useLocationsDataSpy.mockClear();
   });
@@ -57,18 +115,18 @@ describe('Controller', () => {
       .mockReturnValueOnce(loadingState)
       .mockReturnValue(resolvedState);
 
-    const { rerender } = render(<Controller />);
+    const { rerender } = render(<Provider />);
 
     expect(useLocationsDataSpy).toHaveBeenCalledTimes(1);
     expect(useLocationsDataSpy).toHaveBeenCalledTimes(1);
     expect(handleListLocations).toHaveBeenCalledTimes(1);
 
-    rerender(<Controller />);
+    rerender(<Provider />);
 
     expect(useLocationsDataSpy).toHaveBeenCalledTimes(2);
     expect(handleListLocations).toHaveBeenCalledTimes(1);
 
-    rerender(<Controller />);
+    rerender(<Provider />);
 
     expect(useLocationsDataSpy).toHaveBeenCalledTimes(3);
     expect(handleListLocations).toHaveBeenCalledTimes(1);
@@ -88,12 +146,12 @@ describe('Controller', () => {
       .mockReturnValue([{ ...resolvedState[0] }, updatedHandleListLocations]);
 
     // initial
-    const { rerender } = render(<Controller />);
+    const { rerender } = render(<Provider />);
 
     // loading
-    rerender(<Controller />);
+    rerender(<Provider />);
     // resolved
-    rerender(<Controller />);
+    rerender(<Provider />);
 
     expect(handleListLocations).toHaveBeenCalledTimes(1);
     expect(handleListLocations).toHaveBeenCalledWith({
@@ -102,12 +160,82 @@ describe('Controller', () => {
     expect(updatedHandleListLocations).not.toHaveBeenCalled();
 
     // reference change
-    rerender(<Controller />);
+    rerender(<Provider />);
 
     expect(handleListLocations).toHaveBeenCalledTimes(1);
     expect(updatedHandleListLocations).toHaveBeenCalledTimes(1);
     expect(updatedHandleListLocations).toHaveBeenCalledWith({
       options: { pageSize: 1000, refresh: true },
+    });
+  });
+
+  it('loads initial location items for a BUCKET location as expected', () => {
+    const handleUpdateActionState = jest.fn();
+    useActionSpy.mockReturnValue([locationItemsState, handleUpdateActionState]);
+
+    useControlSpy.mockImplementation(
+      ({ type }) =>
+        ({
+          ACTION_SELECT: INITIAL_ACTION_STATE,
+          NAVIGATE: [
+            {
+              location: {
+                scope: 's3://test-bucket/*',
+                permission: 'READ',
+                type: 'BUCKET',
+              },
+              history: [{ prefix: '', position: 0 }],
+              path: '',
+            },
+            jest.fn(),
+          ],
+          PAGINATE: INITIAL_PAGINATE_STATE,
+        })[type]
+    );
+
+    render(<Provider />);
+
+    expect(handleUpdateActionState).toHaveBeenCalledTimes(1);
+    expect(handleUpdateActionState).toHaveBeenCalledWith({
+      prefix: '',
+      options: { delimiter: '/', pageSize: 1000, refresh: true },
+    });
+  });
+
+  it('loads initial location items for a PREFIX location as expected', () => {
+    const handleUpdateActionState = jest.fn();
+    useActionSpy.mockReturnValue([locationItemsState, handleUpdateActionState]);
+
+    useControlSpy.mockImplementation(
+      ({ type }) =>
+        ({
+          ACTION_SELECT: INITIAL_ACTION_STATE,
+          NAVIGATE: [
+            {
+              location: {
+                scope: 's3://test-bucket/test-prefix/*',
+                permission: 'READ',
+                type: 'PREFIX',
+              },
+              history: [{ prefix: 'test-prefix/', position: 0 }],
+              path: 'test-prefix/',
+            },
+            jest.fn(),
+          ],
+          PAGINATE: INITIAL_PAGINATE_STATE,
+        })[type]
+    );
+
+    render(<Provider />);
+
+    expect(handleUpdateActionState).toHaveBeenCalledTimes(1);
+    expect(handleUpdateActionState).toHaveBeenCalledWith({
+      prefix: 'test-prefix/',
+      options: {
+        delimiter: '/',
+        pageSize: 1000,
+        refresh: true,
+      },
     });
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Move out `LIST_LOCATION_ITEMS` action call from location detail view table into `Controller`
  - Note: separating this into it's own separate PR in preparation for refactoring location detail view table with `DataTable`


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
