### PR TITLE
chore(storage-browser): use plain text for current breadcrumb item

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -17,9 +17,7 @@ import { CLASS_BASE } from '../constants';
 
 import { LocationData, useAction } from '../../context/actions';
 
-interface NavigateItemProps extends ButtonElementProps {
-  seperator?: React.ReactNode;
-}
+interface NavigateItemProps extends ButtonElementProps {}
 
 type RenderNavigateItem = (props: NavigateItemProps) => React.JSX.Element;
 
@@ -45,7 +43,6 @@ function Separator() {
 export const NavigateItem = ({
   className = `${BLOCK_NAME}__button`,
   children,
-  seperator = null,
   ...props
 }: NavigateItemProps): React.JSX.Element => {
   return (
@@ -53,7 +50,7 @@ export const NavigateItem = ({
       <ButtonElement {...props} className={className} variant="navigate">
         {children}
       </ButtonElement>
-      {seperator}
+      <Separator />
     </ListItemElement>
   );
 };
@@ -95,7 +92,6 @@ export function NavigateControl(): React.JSX.Element {
           handleUpdateState({ type: 'EXIT' });
           handleUpdateList({ prefix: '', options: { reset: true } });
         }}
-        seperator={<Separator />}
       >
         {HOME_NAVIGATE_ITEM}
       </NavigateItem>
@@ -123,13 +119,11 @@ export function NavigateControl(): React.JSX.Element {
           </ListItemElement>
         ) : (
           <NavigateItem
-            aria-current={isCurrent ? 'page' : undefined}
             disabled={isLoading}
             key={`${prefix}/${position}`}
             onClick={() => {
               handleUpdateState({ type: 'NAVIGATE', entry });
             }}
-            seperator={isCurrent ? null : <Separator />}
           >
             {displayValue}
           </NavigateItem>

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -114,7 +114,14 @@ export function NavigateControl(): React.JSX.Element {
 
         const isCurrent = index === history.length - 1;
 
-        return (
+        return isCurrent ? (
+          <ListItemElement
+            className={`${BLOCK_NAME}__item`}
+            aria-current="page"
+          >
+            <SpanElement variant="navigate-current">{displayValue}</SpanElement>
+          </ListItemElement>
+        ) : (
           <NavigateItem
             aria-current={isCurrent ? 'page' : undefined}
             disabled={isLoading}

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -17,7 +17,9 @@ import { CLASS_BASE } from '../constants';
 
 import { LocationData, useAction } from '../../context/actions';
 
-interface NavigateItemProps extends ButtonElementProps {}
+interface NavigateItemProps extends ButtonElementProps {
+  isCurrent?: boolean;
+}
 
 type RenderNavigateItem = (props: NavigateItemProps) => React.JSX.Element;
 
@@ -43,14 +45,21 @@ function Separator() {
 export const NavigateItem = ({
   className = `${BLOCK_NAME}__button`,
   children,
+  isCurrent = false,
   ...props
 }: NavigateItemProps): React.JSX.Element => {
   return (
     <ListItemElement className={`${BLOCK_NAME}__item`}>
-      <ButtonElement {...props} className={className} variant="navigate">
-        {children}
-      </ButtonElement>
-      <Separator />
+      {isCurrent ? (
+        <SpanElement variant="navigate-current">{children}</SpanElement>
+      ) : (
+        <>
+          <ButtonElement {...props} className={className} variant="navigate">
+            {children}
+          </ButtonElement>
+          <Separator />
+        </>
+      )}
     </ListItemElement>
   );
 };
@@ -109,21 +118,14 @@ export function NavigateControl(): React.JSX.Element {
             : prefix;
 
         const isCurrent = index === history.length - 1;
-
-        return isCurrent ? (
-          <ListItemElement
-            className={`${BLOCK_NAME}__item`}
-            aria-current="page"
-          >
-            <SpanElement variant="navigate-current">{displayValue}</SpanElement>
-          </ListItemElement>
-        ) : (
+        return (
           <NavigateItem
             disabled={isLoading}
             key={`${prefix}/${position}`}
             onClick={() => {
               handleUpdateState({ type: 'NAVIGATE', entry });
             }}
+            isCurrent={isCurrent}
           >
             {displayValue}
           </NavigateItem>

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/Navigate.tsx
@@ -49,7 +49,10 @@ export const NavigateItem = ({
   ...props
 }: NavigateItemProps): React.JSX.Element => {
   return (
-    <ListItemElement className={`${BLOCK_NAME}__item`}>
+    <ListItemElement
+      aria-current={isCurrent ? 'page' : undefined}
+      className={`${BLOCK_NAME}__item`}
+    >
       {isCurrent ? (
         <SpanElement variant="navigate-current">{children}</SpanElement>
       ) : (

--- a/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Navigate.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/Controls/__tests__/Navigate.spec.tsx
@@ -118,9 +118,8 @@ describe('NavigateControl', () => {
     const lastSeparator = lastItem.querySelector(
       '.storage-browser__navigate__separator'
     );
-    const currentButton = lastItem.querySelector('button');
 
-    expect(currentButton).toHaveAttribute('aria-current', 'page');
+    expect(lastItem).toHaveAttribute('aria-current', 'page');
     expect(lastSeparator).toBeNull();
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/context/elements/defaults.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/elements/defaults.tsx
@@ -129,7 +129,15 @@ function Heading(props: HeadingElementProps): React.JSX.Element {
 function Span(props: SpanElementProps): React.JSX.Element {
   const { variant } = props;
   if (variant === 'navigate-current') {
-    return <_View {...props} as="span" padding="xs" color="font.secondary" />;
+    return (
+      <_View
+        {...props}
+        as="span"
+        padding="xs"
+        color="font.secondary"
+        fontSize="small"
+      />
+    );
   }
   return <_View {...props} as="span" />;
 }

--- a/packages/react-storage/src/components/StorageBrowser/context/elements/defaults.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/elements/defaults.tsx
@@ -21,6 +21,7 @@ import {
   InputElementProps,
   LabelElementProps,
   NavElementProps,
+  SpanElementProps,
   TableBodyElementProps,
   TableDataElementProps,
   TableElementProps,
@@ -125,6 +126,14 @@ function Heading(props: HeadingElementProps): React.JSX.Element {
   );
 }
 
+function Span(props: SpanElementProps): React.JSX.Element {
+  const { variant } = props;
+  if (variant === 'navigate-current') {
+    return <_View {...props} as="span" padding="xs" color="font.secondary" />;
+  }
+  return <_View {...props} as="span" />;
+}
+
 function Table(props: TableElementProps): React.JSX.Element {
   return (
     <_Table {...props} size="small" lineHeight="small" variation="striped" />
@@ -207,6 +216,7 @@ export const elementsDefault = {
   Label,
   Nav,
   Heading,
+  Span,
   Table,
   TableBody,
   TableData,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Rendered a span with plain text for current Navigate item instead of a button

**After**
<img width="576" alt="Screenshot 2024-09-03 at 1 14 05 PM" src="https://github.com/user-attachments/assets/12302e5f-c61e-43bb-8d98-1e2dda271125">


<img width="478" alt="Screenshot 2024-09-03 at 11 44 54 AM" src="https://github.com/user-attachments/assets/086901a5-0814-4c26-8dcd-c86feb07c5d5">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
