### PR TITLE
test(e2e): add cy commands for storage-browser

### DIFF
--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -10,38 +10,6 @@ let window = null;
 let stub = null;
 export const randomFileName = `fileName${Math.random() * 10000}`;
 
-const doesDocumentContainText = (text: string) => {
-  cy.findByRole('document')
-    .contains(new RegExp(escapeRegExp(text), 'i'))
-    .should('exist');
-};
-
-const clickButtonWithText = (name: string) => {
-  cy.findByRole('button', {
-    name: new RegExp(`${escapeRegExp(name)}`, 'i'),
-  }).click();
-};
-
-const typeInInputHandler = (field: string, value: string) => {
-  cy.findInputField(field).type(value);
-};
-
-const fileInputUpload = (fileCount: number = 1, folderName?: string) => {
-  const folderFiles = [];
-  for (let i = 1; i <= fileCount; i++) {
-    const fileName = folderName
-      ? `${folderName}/${randomFileName}-${i}`
-      : `${randomFileName}-${i}`;
-
-    folderFiles.push({
-      contents: Cypress.Buffer.from(`File ${i} content`),
-      fileName,
-      mimeType: 'text/plain',
-    });
-  }
-  cy.get('input[type="file"]').selectFile(folderFiles, { force: true });
-};
-
 const getRoute = (routeMatcher: { headers: { [key: string]: string } }) => {
   return `${routeMatcher.headers?.['X-Amz-Target'] || 'route'}`;
 };
@@ -272,10 +240,10 @@ When('I type a new {string}', (field: string) => {
   cy.findInputField(field).typeAliasWithStatus(field, `${Date.now()}`);
 });
 
