### PR TITLE
Add new attribute initialvalue to the form-field

### DIFF
--- a/.changeset/sour-onions-shout.md
+++ b/.changeset/sour-onions-shout.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui-angular': patch
+'@aws-amplify/ui': patch
+---
+
+Add defalut value attribute to the form-field

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.html
@@ -33,6 +33,7 @@
     [name]="name"
     [label]="formField.label"
     [placeholder]="formField.placeholder"
+    [initialValue]="formField.value"
     [required]="formField.isRequired"
     [labelHidden]="formField.labelHidden"
     [autocomplete]="formField.autocomplete"

--- a/packages/ui/src/types/authenticator/form.ts
+++ b/packages/ui/src/types/authenticator/form.ts
@@ -46,6 +46,8 @@ export interface FormFieldOptions {
   label?: string;
   /** Placeholder text */
   placeholder?: string;
+  /** default value */
+  value?: string;
   /**
    * @deprecated For internal use only, please use `isRequired` instead.
    */


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Update the `form-field.component` and `FormFieldOptions` so the form could accept default value input.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

It is regarding to this [issue](https://github.com/aws-amplify/amplify-ui/issues/5962)

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I have used `yarn build` and ` yarn pack` to pack the package and install it from my project, and tested the functionality. And it works fine.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
