### PR TITLE
chore(storage-browser): move back button, UI cleanup

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/CreateFolderControls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/CreateFolderControls.tsx
@@ -95,16 +95,13 @@ export const CreateFolderControls = (): React.JSX.Element => {
 
   return (
     <>
-      <Title />
       <Exit
         onClick={() => {
           handleClose();
         }}
       />
+      <Title />
       <Primary {...primaryProps} />
-      {result?.status === 'COMPLETE' || result?.status === 'FAILED' ? (
-        <CreateFolderMessage />
-      ) : null}
       <Target.Field.Container>
         <Target.Field.Label htmlFor="folder-name-input">
           Enter folder name:
@@ -124,6 +121,9 @@ export const CreateFolderControls = (): React.JSX.Element => {
           </Target.Field.Error>
         ) : null}
       </Target.Field.Container>
+      {result?.status === 'COMPLETE' || result?.status === 'FAILED' ? (
+        <CreateFolderMessage />
+      ) : null}
     </>
   );
 };

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/UploadControls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/UploadControls.tsx
@@ -306,8 +306,8 @@ export const UploadControls = (): JSX.Element => {
   return (
     <>
       {fileSelect}
-      <Title />
       <Exit onClick={() => handleUpdateState({ type: 'CLEAR' })} />
+      <Title />
       <Primary
         disabled={disabled}
         onClick={() => {

--- a/packages/react-storage/src/components/StorageBrowser/context/elements/__tests__/defaults.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/elements/__tests__/defaults.spec.tsx
@@ -14,7 +14,7 @@ const BUTTON_VARIANTS: [ButtonElementVariant, string[]][] = [
   ['action-submit', []],
   ['cancel', ['amplify-button--link', 'amplify-button--link--error']],
   ['download', ['amplify-button--link']],
-  ['exit', ['amplify-button--outlined--overlay']],
+  ['exit', ['amplify-button--link']],
   ['message-dismiss', ['amplify-button--link--overlay']],
   ['navigate', ['amplify-button--link']],
   ['primary', ['amplify-button--primary']],

--- a/packages/react-storage/src/components/StorageBrowser/context/elements/defaults.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/elements/defaults.tsx
@@ -63,7 +63,13 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonElementProps>(
         );
       case 'exit':
         return (
-          <_Button {...props} size="small" colorTheme="overlay" ref={ref} />
+          <_Button
+            {...props}
+            size="small"
+            paddingInline="xs"
+            variation="link"
+            ref={ref}
+          />
         );
       case 'message-dismiss':
         return (

--- a/packages/react-storage/src/styles/storage-browser.css
+++ b/packages/react-storage/src/styles/storage-browser.css
@@ -14,7 +14,7 @@
 
 .storage-browser__title {
   margin: 0;
-  grid-column: 1 / 4;
+  grid-column: 1 / 3;
   margin-inline-start: var(--storage-browser-gap);
 }
 
@@ -62,34 +62,10 @@
 
 .storage-browser__target__field {
   grid-column: 1 / -1;
-  display: inline-grid;
-  gap: var(--storage-browser-gap);
-  grid-template-rows: repeat(3, auto);
-  grid-template-columns: 1fr auto;
-  grid-template-areas:
-    'label label'
-    'input submit'
-    'error error';
-}
-
-.storage-browser__target__label {
-  grid-area: label;
-}
-.storage-browser__target__input {
-  grid-area: input;
-}
-.storage-browser__target__button {
-  grid-area: submit;
-}
-.storage-browser__target__error {
-  grid-area: error;
-}
-.storage-browser__target__destination {
   display: flex;
+  flex-direction: column;
+  margin-inline-start: var(--storage-browser-gap);
   gap: var(--storage-browser-gap);
-}
-.storage-browser__target__destination__value {
-  word-break: break-word;
 }
 
 .storage-browser__message {
@@ -97,6 +73,7 @@
   align-items: flex-start;
   display: flex;
   gap: var(--storage-browser-gap);
+  margin-inline-start: var(--storage-browser-gap);
 }
 .storage-browser__message__icon,
 .storage-browser__message__dismiss {
@@ -116,7 +93,7 @@
 
 .storage-browser__destination {
   grid-column: 1 / 3;
-  margin: -0;
+  margin-inline-start: var(--storage-browser-gap);
 }
 
 .storage-browser__summary__definition,
@@ -221,15 +198,13 @@
 }
 
 .storage-browser__primary {
-  grid-column: 5 / -1;
-  grid-row-start: 1;
+  grid-column: 4 / -1;
   justify-self: flex-end;
 }
 
 .storage-browser__exit {
-  grid-column: 4 / 5;
-  grid-row-start: 1;
-  justify-self: flex-end;
+  grid-column: 1 / -1;
+  justify-self: flex-start;
 }
 
 .storage-browser__add-files {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- Moves the Back button to where the breadcrumbs are, updates style
- Moves the Message for Create Folder to appear below the input field
- Some other CSS cleanup for elements we're not using, fixes left alignment, etc

**Upload files screen**

<img width="1466" alt="Screenshot 2024-08-27 at 3 08 48 PM" src="https://github.com/user-attachments/assets/5bcb3521-8c37-486d-bd78-62e1c70cdfae">

**Create folder screen**

<img width="1463" alt="Screenshot 2024-08-27 at 3 09 41 PM" src="https://github.com/user-attachments/assets/6c2a8cd3-22e1-4da6-823b-d359b8714066">



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
