### PR TITLE
fix: set file status "uploading" earlier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ docs/public/previews
 
 # flutter assets are built with `yarn flutter:build` and should not be checked in to source control
 **/public/flutter/**/
+
+.idea

--- a/packages/react-storage/src/components/FileUploader/hooks/useFileUploader/actions.ts
+++ b/packages/react-storage/src/components/FileUploader/hooks/useFileUploader/actions.ts
@@ -32,11 +32,9 @@ export const setProcessedKeyAction = (input: {
 
 export const setUploadingFileAction = ({
   id,
-  uploadTask,
 }: TaskEvent): Action => ({
   type: FileUploaderActionTypes.SET_STATUS_UPLOADING,
   id,
-  uploadTask,
 });
 
 export const setUploadProgressAction = ({

--- a/packages/react-storage/src/components/FileUploader/hooks/useFileUploader/useFileUploader.ts
+++ b/packages/react-storage/src/components/FileUploader/hooks/useFileUploader/useFileUploader.ts
@@ -71,10 +71,9 @@ export function useFileUploader(
   };
 
   const setUploadingFile: UseFileUploader['setUploadingFile'] = ({
-    uploadTask,
     id,
   }) => {
-    dispatch(setUploadingFileAction({ id, uploadTask }));
+    dispatch(setUploadingFileAction({ id }));
   };
 
   const setProcessedKey: UseFileUploader['setProcessedKey'] = (input) => {

--- a/packages/react-storage/src/components/FileUploader/hooks/useUploadFiles/useUploadFiles.ts
+++ b/packages/react-storage/src/components/FileUploader/hooks/useUploadFiles/useUploadFiles.ts
@@ -82,6 +82,7 @@ export function useUploadFiles({
           useAccelerateEndpoint,
         });
 
+        setUploadingFile({ id });
         uploadFile({
           input,
           onComplete: (event) => {
@@ -99,11 +100,11 @@ export function useUploadFiles({
               onUploadError(error.message, { key });
             }
           },
-          onStart: ({ key, uploadTask }) => {
+          onStart: ({ key }) => {
             if (isFunction(onUploadStart)) {
               onUploadStart({ key });
             }
-            setUploadingFile({ id, uploadTask });
+            // setUploadingFile({ id, uploadTask });
           },
         });
       }

--- a/packages/react-storage/src/components/FileUploader/utils/uploadFile.ts
+++ b/packages/react-storage/src/components/FileUploader/utils/uploadFile.ts
@@ -20,7 +20,7 @@ export type PathCallback = (input: {
 export type UploadTask = UploadDataOutput | UploadDataWithPathOutput;
 export interface TaskEvent {
   id: string;
-  uploadTask: UploadTask;
+  uploadTask?: UploadTask;
 }
 
 // omit `path` callback, `path` must always be a string to support resolving


### PR DESCRIPTION
#### Description of changes

File status "uploading" should be set earlier as proposed [here](https://github.com/aws-amplify/amplify-ui/issues/5800#issuecomment-2357875585)

#### Issue #, if available

https://github.com/aws-amplify/amplify-ui/issues/5800

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
