### PR TITLE
fix(liveness): use video stream dimensions instead of videoEl dimensions

### DIFF
--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/streamProvider.ts
@@ -60,7 +60,7 @@ export class LivenessStreamProvider {
   private _reader!: ReadableStreamDefaultReader;
   private videoEl: HTMLVideoElement;
   private _client!: RekognitionStreamingClient;
-  private _stream: MediaStream;
+  private stream: MediaStream;
   private initPromise: Promise<void>;
 
   constructor({
@@ -74,7 +74,7 @@ export class LivenessStreamProvider {
   }: StreamProviderArgs) {
     this.sessionId = sessionId;
     this.region = region;
-    this._stream = stream;
+    this.stream = stream;
     this.videoEl = videoEl;
     this.videoRecorder = new VideoRecorder(stream);
     this.credentialProvider = credentialProvider;
@@ -198,13 +198,15 @@ export class LivenessStreamProvider {
       this.videoRecorder.videoStream
     )();
 
+    const mediaSettings = this.stream.getTracks()[0].getSettings();
+
     const response = await this._client.send(
       new StartFaceLivenessSessionCommand({
         ChallengeVersions: 'FaceMovementAndLightChallenge_1.0.0',
         SessionId: this.sessionId,
         LivenessRequestStream: livenessRequestGenerator,
-        VideoWidth: this.videoEl.videoWidth.toString(),
-        VideoHeight: this.videoEl.videoHeight.toString(),
+        VideoWidth: (mediaSettings.width ?? this.videoEl.width).toString(),
+        VideoHeight: (mediaSettings.height ?? this.videoEl.height).toString(),
       })
     );
     return response.LivenessResponseStream!;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- In some very specific cases when flipping the phones orientation many times before attempting a check there seems to have been a mismatch between the video dimensions and the dimensions we send to the rekognition service which would cause a distorted audit image
- Tested this by sending flipped dimensions to the rekognition service and got a distorted image
- Will need to test this extensively since I believe we initially used the layout width and height because some browser / device combinations would return flipped width and height from `getUserMedia`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
