### PR TITLE
fix: update FileUploader docs to use FileUploader in examples

### DIFF
--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/ComponentOverrides.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/ComponentOverrides.tsx
@@ -9,11 +9,11 @@ import {
   Loader,
   Icon,
 } from '@aws-amplify/ui-react';
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 export const App = () => {
   return (
-    <StorageManager
+    <FileUploader
       acceptedFileTypes={['image/*']}
       path="public/"
       maxFileCount={100}

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Default.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Default.tsx
@@ -1,8 +1,8 @@
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 export const App = () => {
   return (
-    <StorageManager
+    <FileUploader
       acceptedFileTypes={['image/*']}
       path="public/"
       maxFileCount={1}

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/DisplayText.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/DisplayText.tsx
@@ -1,8 +1,8 @@
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 export const App = () => {
   return (
-    <StorageManager
+    <FileUploader
       acceptedFileTypes={['image/*']}
       path="public/"
       maxFileCount={1}

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Event.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Event.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 export const App = () => {
   const [files, setFiles] = React.useState({});
 
   return (
     <>
-      <StorageManager
+      <FileUploader
         acceptedFileTypes={['image/*']}
         // private uploads will fail intentionally in docs // IGNORE
         path={({ identityId }) => `private/${identityId}/`}

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/FileTypes.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/FileTypes.tsx
@@ -1,8 +1,8 @@
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 export const App = () => {
   return (
-    <StorageManager
+    <FileUploader
       acceptedFileTypes={[
         // you can list file extensions:
         '.gif',

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Handle.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Handle.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { Button } from '@aws-amplify/ui-react';
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 export const App = () => {
   const ref = React.useRef(null);
 
   return (
     <>
-      <StorageManager
+      <FileUploader
         acceptedFileTypes={['image/*']}
         path="public/"
         maxFileCount={3}

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Hash.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Hash.tsx
@@ -1,4 +1,4 @@
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 const processFile = async ({ file }) => {
   const fileExtension = file.name.split('.').pop();
@@ -17,7 +17,7 @@ const processFile = async ({ file }) => {
 
 export const App = () => {
   return (
-    <StorageManager
+    <FileUploader
       acceptedFileTypes={['image/*']}
       path="public/"
       maxFileCount={1}

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Metadata.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Metadata.tsx
@@ -1,4 +1,4 @@
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 const processFile = ({ file, key }) => {
   return {
@@ -12,7 +12,7 @@ const processFile = ({ file, key }) => {
 
 export function App() {
   return (
-    <StorageManager
+    <FileUploader
       acceptedFileTypes={['image/*']}
       path="public/"
       maxFileCount={3}

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/PathProp.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/PathProp.tsx
@@ -1,8 +1,8 @@
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 export const App = () => {
   return (
-    <StorageManager
+    <FileUploader
       path="public/images/"
       acceptedFileTypes={['image/*']}
       maxFileCount={1}

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Resumable.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Resumable.tsx
@@ -1,8 +1,8 @@
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 export const App = () => {
   return (
-    <StorageManager
+    <FileUploader
       acceptedFileTypes={['image/*', '.zip', '.mp4']}
       path="public/"
       maxFileCount={10}

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Theme.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/Theme.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider } from '@aws-amplify/ui-react';
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 const theme = {
   name: 'my-theme',
@@ -20,7 +20,7 @@ const theme = {
 export const App = () => {
   return (
     <ThemeProvider theme={theme}>
-      <StorageManager
+      <FileUploader
         acceptedFileTypes={['image/*']}
         path="public/"
         maxFileCount={5}

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/UploadActions.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/UploadActions.tsx
@@ -1,8 +1,8 @@
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 export const App = () => {
   return (
-    <StorageManager
+    <FileUploader
       acceptedFileTypes={['image/*']}
       path="public/"
       autoUpload={false}

--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/i18n.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/examples/i18n.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ToggleButtonGroup, ToggleButton } from '@aws-amplify/ui-react';
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 
 const dictionary = {
   // use default strings for english
@@ -58,7 +58,7 @@ export const App = () => {
         <ToggleButton value="en">En</ToggleButton>
         <ToggleButton value="es">Es</ToggleButton>
       </ToggleButtonGroup>
-      <StorageManager
+      <FileUploader
         acceptedFileTypes={['image/*']}
         path="public/"
         maxFileCount={1}

--- a/docs/src/pages/[platform]/theming/icons/IconSwitcher.tsx
+++ b/docs/src/pages/[platform]/theming/icons/IconSwitcher.tsx
@@ -195,7 +195,7 @@ export default function IconProviderExample() {
             <Rating value={3.5} />
           </Flex>
         </Flex>
-        <FileUploader accessLevel="guest" maxFileCount={5} />
+        <FileUploader path="public/" maxFileCount={5} />
       </Flex>
     </IconsProvider>
   );

--- a/docs/src/pages/[platform]/theming/icons/IconSwitcher.tsx
+++ b/docs/src/pages/[platform]/theming/icons/IconSwitcher.tsx
@@ -42,7 +42,7 @@ import {
   HiStar,
   HiUpload,
 } from 'react-icons/hi';
-import { StorageManager } from '@aws-amplify/ui-react-storage';
+import { FileUploader } from '@aws-amplify/ui-react-storage';
 import {
   FcExpand,
   FcHighPriority,
@@ -195,7 +195,7 @@ export default function IconProviderExample() {
             <Rating value={3.5} />
           </Flex>
         </Flex>
-        <StorageManager accessLevel="guest" maxFileCount={5} />
+        <FileUploader accessLevel="guest" maxFileCount={5} />
       </Flex>
     </IconsProvider>
   );


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
* Changes use of `StorageManager` to `FileUploader` in FileUploader docs examples

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
