### PR TITLE
fix(sto-bro): keep create folder and upload actions always enabled

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/defaults.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/defaults.spec.ts
@@ -40,12 +40,12 @@ describe('defaultActionConfigs', () => {
       }
     });
 
-    it('disables the action list item as expected', () => {
+    it('not to disable the action regardless the disable callback param', () => {
       const disable =
         (createFolderActionConfig.actionsListItemConfig as ActionListItemConfig)!
           .disable!;
 
-      expect(disable([file])).toBe(true);
+      expect(disable([file])).toBe(false);
       expect(disable(undefined)).toBe(false);
     });
   });
@@ -79,10 +79,10 @@ describe('defaultActionConfigs', () => {
       }
     });
 
-    it('disables the action list item as expected', () => {
+    it('not to disable the action regardless the disable callback param', () => {
       const uploadFileListItem = uploadActionConfig.actionsListItemConfig!;
 
-      expect(uploadFileListItem.disable?.([file])).toBe(true);
+      expect(uploadFileListItem.disable?.([file])).toBe(false);
       expect(uploadFileListItem.disable?.(undefined)).toBe(false);
     });
   });

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/defaults.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/defaults.spec.ts
@@ -40,7 +40,7 @@ describe('defaultActionConfigs', () => {
       }
     });
 
-    it('not to disable the action regardless the disable callback param', () => {
+    it('is never disabled', () => {
       const disable =
         (createFolderActionConfig.actionsListItemConfig as ActionListItemConfig)!
           .disable!;
@@ -79,7 +79,7 @@ describe('defaultActionConfigs', () => {
       }
     });
 
-    it('not to disable the action regardless the disable callback param', () => {
+    it('is never disabled', () => {
       const uploadFileListItem = uploadActionConfig.actionsListItemConfig!;
 
       expect(uploadFileListItem.disable?.([file])).toBe(false);

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/defaults.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/defaults.tsx
@@ -43,7 +43,7 @@ export const deleteActionConfig: DeleteActionConfig = {
 export const createFolderActionConfig: CreateFolderActionConfig = {
   componentName: 'CreateFolderView',
   actionsListItemConfig: {
-    disable: (selected) => !!selected,
+    disable: () => false,
     hide: (permissions) => !permissions.includes('write'),
     icon: 'create-folder',
     label: 'Create folder',
@@ -76,7 +76,7 @@ export const listLocationsActionConfig: ListLocationsActionConfig = {
 export const uploadActionConfig: UploadActionConfig = {
   componentName: 'UploadView',
   actionsListItemConfig: {
-    disable: (selectedValues) => !!selectedValues,
+    disable: () => false,
     fileSelection: 'FILE',
     hide: (permissions) => !permissions.includes('write'),
     icon: 'upload-file',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Made the `disable` callback function of the default `uploadActionConfig` and `createFolderActionConfig` to always return `true` so these two actions won't get disabled when selecting/deselecting items in the location details view.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- unit tests
- manual tests with the example apps

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
