### PR TITLE
fix(e2e): fix placeholder matching rn e2e android

### DIFF
--- a/packages/e2e/detox/integration/common/shared.ts
+++ b/packages/e2e/detox/integration/common/shared.ts
@@ -93,7 +93,18 @@ Then(
 );
 
 Then('I see placeholder {string}', async (placeholder: string) => {
-  await expect(element(by.text(placeholder))).toExist();
+  const emailField = element(
+    by.id('authenticator__text-field__input-username')
+  );
+  await expect(emailField).toExist();
+  const attributes = await emailField.getAttributes();
+  if ((attributes as Detox.ElementAttributes).placeholder) {
+    if ((attributes as any).placeholder !== placeholder) {
+      throw new Error(
+        `No element found with placeholder value: ${placeholder}`
+      );
+    }
+  }
 });
 
 Then(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Noticed when running e2e RN android tests locally this placeholder test would consistently fail
- Updated to match by testId
- Updated to check attribute on element
- Example failure screenshot below to see what throwing looking like

<img width="896" alt="Screenshot 2024-09-11 at 12 08 22 PM" src="https://github.com/user-attachments/assets/7ecca3f5-83b4-45f7-9b1d-aa1eed7adb5d">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
