### PR TITLE
chore(docs): update i18n list in authenticator docs to reflect supported languages

### DIFF
--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.react-native.mdx
@@ -7,16 +7,20 @@ The `Authenticator` ships with [translations](https://github.com/aws-amplify/amp
 - `nl` – Dutch
 - `fr` – French
 - `de` – German
+- `he` – Hebrew
 - `id` – Indonesian
 - `it` – Italian
 - `ja` – Japanese
 - `ko` – Korean
+- `nb` - Norwegian
 - `pl` – Polish
 - `pt` – Portuguese
 - `ru` – Russian
 - `es` – Spanish
 - `sv` – Swedish
+- `th` - Thai
 - `tr` – Turkish
+- `ua` – Ukrainian
 
 These [translations](https://github.com/aws-amplify/amplify-ui/blob/main/packages/ui/src/i18n/translations.ts) can be customized using the [Amplify JS' `I18n`](https://docs.amplify.aws/lib/utilities/i18n/q/platform/js/) module:
 

--- a/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
+++ b/docs/src/pages/[platform]/connected-components/authenticator/customization/customization.i18n.web.mdx
@@ -19,6 +19,7 @@ The `Authenticator` ships with [translations](https://github.com/aws-amplify/amp
 - `ru` – Russian
 - `es` – Spanish
 - `sv` – Swedish
+- `th` - Thai
 - `tr` – Turkish
 - `ua` – Ukrainian
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

* Added reference to Thai support to both web and React Native i18n language lists
* Updated React Native i18n language list to include Hebrew, Norwegian, and Ukrainian as well

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
