### PR TITLE
fix(sto-bro): conditionally return undefined for task.cancel in useProcessTasks

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/tasks/__tests__/useProcessTasks.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/tasks/__tests__/useProcessTasks.spec.ts
@@ -194,11 +194,9 @@ describe('useProcessTasks', () => {
   });
 
   it('cancels a QUEUED task as expected', () => {
-    const cancelableAction = createTimedAction({});
+    const action = createTimedAction({});
 
-    const { result } = renderHook(() =>
-      useProcessTasks(cancelableAction, items)
-    );
+    const { result } = renderHook(() => useProcessTasks(action, items));
 
     expect(result.current[0].tasks[0].cancel).toBeDefined();
     expect(result.current[0].tasks[0].status).toBe('QUEUED');
@@ -376,6 +374,29 @@ describe('useProcessTasks', () => {
 
     expect(completedState.isProcessing).toBe(false);
     expect(completedState.isProcessingComplete).toBe(true);
+  });
+
+  it('returns a `task` with a `cancel` value of `undefined` when the underlying action does not provide cancel from its output', () => {
+    const action = createTimedAction({});
+
+    const { result } = renderHook(() => useProcessTasks(action, items));
+
+    const [initState, handleProcess] = result.current;
+
+    expect(initState.isProcessing).toBe(false);
+    // cancel is defined before process start
+    expect(initState.tasks[0].cancel).toBeDefined();
+
+    act(() => {
+      handleProcess({ config, prefix });
+    });
+
+    const [processingState] = result.current;
+
+    expect(processingState.isProcessing).toBe(true);
+
+    // cancel is undefined while processing
+    expect(processingState.tasks[0].cancel).toBeUndefined();
   });
 
   it.todo('ignores calls to handle processing when isProcessing is true');

--- a/packages/react-storage/src/components/StorageBrowser/tasks/useProcessTasks.ts
+++ b/packages/react-storage/src/components/StorageBrowser/tasks/useProcessTasks.ts
@@ -170,13 +170,13 @@ export const useProcessTasks: UseProcessTasks = <
       input as TaskHandlerInput<T> & K
     );
 
-    const cancel = () => {
-      if (!_cancel) return;
-
-      const task = getTask();
-      if (task && isFunction(onTaskCancel)) onTaskCancel(task);
-      _cancel();
-    };
+    const cancel = !_cancel
+      ? undefined
+      : () => {
+          const task = getTask();
+          if (task && isFunction(onTaskCancel)) onTaskCancel(task);
+          _cancel();
+        };
 
     result
       .then((output) => {


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update `useProcessTasks` to conditionally return `undefined` for `task.cancel` based on return shape of provided action
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual test, unit tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
