### PR TITLE
fix(useFileSelect): fix useFileSelect to handle folder selection

### DIFF
--- a/packages/react/src/components/FileSelect/FileSelect.tsx
+++ b/packages/react/src/components/FileSelect/FileSelect.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 
+// `FileSelect` input `type` must always be set to `file`
+const INPUT_TYPE = 'file';
+
+export type SelectionType = 'FILE' | 'FOLDER';
+
 /**
  * @internal @unstable
  */
@@ -7,8 +12,8 @@ export interface FileSelectProps {
   accept?: string;
   multiple?: boolean;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  selectionType?: SelectionType;
   testId?: string;
-  type?: 'file' | 'folder';
 }
 
 /**
@@ -18,7 +23,7 @@ export interface FileSelectOptions
   extends Omit<FileSelectProps, 'onChange' | 'type'> {}
 
 type HandleSelect = (
-  type: 'file' | 'folder',
+  selectionTyoe: SelectionType,
   options?: FileSelectOptions
 ) => void;
 
@@ -44,8 +49,8 @@ export const FileSelect = React.forwardRef<HTMLInputElement, FileSelectProps>(
   function FileSelect(
     {
       multiple = true,
+      selectionType = 'FILE',
       testId = 'amplify-file-select',
-      type = 'file',
       ...props
     },
     ref
@@ -54,11 +59,11 @@ export const FileSelect = React.forwardRef<HTMLInputElement, FileSelectProps>(
       <input
         {...DEFAULT_PROPS}
         {...props}
-        {...(type === 'folder' ? { webkitdirectory: '' } : undefined)}
+        {...(selectionType === 'FOLDER' ? { webkitdirectory: '' } : undefined)}
         data-testid={testId}
         multiple={multiple}
         ref={ref}
-        type="file"
+        type={INPUT_TYPE}
       />
     );
   }
@@ -93,9 +98,12 @@ export const useFileSelect = (
   >(undefined);
 
   const ref = React.useRef<HTMLInputElement>(null);
-  const handleSelect: HandleSelect = React.useCallback((type, options) => {
-    setInputProps({ type, ...options });
-  }, []);
+  const handleSelect: HandleSelect = React.useCallback(
+    (selectionType, options) => {
+      setInputProps({ selectionType, ...options });
+    },
+    []
+  );
 
   React.useEffect(() => {
     if (inputProps) {

--- a/packages/react/src/components/FileSelect/FileSelect.tsx
+++ b/packages/react/src/components/FileSelect/FileSelect.tsx
@@ -23,7 +23,7 @@ export interface FileSelectOptions
   extends Omit<FileSelectProps, 'onChange' | 'type'> {}
 
 type HandleSelect = (
-  selectionTyoe: SelectionType,
+  selectionType: SelectionType,
   options?: FileSelectOptions
 ) => void;
 

--- a/packages/react/src/components/FileSelect/FileSelect.tsx
+++ b/packages/react/src/components/FileSelect/FileSelect.tsx
@@ -7,6 +7,7 @@ export interface FileSelectProps {
   accept?: string;
   multiple?: boolean;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  testId?: string;
   type?: 'file' | 'folder';
 }
 
@@ -40,14 +41,24 @@ export const DEFAULT_PROPS = {
  * @internal @unstable
  */
 export const FileSelect = React.forwardRef<HTMLInputElement, FileSelectProps>(
-  function FileSelect({ multiple = true, type = 'file', ...props }, ref) {
+  function FileSelect(
+    {
+      multiple = true,
+      testId = 'amplify-file-select',
+      type = 'file',
+      ...props
+    },
+    ref
+  ) {
     return (
       <input
         {...DEFAULT_PROPS}
-        {...(type === 'folder' ? { webkitdirectory: '' } : undefined)}
         {...props}
+        {...(type === 'folder' ? { webkitdirectory: '' } : undefined)}
+        data-testid={testId}
         multiple={multiple}
         ref={ref}
+        type="file"
       />
     );
   }
@@ -82,18 +93,14 @@ export const useFileSelect = (
   >(undefined);
 
   const ref = React.useRef<HTMLInputElement>(null);
-  const handleSelect = React.useRef<HandleSelect>((type, options) => {
+  const handleSelect: HandleSelect = React.useCallback((type, options) => {
     setInputProps({ type, ...options });
-  }).current;
+  }, []);
 
   React.useEffect(() => {
     if (inputProps) {
       ref.current?.click();
     }
-
-    return () => {
-      setInputProps(undefined);
-    };
   }, [inputProps]);
 
   const fileSelect = (
@@ -101,6 +108,7 @@ export const useFileSelect = (
       {...inputProps}
       onChange={({ target }) => {
         onSelect?.([...(target.files ?? [])]);
+        setInputProps(undefined);
       }}
       ref={ref}
     />

--- a/packages/react/src/components/FileSelect/__tests__/FileSelect.spec.tsx
+++ b/packages/react/src/components/FileSelect/__tests__/FileSelect.spec.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
-import { useFileSelect } from '../FileSelect';
+import { SelectionType, useFileSelect } from '../FileSelect';
 
 const TestComponent = ({
   onSelect,
   type,
 }: {
   onSelect: (files: File[]) => void;
-  type: 'file' | 'folder';
+  type: SelectionType;
 }) => {
   const [fileSelect, handleSelect] = useFileSelect(onSelect);
 
@@ -26,7 +26,7 @@ const TestComponent = ({
 };
 
 describe('useFileSelect', () => {
-  it.each(['file', 'folder'] as const)(
+  it.each(['FILE', 'FOLDER'] as const)(
     'handles a provided %s type as expected',
     async (type) => {
       const user = userEvent.setup();

--- a/packages/react/src/components/FileSelect/__tests__/FileSelect.spec.tsx
+++ b/packages/react/src/components/FileSelect/__tests__/FileSelect.spec.tsx
@@ -27,7 +27,7 @@ const TestComponent = ({
 
 describe('useFileSelect', () => {
   it.each(['file', 'folder'] as const)(
-    'behaves as expected with a %s type as expected',
+    'handles a provided %s type as expected',
     async (type) => {
       const user = userEvent.setup();
       const onSelect = jest.fn();
@@ -48,7 +48,9 @@ describe('useFileSelect', () => {
       expect(input).not.toBeNull();
 
       const file = new File([], 'file one');
-      await user.upload(input!, file);
+      await waitFor(async () => {
+        await user.upload(input!, file);
+      });
 
       expect(input?.files?.[0]).toStrictEqual(file);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fix `useFileSelect` to handle folder selection and move clearing of `inputProps` to `onChange`
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual tests, unit tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
