### PR TITLE
chore(storage-browser): add delimiter to refresh list location items call

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/Controls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/Controls.tsx
@@ -45,7 +45,10 @@ const RefreshControl = () => {
     <Refresh
       disabled={isLoading || data.result.length <= 0}
       onClick={() =>
-        handleList({ prefix: path, options: { refresh: true, pageSize: 1000 } })
+        handleList({
+          prefix: path,
+          options: { refresh: true, pageSize: 1000, delimiter: '/' },
+        })
       }
     />
   );

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/__tests__/LocationDetailView.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationDetailView/__tests__/LocationDetailView.spec.tsx
@@ -93,6 +93,9 @@ describe('LocationDetailView', () => {
       await user.click(refreshButton);
     });
 
-    expect(handleList).toHaveBeenCalled();
+    expect(handleList).toHaveBeenCalledWith({
+      prefix: 'cat-cat/',
+      options: { refresh: true, pageSize: 1000, delimiter: '/' },
+    });
   });
 });


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Add `delimiter: '/'` to refresh call so that it works as expected

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
