### PR TITLE
fix(storage-browser): disable buttons on any status other than initial

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/UploadControls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/UploadControls.tsx
@@ -304,7 +304,7 @@ export const UploadControls = (): JSX.Element => {
     [direction, selection]
   );
 
-  const disabled = tasks.some((task) => task.status === 'PENDING');
+  const disabled = tasks.some((task) => task.status !== 'INITIAL');
   const queuedTasks = tasks.filter((task) => task.status === 'QUEUED').length;
   const canceledTasks = tasks.filter(
     (task) => task.status === 'CANCELED'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Disable buttons on any status other than `INITIAL`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
