### PR TITLE
fix(react-storage): url encode copy source

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/copy.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/copy.spec.ts
@@ -24,6 +24,10 @@ const baseInput: CopyHandlerInput = {
 };
 
 describe('copyHandler', () => {
+  afterEach(() => {
+    copySpy.mockClear();
+  });
+
   it('calls `copy` wth the expected values', () => {
     copyHandler(baseInput);
 
@@ -48,6 +52,32 @@ describe('copyHandler', () => {
         customEndpoint: baseInput.config.customEndpoint,
       },
     };
+
+    expect(copySpy).toHaveBeenCalledWith(expected);
+  });
+
+  it.each([
+    ['unicode', 'bucket/path/☺️', 'bucket/path/%E2%98%BA%EF%B8%8F'],
+    ['already encoded', 'bucket/path/%20', 'bucket/path/%2520'],
+    [
+      'characters to be uri encoded',
+      'bucket/path/&$@=;:+,?',
+      'bucket/path/%26%24%40%3D%3B%3A%2B%2C%3F',
+    ],
+  ])('encodes the source path that is %s', (_, sourcePath, expectedPath) => {
+    copyHandler({
+      ...baseInput,
+      data: {
+        ...baseInput.data,
+        key: sourcePath,
+      },
+    });
+
+    const expected = expect.objectContaining({
+      source: expect.objectContaining({
+        path: expectedPath,
+      }),
+    });
 
     expect(copySpy).toHaveBeenCalledWith(expected);
   });

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/copy.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/copy.ts
@@ -32,7 +32,18 @@ export const copyHandler: CopyHandler = (input) => {
   const bucket = constructBucket(config);
 
   const destinationPath = `${path}${fileKey}`;
-  const source = { bucket, expectedBucketOwner, path: sourcePath };
+  const source = {
+    bucket,
+    expectedBucketOwner,
+    /**
+     * Per S3 requirement, copy source must the URI encoded.
+     * This is NOT added to Amplify JS v6 because it will be a breaking
+     * change to suddenly introduce URI encode to copy API source.
+     *
+     * see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_RequestSyntax
+     */
+    path: sourcePath.split('/').map(encodeURIComponent).join('/'),
+  };
   const destination = { bucket, expectedBucketOwner, path: destinationPath };
 
   const result = copy({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add URI encoding to the copy source to handle copying the object key containing special characters. Techinically it should be added to the Amplify JS library. However, since customers may have already encode the copy source to workaround this problem, it's not safe to introduce the change in Amplify JS library. 

Add this change to StorageBrowser will prevent breaking change but also handle the scpecial characters in the source.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
