### PR TITLE
fix(liveness): Fix oval render when switching cameras 

### DIFF
--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -163,35 +163,20 @@ export const LivenessCameraModule = (
     (!isMobileScreen || isFaceMovementChallenge);
 
   React.useEffect(() => {
-    if (
+    const shouldDrawOval =
       canvasRef?.current &&
       videoRef?.current &&
       videoStream &&
       isStartView &&
-      isMetadataLoaded
-    ) {
-      drawStaticOval(canvasRef.current, videoRef.current, videoStream);
-    }
-  }, [
-    canvasRef,
-    videoRef,
-    videoStream,
-    colorMode,
-    isStartView,
-    isMetadataLoaded,
-  ]);
+      isMetadataLoaded;
 
-  React.useEffect(() => {
+    if (shouldDrawOval) {
+      drawStaticOval(canvasRef.current, videoRef.current!, videoStream);
+    }
+
     const updateColorModeHandler = (e: MediaQueryListEvent) => {
-      if (
-        e.matches &&
-        canvasRef?.current &&
-        videoRef?.current &&
-        videoStream &&
-        isStartView &&
-        isMetadataLoaded
-      ) {
-        drawStaticOval(canvasRef.current, videoRef.current, videoStream);
+      if (e.matches && shouldDrawOval) {
+        drawStaticOval(canvasRef.current, videoRef.current!, videoStream);
       }
     };
 
@@ -209,7 +194,14 @@ export const LivenessCameraModule = (
       darkModePreference.removeEventListener('change', updateColorModeHandler);
       lightModePreference.addEventListener('change', updateColorModeHandler);
     };
-  }, [canvasRef, videoRef, videoStream, isStartView, isMetadataLoaded]);
+  }, [
+    canvasRef,
+    videoRef,
+    videoStream,
+    colorMode,
+    isStartView,
+    isMetadataLoaded,
+  ]);
 
   React.useLayoutEffect(() => {
     if (isCameraReady) {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -194,14 +194,7 @@ export const LivenessCameraModule = (
       darkModePreference.removeEventListener('change', updateColorModeHandler);
       lightModePreference.addEventListener('change', updateColorModeHandler);
     };
-  }, [
-    canvasRef,
-    videoRef,
-    videoStream,
-    colorMode,
-    isStartView,
-    isMetadataLoaded,
-  ]);
+  }, [videoRef, videoStream, colorMode, isStartView, isMetadataLoaded]);
 
   React.useLayoutEffect(() => {
     if (isCameraReady) {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -280,17 +280,14 @@ export const LivenessCameraModule = (
           },
           audio: false,
         });
-        // Only update the stream and draw oval once metadata is loaded
-        if (isMetadataLoaded) {
-          send({
-            type: 'UPDATE_DEVICE_AND_STREAM',
-            data: { newDeviceId, newStream },
-          });
-        }
+        send({
+          type: 'UPDATE_DEVICE_AND_STREAM',
+          data: { newDeviceId, newStream },
+        });
       };
       changeCamera();
     },
