### PR TITLE
fix(storage-browser): create folder alignment

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CreateFolderControls.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CreateFolderControls.tsx
@@ -114,25 +114,28 @@ export const CreateFolderControls = ({
         }}
       />
       <Title />
-      <ActionStartControl
-        className={`${CLASS_BASE}__create-folder-action-start`}
-      />
-      <Field
-        label="Enter folder name:"
-        disabled={isLoading || !!result?.status}
-        aria-invalid={fieldValidationError ? 'true' : undefined}
-        aria-describedby="fieldError"
-        type="text"
-        id="folder-name-input"
-        onBlur={handleBlur}
-        onChange={handleChange}
-      >
-        {fieldValidationError ? (
-          <SpanElement id={'fieldError'} variant="field-error">
-            {fieldValidationError}
-          </SpanElement>
-        ) : null}
-      </Field>
+      <div className={`${CLASS_BASE}__create-folder-action-container`}>
+        <Field
+          className={`${CLASS_BASE}__field ${CLASS_BASE}__create-folder-action-field`}
+          label="Enter folder name:"
+          disabled={isLoading || !!result?.status}
+          aria-invalid={fieldValidationError ? 'true' : undefined}
+          aria-describedby="fieldError"
+          type="text"
+          id="folder-name-input"
+          onBlur={handleBlur}
+          onChange={handleChange}
+        >
+          {fieldValidationError ? (
+            <SpanElement id={'fieldError'} variant="field-error">
+              {fieldValidationError}
+            </SpanElement>
+          ) : null}
+        </Field>
+        <ActionStartControl
+          className={`${CLASS_BASE}__create-folder-action-start`}
+        />
+      </div>
       {result?.status === 'COMPLETE' || result?.status === 'FAILED' ? (
         <CreateFolderMessage />
       ) : null}

--- a/packages/react-storage/src/styles/storage-browser.css
+++ b/packages/react-storage/src/styles/storage-browser.css
@@ -575,3 +575,17 @@
 .storage-browser__search-toggle__container {
   margin-left: var(--storage-browser-gap);
 }
+
+.storage-browser__create-folder-action-container {
+  display: flex;
+  flex-direction: row;
+}
+
+.storage-browser__create-folder-action-field {
+  flex-grow: 0.1;
+}
+
+.storage-browser__create-folder-action-start {
+  align-self: flex-end;
+  margin-left: 10px;
+}


### PR DESCRIPTION
#### Description of changes
On the `LocationActionView -> create folder` update the `Create Folder` button alignment

#### Description of how you validated changes
Before
<img width="1455" alt="Screenshot 2024-11-11 at 9 59 31 AM" src="https://github.com/user-attachments/assets/47fb127d-b67f-4fa9-acee-180f6b6d57f4">


After
<img width="478" alt="Screenshot 2024-11-11 at 9 57 21 AM" src="https://github.com/user-attachments/assets/b80699db-afaf-47e6-a210-516ce1ae3537">

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
