### PR TITLE
feat(theming): add global style ability

### DIFF
--- a/.changeset/red-fans-pretend.md
+++ b/.changeset/red-fans-pretend.md
@@ -1,0 +1,18 @@
+---
+"@aws-amplify/ui-react": patch
+"@aws-amplify/ui": patch
+---
+
+feat(theming): add global style ability (experimental)
+
+Adding the ability to create global styles with the experimental theming APIs
+
+```jsx
+<GlobalStyle styles={{
+  'body': {
+    backgroundColor: 'purple'
+    // supports design tokens!
+    color: theme.tokens.colors.font.primary
+  }
+}} />
+```

--- a/packages/react/__tests__/__snapshots__/exports.ts.snap
+++ b/packages/react/__tests__/__snapshots__/exports.ts.snap
@@ -123,6 +123,7 @@ exports[`@aws-amplify/ui-react/internal exports should match snapshot 1`] = `
 exports[`@aws-amplify/ui-react/server exports should match snapshot 1`] = `
 [
   "ComponentStyle",
+  "GlobalStyle",
   "ThemeStyle",
   "createComponentClasses",
   "createTheme",

--- a/packages/react/src/components/ThemeProvider/ComponentStyle.tsx
+++ b/packages/react/src/components/ThemeProvider/ComponentStyle.tsx
@@ -1,17 +1,9 @@
 import * as React from 'react';
 import { WebTheme, createComponentCSS } from '@aws-amplify/ui';
-import {
-  BaseComponentProps,
-  ElementType,
-  ForwardRefPrimitive,
-  Primitive,
-  PrimitiveProps,
-} from '../../primitives/types';
-import { primitiveWithForwardRef } from '../../primitives/utils/primitiveWithForwardRef';
 import { BaseComponentTheme } from '@aws-amplify/ui';
 import { Style } from './Style';
 
-interface BaseComponentStyleProps extends BaseComponentProps {
+interface ComponentStyleProps extends React.StyleHTMLAttributes<{}> {
   /**
    * Provide a server generated nonce which matches your CSP `style-src` rule.
    * This will be attached to the generated <style> tag.
@@ -22,13 +14,15 @@ interface BaseComponentStyleProps extends BaseComponentProps {
   componentThemes: BaseComponentTheme[];
 }
 
-export type ComponentStyleProps<Element extends ElementType = 'style'> =
-  PrimitiveProps<BaseComponentStyleProps, Element>;
-
-const ComponentStylePrimitive: Primitive<ComponentStyleProps, 'style'> = (
-  { theme, componentThemes = [], ...rest },
-  ref
-) => {
+/**
+ * @experimental
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/theme)
+ */
+export const ComponentStyle = ({
+  theme,
+  componentThemes = [],
+  ...rest
+}: ComponentStyleProps): JSX.Element | null => {
   if (!theme || !componentThemes.length) {
     return null;
   }
@@ -38,16 +32,7 @@ const ComponentStylePrimitive: Primitive<ComponentStyleProps, 'style'> = (
     components: componentThemes,
   });
 
-  return <Style {...rest} ref={ref} cssText={cssText} />;
+  return <Style {...rest} cssText={cssText} />;
 };
-
-/**
- * @experimental
- * [📖 Docs](https://ui.docs.amplify.aws/react/components/theme)
- */
-export const ComponentStyle: ForwardRefPrimitive<
-  BaseComponentStyleProps,
-  'style'
-> = primitiveWithForwardRef(ComponentStylePrimitive);
 
 ComponentStyle.displayName = 'ComponentStyle';

--- a/packages/react/src/components/ThemeProvider/ComponentStyle.tsx
+++ b/packages/react/src/components/ThemeProvider/ComponentStyle.tsx
@@ -3,7 +3,7 @@ import { WebTheme, createComponentCSS } from '@aws-amplify/ui';
 import { BaseComponentTheme } from '@aws-amplify/ui';
 import { Style } from './Style';
 
-interface ComponentStyleProps extends React.StyleHTMLAttributes<'style'> {
+interface ComponentStyleProps extends React.ComponentProps<'style'> {
   /**
    * Provide a server generated nonce which matches your CSP `style-src` rule.
    * This will be attached to the generated <style> tag.

--- a/packages/react/src/components/ThemeProvider/ComponentStyle.tsx
+++ b/packages/react/src/components/ThemeProvider/ComponentStyle.tsx
@@ -3,7 +3,7 @@ import { WebTheme, createComponentCSS } from '@aws-amplify/ui';
 import { BaseComponentTheme } from '@aws-amplify/ui';
 import { Style } from './Style';
 
-interface ComponentStyleProps extends React.StyleHTMLAttributes<{}> {
+interface ComponentStyleProps extends React.StyleHTMLAttributes<'style'> {
   /**
    * Provide a server generated nonce which matches your CSP `style-src` rule.
    * This will be attached to the generated <style> tag.

--- a/packages/react/src/components/ThemeProvider/GlobalStyle.tsx
+++ b/packages/react/src/components/ThemeProvider/GlobalStyle.tsx
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { createGlobalCSS } from '@aws-amplify/ui';
-import {
-  BaseComponentProps,
-  ElementType,
-  ForwardRefPrimitive,
-  Primitive,
-  PrimitiveProps,
-} from '../../primitives/types';
-import { primitiveWithForwardRef } from '../../primitives/utils/primitiveWithForwardRef';
 import { Style } from './Style';
 
-interface BaseGlobalStyleProps extends BaseComponentProps {
+interface GlobalStyleProps extends React.StyleHTMLAttributes<{}> {
   /**
    * Provide a server generated nonce which matches your CSP `style-src` rule.
    * This will be attached to the generated <style> tag.
@@ -20,27 +12,21 @@ interface BaseGlobalStyleProps extends BaseComponentProps {
   styles: Parameters<typeof createGlobalCSS>[0];
 }
 
-export type GlobalStyleProps<Element extends ElementType = 'style'> =
-  PrimitiveProps<BaseGlobalStyleProps, Element>;
-
-const GlobalStylePrimitive: Primitive<GlobalStyleProps, 'style'> = (
-  { styles, ...rest },
-  ref
-) => {
+/**
+ * @experimental
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/theme)
+ */
+export const GlobalStyle = ({
+  styles,
+  ...rest
+}: GlobalStyleProps): JSX.Element | null => {
   if (!styles) {
     return null;
   }
 
   const cssText = createGlobalCSS(styles);
 
-  return <Style {...rest} ref={ref} cssText={cssText} />;
+  return <Style {...rest} cssText={cssText} />;
 };
-
-/**
- * @experimental
- * [📖 Docs](https://ui.docs.amplify.aws/react/components/theme)
- */
-export const GlobalStyle: ForwardRefPrimitive<BaseGlobalStyleProps, 'style'> =
-  primitiveWithForwardRef(GlobalStylePrimitive);
 
 GlobalStyle.displayName = 'GlobalStyle';

--- a/packages/react/src/components/ThemeProvider/GlobalStyle.tsx
+++ b/packages/react/src/components/ThemeProvider/GlobalStyle.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { createGlobalCSS } from '@aws-amplify/ui';
+import {
+  BaseComponentProps,
+  ElementType,
+  ForwardRefPrimitive,
+  Primitive,
+  PrimitiveProps,
+} from '../../primitives/types';
+import { primitiveWithForwardRef } from '../../primitives/utils/primitiveWithForwardRef';
+import { Style } from './Style';
+
+interface BaseGlobalStyleProps extends BaseComponentProps {
+  /**
+   * Provide a server generated nonce which matches your CSP `style-src` rule.
+   * This will be attached to the generated <style> tag.
+   * @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
+   */
+  nonce?: string;
+  styles: Parameters<typeof createGlobalCSS>[0];
+}
+
+export type GlobalStyleProps<Element extends ElementType = 'style'> =
+  PrimitiveProps<BaseGlobalStyleProps, Element>;
+
+const GlobalStylePrimitive: Primitive<GlobalStyleProps, 'style'> = (
+  { styles, ...rest },
+  ref
+) => {
+  if (!styles) {
+    return null;
+  }
+
+  const cssText = createGlobalCSS(styles);
+
+  return <Style {...rest} ref={ref} cssText={cssText} />;
+};
+
+/**
+ * @experimental
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/theme)
+ */
+export const GlobalStyle: ForwardRefPrimitive<BaseGlobalStyleProps, 'style'> =
+  primitiveWithForwardRef(GlobalStylePrimitive);
+
+GlobalStyle.displayName = 'GlobalStyle';

--- a/packages/react/src/components/ThemeProvider/GlobalStyle.tsx
+++ b/packages/react/src/components/ThemeProvider/GlobalStyle.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createGlobalCSS } from '@aws-amplify/ui';
 import { Style } from './Style';
 
-interface GlobalStyleProps extends React.StyleHTMLAttributes<'style'> {
+interface GlobalStyleProps extends React.ComponentProps<'style'> {
   /**
    * Provide a server generated nonce which matches your CSP `style-src` rule.
    * This will be attached to the generated <style> tag.

--- a/packages/react/src/components/ThemeProvider/GlobalStyle.tsx
+++ b/packages/react/src/components/ThemeProvider/GlobalStyle.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createGlobalCSS } from '@aws-amplify/ui';
 import { Style } from './Style';
 
-interface GlobalStyleProps extends React.StyleHTMLAttributes<{}> {
+interface GlobalStyleProps extends React.StyleHTMLAttributes<'style'> {
   /**
    * Provide a server generated nonce which matches your CSP `style-src` rule.
    * This will be attached to the generated <style> tag.

--- a/packages/react/src/components/ThemeProvider/Style.tsx
+++ b/packages/react/src/components/ThemeProvider/Style.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-interface StyleProps extends React.StyleHTMLAttributes<'style'> {
+interface StyleProps extends React.ComponentProps<'style'> {
   cssText?: string;
 }
 

--- a/packages/react/src/components/ThemeProvider/Style.tsx
+++ b/packages/react/src/components/ThemeProvider/Style.tsx
@@ -1,26 +1,14 @@
 import * as React from 'react';
-import {
-  BaseComponentProps,
-  ElementType,
-  ForwardRefPrimitive,
-  Primitive,
-  PrimitiveProps,
-} from '../../primitives/types';
-import { primitiveWithForwardRef } from '../../primitives/utils/primitiveWithForwardRef';
 
-interface BaseStyleProps extends BaseComponentProps {
+interface StyleProps extends React.StyleHTMLAttributes<{}> {
   cssText?: string;
 }
 
-export type StyleProps<Element extends ElementType = 'style'> = PrimitiveProps<
-  BaseStyleProps,
-  Element
->;
-
-const StylePrimitive: Primitive<StyleProps, 'style'> = (
-  { cssText, ...rest },
-  ref
-) => {
+/**
+ * @experimental
+ * [📖 Docs](https://ui.docs.amplify.aws/react/components/theme)
+ */
+export const Style = ({ cssText, ...rest }: StyleProps): JSX.Element | null => {
   /*
     Only inject theme CSS variables if given a theme.
     The CSS file users import already has the default theme variables in it.
@@ -69,22 +57,14 @@ const StylePrimitive: Primitive<StyleProps, 'style'> = (
   if (cssText === undefined || /<\/style/i.test(cssText)) {
     return null;
   }
-  
+
   return (
     <style
       {...rest}
-      ref={ref}
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: cssText }}
     />
   );
 };
-
-/**
- * @experimental
- * [📖 Docs](https://ui.docs.amplify.aws/react/components/theme)
- */
-export const Style: ForwardRefPrimitive<BaseStyleProps, 'style'> =
-  primitiveWithForwardRef(StylePrimitive);
 
 Style.displayName = 'Style';

--- a/packages/react/src/components/ThemeProvider/Style.tsx
+++ b/packages/react/src/components/ThemeProvider/Style.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-interface StyleProps extends React.StyleHTMLAttributes<{}> {
+interface StyleProps extends React.StyleHTMLAttributes<'style'> {
   cssText?: string;
 }
 

--- a/packages/react/src/components/ThemeProvider/ThemeStyle.tsx
+++ b/packages/react/src/components/ThemeProvider/ThemeStyle.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { WebTheme } from '@aws-amplify/ui';
 import { Style } from './Style';
 
-interface ThemeStyleProps extends React.StyleHTMLAttributes<'style'> {
+interface ThemeStyleProps extends React.ComponentProps<'style'> {
   /**
    * Provide a server generated nonce which matches your CSP `style-src` rule.
    * This will be attached to the generated <style> tag.

--- a/packages/react/src/components/ThemeProvider/ThemeStyle.tsx
+++ b/packages/react/src/components/ThemeProvider/ThemeStyle.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { WebTheme } from '@aws-amplify/ui';
 import { Style } from './Style';
 
-interface ThemeStyleProps extends React.StyleHTMLAttributes<{}> {
+interface ThemeStyleProps extends React.StyleHTMLAttributes<'style'> {
   /**
    * Provide a server generated nonce which matches your CSP `style-src` rule.
    * This will be attached to the generated <style> tag.

--- a/packages/react/src/components/ThemeProvider/ThemeStyle.tsx
+++ b/packages/react/src/components/ThemeProvider/ThemeStyle.tsx
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { WebTheme } from '@aws-amplify/ui';
-import {
-  BaseComponentProps,
-  ElementType,
-  ForwardRefPrimitive,
-  Primitive,
-  PrimitiveProps,
-} from '../../primitives/types';
-import { primitiveWithForwardRef } from '../../primitives/utils/primitiveWithForwardRef';
 import { Style } from './Style';
 
-interface BaseStyleThemeProps extends BaseComponentProps {
+interface ThemeStyleProps extends React.StyleHTMLAttributes<{}> {
   /**
    * Provide a server generated nonce which matches your CSP `style-src` rule.
    * This will be attached to the generated <style> tag.
@@ -20,32 +12,18 @@ interface BaseStyleThemeProps extends BaseComponentProps {
   theme?: WebTheme;
 }
 
-export type ThemeStyleProps<Element extends ElementType = 'style'> =
-  PrimitiveProps<BaseStyleThemeProps, Element>;
-
-const ThemeStylePrimitive: Primitive<ThemeStyleProps, 'style'> = (
-  { theme, nonce, ...rest },
-  ref
-) => {
-  if (!theme) return null;
-
-  const { name, cssText } = theme;
-  return (
-    <Style
-      {...rest}
-      ref={ref}
-      cssText={cssText}
-      nonce={nonce}
-      id={`amplify-theme-${name}`}
-    />
-  );
-};
-
 /**
  * @experimental
  * [📖 Docs](https://ui.docs.amplify.aws/react/components/theme)
  */
-export const ThemeStyle: ForwardRefPrimitive<BaseStyleThemeProps, 'style'> =
-  primitiveWithForwardRef(ThemeStylePrimitive);
+export const ThemeStyle = ({
+  theme,
+  ...rest
+}: ThemeStyleProps): JSX.Element | null => {
+  if (!theme) return null;
+
+  const { name, cssText } = theme;
+  return <Style {...rest} cssText={cssText} id={`amplify-theme-${name}`} />;
+};
 
 ThemeStyle.displayName = 'ThemeStyle';

--- a/packages/react/src/components/ThemeProvider/__tests__/GlobalStyle.test.tsx
+++ b/packages/react/src/components/ThemeProvider/__tests__/GlobalStyle.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+
+import { GlobalStyle } from '../GlobalStyle';
+
+describe('GlobalStyle', () => {
+  it('does not render anything if no theme is passed', async () => {
+    // @ts-expect-error - missing props
+    const { container } = render(<GlobalStyle />);
+
+    const styleTag = container.querySelector(`style`);
+    expect(styleTag).toBe(null);
+  });
+
+  it('renders a style tag if styles are passed', async () => {
+    const { container } = render(
+      <GlobalStyle
+        styles={{
+          '.foo': {
+            backgroundColor: 'red',
+          },
+        }}
+      />
+    );
+
+    const styleTag = container.querySelector(`style`);
+    expect(styleTag).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/server.ts
+++ b/packages/react/src/server.ts
@@ -1,5 +1,6 @@
 export { ThemeStyle } from './components/ThemeProvider/ThemeStyle';
 export { ComponentStyle } from './components/ThemeProvider/ComponentStyle';
+export { GlobalStyle } from './components/ThemeProvider/GlobalStyle';
 export {
   createTheme,
   defineComponentTheme,

--- a/packages/ui/src/theme/createTheme/__tests__/__snapshots__/createGlobalCSS.test.ts.snap
+++ b/packages/ui/src/theme/createTheme/__tests__/__snapshots__/createGlobalCSS.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@aws-amplify/ui createGlobalCSS should handle psuedo-states 1`] = `
+".bar:active { background-color:#ff9900;  }
+.bar { background-color:#bada55;  }
+"
+`;
+
+exports[`@aws-amplify/ui createGlobalCSS should work with design tokens 1`] = `
+".bar:active { background-color:var(--amplify-colors-blue-40);  }
+.bar { background-color:var(--amplify-colors-blue-20);  }
+"
+`;
+
+exports[`@aws-amplify/ui createGlobalCSS should work with regular styles 1`] = `
+".foo { background-color:red;  }
+button > .icon { color:blueviolet;  }
+"
+`;

--- a/packages/ui/src/theme/createTheme/__tests__/createGlobalCSS.test.ts
+++ b/packages/ui/src/theme/createTheme/__tests__/createGlobalCSS.test.ts
@@ -1,0 +1,45 @@
+import { createGlobalCSS } from '../createGlobalCSS';
+import { createTheme } from '../createTheme';
+
+const { tokens } = createTheme();
+
+describe('@aws-amplify/ui', () => {
+  describe('createGlobalCSS', () => {
+    it('should work with regular styles', () => {
+      expect(
+        createGlobalCSS({
+          '.foo': {
+            backgroundColor: 'red',
+          },
+          'button > .icon': {
+            color: 'blueviolet',
+          },
+        })
+      ).toMatchSnapshot();
+    });
+    it('should handle psuedo-states', () => {
+      expect(
+        createGlobalCSS({
+          '.bar': {
+            backgroundColor: '#bada55',
+            ':active': {
+              backgroundColor: '#ff9900',
+            },
+          },
+        })
+      ).toMatchSnapshot();
+    });
+    it('should work with design tokens', () => {
+      expect(
+        createGlobalCSS({
+          '.bar': {
+            backgroundColor: tokens.colors.blue[20],
+            ':active': {
+              backgroundColor: tokens.colors.blue[40],
+            },
+          },
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/ui/src/theme/createTheme/createComponentCSS.ts
+++ b/packages/ui/src/theme/createTheme/createComponentCSS.ts
@@ -14,7 +14,7 @@ function addVars(selector: string, vars: Record<string, unknown>) {
     .join(' ')}}\n`;
 }
 
-function recursiveComponentCSS(baseSelector: string, theme: BaseTheme) {
+export function recursiveComponentCSS(baseSelector: string, theme: BaseTheme) {
   let str = '';
   const { _modifiers = {}, _element = {}, _vars, ...props } = theme;
 

--- a/packages/ui/src/theme/createTheme/createGlobalCSS.ts
+++ b/packages/ui/src/theme/createTheme/createGlobalCSS.ts
@@ -1,0 +1,14 @@
+import { ComponentStyles } from '../components/utils';
+import { recursiveComponentCSS } from './createComponentCSS';
+
+type GlobalCSS = Record<string, ComponentStyles>;
+
+export function createGlobalCSS(css: GlobalCSS) {
+  let cssText = ``;
+
+  for (const [selector, styles] of Object.entries(css)) {
+    cssText += recursiveComponentCSS(selector, styles);
+  }
+
+  return cssText;
+}

--- a/packages/ui/src/theme/createTheme/index.ts
+++ b/packages/ui/src/theme/createTheme/index.ts
@@ -1,6 +1,7 @@
 export { createTheme } from './createTheme';
 export { defineComponentTheme } from './defineComponentTheme';
 export { createComponentCSS } from './createComponentCSS';
+export { createGlobalCSS } from './createGlobalCSS';
 export {
   cssNameTransform,
   setupTokens,

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -3,6 +3,7 @@ export {
   defineComponentTheme,
   createComponentClasses,
   createComponentCSS,
+  createGlobalCSS,
   cssNameTransform,
   isDesignToken,
   setupTokens,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adding the ability to create global styles with the experimental theming APIs

```jsx
<GlobalStyle styles={{
  'body': {
    backgroundColor: 'purple'
    // supports design tokens!
    color: theme.tokens.colors.font.primary
  }
}} />
```

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
