### PR TITLE
feat(avatar): add loading state to avatar and AIConversation

### DIFF
--- a/.changeset/olive-bats-obey.md
+++ b/.changeset/olive-bats-obey.md
@@ -1,0 +1,12 @@
+---
+"@aws-amplify/ui-react-ai": minor
+"@aws-amplify/ui-react": minor
+"@aws-amplify/ui": minor
+---
+
+feat(avatar): add loading state to avatar and AIConversation
+
+
+```jsx
+<Avatar isLoading />
+```

--- a/docs/__tests__/__snapshots__/props-table.test.ts.snap
+++ b/docs/__tests__/__snapshots__/props-table.test.ts.snap
@@ -1123,6 +1123,13 @@ exports[`Props Table 1`] = `
                         "category": "BaseAvatarProps",
                         "isOptional": true
                     },
+                    "isLoading": {
+                        "name": "isLoading",
+                        "type": "boolean | undefined",
+                        "description": "The isLoading property will display a loader around the avatar",
+                        "category": "BaseAvatarProps",
+                        "isOptional": true
+                    },
                     "isDisabled": {
                         "name": "isDisabled",
                         "type": "boolean | undefined",

--- a/docs/src/components/ComponentsMetadata.ts
+++ b/docs/src/components/ComponentsMetadata.ts
@@ -285,6 +285,11 @@ export const ComponentsMetadata: ComponentClassNameItems = {
     components: ['Avatar'],
     description: 'Class applied to the icon element',
   },
+  AvatarLoader: {
+    className: ComponentClassName.AvatarLoader,
+    components: ['Avatar'],
+    description: 'Class applied to the loader element',
+  },
   Badge: {
     className: ComponentClassName.Badge,
     components: ['Badge'],

--- a/docs/src/pages/[platform]/components/avatar/examples/AvatarLoadingExample.tsx
+++ b/docs/src/pages/[platform]/components/avatar/examples/AvatarLoadingExample.tsx
@@ -1,0 +1,11 @@
+import { Avatar, Flex } from '@aws-amplify/ui-react';
+
+export default function AvatarLoadingExample() {
+  return (
+    <Flex>
+      <Avatar isLoading />
+      <Avatar isLoading colorTheme="info" />
+      <Avatar isLoading variation="outlined" colorTheme="success" />
+    </Flex>
+  );
+}

--- a/docs/src/pages/[platform]/components/avatar/examples/index.ts
+++ b/docs/src/pages/[platform]/components/avatar/examples/index.ts
@@ -6,3 +6,4 @@ export { default as AvatarVariationExample } from './AvatarVariationExample';
 export { default as AvatarStyleExample } from './AvatarStyleExample';
 export { default as AvatarThemeExample } from './AvatarThemeExample';
 export { default as AvatarAccessibilityExample } from './AvatarAccessibilityExample';
+export { default as AvatarLoadingExample } from './AvatarLoadingExample';

--- a/docs/src/pages/[platform]/components/avatar/react.mdx
+++ b/docs/src/pages/[platform]/components/avatar/react.mdx
@@ -15,6 +15,7 @@ import {
   AvatarStyleExample,
   AvatarThemeExample,
   AvatarAccessibilityExample,
+  AvatarLoadingExample,
 } from './examples';
 
 ## Demo
@@ -83,6 +84,23 @@ Import the Avatar primitive and styles.
   <ExampleCode>
 
 ```jsx file=./examples/AvatarColorExample.tsx
