### PR TITLE
chore(storage-browser): flatten control hooks to return props directly

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/composables/context.ts
+++ b/packages/react-storage/src/components/StorageBrowser/composables/context.ts
@@ -1,7 +1,7 @@
 import { createContextUtilities } from '@aws-amplify/ui-react-core';
-import { Composables } from './types';
+import { ComposablesContext } from './types';
 
-const defaultValue: Composables = {};
+const defaultValue: ComposablesContext = {};
 
 export const { useComposables, ComposablesProvider } = createContextUtilities({
   contextName: 'Composables',

--- a/packages/react-storage/src/components/StorageBrowser/composables/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/composables/types.ts
@@ -1,13 +1,11 @@
-import { DataTable } from './DataTable';
-import { StatusDisplay } from './StatusDisplay';
-
-const composables = {
-  DataTable,
-  StatusDisplay,
-};
-
-export type ComposableTypes = typeof composables;
+import { DataTableProps } from './DataTable';
+import { StatusDisplayProps } from './StatusDisplay';
 
 export interface Composables {
-  composables?: ComposableTypes;
+  DataTable: React.ComponentType<DataTableProps>;
+  StatusDisplay: React.ComponentType<StatusDisplayProps>;
+}
+
+export interface ComposablesContext {
+  composables?: Composables;
 }

--- a/packages/react-storage/src/components/StorageBrowser/controls/DataTableControl.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/controls/DataTableControl.tsx
@@ -9,7 +9,7 @@ import { ControlProps } from './types';
 export const DataTableControl = ({
   className,
 }: ControlProps): React.JSX.Element | null => {
-  const { props } = useDataTable();
+  const props = useDataTable();
 
   const ResolvedDataTable = useResolvedComposable(DataTable, 'DataTable');
 

--- a/packages/react-storage/src/components/StorageBrowser/controls/StatusDisplayControl.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/controls/StatusDisplayControl.tsx
@@ -9,7 +9,7 @@ import { useStatusDisplay } from './hooks/useStatusDisplay';
 export const StatusDisplayControl = ({
   className,
 }: ControlProps): React.JSX.Element | null => {
-  const { props } = useStatusDisplay();
+  const props = useStatusDisplay();
 
   const ResolvedStatusDisplay = useResolvedComposable(
     StatusDisplay,

--- a/packages/react-storage/src/components/StorageBrowser/controls/__tests__/DataTableControl.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/controls/__tests__/DataTableControl.spec.tsx
@@ -25,49 +25,47 @@ describe('DataTableControl', () => {
 
   it('renders', () => {
     mockUseDataTable.mockReturnValue({
-      props: {
-        headers: [
-          {
-            key: 'header-1',
-            type: 'checkbox',
-            content: { onSelect: jest.fn() },
-          },
-          { key: 'header-2', type: 'sort', content: {} },
-          { key: 'header-3', type: 'text', content: {} },
-          { key: 'header-4', type: 'text', content: {} },
-          { key: 'header-5', type: 'text', content: {} },
-        ],
-        rows: [
-          {
-            key: 'row-1',
-            content: [
-              {
-                key: 'row-1 data-cell-1',
-                type: 'checkbox',
-                content: { onSelect: jest.fn() },
-              },
-              { key: 'row-1 data-cell-2', type: 'button', content: {} },
-              { key: 'row-1 data-cell-3', type: 'date', content: {} },
-              { key: 'row-1 data-cell-4', type: 'number', content: {} },
-              { key: 'row-1 data-cell-5', type: 'text', content: {} },
-            ],
-          },
-          {
-            key: 'row-2',
-            content: [
-              {
-                key: 'row-2 data-cell-1',
-                type: 'checkbox',
-                content: { onSelect: jest.fn() },
-              },
-              { key: 'row-2 data-cell-2', type: 'button', content: {} },
-              { key: 'row-2 data-cell-3', type: 'date', content: {} },
-              { key: 'row-2 data-cell-4', type: 'number', content: {} },
-              { key: 'row-2 data-cell-5', type: 'text', content: {} },
-            ],
-          },
-        ],
-      },
+      headers: [
+        {
+          key: 'header-1',
+          type: 'checkbox',
+          content: { onSelect: jest.fn() },
+        },
+        { key: 'header-2', type: 'sort', content: {} },
+        { key: 'header-3', type: 'text', content: {} },
+        { key: 'header-4', type: 'text', content: {} },
+        { key: 'header-5', type: 'text', content: {} },
+      ],
+      rows: [
+        {
+          key: 'row-1',
+          content: [
+            {
+              key: 'row-1 data-cell-1',
+              type: 'checkbox',
+              content: { onSelect: jest.fn() },
+            },
+            { key: 'row-1 data-cell-2', type: 'button', content: {} },
+            { key: 'row-1 data-cell-3', type: 'date', content: {} },
+            { key: 'row-1 data-cell-4', type: 'number', content: {} },
+            { key: 'row-1 data-cell-5', type: 'text', content: {} },
+          ],
+        },
+        {
+          key: 'row-2',
+          content: [
+            {
+              key: 'row-2 data-cell-1',
+              type: 'checkbox',
+              content: { onSelect: jest.fn() },
+            },
+            { key: 'row-2 data-cell-2', type: 'button', content: {} },
+            { key: 'row-2 data-cell-3', type: 'date', content: {} },
+            { key: 'row-2 data-cell-4', type: 'number', content: {} },
+            { key: 'row-2 data-cell-5', type: 'text', content: {} },
+          ],
+        },
+      ],
     });
 
     render(<DataTableControl />);

--- a/packages/react-storage/src/components/StorageBrowser/controls/__tests__/StatusDisplayControl.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/controls/__tests__/StatusDisplayControl.spec.tsx
@@ -25,14 +25,12 @@ describe('StatusDisplayControl', () => {
 
   it('renders', () => {
     mockUseStatusDisplay.mockReturnValue({
-      props: {
-        statuses: [
-          { name: 'foo', count: 1 },
-          { name: 'bar', count: 2 },
-          { name: 'qux', count: 3 },
-        ],
-        total: 6,
-      },
+      statuses: [
+        { name: 'foo', count: 1 },
+        { name: 'bar', count: 2 },
+        { name: 'qux', count: 3 },
+      ],
+      total: 6,
     });
 
     render(<StatusDisplayControl />);

--- a/packages/react-storage/src/components/StorageBrowser/controls/hooks/__tests__/useDataTable.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/controls/hooks/__tests__/useDataTable.spec.tsx
@@ -73,7 +73,7 @@ describe('useDataTable', () => {
 
     const { result } = renderHook(() => useDataTable());
 
-    expect(result.current.props).toStrictEqual({
+    expect(result.current).toStrictEqual({
       headers: [
         { key: 'header-1', ...checkboxHeader },
         {
@@ -108,7 +108,7 @@ describe('useDataTable', () => {
 
     const { result } = renderHook(() => useDataTable());
 
-    expect(result.current).toStrictEqual({});
+    expect(result.current).toBeNull();
   });
 
   it('handles data with no sortable columns', () => {
@@ -128,7 +128,7 @@ describe('useDataTable', () => {
 
     const { result } = renderHook(() => useDataTable());
 
-    expect(result.current.props).toStrictEqual({
+    expect(result.current).toStrictEqual({
       headers: [expect.objectContaining({ key: 'header-1' })],
       rows: [expect.objectContaining({ key: 'row-1' })],
     });
@@ -159,7 +159,7 @@ describe('useDataTable', () => {
 
     const { result } = renderHook(() => useDataTable());
 
-    expect(result.current.props).toStrictEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         headers: [
           expect.objectContaining({ key: 'header-1' }),
@@ -214,7 +214,7 @@ describe('useDataTable', () => {
     mockCompareNumberData.mockReturnValue(1);
 
     const { result } = renderHook(() => useDataTable());
-    expect(result.current.props).toStrictEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         rows: [
           expect.objectContaining({ key: 'row-1' }),
@@ -224,11 +224,11 @@ describe('useDataTable', () => {
     );
 
     act(() => {
-      const [, sortDateData] = result.current.props!.headers;
+      const [, sortDateData] = result.current!.headers;
       (sortDateData as DataTableSortHeader).content.onSort!();
     });
 
-    expect(result.current.props).toStrictEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         rows: [
           expect.objectContaining({ key: 'row-2' }),
@@ -238,11 +238,11 @@ describe('useDataTable', () => {
     );
 
     act(() => {
-      const [, , sortNumberData] = result.current.props!.headers;
+      const [, , sortNumberData] = result.current!.headers;
       (sortNumberData as DataTableSortHeader).content.onSort!();
     });
 
-    expect(result.current.props).toStrictEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         rows: [
           expect.objectContaining({ key: 'row-1' }),
@@ -278,7 +278,7 @@ describe('useDataTable', () => {
     mockCompareButtonData.mockReturnValue(-1);
 
     const { result } = renderHook(() => useDataTable());
-    expect(result.current.props).toStrictEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         rows: [
           expect.objectContaining({ key: 'row-2' }),
@@ -313,7 +313,7 @@ describe('useDataTable', () => {
     mockCompareDateData.mockReturnValue(-1);
 
     const { result } = renderHook(() => useDataTable());
-    expect(result.current.props).toStrictEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         rows: [
           expect.objectContaining({ key: 'row-2' }),
@@ -348,7 +348,7 @@ describe('useDataTable', () => {
     mockCompareNumberData.mockReturnValue(-1);
 
     const { result } = renderHook(() => useDataTable());
-    expect(result.current.props).toStrictEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         rows: [
           expect.objectContaining({ key: 'row-2' }),
@@ -383,7 +383,7 @@ describe('useDataTable', () => {
     mockCompareTextData.mockReturnValue(-1);
 
     const { result } = renderHook(() => useDataTable());
-    expect(result.current.props).toStrictEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         rows: [
           expect.objectContaining({ key: 'row-2' }),
@@ -417,7 +417,7 @@ describe('useDataTable', () => {
     });
 
     const { result } = renderHook(() => useDataTable());
-    expect(result.current.props).toStrictEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         rows: [
           expect.objectContaining({ key: 'row-1' }),
@@ -491,7 +491,7 @@ describe('useDataTable', () => {
     mockCompareTextData.mockReturnValue(-1);
 
     const { result } = renderHook(() => useDataTable());
-    expect(result.current.props).toStrictEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         rows: [
           expect.objectContaining({ key: 'checkbox-row-1' }),
@@ -514,11 +514,11 @@ describe('useDataTable', () => {
     mockCompareTextData.mockReturnValue(1);
 
     act(() => {
-      const [sortData] = result.current.props!.headers;
+      const [sortData] = result.current!.headers;
       (sortData as DataTableSortHeader).content.onSort!();
     });
 
-    expect(result.current.props).toStrictEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         rows: [
           expect.objectContaining({ key: 'text-row-1' }),

--- a/packages/react-storage/src/components/StorageBrowser/controls/hooks/__tests__/useStatusDisplay.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/controls/hooks/__tests__/useStatusDisplay.spec.tsx
@@ -31,22 +31,20 @@ describe('useStatusDisplay', () => {
     mockUseControlsContext.mockReturnValue({ data, actionsConfig });
 
     expect(useStatusDisplay()).toStrictEqual({
-      props: {
-        statuses: [
-          expect.objectContaining({ count: 4 }),
-          expect.objectContaining({ count: 3 }),
-          expect.objectContaining({ count: 2 }),
-          expect.objectContaining({ count: 1 }),
-        ],
-        total: 10,
-      },
+      statuses: [
+        expect.objectContaining({ count: 4 }),
+        expect.objectContaining({ count: 3 }),
+        expect.objectContaining({ count: 2 }),
+        expect.objectContaining({ count: 1 }),
+      ],
+      total: 10,
     });
   });
 
   it('returns empty object if taskCounts is undefined', () => {
     mockUseControlsContext.mockReturnValue({ data: {}, actionsConfig });
 
-    expect(useStatusDisplay()).toStrictEqual({});
+    expect(useStatusDisplay()).toBeNull();
   });
 
   it('returns empty object if taksCount total is 0', () => {
@@ -65,7 +63,7 @@ describe('useStatusDisplay', () => {
       actionsConfig,
     });
 
-    expect(useStatusDisplay()).toStrictEqual({});
+    expect(useStatusDisplay()).toBeNull();
   });
 
   it('returns empty object if not a batch action', () => {
@@ -77,7 +75,7 @@ describe('useStatusDisplay', () => {
       },
     });
 
-    expect(useStatusDisplay()).toStrictEqual({});
+    expect(useStatusDisplay()).toBeNull();
   });
 
   it('omits canceled status if action is not cancelable', () => {
@@ -100,14 +98,12 @@ describe('useStatusDisplay', () => {
     });
 
     expect(useStatusDisplay()).toStrictEqual({
-      props: {
-        statuses: [
-          expect.objectContaining({ count: 4 }),
-          expect.objectContaining({ count: 3 }),
-          expect.objectContaining({ count: 1 }),
-        ],
-        total: 8,
-      },
+      statuses: [
+        expect.objectContaining({ count: 4 }),
+        expect.objectContaining({ count: 3 }),
+        expect.objectContaining({ count: 1 }),
+      ],
+      total: 8,
     });
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/controls/hooks/useDataTable.ts
+++ b/packages/react-storage/src/components/StorageBrowser/controls/hooks/useDataTable.ts
@@ -14,10 +14,6 @@ import { compareDateData } from '../compareFunctions/compareDateData';
 import { compareNumberData } from '../compareFunctions/compareNumberData';
 import { compareTextData } from '../compareFunctions/compareTextData';
 
-export type UseDataTable = () => {
-  props?: DataTableProps;
-};
-
 interface SortState {
   index: number;
   direction: SortDirection;
@@ -37,7 +33,7 @@ const GROUP_ORDER: DataTableDataCell['type'][] = [
 
 const UNSORTABLE_GROUPS: DataTableDataCell['type'][] = ['checkbox'];
 
-export const useDataTable: UseDataTable = () => {
+export const useDataTable = (): DataTableProps | null => {
   const { data } = useControlsContext();
   const { tableData } = data;
 
@@ -157,14 +153,12 @@ export const useDataTable: UseDataTable = () => {
   }, [sortState, tableData]);
 
   if (!tableData) {
-    return {};
+    return null;
   }
 
   return {
-    props: {
-      ...tableData,
-      headers: mappedHeaders ?? [],
-      rows: sortedRows ?? [],
-    },
+    ...tableData,
+    headers: mappedHeaders ?? [],
+    rows: sortedRows ?? [],
   };
 };

--- a/packages/react-storage/src/components/StorageBrowser/controls/hooks/useResolvedComposable.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/controls/hooks/useResolvedComposable.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import { useComposables } from '../../composables/context';
-import { ComposableTypes } from '../../composables/types';
+import { Composables } from '../../composables/types';
 
 export function useResolvedComposable<
   T extends React.ComponentType<any>,
-  K extends keyof ComposableTypes,
+  K extends keyof Composables,
 >(
   DefaultComposable: T,
   name: K

--- a/packages/react-storage/src/components/StorageBrowser/controls/hooks/useStatusDisplay.ts
+++ b/packages/react-storage/src/components/StorageBrowser/controls/hooks/useStatusDisplay.ts
@@ -2,17 +2,13 @@ import { StatusDisplayProps } from '../../composables/StatusDisplay';
 import { useControlsContext } from '../../controls/context';
 import { displayText } from '../../displayText/en';
 
-export type UseStatusDisplay = () => {
-  props?: StatusDisplayProps;
-};
-
-export const useStatusDisplay: UseStatusDisplay = () => {
+export const useStatusDisplay = (): StatusDisplayProps | null => {
   const { data, actionsConfig } = useControlsContext();
   const { taskCounts } = data;
   const { isCancelable, type } = actionsConfig;
 
   if (!taskCounts?.TOTAL || type !== 'BATCH_ACTION') {
-    return {};
+    return null;
   }
 
   const statuses = [
@@ -29,9 +25,7 @@ export const useStatusDisplay: UseStatusDisplay = () => {
   }
 
   return {
-    props: {
-      statuses,
-      total: taskCounts.TOTAL,
-    },
+    statuses,
+    total: taskCounts.TOTAL,
   };
 };

--- a/packages/react-storage/src/components/StorageBrowser/controls/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/controls/types.ts
@@ -1,4 +1,4 @@
-import { ComposableTypes } from '../composables/types';
+import { Composables } from '../composables/types';
 import { DataTableSortHeader, DataTableProps } from '../composables/DataTable';
 import { INITIAL_STATUS_COUNTS } from '../views/LocationActionView/constants';
 
@@ -7,10 +7,10 @@ export interface ControlProps {
 }
 
 export interface Controls {
-  props: React.ComponentProps<ComposableTypes[keyof ComposableTypes]>;
+  props: React.ComponentProps<Composables[keyof Composables]>;
 }
 
-export type ControlKey = keyof ComposableTypes;
+export type ControlKey = keyof Composables;
 
 export type TaskCounts = typeof INITIAL_STATUS_COUNTS;
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR flattens control hooks to just vend the props directly rather than nested under `props` field.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
