### PR TITLE
fix(storage-browser): Reintroduce folder conditional on drag and drop

### DIFF
--- a/packages/e2e/features/ui/components/storage/storage-browser/drag-and-drop.feature
+++ b/packages/e2e/features/ui/components/storage/storage-browser/drag-and-drop.feature
@@ -14,7 +14,7 @@ Feature: Drag and drop files within Storage Browser
       Then I see "test.txt"
   
   @react
-  Scenario: Drag and drop file into Location Detail view
+  Scenario: Drag and drop folder into Location Detail view
       When I type my "email" with status "CONFIRMED"
       Then I type my password
       Then I click the "Sign in" button

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/__tests__/useLocationDetailView.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/__tests__/useLocationDetailView.spec.tsx
@@ -342,7 +342,63 @@ describe('useLocationDetailView', () => {
       type: 'ADD_FILE_ITEMS',
       files: mockFiles,
     });
+    expect(handleStoreActionMock).toHaveBeenCalledWith({
+      type: 'SET_ACTION_TYPE',
+      actionType: 'UPLOAD_FILES',
+    });
   });
+
+  it('should handle adding folders', () => {
+    const handleStoreActionMock = jest.fn();
+    useStoreSpy.mockReturnValue([
+      { ...testStoreState, location: mockLocation },
+      handleStoreActionMock,
+    ]);
+
+    const { result } = renderHook(() => useLocationDetailView());
+
+    const mockFile = new File(['blob-part'], `blob.pdf`, {
+      type: 'application/pdf',
+    });
+    const mockFolder = new File([''], 'Folder', { type: '' });
+    act(() => {
+      const state = result.current;
+      state.onAddFiles([mockFile, mockFolder]);
+    });
+    expect(handleStoreActionMock).toHaveBeenCalledWith({
+      type: 'ADD_FILE_ITEMS',
+      files: [mockFile, mockFolder],
+    });
+    expect(handleStoreActionMock).toHaveBeenCalledWith({
+      type: 'SET_ACTION_TYPE',
+      actionType: 'UPLOAD_FILES',
+    });
+  });
+
+  it('should handle as files if adding files and folders', () => {
+    const handleStoreActionMock = jest.fn();
+    useStoreSpy.mockReturnValue([
+      { ...testStoreState, location: mockLocation },
+      handleStoreActionMock,
+    ]);
+
+    const { result } = renderHook(() => useLocationDetailView());
+    // uploads folder
+    const mockFolder = new File([''], 'Folder', { type: '' });
+    act(() => {
+      const state = result.current;
+      state.onAddFiles([mockFolder]);
+    });
+    expect(handleStoreActionMock).toHaveBeenCalledWith({
+      type: 'ADD_FILE_ITEMS',
+      files: [mockFolder],
+    });
+    expect(handleStoreActionMock).toHaveBeenCalledWith({
+      type: 'SET_ACTION_TYPE',
+      actionType: 'UPLOAD_FOLDER',
+    });
+  });
+
   it('should handle search', () => {
     const handleStoreActionMock = jest.fn();
     useStoreSpy.mockReturnValue([testStoreState, handleStoreActionMock]);

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/__tests__/useLocationDetailView.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/__tests__/useLocationDetailView.spec.tsx
@@ -356,6 +356,30 @@ describe('useLocationDetailView', () => {
     ]);
 
     const { result } = renderHook(() => useLocationDetailView());
+    // uploads folder
+    const mockFolder = new File([''], 'Folder', { type: '' });
+    act(() => {
+      const state = result.current;
+      state.onAddFiles([mockFolder]);
+    });
+    expect(handleStoreActionMock).toHaveBeenCalledWith({
+      type: 'ADD_FILE_ITEMS',
+      files: [mockFolder],
+    });
+    expect(handleStoreActionMock).toHaveBeenCalledWith({
+      type: 'SET_ACTION_TYPE',
+      actionType: 'UPLOAD_FOLDER',
+    });
+  });
+
+  it('should handle as files if adding files and folders', () => {
+    const handleStoreActionMock = jest.fn();
+    useStoreSpy.mockReturnValue([
+      { ...testStoreState, location: mockLocation },
+      handleStoreActionMock,
+    ]);
+
+    const { result } = renderHook(() => useLocationDetailView());
 
     const mockFile = new File(['blob-part'], `blob.pdf`, {
       type: 'application/pdf',
@@ -372,30 +396,6 @@ describe('useLocationDetailView', () => {
     expect(handleStoreActionMock).toHaveBeenCalledWith({
       type: 'SET_ACTION_TYPE',
       actionType: 'UPLOAD_FILES',
-    });
-  });
-
-  it('should handle as files if adding files and folders', () => {
-    const handleStoreActionMock = jest.fn();
-    useStoreSpy.mockReturnValue([
-      { ...testStoreState, location: mockLocation },
-      handleStoreActionMock,
-    ]);
-
-    const { result } = renderHook(() => useLocationDetailView());
-    // uploads folder
-    const mockFolder = new File([''], 'Folder', { type: '' });
-    act(() => {
-      const state = result.current;
-      state.onAddFiles([mockFolder]);
-    });
-    expect(handleStoreActionMock).toHaveBeenCalledWith({
-      type: 'ADD_FILE_ITEMS',
-      files: [mockFolder],
-    });
-    expect(handleStoreActionMock).toHaveBeenCalledWith({
-      type: 'SET_ACTION_TYPE',
-      actionType: 'UPLOAD_FOLDER',
     });
   });
 

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/useLocationDetailView.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/useLocationDetailView.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { isFunction, isUndefined } from '@aws-amplify/ui';
+import { isUndefined } from '@aws-amplify/ui';
 import { useDataState } from '@aws-amplify/ui-react-core';
 
 import { usePaginate } from '../hooks/usePaginate';
@@ -10,7 +10,7 @@ import {
   LocationData,
   LocationItemData,
 } from '../../actions';
-import { isLastPage } from '../utils';
+import { isFile, isLastPage } from '../utils';
 import { LocationState } from '../../providers/store/location';
 import { createEnhancedListHandler } from '../../actions/createEnhancedListHandler';
 import { useGetActionInput } from '../../providers/configuration';
@@ -188,12 +188,14 @@ export function useLocationDetailView(
     },
     onAddFiles: (files: File[]) => {
       dispatchStoreAction({ type: 'ADD_FILE_ITEMS', files });
+      const actionType = files.some((file) => isFile(file))
+        ? 'UPLOAD_FILES'
+        : 'UPLOAD_FOLDER';
       dispatchStoreAction({
         type: 'SET_ACTION_TYPE',
-        actionType: 'UPLOAD_FILES',
+        actionType,
       });
-
-      if (isFunction(onActionSelect)) onActionSelect('UPLOAD_FILES');
+      onActionSelect?.(actionType);
     },
     onNavigateHome: () => {
       onExit?.();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR reintroduces a conditional which determines whether a drag and dropped items are files, folders or both. This determination subsequently triggers either routing to the upload file or folder actions. In the case of a mix of files/folders being dropped, the action will be treated as uploading files.

This should also fix the drag and drop e2e test which currently fails locally.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
