### PR TITLE
fix(storage-browser): show search exhausted message on empty results

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/displayText/libraries/en/__tests__/__snapshots__/locationDetailView.spec.ts.snap
+++ b/packages/react-storage/src/components/StorageBrowser/displayText/libraries/en/__tests__/__snapshots__/locationDetailView.spec.ts.snap
@@ -30,6 +30,13 @@ exports[`LocationDetailView display text \`getListResultsMessage\` returns the e
 }
 `;
 
+exports[`LocationDetailView display text \`getListResultsMessage\` returns the expected values in the search exhausted with no results scenario 1`] = `
+{
+  "content": "No results found in the first 10,000 items.",
+  "type": "info",
+}
+`;
+
 exports[`LocationDetailView display text \`getListResultsMessage\` returns the expected values in the search failed scenario 1`] = `
 {
   "content": "Network got confused",

--- a/packages/react-storage/src/components/StorageBrowser/displayText/libraries/en/__tests__/scenarios.ts
+++ b/packages/react-storage/src/components/StorageBrowser/displayText/libraries/en/__tests__/scenarios.ts
@@ -324,6 +324,14 @@ export const LIST_ITEMS_SCENARIOS: [
     },
   ],
   [
+    'search exhausted with no results',
+    {
+      items: [],
+      query: 'something to look for',
+      hasExhaustedSearch: true,
+    },
+  ],
+  [
     'loading',
     {
       items: [],

--- a/packages/react-storage/src/components/StorageBrowser/displayText/libraries/en/locationDetailView.ts
+++ b/packages/react-storage/src/components/StorageBrowser/displayText/libraries/en/locationDetailView.ts
@@ -26,6 +26,13 @@ export const DEFAULT_LOCATION_DETAIL_VIEW_DISPLAY_TEXT: DefaultLocationDetailVie
         };
       }
 
+      if (!items?.length && hasExhaustedSearch) {
+        return {
+          type: 'info',
+          content: `No results found in the first 10,000 items.`,
+        };
+      }
+
       if (!items?.length) {
         return {
           type: 'info',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- fixes an issue where search results message is incorrect when no results are found 
- add test

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
