### PR TITLE
feat(storage-browser): add action configs

### DIFF
--- a/packages/react-storage/jest.config.ts
+++ b/packages/react-storage/jest.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
       // functions: 90,
       // lines: 95,
       // statements: 95,
-      branches: 77,
+      branches: 79,
       functions: 82,
       lines: 90,
       statements: 89,

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/__snapshots__/defaults.spec.ts.snap
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/__snapshots__/defaults.spec.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`defaultActionConfigs matches expected shape 1`] = `
+{
+  "CreateFolder": {
+    "actionsListItemConfig": {
+      "disable": [Function],
+      "hide": [Function],
+      "icon": "create-folder",
+      "label": "Create Folder",
+    },
+    "handler": null,
+    "isCancelable": false,
+    "title": "Create Folder",
+    "type": "SINGLE_ACTION",
+  },
+  "ListLocationItems": {
+    "handler": null,
+    "title": [Function],
+    "type": "LIST_LOCATION_ITEMS",
+  },
+  "ListLocations": {
+    "handler": null,
+    "title": "Home",
+    "type": "LIST_LOCATIONS",
+  },
+  "Upload": {
+    "actionsListItemConfig": [
+      {
+        "disable": [Function],
+        "fileSelection": "FILE",
+        "hide": [Function],
+        "icon": "upload-file",
+        "label": "Upload File",
+      },
+      {
+        "disable": [Function],
+        "fileSelection": "FOLDER",
+        "hide": [Function],
+        "icon": "upload-folder",
+        "label": "Upload FOLDER",
+      },
+    ],
+    "handler": null,
+    "isCancelable": true,
+    "title": "Upload",
+    "type": "BATCH_ACTION",
+  },
+}
+`;

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/context.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/context.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+
+import { defaultActionConfigs } from '../defaults';
+import { ActionConfigs } from '../types';
+
+import { ActionConfigsProvider, useActionConfigs } from '../context';
+
+describe('useActionConfigs', () => {
+  it('returns default and custom config values passed to `ActionConfigsProvider`', () => {
+    const someCoolHandler = jest.fn();
+    const configs: ActionConfigs = {
+      ...defaultActionConfigs,
+      SomeCoolAction: {
+        handler: someCoolHandler,
+        isCancelable: false,
+        title: 'Do Cool Action',
+        type: 'BATCH_ACTION',
+      },
+    };
+
+    const { result } = renderHook(useActionConfigs, {
+      wrapper: (props) => <ActionConfigsProvider {...props} {...configs} />,
+    });
+
+    expect(result.current).toStrictEqual(configs);
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/defaults.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/defaults.spec.ts
@@ -1,0 +1,78 @@
+import { ActionListItemConfig } from '../types';
+import {
+  createFolderActionConfig,
+  defaultActionConfigs,
+  listLocationItemsActionConfig,
+  uploadActionConfig,
+} from '../defaults';
+
+const file = {
+  key: 'key',
+  lastModified: new Date(),
+  size: 100,
+  type: 'FILE' as const,
+};
+
+describe('defaultActionConfigs', () => {
+  it('matches expected shape', () => {
+    expect(defaultActionConfigs).toMatchSnapshot();
+  });
+
+  describe('createFolderActionConfig', () => {
+    it('hides the action list item as expected', () => {
+      const hide =
+        (createFolderActionConfig.actionsListItemConfig as ActionListItemConfig)!
+          .hide!;
+
+      expect(hide('READ')).toBe(true);
+      expect(hide('READWRITE')).toBe(false);
+      expect(hide('WRITE')).toBe(false);
+    });
+
+    it('disables the action list item as expected', () => {
+      const disable =
+        (createFolderActionConfig.actionsListItemConfig as ActionListItemConfig)!
+          .disable!;
+
+      expect(disable([file])).toBe(true);
+      expect(disable(undefined)).toBe(false);
+    });
+  });
+
+  describe('listLocationItemsActionConfig', () => {
+    it('returns the expected value of title', () => {
+      const { title } = listLocationItemsActionConfig;
+
+      expect(title(undefined, undefined)).toBe('-');
+      expect(title('bucket', undefined)).toBe('bucket');
+      expect(title('bucket', 'prefix/')).toBe('bucket: prefix/');
+      expect(title('bucket', 'prefix/nested/')).toBe('bucket: ../nested/');
+    });
+  });
+
+  describe('uploadActionConfig', () => {
+    it('hides the action list item as expected', () => {
+      const [uploadFileListItem, uploadFolderListItem] =
+        uploadActionConfig.actionsListItemConfig as ActionListItemConfig[];
+
+      expect(uploadFileListItem.hide?.('READ')).toBe(true);
+      expect(uploadFileListItem.hide?.('READWRITE')).toBe(false);
+      expect(uploadFileListItem.hide?.('WRITE')).toBe(false);
+
+      expect(uploadFolderListItem.hide?.('READ')).toBe(true);
+      expect(uploadFolderListItem.hide?.('READWRITE')).toBe(false);
+      expect(uploadFolderListItem.hide?.('WRITE')).toBe(false);
+    });
+
+    it('disables the action list item as expected', () => {
+      const [uploadFileListItem, uploadFolderListItem] =
+        uploadActionConfig.actionsListItemConfig as ActionListItemConfig[];
+
+      expect(uploadFileListItem.disable?.([file])).toBe(true);
+      expect(uploadFileListItem.disable?.(undefined)).toBe(false);
+
+      expect(uploadFolderListItem.disable?.([file])).toBe(true);
+      expect(uploadFolderListItem.disable?.(undefined)).toBe(false);
+    });
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/context.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/context.ts
@@ -1,0 +1,7 @@
+import { createContextUtilities } from '@aws-amplify/ui-react-core';
+import { ActionConfigs } from './types';
+
+const defaultValue: ActionConfigs = {};
+
+export const { useActionConfigs, ActionConfigsProvider } =
+  createContextUtilities({ contextName: 'ActionConfigs', defaultValue });

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/defaults.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/defaults.ts
@@ -1,0 +1,76 @@
+import {
+  listLocationItemsAction,
+  listLocationsAction,
+  createFolderAction,
+  uploadAction,
+} from '../handlers';
+import {
+  ListLocationItemsActionConfig,
+  ListLocationsActionConfig,
+  CreateFolderActionConfig,
+  UploadActionConfig,
+  ActionConfigs,
+} from './types';
+
+export const createFolderActionConfig: CreateFolderActionConfig = {
+  actionsListItemConfig: {
+    disable: (selected) => !!selected,
+    hide: (permission) => permission === 'READ',
+    icon: 'create-folder',
+    label: 'Create Folder',
+  },
+  handler: createFolderAction,
+  isCancelable: false,
+  title: 'Create Folder',
+  type: 'SINGLE_ACTION',
+};
+
+export const listLocationItemsActionConfig: ListLocationItemsActionConfig = {
+  handler: listLocationItemsAction,
+  title: (bucket, prefix) => {
+    if (bucket && prefix) {
+      const prefixes = prefix.split('/');
+      return `${bucket}: ${
+        prefixes.length > 2 ? `../${prefixes[prefixes.length - 2]}/` : prefix
+      }`;
+    }
+    return !bucket ? '-' : bucket;
+  },
+  type: 'LIST_LOCATION_ITEMS',
+};
+
+export const listLocationsActionConfig: ListLocationsActionConfig = {
+  handler: listLocationsAction,
+  title: 'Home',
+  type: 'LIST_LOCATIONS',
+};
+
+export const uploadActionConfig: UploadActionConfig = {
+  actionsListItemConfig: [
+    {
+      disable: (selectedValues) => !!selectedValues,
+      fileSelection: 'FILE',
+      hide: (permission) => permission === 'READ',
+      icon: 'upload-file',
+      label: 'Upload File',
+    },
+    {
+      disable: (selectedValues) => !!selectedValues,
+      fileSelection: 'FOLDER',
+      hide: (permission) => permission === 'READ',
+      icon: 'upload-folder',
+      label: 'Upload FOLDER',
+    },
+  ],
+  isCancelable: true,
+  handler: uploadAction,
+  title: 'Upload',
+  type: 'BATCH_ACTION',
+};
+
+export const defaultActionConfigs: ActionConfigs = {
+  CreateFolder: createFolderActionConfig,
+  ListLocationItems: listLocationItemsActionConfig,
+  ListLocations: listLocationsActionConfig,
+  Upload: uploadActionConfig,
+};

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/types.ts
@@ -1,4 +1,4 @@
-import { Permission } from '@aws-amplify/storage/internals';
+import { Permission } from '../../storage-internal';
 import { IconVariant } from '../../context/elements';
 
 import {

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/types.ts
@@ -1,0 +1,143 @@
+import { Permission } from '@aws-amplify/storage/internals';
+import { IconVariant } from '../../context/elements';
+
+import {
+  ListLocationsAction,
+  ListLocationItemsAction,
+  LocationItem,
+  LocationItemType,
+  UploadAction,
+  CreateFolderAction,
+} from '../handlers';
+import { TaskAction, TaskActionOutput } from '../types';
+
+/**
+ * native OS file picker type. to restrict selectable file types, define the picker types
+ * followed by accepted file types as strings
+ * @example
+ * ```ts
+ * type JPEGOnly = ['FOLDER', '.jpeg'];
+ * ```
+ */
+export type SelectionType = LocationItemType | [LocationItemType, ...string[]];
+
+export interface ActionConfigTemplate<T> {
+  /**
+   * action handler
+   */
+  handler: T;
+}
+
+export interface ActionListItemConfig {
+  /**
+   * conditionally disable item selection based on currently selected values
+   * @default false
+   */
+  disable?: (selectedValues: LocationItem[] | undefined) => boolean;
+
+  /**
+   * open native OS file picker with associated selection type on item select
+   */
+  fileSelection?: SelectionType;
+
+  /**
+   * conditionally render list item based on location permission
+   * @default false
+   */
+  hide?: (permission: Permission) => boolean;
+
+  /**
+   * list item icon
+   */
+  icon: IconVariant | Exclude<React.ReactNode, string>;
+
+  /**
+   * list item label
+   */
+  label: string;
+}
+
+type IsCancelableTaskAction<T> = T extends TaskAction<
+  any,
+  TaskActionOutput<infer K>
+>
+  ? K extends 'CANCELED'
+    ? true
+    : false
+  : never;
+
+/**
+ * defines an action to be included in the actions list of the `LocationDetailView` with
+ * a dedicated subcomponent of the `LocationActionView`
+ */
+export interface TaskActionConfig<T extends TaskAction> {
+  /**
+   * configure action list item behavior. provide multiple configs
+   * to create additional list items for a single action
+   */
+  actionsListItemConfig?: ActionListItemConfig | ActionListItemConfig[];
+
+  /**
+   * whether the action allows inflight cancellation
+   */
+  isCancelable: IsCancelableTaskAction<T>;
+
+  /**
+   * action handler
+   */
+  handler: T;
+
+  /**
+   * default title value displayed on action view
+   */
+  title: string;
+
+  /**
+   * sets action view subcomponent type and action processing behavior
+   */
+  type: 'BATCH_ACTION' | 'SINGLE_ACTION';
+}
+
+export interface ListActionConfig<T> extends ActionConfigTemplate<T> {}
+
+export interface UploadActionConfig extends TaskActionConfig<UploadAction> {}
+
+export interface CreateFolderActionConfig
+  extends TaskActionConfig<CreateFolderAction> {}
+
+export interface ListLocationsActionConfig
+  extends ListActionConfig<ListLocationsAction> {
+  title: string;
+  type: 'LIST_LOCATIONS';
+}
+
+export interface ListLocationItemsActionConfig
+  extends ListActionConfig<ListLocationItemsAction> {
+  title: (bucket: string | undefined, prefix: string | undefined) => string;
+  type: 'LIST_LOCATION_ITEMS';
+}
+
+export interface DefaultActionConfigs {
+  listLocationItems: ListLocationItemsActionConfig;
+  listLocations: ListLocationsActionConfig;
+  createFolder: CreateFolderActionConfig;
+  upload: UploadActionConfig;
+}
+
+export type DefaultActionKey = keyof DefaultActionConfigs;
+export type CustomActionKey<T> = keyof Omit<T, DefaultActionKey>;
+
+export type ActionConfigs = Record<
+  Capitalize<string>,
+  | TaskActionConfig<TaskAction>
+  | ListLocationItemsActionConfig
+  | ListLocationsActionConfig
+>;
+
+export type ResolveAction<T> = T extends
+  | TaskActionConfig<infer K>
+  | ListActionConfig<infer K>
+  ? K
+  : never;
+
+export type ResolveActions<T> = { [K in keyof T]: ResolveAction<T[K]> };

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/copyAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/copyAction.ts
@@ -1,15 +1,12 @@
 import { CopyWithPathInput } from '@aws-amplify/storage';
-import {
-  DataTaskAction,
-  DataTaskActionInput,
-  DataTaskActionOutput,
-} from '../types';
+import { TaskAction, TaskActionInput, TaskActionOutput } from '../types';
 
 interface CopyData extends Pick<CopyWithPathInput, 'destination' | 'source'> {}
 
-export interface CopyActionInput extends DataTaskActionInput<CopyData> {}
-export interface CopyActionOutput extends DataTaskActionOutput {}
+export interface CopyActionInput extends TaskActionInput<CopyData> {}
+export interface CopyActionOutput extends TaskActionOutput {}
 
-export interface CopyAction extends DataTaskAction<DataTaskActionInput> {}
+export interface CopyAction
+  extends TaskAction<TaskActionInput, CopyActionOutput> {}
 
 export const copyAction: CopyAction = null as unknown as CopyAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/createFolderAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/createFolderAction.ts
@@ -1,8 +1,4 @@
-import {
-  DataTaskAction,
-  DataTaskActionInput,
-  DataTaskActionOutput,
-} from '../types';
+import { TaskAction, TaskActionInput, TaskActionOutput } from '../types';
 
 interface CreateFolderActionData {
   target: string;
@@ -11,14 +7,11 @@ interface CreateFolderActionOptions {
   preventOverwite?: boolean;
 }
 export interface CreateFolderActionInput
-  extends DataTaskActionInput<
-    CreateFolderActionData,
-    CreateFolderActionOptions
-  > {}
-export interface CreateFolderActionOutput extends DataTaskActionOutput {}
+  extends TaskActionInput<CreateFolderActionData, CreateFolderActionOptions> {}
+export interface CreateFolderActionOutput extends TaskActionOutput {}
 
 export interface CreateFolderAction
-  extends DataTaskAction<DataTaskActionInput> {}
+  extends TaskAction<CreateFolderActionInput, CreateFolderActionOutput> {}
 
 export const createFolderAction: CreateFolderAction =
   null as unknown as CreateFolderAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/deleteAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/deleteAction.ts
@@ -1,12 +1,13 @@
-import {
-  DataTaskAction,
-  DataTaskActionInput,
-  DataTaskActionOutput,
-} from '../types';
+import { TaskAction, TaskActionInput, TaskActionOutput } from '../types';
 
-export interface DeleteActionInput extends DataTaskActionInput {}
-export interface DeleteActionOutput extends DataTaskActionOutput {}
+interface DeleteActionOptions {
+  key: string;
+}
+export interface DeleteActionInput
+  extends TaskActionInput<DeleteActionOptions> {}
+export interface DeleteActionOutput extends TaskActionOutput {}
 
-export interface DeleteAction extends DataTaskAction<DataTaskActionInput> {}
+export interface DeleteAction
+  extends TaskAction<DeleteActionInput, DeleteActionOutput> {}
 
 export const deleteAction: DeleteAction = null as unknown as DeleteAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/downloadAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/downloadAction.ts
@@ -1,8 +1,4 @@
-import {
-  DataTaskAction,
-  DataTaskActionInput,
-  DataTaskActionOutput,
-} from '../types';
+import { TaskAction, TaskActionInput, TaskActionOutput } from '../types';
 
 interface DownloadActionData {
   key: string;
@@ -11,9 +7,9 @@ interface DownloadActionOptions {
   onProgress?: (progress: number) => void;
 }
 export interface DownloadActionInput
-  extends DataTaskActionInput<DownloadActionData, DownloadActionOptions> {}
-export interface DownloadActionOutput extends DataTaskActionOutput {}
+  extends TaskActionInput<DownloadActionData, DownloadActionOptions> {}
+export interface DownloadActionOutput extends TaskActionOutput {}
 
-export interface DownloadAction extends DataTaskAction<DataTaskActionInput> {}
+export interface DownloadAction extends TaskAction<DownloadActionInput> {}
 
 export const downloadAction: DownloadAction = null as unknown as DownloadAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationItemsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationItemsAction.ts
@@ -23,7 +23,7 @@ export interface FileItem {
 
 export type LocationItem = FileItem | FolderItem;
 
-type LocationItemType = LocationItem['type'];
+export type LocationItemType = LocationItem['type'];
 
 export interface ListLocationItemsOptions
   extends ListActionOptions<LocationItemType> {

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
@@ -1,11 +1,8 @@
 import { Permission } from '@aws-amplify/storage/internals';
 
-import {
-  ListActionOptions,
-  ListActionOutput,
-  ListAction,
-  LocationType,
-} from '../types';
+import { ListActionOptions, ListActionOutput, ListAction } from '../types';
+
+export type LocationType = 'OBJECT' | 'PREFIX' | 'BUCKET';
 
 export interface LocationData {
   bucket: string;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/uploadAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/uploadAction.ts
@@ -1,7 +1,7 @@
 import {
-  DataTaskAction,
-  DataTaskActionInput,
-  DataTaskActionOutput,
+  CancelableTaskActionOutput,
+  TaskAction,
+  TaskActionInput,
 } from '../types';
 
 export interface UploadActionOptions {
@@ -9,9 +9,10 @@ export interface UploadActionOptions {
   preventOverwrite?: boolean;
 }
 export interface UploadActionInput
-  extends DataTaskActionInput<File, UploadActionOptions> {}
-export interface UploadActionOutput extends DataTaskActionOutput {}
+  extends TaskActionInput<File, UploadActionOptions> {}
+export interface UploadActionOutput extends CancelableTaskActionOutput {}
 
-export interface UploadAction extends DataTaskAction<UploadActionInput> {}
+export interface UploadAction
+  extends TaskAction<UploadActionInput, UploadActionOutput> {}
 
 export const uploadAction: UploadAction = null as unknown as UploadAction;

--- a/packages/react-storage/src/components/StorageBrowser/actions/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/index.ts
@@ -1,4 +1,6 @@
 export {
+  createFolderAction,
+  CreateFolderAction,
   listLocationItemsAction,
   ListLocationItemsAction,
   ListLocationItemsActionInput,
@@ -11,18 +13,20 @@ export {
   ListLocationsActionOutput,
   LocationData,
   LocationItem,
+  LocationItemType,
+  LocationType,
   uploadAction,
   UploadAction,
   UploadActionInput,
-  UploadActionOutput,
   UploadActionOptions,
+  UploadActionOutput,
 } from './handlers';
 
 export {
   ActionInputConfig,
-  DataTaskAction,
-  DataTaskActionInput,
-  DataTaskActionOutput,
+  TaskAction,
+  TaskActionInput,
+  TaskActionOutput,
   ListAction,
   ListActionInput,
   ListActionOptions,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add standardized action config interfaces

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
