### PR TITLE
fix(storage-browser): Move folder init into copy hook

### DIFF
--- a/examples/next/pages/ui/components/storage/storage-browser/composable-playground/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-browser/composable-playground/index.page.tsx
@@ -42,7 +42,23 @@ const { StorageBrowser, useView } = createStorageBrowser({
   config,
 });
 
-const { CreateFolderView, DeleteView, LocationActionView } = StorageBrowser;
+const { CopyView, CreateFolderView, DeleteView, LocationActionView } =
+  StorageBrowser;
+
+const MyCopyView = () => {
+  const viewState = useView('Copy');
+  const { isProcessing } = viewState;
+
+  return (
+    <CopyView.Provider {...viewState}>
+      {isProcessing ? <h1>Copy in progress</h1> : null}
+      <CopyView.Start />
+      <CopyView.TasksTable />
+      <CopyView.FoldersTable />
+      <CopyView.Destination />
+    </CopyView.Provider>
+  );
+};
 
 const MyCreateFolderView = () => {
   const viewState = useView('CreateFolder');
@@ -73,6 +89,9 @@ function MyLocationActionView({ type }: { type?: string }) {
   if (!type) return DialogContent;
 
   switch (type) {
+    case 'copy':
+      DialogContent = MyCopyView;
+      break;
     case 'createFolder':
       DialogContent = MyCreateFolderView;
       break;

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/CopyView.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/CopyView.tsx
@@ -29,15 +29,7 @@ import { classNames } from '@aws-amplify/ui';
 
 export const CopyView: CopyViewType = ({ className, ...props }) => {
   const state = useCopyView(props);
-  const {
-    isProcessing,
-    isProcessingComplete,
-    folders: { onInitialize },
-  } = state;
-
-  React.useEffect(() => {
-    onInitialize();
-  }, [onInitialize]);
+  const { isProcessing, isProcessingComplete } = state;
 
   return (
     <ViewElement className={classNames(STORAGE_BROWSER_BLOCK, className)}>

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/useCopyView.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/useCopyView.ts
@@ -19,7 +19,6 @@ export const useCopyView = (options?: UseCopyViewOptions): CopyViewState => {
     },
     dispatchStoreAction,
   ] = useStore();
-  const { current } = location;
 
   const getInput = useGetActionInput();
 
@@ -28,11 +27,19 @@ export const useCopyView = (options?: UseCopyViewOptions): CopyViewState => {
     fileDataItems,
     { concurrency: 4 }
   );
+  const [destination, setDestination] = useState(location);
+
+  const folders = useFolders({ destination, setDestination });
 
   const { isProcessing, isProcessingComplete, statusCounts, tasks } =
     processState;
+  const { current } = location;
+  const { onInitialize } = folders;
 
-  const [destination, setDestination] = useState(location);
+  // initial load
+  React.useEffect(() => {
+    onInitialize();
+  }, [onInitialize]);
 
   const onActionStart = () => {
     handleProcess({
@@ -61,8 +68,6 @@ export const useCopyView = (options?: UseCopyViewOptions): CopyViewState => {
     },
     [dispatchStoreAction]
   );
-
-  const folders = useFolders({ destination, setDestination });
 
   const onSelectDestination = (
     selectedDestination: LocationData,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR moves the folders listing behavior into the `useCopyView` hook to support composability in the same way as the other views which auto-list data within the view hooks.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
