### PR TITLE
chore(storage-browser): update CreateFolder test for conditional in parent component

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/__tests__/CreateFolderControls.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/__tests__/CreateFolderControls.spec.tsx
@@ -208,7 +208,7 @@ describe('CreateFolderControls', () => {
     await waitFor(() => {
       render(
         <Provider>
-          <CreateFolderMessage />
+          <CreateFolderControls />
         </Provider>
       );
     });

--- a/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/__tests__/CreateFolderControls.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/Views/LocationActionView/__tests__/CreateFolderControls.spec.tsx
@@ -184,7 +184,7 @@ describe('CreateFolderControls', () => {
     await waitFor(() => {
       render(
         <Provider>
-          <CreateFolderMessage />
+          <CreateFolderControls />
         </Provider>
       );
     });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Bumps up our branch coverage a teeny tiny bit for this missing CreateFolderMessage render when there is a FAILED or COMPLETE status.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
