### PR TITLE
fix(storage-browser): update subpath exports post rollup mv bump

### DIFF
--- a/packages/react-storage/browser/package.json
+++ b/packages/react-storage/browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-amplify/ui-react-storage/browser",
   "main": "../dist/browser.js",
-  "module": "../dist/esm/components/StorageBrowser/browser.mjs",
+  "module": "../dist/esm/browser.mjs",
   "types": "../dist/types/components/StorageBrowser/index.d.ts",
   "private": true,
   "sideEffects": false

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -12,7 +12,7 @@
     "./browser": {
       "main": "./dist/browser.js",
       "types": "./dist/types/components/StorageBrowser/index.d.ts",
-      "import": "./dist/esm/components/StorageBrowser/browser.mjs"
+      "import": "./dist/esm/browser.mjs"
     },
     "./styles.css": "./dist/styles.css",
     "./storage-browser-styles.css": "./dist/storage-browser-styles.css"
@@ -65,7 +65,7 @@
   "size-limit": [
     {
       "name": "createStorageBrowser",
-      "path": "dist/esm/components/StorageBrowser/browser.mjs",
+      "path": "dist/esm/browser.mjs",
       "import": "{ createStorageBrowser }",
       "limit": "15.2 kB"
     },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fix _dist_ path resolution of `StorageBrowser`  subpath exports
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- `yarn build && yarn size`
- smoke test default and managed auth apps
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
