### PR TITLE
fix(react-storage): filter out only dot or slash items

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/listLocationItems.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/listLocationItems.spec.ts
@@ -111,4 +111,20 @@ describe('parseResult', () => {
     const result = parseResult(output, prefix);
     expect(result).toHaveLength(0);
   });
+
+  describe('filterDotItems', () => {
+    it('should filter out items starting with "/" or "." or "..', () => {
+      const output = {
+        items: [
+          { path: `/`, lastModified: new Date(), size: 0 },
+          { path: `.`, lastModified: new Date(), size: 0 },
+          { path: `..`, lastModified: new Date(), size: 0 },
+          { path: `${prefix}visible`, lastModified: new Date(), size: 0 },
+        ],
+      };
+      const result = parseResult(output, prefix);
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe(`${prefix}visible`);
+    });
+  });
 });

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationItems.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationItems.ts
@@ -62,13 +62,28 @@ const parseItems = (
 const parseExcludedPaths = (paths: string[] | undefined): LocationItemData[] =>
   paths?.map((key) => ({ key, id: crypto.randomUUID(), type: 'FOLDER' })) ?? [];
 
+export const filterDotItems = (
+  items: LocationItemData[],
+  prefix: string
+): LocationItemData[] =>
+  items.filter(
+    // matches strings that are exactly either a single forward slash ("/") or one to two dots ("." or ".."), nothing else.
+    (item) =>
+      !(
+        item.key.startsWith(prefix)
+          ? item.key.substring(prefix.length)
+          : item.key
+      ).match(/^(\/|\.{1,2})$/)
+  );
+
 export const parseResult = (
   { excludedSubpaths, items }: ListOutput,
   prefix: string
-): LocationItemData[] => [
-  ...parseExcludedPaths(excludedSubpaths),
-  ...parseItems(items, prefix),
-];
+): LocationItemData[] =>
+  filterDotItems(
+    [...parseExcludedPaths(excludedSubpaths), ...parseItems(items, prefix)],
+    prefix
+  );
 
 export const listLocationItemsHandler: ListLocationItemsHandler = async (
   input


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Filter out display items that have only "/" or "." or ".." as their key so it cannot be navigated into.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual tests and unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
