### PR TITLE
feat(storage-browser): add enhanced list handler

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/actions/__tests__/createEnhancedListHandler.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/__tests__/createEnhancedListHandler.spec.ts
@@ -1,0 +1,165 @@
+import {
+  createEnhancedListHandler,
+  SEARCH_LIMIT,
+} from '../createEnhancedListHandler';
+import { ActionInputConfig, ListHandlerOptions } from '../types';
+
+const mockAction = jest.fn();
+
+const config: ActionInputConfig = {
+  bucket: 'bucky',
+  credentials: jest.fn(),
+  region: 'us-weast-1',
+};
+
+describe('createEnhancedListHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return an empty state when reset is true', async () => {
+    const handler = createEnhancedListHandler(mockAction);
+    const prevState = { items: [{ id: 1 }], nextToken: 'abc' };
+    const options = { reset: true };
+
+    const result = await handler(prevState, {
+      config,
+      prefix: 'a_prefix',
+      options,
+    });
+
+    expect(result).toEqual({ items: [], nextToken: undefined });
+  });
+
+  it('should collect and filter results when search is provided', async () => {
+    mockAction
+      .mockResolvedValueOnce({
+        items: [{ name: 'apple' }, { name: 'banana' }],
+        nextToken: 'next',
+      })
+      .mockResolvedValueOnce({
+        items: [{ name: 'cherry' }, { name: 'date' }],
+        nextToken: null,
+      });
+
+    const handler = createEnhancedListHandler<
+      ListHandlerOptions,
+      {
+        name: string;
+      }
+    >(mockAction);
+    const prevState = { items: [], nextToken: undefined };
+    const options = {
+      search: { query: 'a', filterKey: 'name' as const },
+    };
+
+    const result = await handler(prevState, {
+      config,
+      prefix: 'a_prefix',
+      options,
+    });
+
+    expect(result.items).toEqual([
+      { name: 'apple' },
+      { name: 'banana' },
+      { name: 'date' },
+    ]);
+    expect(result.nextToken).toBeUndefined();
+  });
+
+  it('should not fail when non-string values are indexed for search', async () => {
+    mockAction.mockResolvedValueOnce({
+      items: [
+        { name: 'apple', id: 1 },
+        { name: 'banana', id: 2 },
+      ],
+      nextToken: null,
+    });
+
+    const handler = createEnhancedListHandler<
+      ListHandlerOptions,
+      {
+        name: string;
+        id: number;
+      }
+    >(mockAction);
+    const prevState = { items: [], nextToken: undefined };
+    const options = {
+      search: { query: 'z', filterKey: 'id' as const },
+    };
+
+    const result = await handler(prevState, {
+      config,
+      prefix: 'a_prefix',
+      options,
+    });
+
+    expect(result.items).toEqual([]);
+    expect(result.nextToken).toBeUndefined();
+  });
+
+  it('should stop collecting results when SEARCH_LIMIT is reached', async () => {
+    const mockItems = new Array(SEARCH_LIMIT).fill({ name: 'item' });
+    mockAction.mockResolvedValue({ items: mockItems, nextToken: null });
+
+    const handler = createEnhancedListHandler<
+      ListHandlerOptions,
+      {
+        name: string;
+      }
+    >(mockAction);
+    const prevState = { items: [], nextToken: undefined };
+    const options = {
+      search: { query: 'item', filterKey: 'name' as const },
+    };
+
+    const result = await handler(prevState, {
+      config,
+      prefix: 'a_prefix',
+      options,
+    });
+
+    expect(result.items.length).toBe(SEARCH_LIMIT);
+    expect(result.nextToken).toBeUndefined();
+  });
+
+  it('should ignore provided nextToken on refresh', async () => {
+    mockAction.mockResolvedValue({
+      items: [{ id: 1 }, { id: 2 }],
+      nextToken: 'next',
+    });
+
+    const handler = createEnhancedListHandler(mockAction);
+    const prevState = { items: [{ id: 0 }], nextToken: 'abc' };
+    const options = { refresh: true };
+
+    const result = await handler(prevState, {
+      config,
+      prefix: 'a_prefix',
+      options,
+    });
+
+    expect(result.items).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(result.nextToken).toBe('next');
+  });
+
+  it('should append items when refresh is false', async () => {
+    mockAction.mockResolvedValue({
+      items: [{ id: 2 }, { id: 3 }],
+      nextToken: 'next',
+    });
+
+    const handler = createEnhancedListHandler(mockAction);
+    const prevState = { items: [{ id: 1 }], nextToken: 'abc' };
+    const options = { refresh: false };
+
+    const result = await handler(prevState, {
+      config,
+      prefix: 'a_prefix',
+      options,
+    });
+
+    expect(result.items).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    expect(result.nextToken).toBe('next');
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/actions/createEnhancedListHandler.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/createEnhancedListHandler.ts
@@ -1,0 +1,92 @@
+import { AsyncDataAction } from '@aws-amplify/ui-react-core';
+import {
+  ListHandler,
+  ListHandlerOptions,
+  ListHandlerInput,
+  ListHandlerOutput,
+} from './types';
+
+interface SearchOptions<K> {
+  query: string;
+  filterKey: keyof K;
+}
+
+export interface EnhancedListHandlerOptions<K> extends ListHandlerOptions {
+  refresh?: boolean;
+  reset?: boolean;
+  search?: SearchOptions<K>;
+}
+
+interface EnhancedListHandler<T, K>
+  extends AsyncDataAction<
+    ListHandlerOutput<K>,
+    ListHandlerInput<EnhancedListHandlerOptions<K> & T>
+  > {}
+
+export const SEARCH_LIMIT = 10000;
+export const SEARCH_PAGE_SIZE = 1000;
+
+export const createEnhancedListHandler = <
+  T extends ListHandlerOptions<I>,
+  K,
+  I = never,
+>(
+  action: ListHandler<ListHandlerInput<T>, ListHandlerOutput<K>>
+): EnhancedListHandler<T, K> => {
+  return async function listActionHandler(prevState, { options, ...input }) {
+    const {
+      nextToken: _nextToken,
+      refresh,
+      reset,
+      search,
+      ...rest
+    } = options ?? {};
+
+    if (reset) {
+      return { items: [], nextToken: undefined };
+    }
+
+    // collect and filter results on `search`
+    if (search) {
+      const { query, filterKey } = search;
+
+      const result = [];
+      let nextNextToken = _nextToken;
+      do {
+        const output = await action({
+          ...input,
+          options: {
+            ...rest,
+            pageSize: SEARCH_PAGE_SIZE,
+            nextToken: nextNextToken,
+          } as T,
+        });
+        result.push(...output.items);
+        nextNextToken = output.nextToken;
+      } while (nextNextToken && result.length < SEARCH_LIMIT);
+
+      return {
+        items: result.filter((item) => {
+          const test = item[filterKey];
+          if (typeof test === 'string') {
+            return test.includes(query);
+          }
+          return false;
+        }),
+        nextToken: undefined,
+      };
+    }
+
+    // ignore provided `nextToken` on `refresh`
+    const nextToken = refresh ? undefined : _nextToken;
+    const output = await action({
+      ...input,
+      options: { ...rest, nextToken } as T,
+    });
+
+    return {
+      items: [...(refresh ? [] : prevState.items), ...output.items],
+      nextToken: output.nextToken,
+    };
+  };
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- Adds a handler that can wrap list handlers to add reset, refresh and search functionality.
- Add unit tests

Includes feedback from https://github.com/aws-amplify/amplify-ui/pull/5994.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
