### PR TITLE
chore(storage-browser): add ErrorBoundary styling

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
@@ -12,9 +12,7 @@ interface ErrorBoundaryState {
 
 const Fallback = (): React.JSX.Element => (
   <div className={CLASS_BASE}>
-    <div className={`${CLASS_BASE}__error`}>
-      Something went wrong. Please try again.
-    </div>
+    <div className={`${CLASS_BASE}__error`}>Something went wrong.</div>
   </div>
 );
 

--- a/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { CLASS_BASE } from '../Views/constants';
+
 interface ErrorBoundaryProps {
   children: React.ReactNode;
 }
@@ -9,7 +11,11 @@ interface ErrorBoundaryState {
 }
 
 const Fallback = (): React.JSX.Element => (
-  <p>Something went wrong. Please try again.</p>
+  <div className={CLASS_BASE}>
+    <div className={`${CLASS_BASE}__error`}>
+      Something went wrong. Please try again.
+    </div>
+  </div>
 );
 
 export class ErrorBoundary extends React.Component<
@@ -29,7 +35,6 @@ export class ErrorBoundary extends React.Component<
   render(): React.ReactNode {
     const { hasError } = this.state;
     const { children } = this.props;
-
     if (hasError) {
       return <Fallback />;
     }

--- a/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/__tests__/ErrorBoundary.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/__tests__/ErrorBoundary.spec.tsx
@@ -21,9 +21,7 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>
     );
 
-    expect(
-      screen.getByText('Something went wrong. Please try again.')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
   });
 
   it('should render children when no error is thrown', () => {

--- a/packages/react-storage/src/styles/storage-browser.css
+++ b/packages/react-storage/src/styles/storage-browser.css
@@ -7,6 +7,8 @@
   --storage-browser-status-progress: hsl(220, 95%, 30%);
   --storage-browser-status-initial: hsl(210, 10%, 58%);
   --storage-browser-loading-animation: spin 1s ease-out infinite;
+  --storage-browser-error-background: hsl(0, 75%, 95%);
+  --storage-browser-error-text: hsl(0, 100%, 20%);
   display: grid;
   gap: var(--storage-browser-gap);
   grid-template-columns: 1fr 1fr 1fr max-content max-content;
@@ -259,4 +261,12 @@
   100% {
     transform: rotate(360deg);
   }
+}
+
+/* Error boundary */
+.storage-browser__error {
+  background-color: var(--storage-browser-error-background);
+  color: var(--storage-browser-error-text);
+  grid-column: 1 / -1;
+  padding: var(--storage-browser-gap-large);
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds some specific styles for the ErrorBoundary message. 
- Since this sits above the elements provider, it has color/background styles associated with it.
- Wraps it in our CLASS_BASE so it can pick up CSS custom props and grid styles.


<img width="1431" alt="Screenshot 2024-09-03 at 2 02 59 PM" src="https://github.com/user-attachments/assets/e8d622d8-9ba2-4545-8288-29960faf36cc">


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
