### PR TITLE
fix: AIConversation doesn't care about conversion, for example Hira to Kanji in Japanese

### DIFF
--- a/.changeset/input-compositionevent.md
+++ b/.changeset/input-compositionevent.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/ui-react-ai": minor
+---
+
+fix: AIConversation doesn't care about conversion, for example Hira to Kanji in Japanese
+
+When to push Return/Enter key in the Form about AIConversation component, it can decide to send a message by whether in editing the text.

--- a/packages/react-ai/src/components/AIConversation/context/elements/definitions.ts
+++ b/packages/react-ai/src/components/AIConversation/context/elements/definitions.ts
@@ -81,6 +81,8 @@ type TextAreaElementProps =
   | 'onChange'
   | 'placeholder'
   | 'autoFocus'
+  | 'onCompositionStart'
+  | 'onCompositionEnd'
   | 'onKeyDown';
 
 export const TextAreaElement = defineBaseElement<

--- a/packages/react-ai/src/components/AIConversation/views/Controls/FormControl.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/FormControl.tsx
@@ -153,6 +153,7 @@ export const FormControl: FormControl = () => {
   const ref = React.useRef<HTMLFormElement | null>(null);
   const responseComponents = React.useContext(ResponseComponentsContext);
   const controls = React.useContext(ControlsContext);
+  const [composing, setComposing] = React.useState(false);
 
   const submitMessage = async () => {
     ref.current?.reset();
@@ -197,7 +198,7 @@ export const FormControl: FormControl = () => {
   ) => {
     const { key, shiftKey } = event;
 
-    if (key === 'Enter' && !shiftKey) {
+    if (key === 'Enter' && !shiftKey && !composing ) {
       event.preventDefault();
 
       const hasInput =
@@ -231,7 +232,11 @@ export const FormControl: FormControl = () => {
         <VisuallyHidden>
           <Label />
         </VisuallyHidden>
-        <TextInput onKeyDown={handleOnKeyDown} />
+        <TextInput 
+          onKeyDown={handleOnKeyDown} 
+          onCompositionStart={() => setComposing(true)}
+          onCompositionEnd={() => setComposing(false)}
+        />
         <AttachmentListControl />
       </InputContainer>
       <SendButton>

--- a/packages/react-ai/src/components/AIConversation/views/default/Form.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/default/Form.tsx
@@ -60,6 +60,7 @@ export const Form: NonNullable<ControlsContextProps['Form']> = ({
   const attachIcon = icons?.attach ?? <IconAttach />;
   const hiddenInput = React.useRef<HTMLInputElement>(null);
   const isLoading = React.useContext(LoadingContext);
+  const [composing, setComposing] = React.useState(false);
   const isInputEmpty = !input?.text?.length && !input?.files?.length;
 
   return (
@@ -112,9 +113,11 @@ export const Form: NonNullable<ControlsContextProps['Form']> = ({
           rows={1}
           value={input?.text ?? ''}
           testId="text-input"
+          onCompositionStart={() => setComposing(true)}
+          onCompositionEnd={() => setComposing(false)}
           onKeyDown={(e) => {
             // Submit on enter key if shift is not pressed also
-            const shouldSubmit = !e.shiftKey && e.key === 'Enter';
+            const shouldSubmit = !e.shiftKey && e.key === 'Enter' && !composing;
             if (shouldSubmit && isHTMLFormElement(e.target)) {
               (e.target.form as HTMLFormElement).requestSubmit();
               e.preventDefault();


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

When to push Return/Enter key in the Form about AIConversation component, it can decide to send a message by whether in editing the text. I used the CompositionEvent that whether to know whether in editing the text.

https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent/data
https://react.dev/reference/react-dom/components/common#compositionevent-handler

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

I used the AIConversation component in Japanese.
Japanese IME need to conversion of Hiragana to Kanji. We use the Return/Enter key when confirm this conversion. But, AIConversation component send the message whenever press Return/Enter key for confirming the conversion.

AIConversation component cannot send the full message in Japanese.

For example, I want to send "今日の東京の天気はなんですか?".
Japanese IME need to press the Enter key for conversion "きょうの" to "今日の". AIConversation component send only "今日の" message. We don't send the full message.

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I checked this change in this sample application
https://github.com/dbanksdesign/amplify-ai-starter

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
