### PR TITLE
[feat] Add Storage browser download tests

### DIFF
--- a/packages/e2e/cypress/integration/common/storagebrowser.ts
+++ b/packages/e2e/cypress/integration/common/storagebrowser.ts
@@ -1,4 +1,4 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { When, Then } from '@badeball/cypress-cucumber-preprocessor';
 
 When(
   'I drag and drop a file into the storage browser with file name {string}',
@@ -34,3 +34,34 @@ When(
     });
   }
 );
+
+Then('I see download for file {string}', (name: string) => {
+  cy.contains('table tbody td:nth-child(2)', new RegExp('^' + name + '$'))
+    .siblings()
+    .last()
+    .children('button');
+});
+
+Then('I see no download for folder {string}', (name: string) => {
+  cy.contains('table tbody td:nth-child(2)', new RegExp('^' + name + '$'))
+    .siblings()
+    .last()
+    .children('div');
+});
+
+Then('I click and see download succeed for {string}', (name: string) => {
+  cy.intercept('HEAD', 'https://*.s3.*.amazonaws.com/**').as(
+    'downloadValidation'
+  );
+
+  cy.contains('table tbody td:nth-child(2)', new RegExp('^' + name + '$'))
+    .siblings()
+    .last()
+    .within(() => {
+      cy.get('button').click({ force: true });
+
+      cy.wait('@downloadValidation').then((interception) => {
+        assert.equal(interception.response.statusCode, 200);
+      });
+    });
+});

--- a/packages/e2e/features/ui/components/storage/storage-browser/download.feature
+++ b/packages/e2e/features/ui/components/storage/storage-browser/download.feature
@@ -1,0 +1,21 @@
+Feature: Download on Storage Browser
+
+  Background:
+    Given I'm running the example "ui/components/storage/storage-browser/default-auth"
+
+  @react
+  Scenario: Download is available for files
+    When I type my "email" with status "CONFIRMED"
+    Then I type my password
+    Then I click the "Sign in" button
+    When I click the first button containing "public"
+    Then I see download for file "001_dont_delete_file.txt"
+    Then I click and see download succeed for "001_dont_delete_file.txt"
+
+  @react
+  Scenario: Download is not available for folder
+    When I type my "email" with status "CONFIRMED"
+    Then I type my password
+    Then I click the "Sign in" button
+    When I click the first button containing "public"
+    Then I see no download for folder "DO_NOT_DELETE/"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- Adds download e2e test for storage browser

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