-When('I type a new {string} with value {string}', typeInInputHandler);
+When('I type a new {string} with value {string}', cy.typeInInputHandler);
 
 When('I type a new {string} with random value', (field: string) => {
-  typeInInputHandler(field, randomFileName);
+  cy.typeInInputHandler(field, randomFileName);
 });
 
 When('I lose focus on {string} input', (field: string) => {
@@ -306,10 +274,10 @@ Then('I press the {string} key', (key: string) => {
   cy.get('body').type(key);
 });
 
-When('I click the button containing {string}', clickButtonWithText);
+When('I click the button containing {string}', cy.clickButtonWithText);
 
 When('I click the button containing random name', () => {
-  clickButtonWithText(randomFileName);
+  cy.clickButtonWithText(randomFileName);
 });
 
 When('I click the first button containing {string}', (name: string) => {
@@ -388,11 +356,11 @@ Then('I see tab {string}', (search: string) => {
   cy.findAllByRole('tab').first().should('be.visible').contains(search);
 });
 
-Then('I see {string}', doesDocumentContainText);
+Then('I see {string}', cy.doesDocumentContainText);
 
 Then('I see {string} files with random names', (count: string) => {
   for (let i = 1; i <= parseInt(count); i++) {
-    doesDocumentContainText(`${randomFileName}-${i}`);
+    cy.doesDocumentContainText(`${randomFileName}-${i}`);
   }
 });
 
@@ -679,11 +647,11 @@ Then('I see the {string} radio button checked', (label: string) => {
 });
 
 When('I upload {string} files with random names', (count: string) =>
-  fileInputUpload(parseInt(count))
+  cy.fileInputUpload(randomFileName, parseInt(count))
 );
 
 When(
   'I upload a folder {string} with {string} files with random names',
   (folderName: string, count: string) =>
-    fileInputUpload(parseInt(count), folderName)
+    cy.fileInputUpload(`${folderName}/${randomFileName}`, parseInt(count))
 );

--- a/packages/e2e/cypress/support/commands.d.ts
+++ b/packages/e2e/cypress/support/commands.d.ts
@@ -34,6 +34,56 @@ declare global {
        * cy.get('.maplibregl-marker').first().click();
        */
       waitForIdleMap(): void;
+
+      /**
+       * Clicks a button with the specified text. This command performs a case-insensitive match
+       * and supports partial or full text matching using regular expressions.
+       *
+       * @example
+       * cy.clickButtonWithText('Submit');
+       * cy.clickButtonWithText('Cancel');
+       *
+       * @param name - The text of the button to click.
+       */
+      clickButtonWithText(name: string): void;
+
+      /**
+       * Checks if the document contains the specified text. This command performs a case-insensitive search
+       * and ensures the text exists within the document's content.
+       *
+       * @example
+       * cy.doesDocumentContainText('Welcome to the application');
+       * cy.doesDocumentContainText('Error: File not found');
+       *
+       * @param text - The text to search for in the document.
+       */
+      doesDocumentContainText(text: string): void;
+
+      /**
+       * Types a value into an input field identified by its label. The label is matched case-insensitively,
+       * allowing for flexible text matching.
+       *
+       * @example
+       * cy.typeInInputHandler('Username', 'testuser');
+       * cy.typeInInputHandler('Password', 'mypassword123');
+       *
+       * @param field - The label of the input field to type into.
+       * @param value - The value to type into the input field.
+       */
+      typeInInputHandler(field: string, value: string): void;
+
+      /**
+       * Uploads one or more files to a file input field. Files are named using the provided base name
+       * with an appended index (e.g., "example-1.txt"). The contents of the files are dynamically generated.
+       *
+       * @example
+       * cy.fileInputUpload('example', 2); // Uploads "example-1.txt" and "example-2.txt"
+       * cy.fileInputUpload('document');  // Uploads "document-1.txt"
+       *
+       * @param fileName - The base name for the files to upload.
+       * @param fileCount - The number of files to upload. Defaults to 1.
+       */
+      fileInputUpload(fileName: string, fileCount?: number): void;
     }
   }
 }

--- a/packages/e2e/cypress/support/commands.ts
+++ b/packages/e2e/cypress/support/commands.ts
@@ -75,3 +75,34 @@ Cypress.Commands.add('findInputField', (field: string) => {
 Cypress.Commands.add('waitForIdleMap', () => {
   cy.window().its('idleMap').should('be.true');
 });
+
+Cypress.Commands.add('clickButtonWithText', (name: string) => {
+  cy.findByRole('button', {
+    name: new RegExp(`${escapeRegExp(name)}`, 'i'),
+  }).click();
+});
+
+Cypress.Commands.add('doesDocumentContainText', (text: string) => {
+  cy.findByRole('document')
+    .contains(new RegExp(escapeRegExp(text), 'i'))
+    .should('exist');
+});
+
+Cypress.Commands.add('typeInInputHandler', (field: string, value: string) => {
+  cy.findInputField(field).type(value);
+});
+
+Cypress.Commands.add(
+  'fileInputUpload',
+  (fileName: string, fileCount: number = 1) => {
+    const folderFiles = [];
+    for (let i = 1; i <= fileCount; i++) {
+      folderFiles.push({
+        contents: Cypress.Buffer.from(`File ${i} content`),
+        fileName: `${fileName}-${i}`,
+        mimeType: 'text/plain',
+      });
+    }
+    cy.get('input[type="file"]').selectFile(folderFiles, { force: true });
+  }
+);

--- a/packages/e2e/features/ui/components/storage/storage-browser/action-menu.feature
+++ b/packages/e2e/features/ui/components/storage/storage-browser/action-menu.feature
@@ -118,12 +118,10 @@ Feature: Create folder with Storage Browser
     # upload file
     Then I see the "Upload" menuitem
     When I click the "Upload" menuitem
-    Then the "Upload" button is disabled
     Then I upload a folder "e2eTemp" with "2" files with random names
     Then I see "Not started"
     Then I click the label containing text "Overwrite existing files"
     When I click the "Upload" button
-    Then I see "100%"
     Then I see "All files uploaded"
     When I click the "Exit" button
     # list uploaded file
@@ -135,7 +133,4 @@ Feature: Create folder with Storage Browser
     Then I click the "Delete" menuitem
     Then I click the "Delete" button
     Then I see "All files deleted"
-    When I click the "Exit" button
-    # verify all files are deleted
-    Then I see "No files"
 


### PR DESCRIPTION
#### Description of changes
- Follow up PR to [address comment](https://github.com/aws-amplify/amplify-ui/pull/6147#discussion_r1852947313) to refactor common cy utils to commands.
- The `upload a folder` test is also cleaned up to only performed required checks
- Add TS doc string to `cypress/support/commands.d.ts`

#### Description of how you validated changes
Tested cypress locally

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
