### PR TITLE
fix(storage-browser): use updated key to remove tasks

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/useHandleUpload.ts
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/useHandleUpload.ts
@@ -73,17 +73,21 @@ export function useHandleUpload({
   const [tasks, setTasks] = React.useState<CancelableTask[]>(() => []);
 
   React.useEffect(() => {
-    const nextTasks = files.map((file) => ({
-      cancel: () => setTasks((prev) => removeTask(prev, file.name)),
-      key:
+    const nextTasks = files.map((file) => {
+      const key =
         file.webkitRelativePath?.length > 0
           ? file.webkitRelativePath
-          : file.name,
-      data: file,
-      size: file.size,
-      status: 'INITIAL' as const,
-      progress: 0,
-    }));
+          : file.name;
+
+      return {
+        cancel: () => setTasks((prev) => removeTask(prev, key)),
+        key,
+        data: file,
+        size: file.size,
+        status: 'INITIAL' as const,
+        progress: 0,
+      };
+    });
     setTasks(nextTasks);
   }, [files]);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Previously, was using an updated `file.key` that contained `webkitRelativePath` value. Forgot to update the `remoteTask` call to use the same value so that items could be removed. This PR updates that

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
