### PR TITLE
fix(liveness): Only apply transform style on user-facing video

### DIFF
--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -21,6 +21,7 @@ import {
 
 import { Hint, Overlay, selectErrorState, MatchIndicator } from '../shared';
 import { LivenessClassNames } from '../types/classNames';
+import { isDeviceUserFacing } from '../utils/device';
 import {
   FaceLivenessErrorModal,
   renderErrorModal,
@@ -128,6 +129,7 @@ export const LivenessCameraModule = (
   const freshnessColorRef = useRef<HTMLCanvasElement | null>(null);
 
   const [isCameraReady, setIsCameraReady] = useState<boolean>(false);
+  const [isCameraUserFacing, setIsCameraUserFacing] = useState<boolean>(false);
   const isInitCamera = state.matches('initCamera');
   const isInitWebsocket = state.matches('initWebsocket');
   const isCheckingCamera = state.matches({ initCamera: 'cameraCheck' });
@@ -160,6 +162,14 @@ export const LivenessCameraModule = (
     isStartView &&
     hasMultipleDevices &&
     (!isMobileScreen || isFaceMovementChallenge);
+
+  React.useEffect(() => {
+    async function checkCameraFacing() {
+      const isUserFacing = await isDeviceUserFacing(selectedDeviceId);
+      setIsCameraUserFacing(isUserFacing);
+    }
+    checkCameraFacing();
+  }, [selectedDeviceId]);
 
   React.useEffect(() => {
     if (canvasRef?.current && videoRef?.current && videoStream && isStartView) {
@@ -405,7 +415,10 @@ export const LivenessCameraModule = (
             height={mediaHeight}
             onCanPlay={handleMediaPlay}
             data-testid="video"
-            className={LivenessClassNames.Video}
+            className={classNames(
+              LivenessClassNames.Video,
+              isCameraUserFacing && LivenessClassNames.UserFacingVideo
+            )}
             aria-label={cameraDisplayText.a11yVideoLabelText}
           />
           <Flex

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -129,7 +129,7 @@ export const LivenessCameraModule = (
   const freshnessColorRef = useRef<HTMLCanvasElement | null>(null);
 
   const [isCameraReady, setIsCameraReady] = useState<boolean>(false);
-  const [isCameraUserFacing, setIsCameraUserFacing] = useState<boolean>(false);
+  const [isCameraUserFacing, setIsCameraUserFacing] = useState<boolean>(true);
   const isInitCamera = state.matches('initCamera');
   const isInitWebsocket = state.matches('initWebsocket');
   const isCheckingCamera = state.matches({ initCamera: 'cameraCheck' });

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/CameraSelector.test.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/CameraSelector.test.tsx
@@ -1,21 +1,53 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { CameraSelector } from '../CameraSelector';
 import React from 'react';
 
-const mockMediaDevice: MediaDeviceInfo = {
-  deviceId: 'foobar',
-  groupId: 'foobar',
-  kind: 'videoinput',
-  label: 'foobar',
-  toJSON: jest.fn(),
-};
+const mockMediaDevices: MediaDeviceInfo[] = [
+  {
+    deviceId: '1',
+    groupId: 'foobar',
+    label: 'Camera 1',
+    kind: 'videoinput',
+    toJSON: jest.fn(),
+  },
+  {
+    deviceId: '2',
+    groupId: 'foobar',
+    label: 'Camera 2',
+    kind: 'videoinput',
+    toJSON: jest.fn(),
+  },
+];
 
+const onChange = jest.fn();
 describe('CameraSelector', () => {
+  beforeEach(() => {
+    onChange.mockClear();
+  });
+
   it('should render', () => {
     const result = render(
-      <CameraSelector onSelect={() => {}} devices={[mockMediaDevice]} />
+      <CameraSelector onSelect={onChange} devices={mockMediaDevices} />
     );
 
     expect(result.container).toBeDefined();
+  });
+
+  it('renders CameraSelector when there are multiple devices and allows changing camera', async () => {
+    render(<CameraSelector onSelect={onChange} devices={mockMediaDevices} />);
+
+    const selectElement = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(selectElement).toBeInTheDocument();
+    expect(selectElement.value).toBe('1');
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(2);
+    expect(options[0].textContent).toBe('Camera 1');
+    expect(options[1].textContent).toBe('Camera 2');
+
+    // Simulate selecting the back camera
+    fireEvent.change(selectElement, { target: { value: '2' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(selectElement.value).toBe('2');
   });
 });

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { when, resetAllWhenMocks } from 'jest-when';
 import { LivenessClassNames } from '../../types/classNames';
 
@@ -35,6 +35,22 @@ jest.mock('../../service');
 const mockUseLivenessActor = getMockedFunction(useLivenessActor);
 const mockUseLivenessSelector = getMockedFunction(useLivenessSelector);
 const mockUseMediaStreamInVideo = getMockedFunction(useMediaStreamInVideo);
+
+const mockDevices = [
+  {
+    deviceId: '123',
+    kind: 'videoinput',
+    label: 'Front Camera',
+    groupId: '',
+  },
+  {
+    deviceId: '456',
+    kind: 'videoinput',
+    label: 'Back Camera',
+    groupId: '',
+  },
+];
+const mockEnumerateDevices = jest.fn().mockResolvedValue(mockDevices);
 
 describe('LivenessCameraModule', () => {
   const mockActorState: any = {
@@ -88,6 +104,13 @@ describe('LivenessCameraModule', () => {
       videoHeight: 100,
       videoWidth: 100,
     });
+    Object.defineProperty(navigator, 'mediaDevices', {
+      writable: true,
+      value: {
+        getUserMedia: jest.fn(),
+        enumerateDevices: mockEnumerateDevices,
+      },
+    });
   });
 
   afterEach(() => {
@@ -137,6 +160,67 @@ describe('LivenessCameraModule', () => {
     );
 
     expect(screen.getByTestId('centered-loader')).toBeInTheDocument();
+  });
+
+  it('should apply correct classNames to user-facing video', async () => {
+    isStart = true;
+    mockStateMatchesAndSelectors();
+
+    // Mock implementation for useLivenessSelector
+    mockUseLivenessSelector.mockReturnValue('123').mockReturnValue(mockDevices);
+
+    renderWithLivenessProvider(
+      <LivenessCameraModule
+        isMobileScreen={false}
+        isRecordingStopped={false}
+        hintDisplayText={hintDisplayText}
+        streamDisplayText={streamDisplayText}
+        errorDisplayText={errorDisplayText}
+        cameraDisplayText={cameraDisplayText}
+        instructionDisplayText={instructionDisplayText}
+      />
+    );
+
+    const cameraSelector = screen.getByRole('combobox') as HTMLSelectElement;
+    const videoEl = screen.getByTestId('video');
+
+    await waitFor(() => {
+      expect(cameraSelector).toBeInTheDocument();
+      expect(cameraSelector.value).toBe('123');
+      expect(videoEl).toHaveClass(LivenessClassNames.Video);
+      expect(videoEl).toHaveClass(LivenessClassNames.UserFacingVideo);
+    });
+  });
+
+  it('should apply correct classNames to video', async () => {
+    isStart = true;
+    mockStateMatchesAndSelectors();
+
+    mockUseLivenessSelector
+      .mockReturnValue('456')
+      .mockReturnValue(mockDevices.reverse());
+
+    renderWithLivenessProvider(
+      <LivenessCameraModule
+        isMobileScreen={false}
+        isRecordingStopped={false}
+        hintDisplayText={hintDisplayText}
+        streamDisplayText={streamDisplayText}
+        errorDisplayText={errorDisplayText}
+        cameraDisplayText={cameraDisplayText}
+        instructionDisplayText={instructionDisplayText}
+      />
+    );
+
+    const cameraSelector = screen.getByRole('combobox') as HTMLSelectElement;
+    const videoEl = screen.getByTestId('video');
+
+    await waitFor(() => {
+      expect(cameraSelector).toBeInTheDocument();
+      expect(cameraSelector.value).toBe('456');
+      expect(videoEl).toHaveClass(LivenessClassNames.Video);
+      expect(videoEl).not.toHaveClass(LivenessClassNames.UserFacingVideo);
+    });
   });
 
   it.skip('should render video and timer when isNotRecording true', async () => {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
@@ -166,7 +166,6 @@ describe('LivenessCameraModule', () => {
     isStart = true;
     mockStateMatchesAndSelectors();
 
-    // Mock implementation for useLivenessSelector
     mockUseLivenessSelector.mockReturnValue('123').mockReturnValue(mockDevices);
 
     renderWithLivenessProvider(

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
@@ -162,11 +162,13 @@ describe('LivenessCameraModule', () => {
     expect(screen.getByTestId('centered-loader')).toBeInTheDocument();
   });
 
-  it('should apply correct classNames to user-facing video', async () => {
+  it.only('should apply correct classNames to user-facing video', async () => {
     isStart = true;
     mockStateMatchesAndSelectors();
-
-    mockUseLivenessSelector.mockReturnValue('123').mockReturnValue(mockDevices);
+    mockUseLivenessSelector
+      .mockReturnValueOnce({}) // videoConstraints
+      .mockReturnValueOnce(123) // selectedDeviceId
+      .mockReturnValueOnce(mockDevices); // selectableDevices
 
     renderWithLivenessProvider(
       <LivenessCameraModule
@@ -196,8 +198,9 @@ describe('LivenessCameraModule', () => {
     mockStateMatchesAndSelectors();
 
     mockUseLivenessSelector
-      .mockReturnValue('456')
-      .mockReturnValue(mockDevices.reverse());
+      .mockReturnValueOnce({}) // videoConstraints
+      .mockReturnValueOnce(456) // selectedDeviceId
+      .mockReturnValueOnce(mockDevices); // selectableDevices
 
     renderWithLivenessProvider(
       <LivenessCameraModule

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { when, resetAllWhenMocks } from 'jest-when';
 import { LivenessClassNames } from '../../types/classNames';
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/__tests__/machine.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/__tests__/machine.test.ts
@@ -889,7 +889,6 @@ describe('Liveness Machine', () => {
         );
         const clientInfo = (mockStreamRecorder.dispatchStreamEvent as jest.Mock)
           .mock.calls[0][0];
-        console.log(clientInfo);
 
         const videoEl = service.state.context.videoAssociatedParams?.videoEl!;
         Object.defineProperty(videoEl, 'videoHeight', { value: 100 });

--- a/packages/react-liveness/src/components/FaceLivenessDetector/types/classNames.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/types/classNames.ts
@@ -43,6 +43,7 @@ export enum LivenessClassNames {
   Toast = 'amplify-liveness-toast',
   ToastContainer = 'amplify-liveness-toast__container',
   ToastMessage = 'amplify-liveness-toast__message',
+  UserFacingVideo = 'amplify-liveness-video-user-facing',
   Video = 'amplify-liveness-video',
   VideoAnchor = 'amplify-liveness-video-anchor',
 }

--- a/packages/react-liveness/src/components/FaceLivenessDetector/types/classNames.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/types/classNames.ts
@@ -43,7 +43,7 @@ export enum LivenessClassNames {
   Toast = 'amplify-liveness-toast',
   ToastContainer = 'amplify-liveness-toast__container',
   ToastMessage = 'amplify-liveness-toast__message',
-  UserFacingVideo = 'amplify-liveness-video-user-facing',
+  UserFacingVideo = 'amplify-liveness-video--user-facing',
   Video = 'amplify-liveness-video',
   VideoAnchor = 'amplify-liveness-video-anchor',
 }

--- a/packages/react-liveness/src/components/FaceLivenessDetector/utils/device.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/utils/device.ts
@@ -18,10 +18,10 @@ export function isMobileScreen(): boolean {
 export async function isDeviceUserFacing(
   deviceId: string | undefined
 ): Promise<boolean> {
-  const devices = await navigator.mediaDevices.enumerateDevices();
+  const devices = await navigator.mediaDevices?.enumerateDevices();
 
   // Find the video input device with the matching deviceId
-  const videoDevice = devices.find(
+  const videoDevice = devices?.find(
     (device) => device.deviceId === deviceId && device.kind === 'videoinput'
   );
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/utils/device.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/utils/device.ts
@@ -15,6 +15,25 @@ export function isMobileScreen(): boolean {
   return isMobileDevice;
 }
 
+export async function isDeviceUserFacing(
+  deviceId: string | undefined
+): Promise<boolean> {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+
+  // Find the video input device with the matching deviceId
+  const videoDevice = devices.find(
+    (device) => device.deviceId === deviceId && device.kind === 'videoinput'
+  );
+
+  if (videoDevice) {
+    // Check if the device label contains the word "back"
+    return !videoDevice.label.toLowerCase().includes('back');
+  }
+
+  // If the device is not found or not a video input device, return false
+  return true;
+}
+
 export function isIOS(): boolean {
   const isIOS = isNewerIpad() || navigator.userAgent.indexOf('like Mac') != -1;
   return isIOS;

--- a/packages/ui/src/theme/css/component/liveness.scss
+++ b/packages/ui/src/theme/css/component/liveness.scss
@@ -59,6 +59,9 @@
   left: 0;
   width: 100%;
   height: 100%;
+}
+
+.amplify-liveness-video-user-facing {
   transform: scaleX(-1);
 }
 

--- a/packages/ui/src/theme/css/component/liveness.scss
+++ b/packages/ui/src/theme/css/component/liveness.scss
@@ -61,7 +61,7 @@
   height: 100%;
 }
 
-.amplify-liveness-video-user-facing {
+.amplify-liveness-video--user-facing {
   transform: scaleX(-1);
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Check whether video is user-facing or not based on the device label
- If video is user-facing, apply `transform: scaleX(-1);` to mirror the video 
- Assume video is user-facing by default since our component/most devices default to choosing user-facing cameras 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- added unit tests
- Manually tested on iOS/desktop on https://main.d2pnskzbmchcgk.amplifyapp.com/ (this deployment contains a few unrelated changes so the relevant part is just whether or not the video mirrors or doesn't mirror depending on which camera you select) 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
