### PR TITLE
chore(ai): add graphql errors to useAIGeneration

### DIFF
--- a/.changeset/fresh-parents-invent.md
+++ b/.changeset/fresh-parents-invent.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-ai": patch
+---
+
+chore(ai): add graphql errors to useAIGeneration

--- a/packages/react-ai/src/hooks/__tests__/createAIHooks.test.tsx
+++ b/packages/react-ai/src/hooks/__tests__/createAIHooks.test.tsx
@@ -211,7 +211,8 @@ describe('createAIHooks', () => {
       expect(awaitedState.data).toStrictEqual(expectedResult);
       expect(awaitedState.isLoading).toBeFalsy();
       expect(awaitedState.hasError).toBeTruthy();
-      expect(awaitedState.message).toContain('error');
+      expect(awaitedState.messages).toHaveLength(1);
+      expect(awaitedState.messages?.[0].message).toContain('error');
     });
   });
 });

--- a/packages/react-ai/src/hooks/__tests__/createAIHooks.test.tsx
+++ b/packages/react-ai/src/hooks/__tests__/createAIHooks.test.tsx
@@ -179,7 +179,14 @@ describe('createAIHooks', () => {
       };
       const generateReturn = {
         data: expectedResult,
-        errors: ['this is just one error'],
+        errors: [
+          {
+            errorType: '',
+            locations: [],
+            path: ['generateRecipe'],
+            message: 'this is just one error',
+          },
+        ],
       };
       generateRecipeMock.mockResolvedValueOnce(generateReturn);
       const { useAIGeneration } = createAIHooks(client);
@@ -202,7 +209,9 @@ describe('createAIHooks', () => {
 
       const [awaitedState] = hookResult.current;
       expect(awaitedState.data).toStrictEqual(expectedResult);
-      expect(awaitedState.graphqlErrors).toHaveLength(1);
+      expect(awaitedState.isLoading).toBeFalsy();
+      expect(awaitedState.hasError).toBeTruthy();
+      expect(awaitedState.message).toContain('error');
     });
   });
 });

--- a/packages/react-ai/src/hooks/useAIGeneration.tsx
+++ b/packages/react-ai/src/hooks/useAIGeneration.tsx
@@ -75,27 +75,30 @@ export function createUseAIGeneration<
       data: undefined,
     }));
 
-    const handleGeneration = async (input: Schema[Key]['args']) => {
-      setDataState(({ data }) => ({ ...LOADING_STATE, data }));
+    const handleGeneration = React.useCallback(
+      async (input: Schema[Key]['args']) => {
+        setDataState(({ data }) => ({ ...LOADING_STATE, data }));
 
-      const result = await (
-        client.generations as AIGenerationClient<Schema>['generations']
-      )[routeName](input);
+        const result = await (
+          client.generations as AIGenerationClient<Schema>['generations']
+        )[routeName](input);
 
-      const { data, errors } = result as SingularReturnValue<
-        Schema[Key]['returnType']
-      >;
+        const { data, errors } = result as SingularReturnValue<
+          Schema[Key]['returnType']
+        >;
 
-      if (errors) {
-        setDataState({
-          ...ERROR_STATE,
-          data,
-          messages: errors,
-        });
-      } else {
-        setDataState({ ...INITIAL_STATE, data });
-      }
-    };
+        if (errors) {
+          setDataState({
+            ...ERROR_STATE,
+            data,
+            messages: errors,
+          });
+        } else {
+          setDataState({ ...INITIAL_STATE, data });
+        }
+      },
+      [routeName]
+    );
 
     return [dataState, handleGeneration];
   };

--- a/packages/react-ai/src/hooks/useAIGeneration.tsx
+++ b/packages/react-ai/src/hooks/useAIGeneration.tsx
@@ -1,4 +1,5 @@
-import { DataState, useDataState } from '@aws-amplify/ui-react-core';
+import * as React from 'react';
+import { DataState } from '@aws-amplify/ui-react-core';
 import { V6Client } from '@aws-amplify/api-graphql';
 import { getSchema } from '../types';
 
