### PR TITLE
chore(storage-browser): add standardized action handler types

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/copyAction.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/copyAction.spec.ts
@@ -1,0 +1,7 @@
+import { copyAction } from '../copyAction';
+
+describe('copyAction', () => {
+  it('is null', () => {
+    expect(copyAction).toBeNull();
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/createFolderAction.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/createFolderAction.spec.ts
@@ -1,0 +1,7 @@
+import { createFolderAction } from '../createFolderAction';
+
+describe('createFolderAction', () => {
+  it('is null', () => {
+    expect(createFolderAction).toBeNull();
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/deleteAction.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/deleteAction.spec.ts
@@ -1,0 +1,7 @@
+import { deleteAction } from '../deleteAction';
+
+describe('deleteAction', () => {
+  it('is null', () => {
+    expect(deleteAction).toBeNull();
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/downloadAction.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/downloadAction.spec.ts
@@ -1,0 +1,7 @@
+import { downloadAction } from '../downloadAction';
+
+describe('downloadAction', () => {
+  it('is null', () => {
+    expect(downloadAction).toBeNull();
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/listLocationItemsAction.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/listLocationItemsAction.spec.ts
@@ -1,0 +1,7 @@
+import { listLocationItemsAction } from '../listLocationItemsAction';
+
+describe('listLocationItemsAction', () => {
+  it('is null', () => {
+    expect(listLocationItemsAction).toBeNull();
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/listLocationsAction.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/listLocationsAction.spec.ts
@@ -1,0 +1,7 @@
+import { listLocationsAction } from '../listLocationsAction';
+
+describe('listLocationsAction', () => {
+  it('is null', () => {
+    expect(listLocationsAction).toBeNull();
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/uploadAction.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/uploadAction.spec.ts
@@ -1,0 +1,7 @@
+import { uploadAction } from '../uploadAction';
+
+describe('uploadAction', () => {
+  it('is null', () => {
+    expect(uploadAction).toBeNull();
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/copyAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/copyAction.ts
@@ -1,0 +1,15 @@
+import { CopyWithPathInput } from '@aws-amplify/storage';
+import {
+  DataTaskAction,
+  DataTaskActionInput,
+  DataTaskActionOutput,
+} from '../types';
+
+interface CopyData extends Pick<CopyWithPathInput, 'destination' | 'source'> {}
+
+export interface CopyActionInput extends DataTaskActionInput<CopyData> {}
+export interface CopyActionOutput extends DataTaskActionOutput {}
+
+export interface CopyAction extends DataTaskAction<DataTaskActionInput> {}
+
+export const copyAction: CopyAction = null as unknown as CopyAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/createFolderAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/createFolderAction.ts
@@ -1,0 +1,24 @@
+import {
+  DataTaskAction,
+  DataTaskActionInput,
+  DataTaskActionOutput,
+} from '../types';
+
+interface CreateFolderActionData {
+  target: string;
+}
+interface CreateFolderActionOptions {
+  preventOverwite?: boolean;
+}
+export interface CreateFolderActionInput
+  extends DataTaskActionInput<
+    CreateFolderActionData,
+    CreateFolderActionOptions
+  > {}
+export interface CreateFolderActionOutput extends DataTaskActionOutput {}
+
+export interface CreateFolderAction
+  extends DataTaskAction<DataTaskActionInput> {}
+
+export const createFolderAction: CreateFolderAction =
+  null as unknown as CreateFolderAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/deleteAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/deleteAction.ts
@@ -9,6 +9,4 @@ export interface DeleteActionOutput extends DataTaskActionOutput {}
 
 export interface DeleteAction extends DataTaskAction<DataTaskActionInput> {}
 
-export const deleteAction: DeleteAction = () => {
-  throw new Error('not implemented');
-};
+export const deleteAction: DeleteAction = null as unknown as DeleteAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/deleteAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/deleteAction.ts
@@ -1,0 +1,14 @@
+import {
+  DataTaskAction,
+  DataTaskActionInput,
+  DataTaskActionOutput,
+} from '../types';
+
+export interface DeleteActionInput extends DataTaskActionInput {}
+export interface DeleteActionOutput extends DataTaskActionOutput {}
+
+export interface DeleteAction extends DataTaskAction<DataTaskActionInput> {}
+
+export const deleteAction: DeleteAction = () => {
+  throw new Error('not implemented');
+};

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/downloadAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/downloadAction.ts
@@ -1,0 +1,19 @@
+import {
+  DataTaskAction,
+  DataTaskActionInput,
+  DataTaskActionOutput,
+} from '../types';
+
+interface DownloadActionData {
+  key: string;
+}
+interface DownloadActionOptions {
+  onProgress?: (progress: number) => void;
+}
+export interface DownloadActionInput
+  extends DataTaskActionInput<DownloadActionData, DownloadActionOptions> {}
+export interface DownloadActionOutput extends DataTaskActionOutput {}
+
+export interface DownloadAction extends DataTaskAction<DataTaskActionInput> {}
+
+export const downloadAction: DownloadAction = null as unknown as DownloadAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/index.ts
@@ -1,0 +1,7 @@
+export * from './copyAction';
+export * from './createFolderAction';
+export * from './deleteAction';
+export * from './downloadAction';
+export * from './listLocationItemsAction';
+export * from './listLocationsAction';
+export * from './uploadAction';

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationItemsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationItemsAction.ts
@@ -23,7 +23,10 @@ export interface FileItem {
 
 export type LocationItem = FileItem | FolderItem;
 
-export interface ListLocationItemsOptions extends ListActionOptions {
+type LocationItemType = LocationItem['type'];
+
+export interface ListLocationItemsOptions
+  extends ListActionOptions<LocationItemType> {
   delimiter?: string;
   query?: string;
 }

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationItemsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationItemsAction.ts
@@ -1,0 +1,44 @@
+import {
+  ListAction,
+  ListActionInput,
+  ListActionOptions,
+  ListActionOutput,
+} from '../types';
+
+/**
+ * handler types
+ */
+export interface FolderItem {
+  key: string;
+  type: 'FOLDER';
+}
+
+export interface FileItem {
+  key: string;
+  data?: File;
+  lastModified: Date;
+  size: number;
+  type: 'FILE';
+}
+
+export type LocationItem = FileItem | FolderItem;
+
+export interface ListLocationItemsOptions extends ListActionOptions {
+  delimiter?: string;
+  query?: string;
+}
+
+export interface ListLocationItemsActionInput
+  extends ListActionInput<ListLocationItemsOptions> {}
+
+export interface ListLocationItemsActionOutput
+  extends ListActionOutput<LocationItem> {}
+
+export interface ListLocationItemsAction
+  extends ListAction<
+    ListLocationItemsActionInput,
+    ListLocationItemsActionOutput
+  > {}
+
+export const listLocationItemsAction: ListLocationItemsAction =
+  null as unknown as ListLocationItemsAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
@@ -1,42 +1,32 @@
 import { Permission } from '@aws-amplify/storage/internals';
 
 import {
-  ActionInputConfig,
   ListActionOptions,
-  ListActionInput,
   ListActionOutput,
   ListAction,
   LocationType,
 } from '../types';
 
-export interface LocationData<T = Permission, K = LocationType> {
+export interface LocationData {
   bucket: string;
-  permission: T;
+  permission: Permission;
   prefix: string;
-  type: K;
+  type: LocationType;
 }
 
-export interface ListLocationsActionOptions<T = Permission | LocationType>
-  extends ListActionOptions {
-  exclude?: T | T[];
-}
-export interface ListLocationsActionInput<T = Permission | LocationType>
-  // `ListLocations` does not require `prefix`
-  extends Omit<
-    ListActionInput<ListLocationsActionOptions<T>>,
-    'config' | 'prefix'
-  > {
-  // `ListLocations` does not require `bucket`
-  config: Omit<ActionInputConfig, 'bucket'>;
-}
-export interface ListLocationsActionOutput<T = Permission | LocationType>
-  extends ListActionOutput<LocationData<T>> {}
+type ExcludeType = Permission | LocationType;
 
-export interface ListLocationsAction<T = Permission | LocationType>
-  extends ListAction<
-    ListLocationsActionInput<T>,
-    ListLocationsActionOutput<T>
-  > {}
+export interface ListLocationsActionOptions
+  extends ListActionOptions<ExcludeType | ExcludeType[]> {}
+
+export interface ListLocationsActionInput {
+  options?: ListLocationsActionOptions;
+}
+export interface ListLocationsActionOutput
+  extends ListActionOutput<LocationData> {}
+
+export interface ListLocationsAction
+  extends ListAction<ListLocationsActionInput, ListLocationsActionOutput> {}
 
 export const listLocationsAction: ListLocationsAction =
   null as unknown as ListLocationsAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
@@ -1,0 +1,42 @@
+import { Permission } from '@aws-amplify/storage/internals';
+
+import {
+  ActionConfig,
+  ListActionOptions,
+  ListActionInput,
+  ListActionOutput,
+  ListAction,
+  LocationType,
+} from '../types';
+
+export interface LocationData<T = Permission, K = LocationType> {
+  bucket: string;
+  permission: T;
+  prefix: string;
+  type: K;
+}
+
+export interface ListLocationsActionOptions<T = Permission | LocationType>
+  extends ListActionOptions {
+  exclude?: T | T[];
+}
+export interface ListLocationsActionInput<T = Permission | LocationType>
+  // `ListLocations` does not require `prefix`
+  extends Omit<
+    ListActionInput<ListLocationsActionOptions<T>>,
+    'config' | 'prefix'
+  > {
+  // `ListLocations` does not require `bucket`
+  config: Omit<ActionConfig, 'bucket'>;
+}
+export interface ListLocationsActionOutput<T = Permission | LocationType>
+  extends ListActionOutput<LocationData<T>> {}
+
+export interface ListLocationsAction<T = Permission | LocationType>
+  extends ListAction<
+    ListLocationsActionInput<T>,
+    ListLocationsActionOutput<T>
+  > {}
+
+export const listLocationsAction: ListLocationsAction =
+  null as unknown as ListLocationsAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
@@ -27,7 +27,7 @@ export interface ListLocationsActionInput<T = Permission | LocationType>
     'config' | 'prefix'
   > {
   // `ListLocations` does not require `bucket`
-  config: Omit<ActionConfig, 'bucket'>;
+  config: Omit<ActionInputConfig, 'bucket'>;
 }
 export interface ListLocationsActionOutput<T = Permission | LocationType>
   extends ListActionOutput<LocationData<T>> {}

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
@@ -1,7 +1,7 @@
 import { Permission } from '@aws-amplify/storage/internals';
 
 import {
-  ActionConfig,
+  ActionInputConfig,
   ListActionOptions,
   ListActionInput,
   ListActionOutput,

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/uploadAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/uploadAction.ts
@@ -1,0 +1,17 @@
+import {
+  DataTaskAction,
+  DataTaskActionInput,
+  DataTaskActionOutput,
+} from '../types';
+
+export interface UploadActionOptions {
+  onProgress?: (key: string, progress: number) => void;
+  preventOverwrite?: boolean;
+}
+export interface UploadActionInput
+  extends DataTaskActionInput<File, UploadActionOptions> {}
+export interface UploadActionOutput extends DataTaskActionOutput {}
+
+export interface UploadAction extends DataTaskAction<UploadActionInput> {}
+
+export const uploadAction: UploadAction = null as unknown as UploadAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/index.ts
@@ -19,7 +19,7 @@ export {
 } from './handlers';
 
 export {
-  ActionConfig,
+  ActionInputConfig,
   DataTaskAction,
   DataTaskActionInput,
   DataTaskActionOutput,

--- a/packages/react-storage/src/components/StorageBrowser/actions/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/index.ts
@@ -1,0 +1,30 @@
+export {
+  listLocationItemsAction,
+  ListLocationItemsAction,
+  ListLocationItemsActionInput,
+  ListLocationItemsActionOutput,
+  ListLocationItemsOptions,
+  listLocationsAction,
+  ListLocationsAction,
+  ListLocationsActionInput,
+  ListLocationsActionOptions,
+  ListLocationsActionOutput,
+  LocationData,
+  LocationItem,
+  uploadAction,
+  UploadAction,
+  UploadActionInput,
+  UploadActionOutput,
+  UploadActionOptions,
+} from './handlers';
+
+export {
+  ActionConfig,
+  DataTaskAction,
+  DataTaskActionInput,
+  DataTaskActionOutput,
+  ListAction,
+  ListActionInput,
+  ListActionOptions,
+  ListActionOutput,
+} from './types';

--- a/packages/react-storage/src/components/StorageBrowser/actions/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/types.ts
@@ -9,7 +9,7 @@ export interface ActionInputConfig {
 }
 
 interface ActionInput<T = any> {
-  config: ActionConfig;
+  config: ActionInputConfig;
   prefix: string;
   options?: T;
 }

--- a/packages/react-storage/src/components/StorageBrowser/actions/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/types.ts
@@ -1,0 +1,44 @@
+import { LocationCredentialsProvider } from '@aws-amplify/storage/internals';
+
+export type LocationType = 'OBJECT' | 'PREFIX' | 'BUCKET';
+export interface ActionConfig {
+  accountId: string;
+  bucket: string;
+  credentials: LocationCredentialsProvider;
+  region: string;
+}
+
+interface ActionInput<T = any> {
+  config: ActionConfig;
+  prefix: string;
+  options?: T;
+}
+
+export interface DataTaskActionInput<T = never, K = undefined>
+  extends ActionInput<K> {
+  data: T;
+}
+
+export interface DataTaskActionOutput {
+  cancel?: () => void;
+  key: string;
+  pause?: () => void;
+  result: Promise<'COMPLETE' | 'FAILED' | 'CANCELED'>;
+  resume?: () => void;
+}
+
+export type DataTaskAction<T = any> = (input: T) => DataTaskActionOutput;
+
+export interface ListActionOptions {
+  nextToken?: string;
+  pageSize?: number;
+}
+
+export interface ListActionInput<T = any> extends ActionInput<T> {}
+
+export interface ListActionOutput<T = any> {
+  nextToken: string | undefined;
+  items: T[];
+}
+
+export type ListAction<T = any, K = any> = (input: T) => Promise<K>;

--- a/packages/react-storage/src/components/StorageBrowser/actions/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/types.ts
@@ -1,7 +1,7 @@
 import { LocationCredentialsProvider } from '@aws-amplify/storage/internals';
 
 export type LocationType = 'OBJECT' | 'PREFIX' | 'BUCKET';
-export interface ActionConfig {
+export interface ActionInputConfig {
   accountId: string;
   bucket: string;
   credentials: LocationCredentialsProvider;

--- a/packages/react-storage/src/components/StorageBrowser/actions/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/types.ts
@@ -5,6 +5,7 @@ export interface ActionInputConfig {
   accountId: string;
   bucket: string;
   credentials: LocationCredentialsProvider;
+  // permission???
   region: string;
 }
 
@@ -29,7 +30,8 @@ export interface DataTaskActionOutput {
 
 export type DataTaskAction<T = any> = (input: T) => DataTaskActionOutput;
 
-export interface ListActionOptions {
+export interface ListActionOptions<T> {
+  exclude?: T;
   nextToken?: string;
   pageSize?: number;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add standardized action handler interfaces for default `StorageBrowser` actions
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
NA
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
