### PR TITLE
fix (Storage/FileUploader): FileUploader does not upload processed file contents in certain scenarios

### DIFF
--- a/.changeset/mighty-ladybugs-chew.md
+++ b/.changeset/mighty-ladybugs-chew.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react-storage': patch
+---
+
+fix (Storage/FileUploader): FileUploader does not upload processed file contents in certain scenarios

--- a/packages/react-storage/src/components/FileUploader/utils/getInput.ts
+++ b/packages/react-storage/src/components/FileUploader/utils/getInput.ts
@@ -61,7 +61,7 @@ export const getInput = ({
         hasCallbackPath ? path({ identityId }) : path
       }${processedKey}`;
 
-      inputResult = { data: file, path: resolvedPath, options };
+      inputResult = { data, path: resolvedPath, options };
     }
 
     return inputResult;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This change fix an issue in which FileUploader does not upload the processed/modified file contents as advertised in [documentation](https://ui.docs.amplify.aws/react/connected-components/storage/fileuploader#pre-upload-processing).

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-ui/issues/6049

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
