### PR TITLE
feat(storage-browser): add search exhausted message to copy view

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/displayText/libraries/en/copyView.ts
+++ b/packages/react-storage/src/components/StorageBrowser/displayText/libraries/en/copyView.ts
@@ -6,7 +6,13 @@ export const DEFAULT_COPY_VIEW_DISPLAY_TEXT: DefaultCopyViewDisplayText = {
   title: 'Copy',
   actionStartLabel: 'Copy',
   actionDestinationLabel: 'Copy destination',
-  getListFoldersResultsMessage: ({ folders, query, message, hasError }) => {
+  getListFoldersResultsMessage: ({
+    folders,
+    query,
+    message,
+    hasError,
+    hasExhaustedSearch,
+  }) => {
     if (!folders?.length) {
       return {
         content: query
@@ -22,6 +28,13 @@ export const DEFAULT_COPY_VIEW_DISPLAY_TEXT: DefaultCopyViewDisplayText = {
 
     if (hasError) {
       return { content: 'Error loading folders.', type: 'error' };
+    }
+
+    if (hasExhaustedSearch) {
+      return {
+        content: 'Showing results for up to the first 10,000 items.',
+        type: 'info',
+      };
     }
   },
   loadingIndicatorLabel: 'Loading',

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/CopyViewProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/CopyViewProvider.tsx
@@ -53,6 +53,7 @@ export function CopyViewProvider({
     hasError: hasFoldersError,
     message: foldersErrorMessage,
     query,
+    hasExhaustedSearch,
     isLoading,
     page,
     pageItems,
@@ -134,6 +135,7 @@ export function CopyViewProvider({
             hasError={hasFoldersError}
             message={foldersErrorMessage}
             query={query}
+            hasExhaustedSearch={hasExhaustedSearch}
           >
             {children}
           </FoldersMessageProvider>

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/FoldersMessageControl.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/FoldersMessageControl.tsx
@@ -14,6 +14,7 @@ export interface FoldersMessageProps {
   message?: string;
   folders?: FolderData[];
   query?: string;
+  hasExhaustedSearch?: boolean;
 }
 
 const defaultValue: FoldersMessageProps = {};
@@ -24,13 +25,15 @@ export const FoldersMessageControl = (): React.JSX.Element => {
   const {
     CopyView: { getListFoldersResultsMessage },
   } = useDisplayText();
-  const { hasError, folders, message, query } = useFoldersMessage();
+  const { hasError, folders, message, query, hasExhaustedSearch } =
+    useFoldersMessage();
 
   const messageContent = getListFoldersResultsMessage({
     hasError,
     folders,
     message,
     query,
+    hasExhaustedSearch,
   });
 
   return (

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/__tests__/CopyViewProvider.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/__tests__/CopyViewProvider.spec.tsx
@@ -92,6 +92,7 @@ const defaultViewState: CopyViewState = {
     page: 1,
     pageItems: [],
     query: '',
+    hasExhaustedSearch: false,
     isLoading: false,
     message: undefined,
     onPaginate: jest.fn(),

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/__tests__/__snapshots__/useFolders.spec.ts.snap
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/__tests__/__snapshots__/useFolders.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`useFolders should return the correct initial state 1`] = `
 {
   "hasError": false,
+  "hasExhaustedSearch": false,
   "hasNextPage": true,
   "highestPageVisited": 1,
   "isLoading": false,

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/types.ts
@@ -45,6 +45,7 @@ export interface FoldersState {
   page: number;
   pageItems: FolderData[];
   query: string;
+  hasExhaustedSearch: boolean;
   onInitialize: () => void;
   onPaginate: (page: number) => void;
   onQuery: (value: string) => void;

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/useFolders.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/useFolders.ts
@@ -50,7 +50,8 @@ export const useFolders = ({
 
   const getInput = useGetActionInput();
 
-  const { items, nextToken } = data;
+  const { items, nextToken, search } = data;
+  const { hasExhaustedSearch = false } = search ?? {};
 
   const onInitialize = React.useCallback(() => {
     handleList({
@@ -126,6 +127,7 @@ export const useFolders = ({
     page,
     pageItems,
     query,
+    hasExhaustedSearch,
     onPaginate,
     onQuery,
     onSearch: onSearchSubmit,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
<img width="1709" alt="Screenshot 2024-11-18 at 9 36 54 AM" src="https://github.com/user-attachments/assets/2d174545-c2ce-4b13-9b06-721fc43f8516">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
