### PR TITLE
fix(storage-browser): makes Last Modified heading into sentence case

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/__tests__/getLocationDetailViewTableData.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/__tests__/getLocationDetailViewTableData.spec.ts
@@ -111,7 +111,7 @@ describe('getLocationDetailViewTableData', () => {
           }),
           expect.objectContaining({ content: { label: 'Name' } }),
           expect.objectContaining({ content: { label: 'Type' } }),
-          expect.objectContaining({ content: { label: 'Last Modified' } }),
+          expect.objectContaining({ content: { label: 'Last modified' } }),
           expect.objectContaining({ content: { label: 'Size' } }),
           expect.objectContaining({ content: { text: '' } }),
         ],

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/constants.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/getLocationDetailViewTableData/constants.ts
@@ -4,7 +4,7 @@ export const LOCATION_DETAIL_VIEW_HEADERS: LocationDetailViewHeaders = [
   { key: 'checkbox', type: 'text', content: { text: '' } },
   { key: 'name', type: 'sort', content: { label: 'Name' } },
   { key: 'type', type: 'sort', content: { label: 'Type' } },
-  { key: 'last-modified', type: 'sort', content: { label: 'Last Modified' } },
+  { key: 'last-modified', type: 'sort', content: { label: 'Last modified' } },
   { key: 'size', type: 'sort', content: { label: 'Size' } },
   { key: 'download', type: 'text', content: { text: '' } },
 ];


### PR DESCRIPTION
#### Description of changes

Makes "Last Modified" column header into sentence case for fit and finish

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [X] PR description included
- [X] `yarn test` passes and tests are updated/added
- [X] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
