### PR TITLE
chore: Recreate StorageAccessLevel type and remove amplify/core peerDep from…

### DIFF
--- a/.changeset/shiny-chairs-judge.md
+++ b/.changeset/shiny-chairs-judge.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-storage": patch
+---
+
+chore: Manually recreate `StorageAccessLevel` type and remove `@aws-amplify/core` peerDep from ui-react-storage package. 

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -46,7 +46,6 @@
     "tslib": "^2.5.2"
   },
   "peerDependencies": {
-    "@aws-amplify/core": "*",
     "aws-amplify": "^6.6.0",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"

--- a/packages/react-storage/src/components/FileUploader/types.ts
+++ b/packages/react-storage/src/components/FileUploader/types.ts
@@ -50,7 +50,7 @@ export interface FileUploaderHandle {
   clearFiles: () => void;
 }
 
-type StorageAccessLevel = 'guest' | 'protected' | 'private';
+export type StorageAccessLevel = 'guest' | 'protected' | 'private';
 
 export interface FileUploaderProps {
   /**

--- a/packages/react-storage/src/components/FileUploader/types.ts
+++ b/packages/react-storage/src/components/FileUploader/types.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import type { StorageAccessLevel } from '@aws-amplify/core';
-
 import {
   ContainerProps,
   DropZoneProps,
@@ -51,6 +49,8 @@ export type ProcessFile = (
 export interface FileUploaderHandle {
   clearFiles: () => void;
 }
+
+type StorageAccessLevel = 'guest' | 'protected' | 'private';
 
 export interface FileUploaderProps {
   /**

--- a/packages/react-storage/src/components/FileUploader/utils/getInput.ts
+++ b/packages/react-storage/src/components/FileUploader/utils/getInput.ts
@@ -1,5 +1,4 @@
 import { fetchAuthSession } from 'aws-amplify/auth';
-import { StorageAccessLevel } from '@aws-amplify/core';
 import { UploadDataWithPathInput, UploadDataInput } from 'aws-amplify/storage';
 
 import { isString, isFunction } from '@aws-amplify/ui';
@@ -7,6 +6,8 @@ import { isString, isFunction } from '@aws-amplify/ui';
 import { ProcessFile } from '../types';
 import { resolveFile } from './resolveFile';
 import { PathCallback, PathInput } from './uploadFile';
+
+type StorageAccessLevel = 'guest' | 'protected' | 'private';
 
 export interface GetInputParams {
   accessLevel: StorageAccessLevel | undefined;

--- a/packages/react-storage/src/components/FileUploader/utils/getInput.ts
+++ b/packages/react-storage/src/components/FileUploader/utils/getInput.ts
@@ -3,11 +3,9 @@ import { UploadDataWithPathInput, UploadDataInput } from 'aws-amplify/storage';
 
 import { isString, isFunction } from '@aws-amplify/ui';
 
-import { ProcessFile } from '../types';
+import { ProcessFile, StorageAccessLevel } from '../types';
 import { resolveFile } from './resolveFile';
 import { PathCallback, PathInput } from './uploadFile';
-
-type StorageAccessLevel = 'guest' | 'protected' | 'private';
 
 export interface GetInputParams {
   accessLevel: StorageAccessLevel | undefined;

--- a/packages/react-storage/src/components/StorageImage/types.ts
+++ b/packages/react-storage/src/components/StorageImage/types.ts
@@ -1,5 +1,6 @@
-import { StorageAccessLevel } from '@aws-amplify/core';
 import { ImageProps } from '@aws-amplify/ui-react';
+
+type StorageAccessLevel = 'guest' | 'protected' | 'private';
 
 export interface StorageImageProps extends Omit<ImageProps, 'src'> {
   // Use imgKey instead of key because key is a reserved keyword

--- a/packages/react-storage/src/components/StorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { FileStatus } from '../FileUploader/types';
+import { FileStatus, StorageAccessLevel } from '../FileUploader/types';
 import {
   FileUploaderDisplayText as StorageManagerDisplayText,
   PathCallback,
@@ -46,8 +46,6 @@ export type ProcessFile = (
 export interface StorageManagerHandle {
   clearFiles: () => void;
 }
-
-type StorageAccessLevel = 'guest' | 'protected' | 'private';
 
 export interface StorageManagerProps {
   /**

--- a/packages/react-storage/src/components/StorageManager/types.ts
+++ b/packages/react-storage/src/components/StorageManager/types.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import type { StorageAccessLevel } from '@aws-amplify/core';
-
 import { FileStatus } from '../FileUploader/types';
 import {
   FileUploaderDisplayText as StorageManagerDisplayText,
@@ -48,6 +46,8 @@ export type ProcessFile = (
 export interface StorageManagerHandle {
   clearFiles: () => void;
 }
+
+type StorageAccessLevel = 'guest' | 'protected' | 'private';
 
 export interface StorageManagerProps {
   /**


### PR DESCRIPTION
… storage package

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Since StorageAccessLevel is a deprecated type we can just copy it and remove a dependency 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
