### PR TITLE
fix(storage-browser): move LOCATION_DETAIL_VIEW_HEADERS to constants file

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/constants.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/constants.ts
@@ -1,0 +1,10 @@
+import { LocationDetailViewHeaders } from './types';
+
+export const LOCATION_DETAIL_VIEW_HEADERS: LocationDetailViewHeaders = [
+  { key: 'checkbox', type: 'text', content: { text: '' } },
+  { key: 'name', type: 'sort', content: { label: 'Name' } },
+  { key: 'type', type: 'sort', content: { label: 'Type' } },
+  { key: 'last-modified', type: 'sort', content: { label: 'Last Modified' } },
+  { key: 'size', type: 'sort', content: { label: 'Size' } },
+  { key: 'download', type: 'text', content: { text: '' } },
+];

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getFileRowContent.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getFileRowContent.ts
@@ -19,7 +19,6 @@ export const getFileRowContent = ({
 }: {
   currentLocation?: LocationData;
   currentPath: string;
-
   isSelected: boolean;
   lastModified: Date;
   rowId: string;

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getFileRowContent.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getFileRowContent.ts
@@ -1,12 +1,15 @@
+import { humanFileSize } from '@aws-amplify/ui';
+
 import { DataTableProps } from '../../../composables/DataTable';
 import { LocationData } from '../../../actions';
-import { LOCATION_DETAIL_VIEW_HEADERS } from './getLocationDetailViewTableData';
-import { humanFileSize } from '@aws-amplify/ui';
 import { displayText } from '../../../displayText/en';
+
+import { LOCATION_DETAIL_VIEW_HEADERS } from './constants';
 
 export const getFileRowContent = ({
   currentLocation,
   currentPath,
+
   isSelected,
   lastModified,
   rowId,
@@ -17,6 +20,7 @@ export const getFileRowContent = ({
 }: {
   currentLocation?: LocationData;
   currentPath: string;
+
   isSelected: boolean;
   lastModified: Date;
   rowId: string;

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getFileRowContent.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getFileRowContent.ts
@@ -9,7 +9,6 @@ import { LOCATION_DETAIL_VIEW_HEADERS } from './constants';
 export const getFileRowContent = ({
   currentLocation,
   currentPath,
-
   isSelected,
   lastModified,
   rowId,

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getFolderRowContent.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getFolderRowContent.ts
@@ -1,5 +1,5 @@
 import { DataTableProps } from '../../../composables/DataTable';
-import { LOCATION_DETAIL_VIEW_HEADERS } from './getLocationDetailViewTableData';
+import { LOCATION_DETAIL_VIEW_HEADERS } from './constants';
 
 export const getFolderRowContent = ({
   itemSubPath,

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getLocationDetailViewTableData.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getLocationDetailViewTableData.ts
@@ -1,31 +1,12 @@
-import { WithKey } from '../../../components/types';
 import { DataTableProps } from '../../../composables/DataTable';
 import { LocationData } from '../../../actions';
-import { LocationItemData } from '../../../../../../dist/types/components/StorageBrowser/actions';
+import { LocationItemData } from '../../../actions/handlers';
 import { getFileRowContent } from './getFileRowContent';
 import { getFolderRowContent } from './getFolderRowContent';
 import { displayText } from '../../../displayText/en';
 import { FileData } from '../../../actions/handlers';
 
-type HeaderKeys =
-  | 'checkbox'
-  | 'name'
-  | 'type'
-  | 'last-modified'
-  | 'size'
-  | 'download';
-
-export const LOCATION_DETAIL_VIEW_HEADERS: WithKey<
-  DataTableProps['headers'][number],
-  HeaderKeys
->[] = [
-  { key: 'checkbox', type: 'text', content: { text: '' } },
-  { key: 'name', type: 'sort', content: { label: 'Name' } },
-  { key: 'type', type: 'sort', content: { label: 'Type' } },
-  { key: 'last-modified', type: 'sort', content: { label: 'Last Modified' } },
-  { key: 'size', type: 'sort', content: { label: 'Size' } },
-  { key: 'download', type: 'text', content: { text: '' } },
-];
+import { LOCATION_DETAIL_VIEW_HEADERS } from './constants';
 
 export const getLocationDetailViewTableData = ({
   areAllFilesSelected,

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/types.ts
@@ -1,0 +1,15 @@
+import { DataTableProps } from '../../../composables/DataTable';
+import { WithKey } from '../../../components/types';
+
+export type HeaderKeys =
+  | 'checkbox'
+  | 'name'
+  | 'type'
+  | 'last-modified'
+  | 'size'
+  | 'download';
+
+export type LocationDetailViewHeaders = WithKey<
+  DataTableProps['headers'][number],
+  HeaderKeys
+>[];


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Move `LOCATION_DETAIL_VIEW_HEADERS` to a shared constants file to resolve circular deps between the `LocationDetailView` table data generation utils and address import from _dist/types/components/StorageBrowser/actions_

```
rollup v4.22.4
bundles src/index.ts, src/components/StorageBrowser/index.ts → dist...
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/configs/context.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/configs/defaults.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/configs/index.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/configs/types.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/handlers/copy.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/handlers/createFolder.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/handlers/delete.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/handlers/download.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/handlers/index.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/handlers/listLocationItems.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/handlers/listLocations.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/handlers/types.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/handlers/upload.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/handlers/utils.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/index.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/actions/types.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/context/elements/IconElement.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/context/elements/defaults.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/context/elements/definitions.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/context/elements/index.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/do-not-import-from-here/actions/createActionStateContext.d.ts' because it would overwrite input file.
(!) [plugin typescript] @rollup/plugin-typescript TS5055: Cannot write file '/Users/cpollman/Amplify/back_back_up/amplify-ui/packages/react-storage/dist/types/components/StorageBrowser/storage-internal.d.ts' because it would overwrite input file.
(!) Circular dependencies
src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getLocationDetailViewTableData.ts -> src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getFileRowContent.ts -> src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getLocationDetailViewTableData.ts
src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getLocationDetailViewTableData.ts -> src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getFolderRowContent.ts -> src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/getLocationDetailViewTableData.ts
```
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`yarn lint && yarn build`
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
