### PR TITLE
fix(ai): fixes reattaching the same file by always triggering the onC…

### DIFF
--- a/.changeset/thin-pants-turn.md
+++ b/.changeset/thin-pants-turn.md
@@ -2,4 +2,4 @@
 "@aws-amplify/ui-react-ai": patch
 ---
 
-fix(ai): fixes reattaching the same file by always triggering the onC…
+fix(ai): fixes reattaching the same file by always triggering the onChange event

--- a/.changeset/thin-pants-turn.md
+++ b/.changeset/thin-pants-turn.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-ai": patch
+---
+
+fix(ai): fixes reattaching the same file by always triggering the onC…

--- a/packages/react-ai/src/components/AIConversation/views/default/Form.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/default/Form.tsx
@@ -16,7 +16,7 @@ function isHTMLFormElement(target: EventTarget): target is HTMLFormElement {
   return 'form' in target;
 }
 
-export const Form: ControlsContextProps['Form'] = ({
+export const Form: NonNullable<ControlsContextProps['Form']> = ({
   setInput,
   input,
   handleSubmit,
@@ -47,6 +47,8 @@ export const Form: ControlsContextProps['Form'] = ({
           className={ComponentClassName.AIConversationFormAttach}
           onClick={() => {
             hiddenInput?.current?.click();
+            if (hiddenInput && hiddenInput.current)
+              hiddenInput.current.value = '';
           }}
         >
           <span>{attachIcon}</span>
@@ -67,6 +69,7 @@ export const Form: ControlsContextProps['Form'] = ({
               }}
               multiple
               accept="*"
+              data-testid="hidden-file-input"
             />
           </VisuallyHidden>
         </Button>
@@ -78,6 +81,7 @@ export const Form: ControlsContextProps['Form'] = ({
           flex="1"
           rows={1}
           value={input?.text ?? ''}
+          testId="text-input"
           onKeyDown={(e) => {
             // Submit on enter key if shift is not pressed also
             const shouldSubmit = !e.shiftKey && e.key === 'Enter';

--- a/packages/react-ai/src/components/AIConversation/views/default/Form.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/default/Form.tsx
@@ -47,8 +47,9 @@ export const Form: NonNullable<ControlsContextProps['Form']> = ({
           className={ComponentClassName.AIConversationFormAttach}
           onClick={() => {
             hiddenInput?.current?.click();
-            if (hiddenInput && hiddenInput.current)
+            if (hiddenInput?.current) {
               hiddenInput.current.value = '';
+            }
           }}
         >
           <span>{attachIcon}</span>

--- a/packages/react-ai/src/components/AIConversation/views/default/__tests__/Form.spec.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/default/__tests__/Form.spec.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Form } from '../Form';
+
+const setInput = jest.fn();
+const input = {};
+const handleSubmit = jest.fn();
+
+describe('Form', () => {
+  beforeEach(() => {
+    setInput.mockClear();
+    handleSubmit.mockClear();
+  });
+
+  it('renders a Form component with the correct elements', () => {
+    const result = render(
+      <Form setInput={setInput} input={input} handleSubmit={handleSubmit} />
+    );
+    expect(result.container).toBeDefined();
+
+    const form = screen.findByRole('form');
+    const buttons = screen.getAllByRole('button');
+    const textInput = screen.getByTestId('text-input');
+    const fileInput = screen.getByTestId('hidden-file-input');
+
+    expect(form).toBeDefined();
+    expect(buttons).toHaveLength(2);
+    expect(textInput).toBeDefined();
+    expect(fileInput).toBeDefined();
+  });
+
+  it('can upload files to the input', async () => {
+    const result = render(
+      <Form setInput={setInput} input={input} handleSubmit={handleSubmit} />
+    );
+    expect(result.container).toBeDefined();
+
+    const fileInput: HTMLInputElement = screen.getByTestId('hidden-file-input');
+    const testFile = new File(['file content'], 'file.txt', {
+      type: 'text/plain',
+    });
+    File.prototype.text = jest.fn().mockResolvedValueOnce('foo.txt');
+    await waitFor(() =>
+      fireEvent.change(fileInput, {
+        target: { files: [testFile] },
+      })
+    );
+    expect(setInput).toHaveBeenCalledTimes(1);
+    expect(fileInput.files).not.toBeNull();
+    expect(fileInput.files![0]).toStrictEqual(testFile);
+  });
+});


### PR DESCRIPTION
…hange event

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Seems like the onChange event was not getting fired when attaching a file, then deleting it, and attempting to reattach it
- This was because the onChange event was not getting fired, found a stack overflow post referencing this issue where resetting the input value to '' ensures that the onchange event is always fired
- https://stackoverflow.com/questions/12030686/html-input-file-selection-event-not-firing-upon-selecting-the-same-file

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
