### PR TITLE
chore(liveness): update video constraints for selected camera

### DIFF
--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/machine/machine.ts
@@ -129,10 +129,6 @@ const responseStreamActor = async (callback: StreamActorCallback) => {
   }
 };
 
-function getLastSelectedCameraId(): string | null {
-  return localStorage.getItem(CAMERA_ID_KEY);
-}
-
 function setLastSelectedCameraId(deviceId: string) {
   localStorage.setItem(CAMERA_ID_KEY, deviceId);
 }
@@ -924,11 +920,9 @@ export const livenessMachine = createMachine<LivenessContext, LivenessEvent>(
         const { videoConstraints } = context.videoAssociatedParams!;
 
         // Get initial stream to enumerate devices with non-empty labels
-        const existingDeviceId = getLastSelectedCameraId();
         const initialStream = await navigator.mediaDevices.getUserMedia({
           video: {
             ...videoConstraints,
-            ...(existingDeviceId ? { deviceId: existingDeviceId } : {}),
           },
           audio: false,
         });

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/__mocks__/testUtils.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/__mocks__/testUtils.ts
@@ -77,10 +77,8 @@ export const mockBlazeFace: any = {
   detectFaces: jest.fn(),
 };
 
-export const mockVideoConstraints: MediaTrackConstraints = {
-  deviceId: 'some-device-id',
-  ...STATIC_VIDEO_CONSTRAINTS,
-};
+export const mockVideoConstraints: MediaTrackConstraints =
+  STATIC_VIDEO_CONSTRAINTS;
 
 export const mockCameraDevice: MediaDeviceInfo = {
   deviceId: 'some-device-id',

--- a/packages/react-liveness/src/components/FaceLivenessDetector/utils/helpers.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/utils/helpers.ts
@@ -8,4 +8,5 @@ export const STATIC_VIDEO_CONSTRAINTS: MediaTrackConstraints = {
     ideal: 480,
   },
   frameRate: { min: 15, ideal: 30, max: 30 },
+  facingMode: 'user',
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- Remove existingDeviceId and add facingMode: 'user' to tell camera to prefer 
- This fixes an issue where the back camera would be chosen for FaceMovementAndLight if it was used most recently (FaceMovementAndLight only works with front camera)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Deployment: https://testing.d2pnskzbmchcgk.amplifyapp.com/
Compare to: https://alpha.d3v0f004886eky.amplifyapp.com/

Selected FaceMovementChallenge and chose a back camera, then went back to FaceMovement + light and verified that front camera was used 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
