### PR TITLE
chore: add aws-amplify/storage/internals export file to remove peerDep

### DIFF
--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -55,7 +55,6 @@
   },
   "peerDependencies": {
     "@aws-amplify/core": "*",
-    "@aws-amplify/storage": "*",
     "aws-amplify": "storage-browser",
     "react": "^16.14.0 || ^17.0 || ^18.0",
     "react-dom": "^16.14.0 || ^17.0 || ^18.0"

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/copyAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/copyAction.ts
@@ -1,4 +1,4 @@
-import { CopyWithPathInput } from '@aws-amplify/storage';
+import { CopyWithPathInput } from 'aws-amplify/storage';
 import {
   DataTaskAction,
   DataTaskActionInput,

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationsAction.ts
@@ -1,4 +1,4 @@
-import { Permission } from '@aws-amplify/storage/internals';
+import { Permission } from '../../storage-internal';
 
 import {
   ListActionOptions,

--- a/packages/react-storage/src/components/StorageBrowser/actions/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/types.ts
@@ -1,4 +1,4 @@
-import { LocationCredentialsProvider } from '@aws-amplify/storage/internals';
+import { LocationCredentialsProvider } from '../storage-internal';
 
 export type LocationType = 'OBJECT' | 'PREFIX' | 'BUCKET';
 export interface ActionInputConfig {

--- a/packages/react-storage/src/components/StorageBrowser/adapters/createAmplifyAuthAdapter.ts
+++ b/packages/react-storage/src/components/StorageBrowser/adapters/createAmplifyAuthAdapter.ts
@@ -1,11 +1,11 @@
 import { Amplify } from 'aws-amplify';
 import { Hub } from 'aws-amplify/utils';
 import { AuthSession, fetchAuthSession } from 'aws-amplify/auth';
-import { LocationCredentialsProvider } from '@aws-amplify/storage/internals';
-
-import { StorageBrowserAuthAdapter } from './types';
-import { LocationAccess } from '../context/types';
 import { isFunction } from '@aws-amplify/ui';
+
+import { LocationAccess } from '../context/types';
+import { LocationCredentialsProvider } from '../storage-internal';
+import { StorageBrowserAuthAdapter } from './types';
 
 export const MISSING_BUCKET_OR_REGION_ERROR =
   'Amplify Storage configuration not found. Did you run `Amplify.configure` from your project root?';

--- a/packages/react-storage/src/components/StorageBrowser/adapters/createManagedAuthAdapter.ts
+++ b/packages/react-storage/src/components/StorageBrowser/adapters/createManagedAuthAdapter.ts
@@ -1,4 +1,4 @@
-import { createManagedAuthConfigAdapter } from '@aws-amplify/storage/internals';
+import { createManagedAuthConfigAdapter } from '../storage-internal';
 import {
   CreateManagedAuthAdapterInput,
   StorageBrowserAuthAdapter,

--- a/packages/react-storage/src/components/StorageBrowser/adapters/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/adapters/types.ts
@@ -1,9 +1,8 @@
+import { RegisterAuthListener } from '../context/useGetCredentialsProvider';
 import {
   AuthConfigAdapter,
   CreateManagedAuthConfigAdapterInput,
-} from '@aws-amplify/storage/internals';
-
-import { RegisterAuthListener } from '../context/useGetCredentialsProvider';
+} from '../storage-internal';
 
 export interface StorageBrowserAuthAdapter extends AuthConfigAdapter {
   registerAuthListener: RegisterAuthListener;

--- a/packages/react-storage/src/components/StorageBrowser/context/__tests__/useGetCredentialsProvider.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/__tests__/useGetCredentialsProvider.spec.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import * as StorageBrowserModule from '@aws-amplify/storage/internals';
+import * as StorageBrowserModule from '../../storage-internal';
 
 import { useGetCredentialsProvider } from '../useGetCredentialsProvider';
 

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/__tests__/listLocationsAction.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/__tests__/listLocationsAction.spec.ts
@@ -1,6 +1,7 @@
-import { ListLocations } from '@aws-amplify/storage/internals';
-import { createListLocationsAction } from '../listLocationsAction';
+import { ListLocations } from '../../../storage-internal';
 import { LocationAccess } from '../../types';
+
+import { createListLocationsAction } from '../listLocationsAction';
 
 const fakeLocation: LocationAccess = {
   scope: 's3://some-bucket/*',

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationItemsAction.ts
@@ -4,7 +4,7 @@ import {
   ListPaginateWithPathOutput,
 } from 'aws-amplify/storage';
 
-import { StorageSubpathStrategy } from '@aws-amplify/storage/internals';
+import { StorageSubpathStrategy } from '../../storage-internal';
 
 import {
   ListActionInput,

--- a/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationsAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/actions/listLocationsAction.ts
@@ -1,7 +1,4 @@
-import {
-  ListLocations,
-  ListLocationsOutput,
-} from '@aws-amplify/storage/internals';
+import { ListLocations, ListLocationsOutput } from '../../storage-internal';
 
 import {
   ListActionInput,

--- a/packages/react-storage/src/components/StorageBrowser/context/config.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/context/config.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GetLocationCredentials } from '@aws-amplify/storage/internals';
+import { GetLocationCredentials } from '../storage-internal';
 
 import { LocationData } from './types';
 

--- a/packages/react-storage/src/components/StorageBrowser/context/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/types.ts
@@ -1,5 +1,5 @@
 import { UploadDataWithPathInput } from 'aws-amplify/storage';
-import { LocationCredentialsProvider } from '@aws-amplify/storage/internals';
+import { LocationCredentialsProvider } from '../storage-internal';
 
 export interface FolderItem {
   key: string;

--- a/packages/react-storage/src/components/StorageBrowser/context/useGetCredentialsProvider.ts
+++ b/packages/react-storage/src/components/StorageBrowser/context/useGetCredentialsProvider.ts
@@ -3,7 +3,7 @@ import {
   createLocationCredentialsStore,
   GetLocationCredentials,
   LocationCredentialsStore,
-} from '@aws-amplify/storage/internals';
+} from '../storage-internal';
 
 export type RegisterAuthListener = (onStateChange: () => void) => void;
 export type GetCredentialsProvider = LocationCredentialsStore['getProvider'];

--- a/packages/react-storage/src/components/StorageBrowser/createProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createProvider.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { ListLocations } from '@aws-amplify/storage/internals';
 import { ElementsProvider } from '@aws-amplify/ui-react-core/elements';
 
 import { ActionProvider, createListLocationsAction } from './context/actions';
@@ -11,8 +10,8 @@ import {
 import { ControlProvider } from './context/control';
 import { StorageBrowserElements } from './context/elements';
 import { LocationActions } from './context/locationActions';
-
 import { ErrorBoundary } from './ErrorBoundary';
+import { ListLocations } from './storage-internal';
 import { ViewsProvider, Views } from './views';
 
 export interface Config

--- a/packages/react-storage/src/components/StorageBrowser/storage-internal.ts
+++ b/packages/react-storage/src/components/StorageBrowser/storage-internal.ts
@@ -1,0 +1,3 @@
+// Re-export internal apis/types of `@aws-amplify/storage` in a single file
+// eslint-disable-next-line import/no-extraneous-dependencies
+export * from '@aws-amplify/storage/internals';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Add _/StorageBrowser/storage-internal.ts_ re-export file pointing to `@aws-amplify/storage/internals`
- disable eslint `import/no-extraneous-dependencies` for _storage-internal.ts_ to prevent need for adding a peerDep for `@aws-amplify/storage` to minimize risk of mismatching install versions

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`yarn lint && yarn build`
#### Checklist
NA
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
