### PR TITLE
fix(ai): fix renders for empty toolUse messages

### DIFF
--- a/.changeset/ten-beds-jump.md
+++ b/.changeset/ten-beds-jump.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-ai": patch
+---
+
+fix(ai): fix renders for empty toolUse messages

--- a/packages/react-ai/src/components/AIConversation/context/ResponseComponentsContext.tsx
+++ b/packages/react-ai/src/components/AIConversation/context/ResponseComponentsContext.tsx
@@ -27,10 +27,13 @@ export const ResponseComponentsProvider = ({
   children?: React.ReactNode;
   responseComponents?: ResponseComponents;
 }): JSX.Element => {
+  const _responseComponents = React.useMemo(
+    () => prependResponseComponents(responseComponents),
+    [responseComponents]
+  );
+
   return (
-    <ResponseComponentsContext.Provider
-      value={prependResponseComponents(responseComponents)}
-    >
+    <ResponseComponentsContext.Provider value={_responseComponents}>
       {children}
     </ResponseComponentsContext.Provider>
   );

--- a/packages/react-ai/src/components/AIConversation/context/ResponseComponentsContext.tsx
+++ b/packages/react-ai/src/components/AIConversation/context/ResponseComponentsContext.tsx
@@ -4,7 +4,7 @@ import { ToolConfiguration } from '../../../types';
 
 type ResponseComponentsContextProps = ResponseComponents | undefined;
 
-export const RESPONSE_COMPONENT_PREFIX = 'UI_';
+export const RESPONSE_COMPONENT_PREFIX = 'AMPLIFY_UI_';
 
 export const ResponseComponentsContext =
   React.createContext<ResponseComponentsContextProps>(undefined);

--- a/packages/react-ai/src/components/AIConversation/context/ResponseComponentsContext.tsx
+++ b/packages/react-ai/src/components/AIConversation/context/ResponseComponentsContext.tsx
@@ -4,8 +4,21 @@ import { ToolConfiguration } from '../../../types';
 
 type ResponseComponentsContextProps = ResponseComponents | undefined;
 
+export const RESPONSE_COMPONENT_PREFIX = 'UI_';
+
 export const ResponseComponentsContext =
   React.createContext<ResponseComponentsContextProps>(undefined);
+
+const prependResponseComponents = (responseComponents?: ResponseComponents) => {
+  if (!responseComponents) return responseComponents;
+  return Object.keys(responseComponents).reduce(
+    (prev, key) => (
+      (prev[`${RESPONSE_COMPONENT_PREFIX}${key}`] = responseComponents[key]),
+      prev
+    ),
+    {} as ResponseComponents
+  );
+};
 
 export const ResponseComponentsProvider = ({
   children,
@@ -15,7 +28,9 @@ export const ResponseComponentsProvider = ({
   responseComponents?: ResponseComponents;
 }): JSX.Element => {
   return (
-    <ResponseComponentsContext.Provider value={responseComponents}>
+    <ResponseComponentsContext.Provider
+      value={prependResponseComponents(responseComponents)}
+    >
       {children}
     </ResponseComponentsContext.Provider>
   );

--- a/packages/react-ai/src/components/AIConversation/context/index.ts
+++ b/packages/react-ai/src/components/AIConversation/context/index.ts
@@ -29,7 +29,10 @@ export {
   ControlsProvider,
 } from './ControlsContext';
 export { LoadingContextProvider } from './LoadingContext';
-export { ResponseComponentsProvider } from './ResponseComponentsContext';
+export {
+  ResponseComponentsProvider,
+  RESPONSE_COMPONENT_PREFIX,
+} from './ResponseComponentsContext';
 export { SendMessageContextProvider } from './SendMessageContext';
 
 export * from './elements';

--- a/packages/react-ai/src/components/AIConversation/views/Controls/MessagesControl.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/MessagesControl.tsx
@@ -12,7 +12,10 @@ import { convertBufferToBase64 } from '../../utils';
 import { ActionsBarControl } from './ActionsBarControl';
 import { AvatarControl } from './AvatarControl';
 import { ConversationMessage } from '../../../../types';
-import { ResponseComponentsContext } from '../../context/ResponseComponentsContext';
+import {
+  RESPONSE_COMPONENT_PREFIX,
+  ResponseComponentsContext,
+} from '../../context/ResponseComponentsContext';
 import { ControlsContext } from '../../context/ControlsContext';
 
 const { Image, Span, Text, View } = AIConversationElements;
@@ -83,7 +86,11 @@ export const MessageControl: MessageControl = ({ message }) => {
         } else if (content.toolUse) {
           // For now tool use is limited to custom response components
           const { name, input } = content.toolUse;
-          if (!responseComponents || !name) {
+          if (
+            !responseComponents ||
+            !name ||
+            !name.startsWith(RESPONSE_COMPONENT_PREFIX)
+          ) {
             return;
           } else {
             const response = responseComponents[name];
@@ -206,9 +213,19 @@ export const MessagesControl: MessagesControl = ({ renderMessage }) => {
     return <controls.MessageList messages={messages!} />;
   }
 
+  const messagesWithRenderableContent =
+    messages?.filter((message) =>
+      message.content.some(
+        (content) =>
+          content.image ??
+          content.text ??
+          content.toolUse?.name.startsWith(RESPONSE_COMPONENT_PREFIX)
+      )
+    ) ?? [];
+
   return (
     <Layout>
-      {messages?.map((message, index) => {
+      {messagesWithRenderableContent?.map((message, index) => {
         return renderMessage ? (
           renderMessage(message)
         ) : (

--- a/packages/react-ai/src/components/AIConversation/views/Controls/__tests__/MessagesControl.spec.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/__tests__/MessagesControl.spec.tsx
@@ -54,7 +54,38 @@ const AIResponseComponentMessage: ConversationMessage = {
   content: [
     {
       toolUse: {
-        name: 'annoyingComponent',
+        name: 'UI_annoyingComponent',
+        input: { text: 'ahoy matey' },
+        toolUseId: 'tooluseID',
+      },
+    },
+  ],
+  role: 'assistant',
+  createdAt: new Date(2023, 4, 21, 15, 25).toDateString(),
+};
+const ToolUseMessage: ConversationMessage = {
+  conversationId: 'foobar',
+  id: '3',
+  content: [
+    {
+      toolUse: {
+        name: '"generateRecipe"',
+        input: { text: 'ahoy matey' },
+        toolUseId: 'tooluseID',
+      },
+    },
+  ],
+  role: 'assistant',
+  createdAt: new Date(2023, 4, 21, 15, 25).toDateString(),
+};
+const TextAndToolUseMessage: ConversationMessage = {
+  conversationId: 'foobar',
+  id: '3',
+  content: [
+    { text: 'hey what up' },
+    {
+      toolUse: {
+        name: '"generateRecipe"',
         input: { text: 'ahoy matey' },
         toolUseId: 'tooluseID',
       },
@@ -344,5 +375,16 @@ describe('MessageControl', () => {
     );
     const message = screen.getByText('argh matey! ahoy matey');
     expect(message).toBeInTheDocument();
+  });
+
+  it('renders text when sent with a tooluse content', () => {
+    render(<MessageControl message={TextAndToolUseMessage} />);
+    const message = screen.getByText('hey what up');
+    expect(message).toBeInTheDocument();
+  });
+
+  it('renders nothing when only a toolUse block is sent', () => {
+    const { container } = render(<MessageControl message={ToolUseMessage} />);
+    expect(container.firstChild).toBeEmptyDOMElement();
   });
 });

--- a/packages/react-ai/src/components/AIConversation/views/Controls/__tests__/MessagesControl.spec.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/__tests__/MessagesControl.spec.tsx
@@ -54,7 +54,7 @@ const AIResponseComponentMessage: ConversationMessage = {
   content: [
     {
       toolUse: {
-        name: 'UI_annoyingComponent',
+        name: 'AMPLIFY_UI_annoyingComponent',
         input: { text: 'ahoy matey' },
         toolUseId: 'tooluseID',
       },

--- a/packages/react-ai/src/components/AIConversation/views/default/MessageList.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/default/MessageList.tsx
@@ -4,6 +4,7 @@ import { MessageControl } from '../Controls/MessagesControl';
 import {
   AvatarsContext,
   MessageVariantContext,
+  RESPONSE_COMPONENT_PREFIX,
   RoleContext,
   useConversationDisplayText,
 } from '../../context';
@@ -99,9 +100,19 @@ export const MessageList: ControlsContextProps['MessageList'] = ({
   messages,
 }) => {
   const isLoading = React.useContext(LoadingContext);
+  const messagesWithRenderableContent =
+    messages?.filter((message) =>
+      message.content.some(
+        (content) =>
+          content.image ??
+          content.text ??
+          content.toolUse?.name.startsWith(RESPONSE_COMPONENT_PREFIX)
+      )
+    ) ?? [];
+
   return (
     <View className={ComponentClassName.AIConversationMessageList}>
-      {messages.map((message, i) => (
+      {messagesWithRenderableContent.map((message, i) => (
         <Message key={`message-${i}`} message={message} />
       ))}
       {isLoading ? <LoadingMessage /> : null}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Developer can override the `sendMessage` utility to send messages with tools that are not renderable in the AIConversation component example below:
- Updates all of our response components to be prefixed with `UI_` to be easier to tell as response component tool uses rather than regular tool uses
- Filters out messages that are not renderable, i.e only render empty tool use blocks
```
handleSendMessage={(content) =>
          sendMessage({
            ...content,
            toolConfiguration: {
              tools: {
                generateRecipe: {
                  description: "List ingredients needed for a recipe",
                  inputSchema: {
                    json: {
                      type: "object",
                      properties: {
                        ingredients: {
                          type: "array",
                          items: {
                            type: "object",
                            properties: {
                              ingredientName: { type: "string" },
                              quantity: { type: "number" },
                              unit: { type: "string" },
                            }
                          },
                        },
                      },
                    },
                  },
                },
              }
            }
          })
        }
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
