### PR TITLE
fix: search matches items in prefix

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/actions/__tests__/search.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/__tests__/search.spec.ts
@@ -228,26 +228,38 @@ describe('Search', () => {
       ]);
     });
 
-    it('should not match prefix', () => {
+    it('should only match paths ahead of prefix', () => {
       const mockData = [
         {
-          key: 'collections/photo1.jpg',
+          key: 'photos/album/random-photos/photo1.jpg',
         },
         {
-          key: 'collections/photos/',
+          key: 'photos/album/cats/pic.jpg',
         },
       ];
 
       const output = searchItems<Item>({
         list: mockData,
-        prefix: 'collections/',
+        prefix: 'photos/album/',
         options: {
           filterBy: 'key',
           groupBy: '/',
-          query: 'collection',
+          query: 'photo',
         },
       });
-      expect(output).toEqual([]);
+
+      expect(output).toEqual([
+        {
+          id: expect.any(String),
+          key: 'photos/album/random-photos/',
+          type: 'FOLDER',
+        },
+        {
+          id: expect.any(String),
+          key: 'photos/album/random-photos/photo1.jpg',
+          type: 'FILE',
+        },
+      ]);
     });
 
     it('should handle consecutive delimiters', () => {

--- a/packages/react-storage/src/components/StorageBrowser/actions/createEnhancedListHandler.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/createEnhancedListHandler.ts
@@ -104,8 +104,8 @@ export function searchItems<T>({ prefix, list, options }: Search<T>): T[] {
         matchedPath += groupBy;
       }
 
-      // ignore prefix for match
-      if (matchedPath !== prefix && !uniquePaths.has(matchedPath)) {
+      // ignore anything below the prefix for matching
+      if (matchedPath.length > prefix.length && !uniquePaths.has(matchedPath)) {
         // add a new item
         uniquePaths.set(matchedPath, {
           ...item,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

previously, we only checked for paths matching the prefix, but we also want to ignore paths that are part of the prefix.

e.g. if `prefix = "photos/album/"`, `path= "photos/album/random-photos/pic.jpg"` and `query="photo"` -- we only want to match `photos/album/random-photos/`
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
