### PR TITLE
chore(sto-bro): surfacing download error from location detail view

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/LocationDetailView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/LocationDetailView.tsx
@@ -21,7 +21,6 @@ import { getLocationDetailViewTableData } from './getLocationDetailViewTableData
 import { useLocationDetailView } from './useLocationDetailView';
 import { LocationDetailViewProps } from './types';
 import { MessageControl } from '../../controls/MessageControl';
-import { MessageProps } from '../../composables/Message';
 
 const DEFAULT_PAGE_SIZE = 100;
 export const DEFAULT_LIST_OPTIONS = {
@@ -61,7 +60,9 @@ export function LocationDetailView({
     fileDataItems,
     hasFiles,
     hasError,
+    hasDownloadError,
     message,
+    downloadErrorMessage,
     searchQuery,
     onDropFiles,
     onRefresh,
@@ -78,25 +79,12 @@ export function LocationDetailView({
     hasExhaustedSearch,
   } = useLocationDetailView({ onNavigate: onNavigateProp, onExit });
 
-  let messageControlContent: MessageProps | undefined;
-
-  if (hasError) {
-    messageControlContent = getListItemsResultMessage({
-      items: pageItems,
-      hasError,
-      message,
-    });
-  } else if (hasExhaustedSearch) {
-    messageControlContent = getListItemsResultMessage({
-      items: pageItems,
-      hasExhaustedSearch,
-      message,
-    });
-  } else {
-    messageControlContent = getListItemsResultMessage({
-      items: pageItems,
-    });
-  }
+  const messageControlContent = getListItemsResultMessage({
+    items: pageItems,
+    hasError: hasError || hasDownloadError,
+    hasExhaustedSearch,
+    message: hasError ? message : downloadErrorMessage,
+  });
 
   return (
     <div

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/__tests__/LocationDetailView.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/__tests__/LocationDetailView.spec.tsx
@@ -189,6 +189,45 @@ describe('LocationDetailView', () => {
       items: expect.any(Array),
       hasError: true,
       message: errorMessage,
+      hasExhaustedSearch: false,
+    });
+  });
+
+  it('invokes getListItemsResultMessage() with expected params when there is a download error', () => {
+    mockUseProcessTasks.mockReturnValueOnce([
+      {
+        isProcessing: false,
+        isProcessingComplete: false,
+        statusCounts: {
+          ...INITIAL_STATUS_COUNTS,
+          FAILED: 1,
+        },
+        tasks: [
+          {
+            data: { key: 'test-key', id: '123' },
+            message: 'NotFound',
+            progress: 0,
+            status: 'FAILED',
+          },
+        ],
+      },
+      jest.fn(),
+    ]);
+
+    mockListItemsAction({
+      isLoading: false,
+      hasError: false,
+      result: [{ key: 'test1', type: 'FOLDER' }],
+      nextToken: 'some-token',
+    });
+
+    render(<LocationDetailView />);
+
+    expect(mockGetListItemsResultMessage).toHaveBeenCalledWith({
+      items: expect.any(Array),
+      hasError: true,
+      message: 'Failed to download test-key due to error: NotFound.',
+      hasExhaustedSearch: false,
     });
   });
 
@@ -269,6 +308,7 @@ describe('LocationDetailView', () => {
     expect(mockGetListItemsResultMessage).toHaveBeenCalledWith({
       items: expect.any(Array),
       hasExhaustedSearch: true,
+      hasError: false,
       message: undefined,
     });
 

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationsView/LocationsView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationsView/LocationsView.tsx
@@ -102,15 +102,11 @@ export function LocationsView({
   } = useLocationsView(props);
 
   // TODO: add hasExhaustedSearch + query param
-  const messageControlContent = hasError
-    ? getListLocationsResultMessage({
-        locations: pageItems,
-        hasError,
-        message,
-      })
-    : getListLocationsResultMessage({
-        locations: pageItems,
-      });
+  const messageControlContent = getListLocationsResultMessage({
+    locations: pageItems,
+    hasError,
+    message,
+  });
 
   const headers = getHeaders({
     hasObjectLocations: pageItems.some(({ type }) => type === 'OBJECT'),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

* Use the result returned by the `useProcessTasks(downloadHandler)` in `useLocationDetailView` to derive download error flag and message
* Render download error message using the existing MessageControl integration

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

* sample app testing
* unit testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