-    [isMetadataLoaded, videoConstraints, send]
+    [videoConstraints, send]
   );
 
   if (isCheckingCamera) {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/LivenessCameraModule.tsx
@@ -212,7 +212,7 @@ export const LivenessCameraModule = (
   }, [canvasRef, videoRef, videoStream, isStartView, isMetadataLoaded]);
 
   React.useLayoutEffect(() => {
-    if (isCameraReady && isMetadataLoaded) {
+    if (isCameraReady) {
       send({
         type: 'SET_DOM_AND_CAMERA_DETAILS',
         data: {
@@ -224,14 +224,14 @@ export const LivenessCameraModule = (
       });
     }
 
-    if (videoRef.current && isMetadataLoaded) {
+    if (videoRef.current) {
       setMediaWidth(videoRef.current.videoWidth);
       setMediaHeight(videoRef.current.videoHeight);
       setAspectRatio(
         videoRef.current.videoWidth / videoRef.current.videoHeight
       );
     }
-  }, [send, videoRef, isCameraReady, isMobileScreen, isMetadataLoaded]);
+  }, [send, videoRef, isCameraReady, isMobileScreen]);
 
   React.useEffect(() => {
     if (isDetectFaceBeforeStart) {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
@@ -386,6 +386,7 @@ describe('LivenessCameraModule', () => {
   it('should not render photosensitivity warning when challenge is FaceMovementChallenge and isNotRecording is true', async () => {
     isNotRecording = true;
     mockStateMatchesAndSelectors();
+    mockUseLivenessSelector.mockReset();
     mockUseLivenessSelector.mockReturnValue('FaceMovementChallenge');
 
     renderWithLivenessProvider(

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
@@ -595,4 +595,33 @@ describe('LivenessCameraModule', () => {
       `${LivenessClassNames.CameraModule}--mobile`
     );
   });
+
+  it('should trigger drawStaticOval once video metadata is loaded', async () => {
+    isStart = true;
+    mockStateMatchesAndSelectors();
+    mockUseLivenessSelector.mockReturnValue(25);
+
+    renderWithLivenessProvider(
+      <LivenessCameraModule
+        isMobileScreen={false}
+        isRecordingStopped={false}
+        hintDisplayText={hintDisplayText}
+        streamDisplayText={streamDisplayText}
+        errorDisplayText={errorDisplayText}
+        cameraDisplayText={cameraDisplayText}
+        instructionDisplayText={instructionDisplayText}
+      />
+    );
+
+    const videoEl = screen.getByTestId('video');
+    await waitFor(() => {
+      videoEl.dispatchEvent(new Event('canplay'));
+    });
+    expect(drawStaticOvalSpy).toHaveBeenCalledTimes(0);
+
+    await waitFor(() => {
+      videoEl.dispatchEvent(new Event('loadedmetadata'));
+    });
+    expect(drawStaticOvalSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/LivenessCheck/__tests__/LivenessCameraModule.test.tsx
@@ -22,6 +22,8 @@ import {
   selectVideoConstraints,
   selectVideoStream,
 } from '../LivenessCameraModule';
+
+import * as ServiceModule from '../../service';
 import { FaceMatchState } from '../../service';
 import { getDisplayText } from '../../utils/getDisplayText';
 import { selectIsRecordingStopped } from '../LivenessCheck';
@@ -31,6 +33,8 @@ jest.mock('../../hooks/useLivenessSelector');
 jest.mock('../../shared/CancelButton');
 jest.mock('../../shared/Hint');
 jest.mock('../../service');
+
+const drawStaticOvalSpy = jest.spyOn(ServiceModule, 'drawStaticOval');
 
 const mockUseLivenessActor = getMockedFunction(useLivenessActor);
 const mockUseLivenessSelector = getMockedFunction(useLivenessSelector);
@@ -88,6 +92,7 @@ describe('LivenessCameraModule', () => {
       videoHeight: 100,
       videoWidth: 100,
     });
+    drawStaticOvalSpy.mockClear();
   });
 
   afterEach(() => {
@@ -163,7 +168,9 @@ describe('LivenessCameraModule', () => {
       screen.getByRole('button', { name: cancelLivenessCheckText })
     ).toBeInTheDocument();
 
-    videoEl.dispatchEvent(new Event('canplay'));
+    await waitFor(() => {
+      videoEl.dispatchEvent(new Event('canplay'));
+    });
 
     expect(screen.queryByTestId('centered-loader')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Countdown timer')).toBeInTheDocument();
@@ -183,7 +190,7 @@ describe('LivenessCameraModule', () => {
     });
   });
 
-  it('should render recording icon when isRecording true', () => {
+  it('should render recording icon when isRecording true', async () => {
     isRecording = true;
     mockStateMatchesAndSelectors();
 
@@ -199,7 +206,9 @@ describe('LivenessCameraModule', () => {
       />
     );
     const videoEl = screen.getByTestId('video');
-    videoEl.dispatchEvent(new Event('canplay'));
+    await waitFor(() => {
+      videoEl.dispatchEvent(new Event('canplay'));
+    });
 
     expect(screen.getByTestId('rec-icon')).toBeInTheDocument();
     expect(screen.getByText(recordingIndicatorText)).toBeInTheDocument();
@@ -227,7 +236,9 @@ describe('LivenessCameraModule', () => {
       />
     );
     const videoEl = screen.getByTestId('video');
-    videoEl.dispatchEvent(new Event('canplay'));
+    await waitFor(() => {
+      videoEl.dispatchEvent(new Event('canplay'));
+    });
 
     const cameraModule = await screen.findByTestId(testId);
     const matchIndicator = cameraModule.getElementsByClassName(
@@ -258,7 +269,9 @@ describe('LivenessCameraModule', () => {
       />
     );
     const videoEl = screen.getByTestId('video');
-    videoEl.dispatchEvent(new Event('canplay'));
+    await waitFor(() => {
+      videoEl.dispatchEvent(new Event('canplay'));
+    });
 
     const cameraModule = await screen.findByTestId(testId);
     const matchIndicator = cameraModule.getElementsByClassName(
@@ -289,7 +302,9 @@ describe('LivenessCameraModule', () => {
       />
     );
     const videoEl = screen.getByTestId('video');
-    videoEl.dispatchEvent(new Event('canplay'));
+    await waitFor(() => {
+      videoEl.dispatchEvent(new Event('canplay'));
+    });
 
     const cameraModule = await screen.findByTestId(testId);
     const matchIndicator = cameraModule.getElementsByClassName(
@@ -320,7 +335,9 @@ describe('LivenessCameraModule', () => {
       />
     );
     const videoEl = screen.getByTestId('video');
-    videoEl.dispatchEvent(new Event('canplay'));
+    await waitFor(() => {
+      videoEl.dispatchEvent(new Event('canplay'));
+    });
 
     const cameraModule = await screen.findByTestId(testId);
     const matchIndicator = cameraModule.getElementsByClassName(
@@ -351,8 +368,9 @@ describe('LivenessCameraModule', () => {
       />
     );
     const videoEl = screen.getByTestId('video');
-    videoEl.dispatchEvent(new Event('canplay'));
-
+    await waitFor(() => {
+      videoEl.dispatchEvent(new Event('canplay'));
+    });
     const cameraModule = await screen.findByTestId(testId);
     const matchIndicator = cameraModule.getElementsByClassName(
       LivenessClassNames.MatchIndicator
@@ -481,7 +499,7 @@ describe('LivenessCameraModule', () => {
     expect(screen.getByTestId('centered-loader')).toBeInTheDocument();
   });
 
-  it('should render hair check screen when isStart = true', () => {
+  it('should render hair check screen when isStart = true', async () => {
     isStart = true;
     mockStateMatchesAndSelectors();
     mockUseLivenessSelector
@@ -500,7 +518,9 @@ describe('LivenessCameraModule', () => {
       />
     );
     const videoEl = screen.getByTestId('video');
-    videoEl.dispatchEvent(new Event('canplay'));
+    await waitFor(() => {
+      videoEl.dispatchEvent(new Event('canplay'));
+    });
 
     expect(screen.getByTestId('popover-icon')).toBeInTheDocument();
     expect(
@@ -508,7 +528,7 @@ describe('LivenessCameraModule', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render hair check screen when isStart = true, should not render camera selector if only one camera', () => {
+  it('should render hair check screen when isStart = true, should not render camera selector if only one camera', async () => {
     isStart = true;
     mockStateMatchesAndSelectors();
     mockUseLivenessSelector.mockReturnValue(25).mockReturnValue(['device-id']);
@@ -525,7 +545,9 @@ describe('LivenessCameraModule', () => {
       />
     );
     const videoEl = screen.getByTestId('video');
-    videoEl.dispatchEvent(new Event('canplay'));
+    await waitFor(() => {
+      videoEl.dispatchEvent(new Event('canplay'));
+    });
 
     expect(screen.getByTestId('popover-icon')).toBeInTheDocument();
     expect(

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
@@ -43,7 +43,6 @@ import {
   estimateIllumination,
   isCameraDeviceVirtual,
   ColorSequenceDisplay,
-  drawStaticOval,
   createSessionStartEvent,
   createColorDisplayEvent,
   createSessionEndEvent,
@@ -262,7 +261,7 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
         },
       },
       start: {
-        entry: ['drawStaticOval', 'initializeFaceDetector'],
+        entry: ['initializeFaceDetector'],
         always: [
           {
             target: 'detectFaceBeforeStart',
@@ -555,12 +554,6 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
           };
         },
       }),
-      drawStaticOval: (context) => {
-        const { canvasEl, videoEl, videoMediaStream } =
-          context.videoAssociatedParams!;
-
-        drawStaticOval(canvasEl!, videoEl!, videoMediaStream!);
-      },
       updateRecordingStartTimestamp: assign({
         videoAssociatedParams: (context) => {
           const {

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
@@ -541,13 +541,10 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
       }),
       updateDeviceAndStream: assign({
         videoAssociatedParams: (context, event) => {
-          const { canvasEl, videoEl, videoMediaStream } =
-            context.videoAssociatedParams!;
           setLastSelectedCameraId(event.data?.newDeviceId as string);
           context.livenessStreamProvider?.setNewVideoStream(
             event.data?.newStream as MediaStream
           );
-          drawStaticOval(canvasEl!, videoEl!, videoMediaStream!);
 
           return {
             ...context.videoAssociatedParams,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Fix for an issue where the oval renders in the wrong location when switching cameras to unblock data collection
- Add an event listener to make sure video metadata (which includes `video.videoHeight` and `video.videoWidth`) is loaded before attempting to draw the oval
- Remove `drawStaticOval` from state machine because we already call it in the LivenessCameraModule. Calling from multiple places caused weird/unpredictable behavior 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Deployment https://testing.d2pnskzbmchcgk.amplifyapp.com/
- Compare to https://alpha.d3v0f004886eky.amplifyapp.com/

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
