### PR TITLE
fix(sto-bro): copy and delete actions remains after deselections

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/defaults.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/__tests__/defaults.spec.ts
@@ -45,6 +45,7 @@ describe('defaultActionConfigs', () => {
         (createFolderActionConfig.actionsListItemConfig as ActionListItemConfig)!
           .disable!;
 
+      expect(disable([])).toBe(false);
       expect(disable([file])).toBe(false);
       expect(disable(undefined)).toBe(false);
     });
@@ -82,8 +83,61 @@ describe('defaultActionConfigs', () => {
     it('is never disabled', () => {
       const uploadFileListItem = uploadActionConfig.actionsListItemConfig!;
 
+      expect(uploadFileListItem.disable?.([])).toBe(false);
       expect(uploadFileListItem.disable?.([file])).toBe(false);
       expect(uploadFileListItem.disable?.(undefined)).toBe(false);
+    });
+  });
+
+  describe('deleteActionConfig', () => {
+    it('hides the action list item as expected', () => {
+      const deleteFileListItem =
+        defaultActionConfigs.delete.actionsListItemConfig!;
+
+      for (const permissionsWithoutDelete of generateCombinations(
+        LOCATION_PERMISSION_VALUES.filter((value) => value !== 'delete')
+      )) {
+        const permissionsWithDelete = [
+          ...permissionsWithoutDelete,
+          'delete' as const,
+        ];
+        expect(deleteFileListItem.hide?.(permissionsWithoutDelete)).toBe(true);
+        expect(deleteFileListItem.hide?.(permissionsWithDelete)).toBe(false);
+      }
+    });
+
+    it('is disabled when no files are selected', () => {
+      const deleteFileListItem =
+        defaultActionConfigs.delete.actionsListItemConfig!;
+
+      expect(deleteFileListItem.disable?.(undefined)).toBe(true);
+      expect(deleteFileListItem.disable?.([])).toBe(true);
+      expect(deleteFileListItem.disable?.([file])).toBe(false);
+    });
+  });
+
+  describe('copyActionConfig', () => {
+    it('hides the action list item as expected', () => {
+      const copyFileListItem = defaultActionConfigs.copy.actionsListItemConfig!;
+
+      for (const permissionsWithoutWrite of generateCombinations(
+        permissionValuesWithoutWrite
+      )) {
+        const permissionsWithWrite = [
+          ...permissionValuesWithoutWrite,
+          'write' as const,
+        ];
+        expect(copyFileListItem.hide?.(permissionsWithoutWrite)).toBe(true);
+        expect(copyFileListItem.hide?.(permissionsWithWrite)).toBe(false);
+      }
+    });
+
+    it('is disabled when no files are selected', () => {
+      const copyFileListItem = defaultActionConfigs.copy.actionsListItemConfig!;
+
+      expect(copyFileListItem.disable?.(undefined)).toBe(true);
+      expect(copyFileListItem.disable?.([])).toBe(true);
+      expect(copyFileListItem.disable?.([file])).toBe(false);
     });
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/defaults.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/defaults.tsx
@@ -19,7 +19,7 @@ import {
 export const copyActionConfig: CopyActionConfig = {
   componentName: 'CopyView',
   actionsListItemConfig: {
-    disable: (selected) => !selected,
+    disable: (selected) => !selected || selected.length === 0,
     hide: (permissions) => !permissions.includes('write'),
     icon: 'copy-file',
     label: 'Copy',
@@ -31,7 +31,7 @@ export const copyActionConfig: CopyActionConfig = {
 export const deleteActionConfig: DeleteActionConfig = {
   componentName: 'DeleteView',
   actionsListItemConfig: {
-    disable: (selected) => !selected,
+    disable: (selected) => !selected || selected.length === 0,
     hide: (permissions) => !permissions.includes('delete'),
     icon: 'delete-file',
     label: 'Delete',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fix the copy and delete actions are not being disabled after deselecting files in the location details view.

Underlying - check param is `undefined` + param is an empty array.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- unit tests
- sample app testsing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
