### PR TITLE
chore: Update pending-maintainer-response and restore pending-triage

### DIFF
--- a/.github/workflows/label-new-issues.yml
+++ b/.github/workflows/label-new-issues.yml
@@ -15,13 +15,14 @@ jobs:
     permissions:
       issues: write
 
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      REPOSITORY_NAME: ${{ github.event.repository.full_name }}
     steps:
       - uses: actions/checkout@b80ff79f1755d06ba70441c368a6fe801f5f3a62 # v4.1.3 https://github.com/actions/checkout/commit/cd7d8d697e10461458bc61a30d094dc601a8b017
-      - name: Add pending-maintainer-response label
+      - name: Add pending-triage label
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
         # run bash script to sanitize issue number and add label
         # first sanitize the ISSUE_NUMBER which is a assumed to be string representing an integer
         # remove any newline characters with tr because awk only works with single lines of code and may have unexpected behavior if newline is present
@@ -33,4 +34,14 @@ jobs:
             echo "Issue number must be a positive integer"
             exit 1
           fi
-          gh issue edit $ISSUE_NUMBER_INT --add-label 'pending-maintainer-response'
+          gh issue edit $ISSUE_NUMBER_INT --repo $REPOSITORY_NAME --add-label 'pending-triage'
+      - name: Add pending-maintainer-response label
+        if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.issue.author_association) }}
+        shell: bash
+        run: |
+          ISSUE_NUMBER_INT=$(echo "$ISSUE_NUMBER" | tr -d '\n' | awk '{print int($0)}')
+          if [ "$ISSUE_NUMBER_INT" -le 0 ]; then
+            echo "Issue number must be a positive integer"
+            exit 1
+          fi
+          gh issue edit $ISSUE_NUMBER_INT --repo $REPOSITORY_NAME --add-label "pending-maintainer-response"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
* `pending-maintainer-response` is now only added to issues not opened by a maintainer
* `pending-triage` is now applied to new issues _in addition to_ `pending-maintainer-response`, as they indicate different meanings
  * Previously, `pending-triage` had been replaced by `pending-maintainer-response`. This was inadequate, as it did not properly communicate the status of an issue.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
