### PR TITLE
fix(storage-browser): Display '-' instead when uploading files

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/getActionViewTableData.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/getActionViewTableData.ts
@@ -70,7 +70,7 @@ export const getActionViewTableData = ({
                         0,
                         webkitRelativePath.lastIndexOf('/') + 1
                       )
-                    : '/',
+                    : '-',
                 },
               };
             }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When uploading a single file, instead of displaying `'/'` as the folder, display `'-'`

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