+
+```
+
+  </ExampleCode>
+</Example>
+
+
+### Loading
+
+<Example>
+  <View>
+    <AvatarLoadingExample />
+  </View>
+  
+  <ExampleCode>
+
+```jsx file=./examples/AvatarLoadingExample.tsx
 
 ```
 

--- a/packages/react-ai/src/components/AIConversation/views/default/MessageList.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/default/MessageList.tsx
@@ -14,6 +14,7 @@ import {
   classNameModifier,
   classNames,
 } from '@aws-amplify/ui';
+import { LoadingContext } from '../../context/LoadingContext';
 
 const MessageMeta = ({ message }: { message: ConversationMessage }) => {
   // need to pass this in as props in order for it to be overridable
@@ -29,6 +30,35 @@ const MessageMeta = ({ message }: { message: ConversationMessage }) => {
       <Text className={ComponentClassName.AIConversationMessageSenderTimestamp}>
         {formatDate(new Date(message.createdAt))}
       </Text>
+    </View>
+  );
+};
+
+const LoadingMessage = () => {
+  const avatars = React.useContext(AvatarsContext);
+  const variant = React.useContext(MessageVariantContext);
+  const avatar = avatars?.ai;
+
+  return (
+    <View
+      className={classNames(
+        ComponentClassName.AIConversationMessage,
+        classNameModifier(ComponentClassName.AIConversationMessage, variant),
+        classNameModifier(ComponentClassName.AIConversationMessage, 'assistant')
+      )}
+    >
+      <View className={ComponentClassName.AIConversationMessageAvatar}>
+        <Avatar isLoading>{avatar?.avatar}</Avatar>
+      </View>
+      <View className={ComponentClassName.AIConversationMessageBody}>
+        <View className={ComponentClassName.AIConversationMessageSender}>
+          <Text
+            className={ComponentClassName.AIConversationMessageSenderUsername}
+          >
+            {avatar?.username}
+          </Text>
+        </View>
+      </View>
     </View>
   );
 };
@@ -67,11 +97,13 @@ const Message = ({ message }: { message: ConversationMessage }) => {
 export const MessageList: ControlsContextProps['MessageList'] = ({
   messages,
 }) => {
+  const isLoading = React.useContext(LoadingContext);
   return (
     <View className={ComponentClassName.AIConversationMessageList}>
       {messages.map((message, i) => (
         <Message key={`message-${i}`} message={message} />
       ))}
+      {isLoading ? <LoadingMessage /> : null}
     </View>
   );
 };

--- a/packages/react/__tests__/__snapshots__/exports.ts.snap
+++ b/packages/react/__tests__/__snapshots__/exports.ts.snap
@@ -1129,6 +1129,9 @@ exports[`primitive catalog should match primitives catalog snapshot 1`] = `
       "isDisabled": {
         "type": "boolean",
       },
+      "isLoading": {
+        "type": "boolean",
+      },
       "left": {
         "type": "string",
       },

--- a/packages/react/src/primitives/Avatar/Avatar.tsx
+++ b/packages/react/src/primitives/Avatar/Avatar.tsx
@@ -10,9 +10,20 @@ import { View } from '../View';
 import { IconUser, useIcons } from '../Icon';
 import { Image } from '../Image';
 import { AvatarProps, BaseAvatarProps } from './types';
+import { Loader } from '../Loader';
 
 const AvatarPrimitive: Primitive<AvatarProps, 'span'> = (
-  { className, children, variation, colorTheme, size, src, alt, ...rest },
+  {
+    className,
+    children,
+    variation,
+    colorTheme,
+    size,
+    src,
+    alt,
+    isLoading,
+    ...rest
+  },
   ref
 ) => {
   const icons = useIcons('avatar');
@@ -40,6 +51,9 @@ const AvatarPrimitive: Primitive<AvatarProps, 'span'> = (
           </View>
         )
       )}
+      {isLoading ? (
+        <Loader className={ComponentClassName.AvatarLoader} />
+      ) : null}
     </View>
   );
 };

--- a/packages/react/src/primitives/Avatar/types.ts
+++ b/packages/react/src/primitives/Avatar/types.ts
@@ -37,6 +37,12 @@ export interface BaseAvatarProps extends BaseViewProps {
    * The size property will affect the size of the avatar.
    */
   size?: AvatarSizes;
+
+  /**
+   * @description
+   * The isLoading property will display a loader around the avatar
+   */
+  isLoading?: boolean;
 }
 
 export type AvatarProps<Element extends ElementType = 'span'> = PrimitiveProps<