@@ -9,7 +10,7 @@ export interface UseAIGenerationHookWrapper<
   useAIGeneration: <U extends Key>(
     routeName: U
   ) => [
-    Awaited<GenerateState<Schema[U]['returnType']>>,
+    Awaited<DataState<Schema[U]['returnType']>>,
     (input: Schema[U]['args']) => void,
   ];
 }
@@ -20,7 +21,7 @@ export type UseAIGenerationHook<
 > = (
   routeName: Key
 ) => [
-  Awaited<GenerateState<Schema[Key]['returnType']>>,
+  Awaited<DataState<Schema[Key]['returnType']>>,
   (input: Schema[Key]['args']) => void,
 ];
 
@@ -42,9 +43,10 @@ type SingularReturnValue<T> = {
   errors?: GraphQLFormattedError[];
 };
 
-type GenerateState<T> = DataState<T> & {
-  graphqlErrors?: GraphQLFormattedError[];
-};
+// default state
+const INITIAL_STATE = { hasError: false, isLoading: false, message: undefined };
+const LOADING_STATE = { hasError: false, isLoading: true, message: undefined };
+const ERROR_STATE = { hasError: true, isLoading: false };
 
 export function createUseAIGeneration<
   Client extends Record<'generations' | 'conversations', Record<string, any>>,
@@ -55,36 +57,39 @@ export function createUseAIGeneration<
   >(
     routeName: Key
   ): [
-    state: GenerateState<Schema[Key]['returnType']>,
+    state: DataState<Schema[Key]['returnType']>,
     handleAction: (input: Schema[Key]['args']) => void,
   ] => {
-    const handleGenerate = (
-      client.generations as AIGenerationClient<Schema>['generations']
-    )[routeName];
+    const [dataState, setDataState] = React.useState<
+      DataState<Schema[Key]['returnType']>
+    >(() => ({
+      ...INITIAL_STATE,
+      data: undefined,
+    }));
 
-    const updateAIGenerationStateAction = async (
-      _prev: Schema[Key]['returnType'],
-      input: Schema[Key]['args']
-    ): Promise<Schema[Key]['returnType']> => {
-      return await handleGenerate(input);
+    const handleGeneration = async (input: Schema[Key]['args']) => {
+      setDataState(({ data }) => ({ ...LOADING_STATE, data }));
+
+      const result = await (
+        client.generations as AIGenerationClient<Schema>['generations']
+      )[routeName](input);
+
+      const { data, errors } = result as SingularReturnValue<
+        Schema[Key]['returnType']
+      >;
+
+      if (errors) {
+        setDataState({
+          ...ERROR_STATE,
+          data,
+          message: errors.map((error) => error.message).join(' '),
+        });
+      } else {
+        setDataState({ ...INITIAL_STATE, data });
+      }
     };
 
-    const [result, handler] = useDataState(
-      updateAIGenerationStateAction,
-      undefined
-    );
-
-    let { hasError, message } = result;
-
-    const { data, errors } =
-      (result?.data as SingularReturnValue<Schema[Key]['returnType']>) ?? {};
-
-    if (errors) {
-      hasError = true;
-      message = errors.map((error) => error.message).join(' ');
-    }
-
-    return [{ ...result, data, hasError, message }, handler];
+    return [dataState, handleGeneration];
   };
 
   return useAIGeneration;

--- a/packages/react-ai/src/hooks/useAIGeneration.tsx
+++ b/packages/react-ai/src/hooks/useAIGeneration.tsx
@@ -74,10 +74,17 @@ export function createUseAIGeneration<
       undefined
     );
 
+    let { hasError, message } = result;
+
     const { data, errors } =
       (result?.data as SingularReturnValue<Schema[Key]['returnType']>) ?? {};
 
-    return [{ ...result, data, graphqlErrors: errors }, handler];
+    if (errors) {
+      hasError = true;
+      message = errors.map((error) => error.message).join(' ');
+    }
+
+    return [{ ...result, data, hasError, message }, handler];
   };
 
   return useAIGeneration;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Errors in GraphQL for AI generation routes are currently being sent to the client in the `errors` part of the response, but the `useAIGeneration` hook wasn't setting the `hasError`. I also moved the error to the `message` part of the hook. It seemed weird that there could be different places to check for the error message?

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
