### PR TITLE
fix(textarea): autoresize textarea resets when value is empty

### DIFF
--- a/packages/react/src/primitives/TextArea/__tests__/useAutoresizeTextarea.test.ts
+++ b/packages/react/src/primitives/TextArea/__tests__/useAutoresizeTextarea.test.ts
@@ -1,0 +1,42 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useAutoresizeTextArea } from '../useAutoresizeTextarea';
+import { text } from '@aws-amplify/ui/dist/types/theme/tokens/components/text';
+
+describe('useAutoresizeTextArea', () => {
+  let textAreaRef: HTMLTextAreaElement;
+
+  beforeEach(() => {
+    textAreaRef = document.createElement('textarea');
+    jest.spyOn(window, 'addEventListener');
+    jest.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should set the height of the textarea', () => {
+    renderHook(() => useAutoresizeTextArea(textAreaRef, 'initial value'));
+    expect(textAreaRef.style.height).toBe('0px');
+  });
+
+  it('should add and remove event listener for window resize', () => {
+    const { unmount } = renderHook(() => useAutoresizeTextArea(textAreaRef));
+    expect(window.addEventListener).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function)
+    );
+
+    unmount();
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function)
+    );
+  });
+
+  it('should not throw error when textAreaRef is null', () => {
+    expect(() => {
+      renderHook(() => useAutoresizeTextArea(null));
+    }).not.toThrow();
+  });
+});

--- a/packages/react/src/primitives/TextArea/useAutoresizeTextarea.ts
+++ b/packages/react/src/primitives/TextArea/useAutoresizeTextarea.ts
@@ -7,7 +7,7 @@ export const useAutoresizeTextArea = (
 ): void => {
   useEffect(() => {
     const resizeTextArea = () => {
-      if (textAreaRef && value) {
+      if (textAreaRef) {
         // We need to reset the height momentarily to get the correct scrollHeight for the textarea
         textAreaRef.style.height = 'auto';
         const { scrollHeight } = textAreaRef;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
