### PR TITLE
chore(storage-browser): sort files on add

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/providers/store/files/__tests__/utils.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/providers/store/files/__tests__/utils.spec.ts
@@ -59,15 +59,15 @@ describe('files context utils', () => {
       expect(output).not.toBe(previous);
       expect(output).toHaveLength(3);
 
-      const newItem = output[2];
+      const newItem = output[1];
 
       expect(newItem.file).toBe(fileThree);
       expect(newItem.key).toBe(fileThree.name);
       expect(typeof newItem.id).toBe('string');
     });
 
-    it('returns the next `items` when previous `items` are `undefined`', () => {
-      const incoming = [fileOne, fileTwo];
+    it('returns the sorted next `items` when previous `items` are `undefined`', () => {
+      const incoming = [fileTwo, fileOne];
       const previous: FileItems = [];
       const output = resolveFiles(previous, incoming);
 
@@ -78,12 +78,23 @@ describe('files context utils', () => {
       expect(itemTwo.file).toBe(fileTwo);
     });
 
-    it('combines and returns previous and next `items`', () => {
+    it('merges, sorts and returns previous and next `items`', () => {
       const incoming = [fileThree];
       const previous = [fileItemOne, fileItemTwo];
       const output = resolveFiles(previous, incoming);
 
       expect(output).toHaveLength(3);
+
+      const [itemOne, itemTwo, itemThree] = output;
+
+      // fileItemOne.key === 'item-one'
+      expect(itemOne.key).toBe(fileItemOne.key);
+
+      // fileThree.name === 'item-three'
+      expect(itemTwo.key).toBe(fileThree.name);
+
+      // fileItemTwo.key === 'item-two'
+      expect(itemThree.key).toBe(fileItemTwo.key);
     });
 
     it('returns the webKitRelativePath as key when available', () => {
@@ -121,6 +132,19 @@ describe('files context utils', () => {
 
       expect(output).toHaveLength(1);
       expect(output[0]).toBe(fileItemTwo);
+    });
+
+    it('returns the previous items on remove when previous and next items are the same length', () => {
+      const previous = [fileItemOne, fileItemTwo];
+      const targetId = 'not a real id lol';
+
+      const output = filesReducer(previous, {
+        type: 'REMOVE_FILE_ITEM',
+        id: targetId,
+      });
+
+      expect(output).toHaveLength(2);
+      expect(output).toBe(previous);
     });
 
     it('resets `fileItems` as expected', () => {

--- a/packages/react-storage/src/components/StorageBrowser/providers/store/files/utils.ts
+++ b/packages/react-storage/src/components/StorageBrowser/providers/store/files/utils.ts
@@ -5,7 +5,10 @@ import { HandleFileSelect } from '@aws-amplify/ui-react/internal';
 
 import { SelectionType } from '../../../actions/configs';
 
-import { FileItems, FilesActionType } from './types';
+import { FileItem, FileItems, FilesActionType } from './types';
+
+const compareFileItems = (prev: FileItem, next: FileItem) =>
+  prev.key.localeCompare(next.key);
 
 export const resolveFiles = (
   prevItems: FileItems,
@@ -32,9 +35,11 @@ export const resolveFiles = (
 
   if (!nextItems.length) return prevItems;
 
-  if (!prevItems.length) return nextItems;
+  if (!prevItems.length) {
+    return nextItems.sort(compareFileItems);
+  }
 
-  return prevItems.concat(nextItems);
+  return prevItems.concat(nextItems).sort(compareFileItems);
 };
 
 export const filesReducer: React.Reducer<
@@ -46,7 +51,11 @@ export const filesReducer: React.Reducer<
       return resolveFiles(prevItems, input.files);
     }
     case 'REMOVE_FILE_ITEM': {
-      return prevItems.filter(({ id }) => id !== input.id);
+      const filteredItems = prevItems.filter(({ id }) => id !== input.id);
+
+      return filteredItems.length === prevItems.length
+        ? prevItems
+        : filteredItems;
     }
     case 'RESET_FILE_ITEMS': {
       return [];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Minor improvements to file state on add and remove:
- sort file items on add in `fileReducer` and return 
- return previous items on remove if next items length matchs previous items length
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual test, unit tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
