### PR TITLE
fix(storage-browser): single page pagination

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/utils.ts
+++ b/packages/react-storage/src/components/StorageBrowser/Views/utils.ts
@@ -16,11 +16,11 @@ export const listViewHelpers = ({
   disableRefresh: boolean;
   range: [start: number, end: number];
 } => {
-  const isLastPage =
-    // Checks if we have more results than pageSize and we're on the last page.
-    Math.round(resultCount / pageSize) === currentPage ||
-    // Checks if we have less results than pageSize (only one page)
-    Math.round(resultCount / pageSize) === 0;
+  // Use Math.ceil so we can round up. For example, if you have
+  // 4 results, and your page size is 3, the last page (Math.ceil(4/3)) will be 2.
+  // If you have 3 results and your page size is 4, the last page will be 1.
+  const isLastPage = Math.ceil(resultCount / pageSize) === currentPage;
+
   const start = currentPage === 1 ? 0 : (currentPage - 1) * pageSize;
   const end = currentPage === 1 ? pageSize : currentPage * pageSize;
 

--- a/packages/react-storage/src/components/StorageBrowser/Views/utils.ts
+++ b/packages/react-storage/src/components/StorageBrowser/Views/utils.ts
@@ -17,7 +17,9 @@ export const listViewHelpers = ({
   range: [start: number, end: number];
 } => {
   const isLastPage =
+    // Checks if we have more results than pageSize and we're on the last page.
     Math.round(resultCount / pageSize) === currentPage ||
+    // Checks if we have less results than pageSize (only one page)
     Math.round(resultCount / pageSize) === 0;
   const start = currentPage === 1 ? 0 : (currentPage - 1) * pageSize;
   const end = currentPage === 1 ? pageSize : currentPage * pageSize;

--- a/packages/react-storage/src/components/StorageBrowser/Views/utils.ts
+++ b/packages/react-storage/src/components/StorageBrowser/Views/utils.ts
@@ -16,7 +16,9 @@ export const listViewHelpers = ({
   disableRefresh: boolean;
   range: [start: number, end: number];
 } => {
-  const isLastPage = Math.round(resultCount / pageSize) === currentPage;
+  const isLastPage =
+    Math.round(resultCount / pageSize) === currentPage ||
+    Math.round(resultCount / pageSize) === 0;
   const start = currentPage === 1 ? 0 : (currentPage - 1) * pageSize;
   const end = currentPage === 1 ? pageSize : currentPage * pageSize;
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Currently if there is only one item to show, it will always show a pagination next button.

**Before**

https://github.com/user-attachments/assets/4fa295c2-c25b-40de-9508-ac758d1f28ea

**After**
<img width="718" alt="Screenshot 2024-09-03 at 11 13 35 AM" src="https://github.com/user-attachments/assets/f71d44a9-3e64-4e35-80b3-085e099fa1b5">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
