### PR TITLE
chore(dependabot): Upgrade vite in canaries

### DIFF
--- a/canary/apps/react/vite/package.json
+++ b/canary/apps/react/vite/package.json
@@ -19,7 +19,7 @@
     "@size-limit/preset-app": "^8.2.6",
     "@vitejs/plugin-react": "^1.0.7",
     "size-limit": "^8.2.6",
-    "vite": "^2.8.0"
+    "vite": "latest"
   },
   "size-limit": [
     {

--- a/canary/apps/react/vite/package.json
+++ b/canary/apps/react/vite/package.json
@@ -5,26 +5,19 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "postbuild": "yarn run size-limit",
     "preview": "vite preview",
     "start": "vite preview --port 3000"
   },
   "dependencies": {
     "@aws-amplify/ui-react": "latest",
     "aws-amplify": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@size-limit/preset-app": "^8.2.6",
-    "@vitejs/plugin-react": "^1.0.7",
-    "size-limit": "^8.2.6",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
     "vite": "latest"
-  },
-  "size-limit": [
-    {
-      "path": "dist/assets/index.*.js",
-      "limit": "300 kB"
-    }
-  ]
+  }
 }

--- a/canary/apps/vue/vite/package.json
+++ b/canary/apps/vue/vite/package.json
@@ -10,10 +10,10 @@
   "dependencies": {
     "@aws-amplify/ui-vue": "latest",
     "aws-amplify": "latest",
-    "vue": "^3.2.27"
+    "vue": "latest"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.0.1",
-    "vite": "^2.7.13"
+    "vite": "latest"
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Vite v2 is no longer supported and has security vulnerabilities so replacing it with `latest` in canaries to resolve the dependabot alerts 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://github.com/aws-amplify/amplify-ui/security/dependabot/166
https://github.com/aws-amplify/amplify-ui/security/dependabot/165
https://github.com/aws-amplify/amplify-ui/security/dependabot/164
https://github.com/aws-amplify/amplify-ui/security/dependabot/163
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Passing POC workflow https://github.com/aws-amplify/amplify-ui/actions/runs/10927229890

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
