### PR TITLE
fix(ai-conversation): allow attachments on amplify component

### DIFF
--- a/.changeset/silly-knives-wash.md
+++ b/.changeset/silly-knives-wash.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-ai": patch
+---
+
+fix(ai-conversation): allow attachments to actually work on amplify component

--- a/packages/react-ai/src/components/AIConversation/AIConversation.tsx
+++ b/packages/react-ai/src/components/AIConversation/AIConversation.tsx
@@ -63,6 +63,7 @@ function AIConversationBase({
       ...controls,
     },
     displayText,
+    allowAttachments,
   });
 
   const providerProps = {
@@ -73,7 +74,6 @@ function AIConversationBase({
       ...avatars,
     },
     isLoading,
-    allowAttachments,
   };
 
   return (


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

There was a bug with the allowAttachments for the Amplify UI AIConversation component that was making it so the attachment button was never showing up. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
