### PR TITLE
chore(storage-browser): remove loading indicator and empty message fr…

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/composables/DataTable/DataTable.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/composables/DataTable/DataTable.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { EmptyMessage } from '../../components/EmptyMessage';
-import { LoadingIndicator } from '../../components/LoadingIndicator';
 import { Table } from '../../components/Table';
 import { SortHeader } from './headers/SortHeader';
 import { TextHeader } from './headers/TextHeader';
@@ -21,13 +19,11 @@ export interface DataTableRow {
 export interface DataTableProps {
   headers: WithKey<DataTableHeader>[];
   rows: WithKey<DataTableRow>[];
-  isLoading?: boolean;
 }
 
 export const DataTable = ({
   headers,
   rows,
-  isLoading,
 }: DataTableProps): React.JSX.Element => {
   const mappedHeaders = headers.map(({ key, content, type }) => {
     switch (type) {
@@ -92,14 +88,5 @@ export const DataTable = ({
     }),
   }));
 
-  return (
-    <>
-      <Table headers={mappedHeaders} rows={mappedRows} />
-      {isLoading ? (
-        <LoadingIndicator />
-      ) : mappedRows.length ? null : (
-        <EmptyMessage>No data available</EmptyMessage>
-      )}
-    </>
-  );
+  return <Table headers={mappedHeaders} rows={mappedRows} />;
 };

--- a/packages/react-storage/src/components/StorageBrowser/composables/__tests__/DataTable/DataTable.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/composables/__tests__/DataTable/DataTable.spec.tsx
@@ -101,35 +101,4 @@ describe('DataTable', () => {
     expect(row2DataCell2).toHaveTextContent('row-2-number');
     expect(row2DataCell3).toHaveTextContent('row-2-text');
   });
-
-  it('displays a loading indicator when loading', () => {
-    const { container } = render(
-      <DataTable headers={[]} rows={[]} isLoading />
-    );
-
-    const table = screen.queryByRole('table');
-    const svg = container.querySelector('svg');
-
-    expect(table).toBeInTheDocument();
-    expect(svg).toBeInTheDocument();
-  });
-
-  it('displays a an empty message if there is no row data', () => {
-    const { container } = render(
-      <DataTable
-        headers={[{ key: 'header', type: 'text', content: {} }]}
-        rows={[]}
-      />
-    );
-
-    const table = screen.queryByRole('table');
-    const tableHeaders = screen.getAllByRole('columnheader');
-    const svg = container.querySelector('svg');
-    const emptyMessage = screen.getByText('No data available');
-
-    expect(table).toBeInTheDocument();
-    expect(tableHeaders).toHaveLength(1);
-    expect(emptyMessage).toBeInTheDocument();
-    expect(svg).not.toBeInTheDocument();
-  });
 });

--- a/packages/react-storage/src/components/StorageBrowser/controls/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/controls/types.ts
@@ -28,7 +28,6 @@ interface TableData {
     | TruncatedSortHeader
   )[];
   rows: DataTableProps['rows'];
-  isLoading?: boolean;
 }
 
 export interface ControlsContext {


### PR DESCRIPTION
…om table

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This PR removes the `isLoading` prop, LoadingIndicator and EmptyMessage from the DataTable composable. The table will continue to render header if no data is present and the responsibility for displaying the empty message can be decoupled while still presenting the same UI result.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
