### PR TITLE
[WIP] chore(storage-browser): add Loading state e2e tests for storage browser

### DIFF
--- a/packages/e2e/cypress/integration/common/storage-browser.ts
+++ b/packages/e2e/cypress/integration/common/storage-browser.ts
@@ -1,0 +1,15 @@
+import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { escapeRegExp } from 'lodash';
+
+When('I click the {string} button on a slow network', (name: string) => {
+  cy.intercept({ method: 'GET' }, (req) => {
+    alert('intercepted');
+    req.on('response', (res) => {
+      res.setDelay(5000);
+    });
+  });
+
+  cy.findByRole('button', {
+    name: new RegExp(`^${escapeRegExp(name)}$`, 'i'),
+  }).click();
+});

--- a/packages/e2e/features/ui/components/storage/storage-browser/loading.default-auth.feature
+++ b/packages/e2e/features/ui/components/storage/storage-browser/loading.default-auth.feature
@@ -19,3 +19,4 @@ Feature: Loading spinner on Storage Browser views
     Then I click the button containing "public"
     Then I click the "Refresh table" button on a slow network
     Then I see "Loading"
+    

--- a/packages/e2e/features/ui/components/storage/storage-browser/loading.default-auth.feature
+++ b/packages/e2e/features/ui/components/storage/storage-browser/loading.default-auth.feature
@@ -1,0 +1,21 @@
+Feature: Loading spinner on Storage Browser views
+
+  Background:
+    Given I'm running the example "ui/components/storage/storage-browser/default-auth"
+  
+  @react
+  Scenario: Loading spinner on LocationDetailView
+    When I type my "email" with status "CONFIRMED"
+    Then I type my password
+    Then I click the "Sign in" button
+    Then I click the button containing "public"
+    Then I see "Loading"
+
+  @react
+  Scenario: Loading spinner on LocationDetailView
+    When I type my "email" with status "CONFIRMED"
+    Then I type my password
+    Then I click the "Sign in" button
+    Then I click the button containing "public"
+    Then I click the "Refresh table" button on a slow network
+    Then I see "Loading"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
