### PR TITLE
fix(ai): update useAIGeneration to add graphqlErrors before return

### DIFF
--- a/.changeset/dirty-cups-chew.md
+++ b/.changeset/dirty-cups-chew.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-ai": patch
+---
+
+fix(ai): update useAIGeneration to manage its own date state

--- a/packages/react-ai/src/hooks/__tests__/createAIHooks.test.tsx
+++ b/packages/react-ai/src/hooks/__tests__/createAIHooks.test.tsx
@@ -171,5 +171,38 @@ describe('createAIHooks', () => {
       const [awaitedState] = hookResult.current;
       expect(awaitedState.data).toStrictEqual(expectedResult);
     });
+
+    it('returns a result with graphqlErrors', async () => {
+      const client = new mockClient();
+      const expectedResult = {
+        recipe: 'This is a recipe for chocolate cake that tastes bad',
+      };
+      const generateReturn = {
+        data: expectedResult,
+        errors: ['this is just one error'],
+      };
+      generateRecipeMock.mockResolvedValueOnce(generateReturn);
+      const { useAIGeneration } = createAIHooks(client);
+
+      const { result: hookResult, waitForNextUpdate } = renderHook(() =>
+        useAIGeneration('generateRecipe')
+      );
+
+      const [_result, generate] = hookResult.current;
+      act(() => {
+        generate({
+          description: 'I want a recipe for a gluten-free chocolate cake.',
+        });
+      });
+
+      const [loadingState] = hookResult.current;
+      expect(loadingState.isLoading).toBeTruthy();
+
+      await waitForNextUpdate();
+
+      const [awaitedState] = hookResult.current;
+      expect(awaitedState.data).toStrictEqual(expectedResult);
+      expect(awaitedState.graphqlErrors).toHaveLength(1);
+    });
   });
 });

--- a/packages/react-ai/src/hooks/useAIGeneration.tsx
+++ b/packages/react-ai/src/hooks/useAIGeneration.tsx
@@ -1,6 +1,7 @@
-import { DataState, useDataState } from '@aws-amplify/ui-react-core';
+import { DataState } from '@aws-amplify/ui-react-core';
 import { V6Client } from '@aws-amplify/api-graphql';
 import { getSchema } from '../types';
+import React from 'react';
 
 export interface UseAIGenerationHookWrapper<
   Key extends keyof AIGenerationClient<Schema>['generations'],
@@ -9,7 +10,7 @@ export interface UseAIGenerationHookWrapper<
   useAIGeneration: <U extends Key>(
     routeName: U
   ) => [
-    Awaited<DataState<Schema[U]['returnType']>>,
+    Awaited<GenerateState<Schema[U]['returnType']>>,
     (input: Schema[U]['args']) => void,
   ];
 }
@@ -20,7 +21,7 @@ export type UseAIGenerationHook<
 > = (
   routeName: Key
 ) => [
-  Awaited<DataState<Schema[Key]['returnType']>>,
+  Awaited<GenerateState<Schema[Key]['returnType']>>,
   (input: Schema[Key]['args']) => void,
 ];
 
@@ -28,6 +29,10 @@ type AIGenerationClient<T extends Record<any, any>> = Pick<
   V6Client<T>,
   'generations'
 >;
+
+const INITIAL_STATE = { hasError: false, isLoading: false, message: undefined };
+const LOADING_STATE = { hasError: false, isLoading: true, message: undefined };
+const ERROR_STATE = { hasError: true, isLoading: false };
 
 interface GraphQLFormattedError {
   readonly message: string;
@@ -37,6 +42,15 @@ interface GraphQLFormattedError {
   };
 }
 
+type SingularReturnValue<T> = Promise<{
+  data: T | null;
+  errors?: GraphQLFormattedError[];
+}>;
+
+type GenerateState<T> = DataState<T> & {
+  graphqlErrors?: GraphQLFormattedError[];
+};
+
 export function createUseAIGeneration<
   Client extends Record<'generations' | 'conversations', Record<string, any>>,
   Schema extends getSchema<Client>,
@@ -45,31 +59,45 @@ export function createUseAIGeneration<
     Key extends keyof AIGenerationClient<Schema>['generations'],
   >(
     routeName: Key
-  ) => {
+  ): [
+    state: GenerateState<Schema[Key]['returnType']>,
+    handleAction: (input: Schema[Key]['args']) => void,
+  ] => {
+    const [dataState, setDataState] = React.useState<
+      GenerateState<Schema[Key]['returnType']>
+    >(() => ({
+      ...INITIAL_STATE,
+      data: undefined,
+    }));
+
     const handleGenerate = (
       client.generations as AIGenerationClient<Schema>['generations']
     )[routeName];
 
-    const updateAIGenerationStateAction = async (
-      _prev: Schema[Key]['returnType'],
-      input: Schema[Key]['args']
-    ): Promise<
-      Schema[Key]['returnType'] & { graphqlErrors?: GraphQLFormattedError[] }
-    > => {
-      const result = await handleGenerate(input);
+    const generateHandler: (input: Schema[Key]['args']) => void =
+      React.useCallback(
+        (input) => {
+          setDataState(({ data }) => ({ ...LOADING_STATE, data }));
 
-      // handleGenerate returns a Promised wrapper around Schema[Key]['returnType'] which includes data, errors, and clientExtensions
-      // The type of data is Schema[Key]['returnType'] which useDataState also wraps in a data return
-      // TODO: follow up with how to type handleGenerate to properly return the promise wrapper shape
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const data = (result as any).data as Schema[Key]['returnType'];
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const graphqlErrors = (result as any).errors;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment
-      return { ...data, ...(graphqlErrors ? { graphqlErrors } : {}) };
-    };
+          const promiseResult = handleGenerate(input);
 
-    return useDataState(updateAIGenerationStateAction, {});
+          (promiseResult as SingularReturnValue<Schema[Key]['returnType']>)
+            .then(({ data, errors }) => {
+              setDataState({ ...INITIAL_STATE, data, graphqlErrors: errors });
+            })
+            .catch(({ message }: Error) => {
+              setDataState(({ data, graphqlErrors }) => ({
+                ...ERROR_STATE,
+                data,
+                message,
+                graphqlErrors,
+              }));
+            });
+        },
+        [handleGenerate]
+      );
+
+    return [dataState, generateHandler];
   };
 
   return useAIGeneration;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Danny noticed an error where simple string type returns from the client were returning malformed objects
- This is because we were assuming all return types from the generate client would be spreadable objects
- Updated called to useDataState to just return the data and massage the return type to add graphqlErrors after to avoid having to spread the return data

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
