### PR TITLE
feat(stroage-browser): exclude locations with write permission and object type

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Controller.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Controller.tsx
@@ -11,7 +11,9 @@ export function Controller(): null {
   const [, handleListLocations] = useLocationsData();
 
   React.useEffect(() => {
-    handleListLocations({ options: { pageSize: 1000, refresh: true } });
+    handleListLocations({
+      options: { pageSize: 1000, refresh: true, exclude: 'WRITE' },
+    });
   }, [handleListLocations]);
 
   const [{ selected }] = useControl({ type: 'ACTION_SELECT' });

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/LocationsView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationsView/LocationsView.tsx
@@ -40,7 +40,7 @@ const LocationsViewRefresh = () => {
       disabled={isLoading || data.result.length <= 0}
       onClick={() =>
         handleListLocations({
-          options: { refresh: true, pageSize: 1000 },
+          options: { refresh: true, pageSize: 1000, exclude: 'WRITE' },
         })
       }
     />

--- a/packages/react-storage/src/components/StorageBrowser/__tests__/Controller.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/__tests__/Controller.spec.tsx
@@ -155,7 +155,7 @@ describe('Controller', () => {
 
     expect(handleListLocations).toHaveBeenCalledTimes(1);
     expect(handleListLocations).toHaveBeenCalledWith({
-      options: { pageSize: 1000, refresh: true },
+      options: { exclude: 'WRITE', pageSize: 1000, refresh: true },
     });
     expect(updatedHandleListLocations).not.toHaveBeenCalled();
 
@@ -165,7 +165,7 @@ describe('Controller', () => {
     expect(handleListLocations).toHaveBeenCalledTimes(1);
     expect(updatedHandleListLocations).toHaveBeenCalledTimes(1);
     expect(updatedHandleListLocations).toHaveBeenCalledWith({
-      options: { pageSize: 1000, refresh: true },
+      options: { exclude: 'WRITE', pageSize: 1000, refresh: true },
     });
   });
 

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/__tests__/listLocationsAction.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/__tests__/listLocationsAction.spec.ts
@@ -8,6 +8,13 @@ const fakeLocation: LocationAccess = {
   type: 'BUCKET',
 };
 
+const getFakeLocation = (
+  permission: LocationAccess['permission'] = 'READWRITE',
+  type: LocationAccess['type'] = 'BUCKET'
+) => {
+  return { ...fakeLocation, permission, type };
+};
+
 const generateMockLocations = (size: number) =>
   Array<LocationAccess>(size).fill(fakeLocation);
 
@@ -132,6 +139,57 @@ describe('createListLocationsAction', () => {
     });
 
     expect(output.result).toHaveLength(70);
+    expect(output.nextToken).toBeUndefined();
+  });
+
+  it(`should filter out locations with write permission and 'OBJECT' type. Return desired pages`, async () => {
+    const fakeReadLocations = [
+      getFakeLocation('READ', 'BUCKET'),
+      getFakeLocation('READ', 'OBJECT'),
+      getFakeLocation('READ', 'PREFIX'),
+    ];
+    const fakeWriteLocations = [
+      getFakeLocation('WRITE', 'BUCKET'),
+      getFakeLocation('WRITE', 'OBJECT'),
+      getFakeLocation('WRITE', 'PREFIX'),
+    ];
+    const fakeReadWriteLocations = [
+      getFakeLocation('READWRITE', 'BUCKET'),
+      getFakeLocation('READWRITE', 'OBJECT'),
+      getFakeLocation('READWRITE', 'PREFIX'),
+    ];
+
+    mockListLocations.mockResolvedValueOnce({
+      locations: [...fakeReadLocations, ...fakeWriteLocations],
+      nextToken: 'next',
+    });
+    mockListLocations.mockResolvedValueOnce({
+      locations: [...fakeReadWriteLocations],
+      nextToken: undefined,
+    });
+
+    const listLocationsAction = createListLocationsAction(mockListLocations);
+    const output = await listLocationsAction(
+      { nextToken: undefined, result: [] },
+      { options: { pageSize: 4, exclude: 'WRITE' } }
+    );
+
+    expect(mockListLocations).toHaveBeenCalledTimes(2);
+    expect(mockListLocations).toHaveBeenCalledWith({
+      pageSize: 4,
+      nextToken: undefined,
+    });
+    expect(mockListLocations).toHaveBeenCalledWith({
+      pageSize: 2,
+      nextToken: 'next',
+    });
+
+    expect(output.result).toStrictEqual([
+      getFakeLocation('READ', 'BUCKET'),
+      getFakeLocation('READ', 'PREFIX'),
+      getFakeLocation('READWRITE', 'BUCKET'),
+      getFakeLocation('READWRITE', 'PREFIX'),
+    ]);
     expect(output.nextToken).toBeUndefined();
   });
 

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationsAction.ts
@@ -16,7 +16,7 @@ const PAGE_SIZE = 1000;
 export interface ListLocationsActionOptions<T>
   extends Omit<ListActionOptions<T>, 'delimiter'> {}
 
-export interface ListLocationsActionInput<T = never>
+export interface ListLocationsActionInput<T = Permission>
   extends Omit<
     ListActionInput<ListLocationsActionOptions<T>>,
     'prefix' | 'config'
@@ -27,7 +27,7 @@ export interface ListLocationsActionOutput<K = Permission>
 
 export type ListLocationsAction<T = never> = (
   prevState: ListLocationsActionOutput,
-  input: ListLocationsActionInput<T>
+  input: ListLocationsActionInput
 ) => Promise<ListLocationsActionOutput<Exclude<Permission, T>>>;
 
 const shouldExclude = <T extends Permission>(
@@ -73,7 +73,8 @@ export const createListLocationsAction = (
       nextNextToken = output.nextToken;
 
       locationsResult = [...locationsResult, ...output.locations].filter(
-        ({ permission }) => !shouldExclude(permission, exclude)
+        ({ permission, type }) =>
+          !(type === 'OBJECT' || shouldExclude(permission, exclude))
       );
     } while (nextNextToken && locationsResult.length < pageSize);
 


### PR DESCRIPTION
#### Description of changes
Overview
- On the `LocationsView` when a location is clicked we drill down to `LocationDetailView` listing it's items.
- location permission types: READ, WRITE, READWRITE
- location object types: bucket, bucket prefix, bucket object

Requirement
- While we can list bucket and bucket prefix items, we can't list a bucket object. (it's already a single item)
- We can only list bucket and bucket prefix items which have read permission    
- exclude `permission:WRITE` and `type:Object`

#### Description of how you validated changes
- Unit tests
- Tested on sample app to make sure locations with write permission and object types aren't displayed

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