--- a/packages/ui/src/theme/components/avatar.ts
+++ b/packages/ui/src/theme/components/avatar.ts
@@ -8,4 +8,11 @@ import {
 
 export type AvatarTheme<Required extends boolean = false> = ComponentStyles &
   Modifiers<Size | ColorTheme | 'filled' | 'outlined', Required> &
-  Elements<{ icon?: ComponentStyles; image?: ComponentStyles }, Required>;
+  Elements<
+    {
+      icon?: ComponentStyles;
+      image?: ComponentStyles;
+      loader?: ComponentStyles;
+    },
+    Required
+  >;

--- a/packages/ui/src/theme/css/component/avatar.scss
+++ b/packages/ui/src/theme/css/component/avatar.scss
@@ -10,6 +10,7 @@
 
   --amplify-components-icon-height: 100%;
 
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -66,6 +67,9 @@
     --avatar-filled-color: var(
       --amplify-components-avatar-warning-background-color
     );
+    --amplify-components-loader-stroke-filled: var(
+      --amplify-components-avatar-warning-color
+    );
   }
 
   &--error {
@@ -80,6 +84,9 @@
     --avatar-filled-color: var(
       --amplify-components-avatar-error-background-color
     );
+    --amplify-components-loader-stroke-filled: var(
+      --amplify-components-avatar-error-color
+    );
   }
 
   &--info {
@@ -93,6 +100,10 @@
     );
     --avatar-filled-color: var(
       --amplify-components-avatar-info-background-color
+    );
+
+    --amplify-components-loader-stroke-filled: var(
+      --amplify-components-avatar-info-color
     );
   }
 
@@ -110,6 +121,10 @@
     --avatar-filled-color: var(
       --amplify-components-avatar-success-background-color
     );
+
+    --amplify-components-loader-stroke-filled: var(
+      --amplify-components-avatar-success-color
+    );
   }
 
   // elements
@@ -125,5 +140,14 @@
     height: 100%;
     object-fit: cover;
     display: block;
+  }
+
+  &__loader {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    // This will make the empty part of the loader not show up
+    stroke: transparent;
   }
 }

--- a/packages/ui/src/theme/tokens/components/avatar.ts
+++ b/packages/ui/src/theme/tokens/components/avatar.ts
@@ -33,7 +33,6 @@ export type AvatarTokens<OutputType extends OutputVariantKey> =
     info?: AvatarVariationTokens<OutputType>;
     success?: AvatarVariationTokens<OutputType>;
     warning?: AvatarVariationTokens<OutputType>;
-    primary?: AvatarVariationTokens<OutputType>;
   };
 
 export const avatar: Required<AvatarTokens<'default'>> = {
@@ -72,12 +71,6 @@ export const avatar: Required<AvatarTokens<'default'>> = {
 
   error: {
     color: { value: '{colors.font.error.value}' },
-    backgroundColor: { value: '{colors.background.error.value}' },
-    borderColor: { value: '{colors.border.error.value}' },
-  },
-
-  primary: {
-    color: { value: '{colors.font.accent.value}' },
     backgroundColor: { value: '{colors.background.error.value}' },
     borderColor: { value: '{colors.border.error.value}' },
   },

--- a/packages/ui/src/theme/tokens/components/avatar.ts
+++ b/packages/ui/src/theme/tokens/components/avatar.ts
@@ -33,6 +33,7 @@ export type AvatarTokens<OutputType extends OutputVariantKey> =
     info?: AvatarVariationTokens<OutputType>;
     success?: AvatarVariationTokens<OutputType>;
     warning?: AvatarVariationTokens<OutputType>;
+    primary?: AvatarVariationTokens<OutputType>;
   };
 
 export const avatar: Required<AvatarTokens<'default'>> = {
@@ -71,6 +72,12 @@ export const avatar: Required<AvatarTokens<'default'>> = {
 
   error: {
     color: { value: '{colors.font.error.value}' },
+    backgroundColor: { value: '{colors.background.error.value}' },
+    borderColor: { value: '{colors.border.error.value}' },
+  },
+
+  primary: {
+    color: { value: '{colors.font.accent.value}' },
     backgroundColor: { value: '{colors.background.error.value}' },
     borderColor: { value: '{colors.border.error.value}' },
   },

--- a/packages/ui/src/types/primitives/componentClassName.ts
+++ b/packages/ui/src/types/primitives/componentClassName.ts
@@ -20,6 +20,7 @@ export const ComponentClassName = {
   Avatar: 'amplify-avatar',
   AvatarIcon: 'amplify-avatar__icon',
   AvatarImage: 'amplify-avatar__image',
+  AvatarLoader: 'amplify-avatar__loader',
   AIConversation: 'amplify-ai-conversation',
   AIConversationAttachment: 'amplify-ai-conversation__attachment',
   AIConversationAttachmentList: 'amplify-ai-conversation__attachment__list',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Added `isLoading` prop to Avatar primitive and added a loading state in the AIConversation which uses it. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

![CleanShot 2024-09-09 at 21 55 13](https://github.com/user-attachments/assets/942683a4-4f52-4857-b06d-2620dd7a48d0)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
