### PR TITLE
fix(storage-browser): add input element for adding files and one for adding a folder

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/__tests__/UploadControls.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/__tests__/UploadControls.spec.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 
 import * as ControlsModule from '../../../context/controls';
 import createProvider from '../../../createProvider';
 import { ActionSelectState } from '../../../context/controls/ActionSelect/ActionSelect';
 
 import { UploadControls, ActionIcon, ICON_CLASS } from '../UploadControls';
+import userEvent from '@testing-library/user-event';
 
 const TEST_ACTIONS = {
   UPLOAD_FILES: { displayName: 'Upload Files', handler: jest.fn() },
@@ -86,6 +87,47 @@ describe('UploadControls', () => {
 
     expect(destination).toBeInTheDocument();
     expect(destinationFolder).toBeInTheDocument();
+  });
+
+  it('opens the file picker when the add files button is clicked and uses the file selection dialog', async () => {
+    const user = userEvent.setup();
+    const files = [
+      new File(['content1'], 'file1.txt', { type: 'text/plain' }),
+      new File(['content2'], 'file2.txt', { type: 'text/plain' }),
+      new File(['content3'], 'file3.txt', {
+        type: 'text/plain',
+      }),
+    ];
+
+    render(
+      <Provider>
+        <UploadControls />
+      </Provider>
+    );
+
+    const button = screen.getByRole('button', { name: 'Add files' });
+    const input: HTMLInputElement = screen.getByTestId('amplify-file-select');
+
+    expect(input).toHaveAttribute('multiple');
+
+    await act(async () => {
+      await user.click(button);
+      await user.upload(input, files);
+    });
+
+    expect(input.files).toHaveLength(3);
+  });
+
+  it('has the webkitdirectory attribute for the input select for folders', () => {
+    render(
+      <Provider>
+        <UploadControls />
+      </Provider>
+    );
+
+    const input: HTMLInputElement = screen.getByTestId('amplify-folder-select');
+
+    expect(input).toHaveAttribute('webkitdirectory');
   });
 });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- For now, added two `input` elements for selecting files and one for folder

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
