### PR TITLE
feat(storage-browser): validate schema of data received from read APIs

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/integrity/checkRequiredKeys.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/integrity/checkRequiredKeys.spec.ts
@@ -1,0 +1,71 @@
+import { checkRequiredKeys } from '../../integrity';
+
+interface TestObject {
+  key1?: string | null;
+  key2?: string | null;
+  key3?: string | null;
+  extraKey?: string | null;
+}
+
+describe('checkRequiredKeys', () => {
+  it('should not throw when all required keys are present', () => {
+    const object: TestObject = {
+      key1: 'value1',
+      key2: 'value2',
+    };
+
+    expect(
+      checkRequiredKeys(object, 'test-object', ['key1', 'key2'])
+    ).toBeUndefined();
+  });
+
+  it('should not throw when required keys array is empty', () => {
+    const object: TestObject = { key1: 'value1', key2: 'value2' };
+
+    expect(checkRequiredKeys(object, 'test-object', [])).toBeUndefined();
+  });
+
+  it('should not throw when the object has extra keys', () => {
+    const object: TestObject = {
+      key1: 'value1',
+      key2: 'value2',
+      extraKey: 'extra',
+    };
+
+    expect(
+      checkRequiredKeys(object, 'test-object', ['key1', 'key2'])
+    ).toBeUndefined();
+  });
+
+  it('should throw when a required key is missing', () => {
+    const object: TestObject = { key1: 'value1', key3: 'value3' };
+
+    expect(() =>
+      checkRequiredKeys(object, 'test-object', ['key1', 'key2'])
+    ).toThrow();
+  });
+
+  it('should throw when object is empty and required keys are specified', () => {
+    const object: TestObject = {};
+
+    expect(() =>
+      checkRequiredKeys(object, 'test-object', ['key1', 'key2'])
+    ).toThrow();
+  });
+
+  it('should throw on null values correctly', () => {
+    const object: TestObject = { key1: null, key2: 'value2' };
+
+    expect(() =>
+      checkRequiredKeys(object, 'test-object', ['key1', 'key2'])
+    ).toThrow();
+  });
+
+  it('should throw on undefined values correctly', () => {
+    const object: TestObject = { key1: undefined, key2: 'value2' };
+
+    expect(() =>
+      checkRequiredKeys(object, 'test-object', ['key1', 'key2'])
+    ).toThrow();
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/listLocationItems.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/listLocationItems.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import * as StorageModule from '../../../storage-internal';
 
 import {
@@ -103,6 +104,33 @@ describe('listLocationItemsHandler', () => {
     const listItems = await listLocationItemsHandler(input);
     expect(listItems.items).toHaveLength(input.options.pageSize);
     expect(listSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw if list does not provide items', async () => {
+    listSpy.mockResolvedValueOnce({} as any);
+    await expect(listLocationItemsHandler(baseInput)).rejects.toThrow(
+      'Required keys missing for ListOutput: items.'
+    );
+  });
+
+  ['path', 'lastModified', 'size'].forEach((requiredKey) => {
+    it(`should throw if any item is missing ${requiredKey}`, async () => {
+      listSpy.mockResolvedValueOnce({
+        items: [
+          { path: `${prefix}-1`, lastModified: new Date(), size: 0 },
+          {
+            path: `${prefix}-2`,
+            lastModified: new Date(),
+            size: 0,
+            [requiredKey]: undefined,
+          },
+        ],
+      });
+
+      await expect(listLocationItemsHandler(baseInput)).rejects.toThrow(
+        `Required keys missing for ListOutputItem #1: ${requiredKey}.`
+      );
+    });
   });
 });
 

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/download.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/download.ts
@@ -1,4 +1,5 @@
 import { getUrl } from '../../storage-internal';
+import { checkRequiredKeys } from './integrity';
 import {
   FileDataItem,
   TaskHandler,
@@ -50,6 +51,7 @@ export const downloadHandler: DownloadHandler = ({
       expectedBucketOwner: accountId,
     },
   }).then((result) => {
+    checkRequiredKeys(result, 'StorageGetUrlOutput', ['url']);
     return result;
   });
 

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/integrity/checkRequiredKeys.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/integrity/checkRequiredKeys.ts
@@ -1,0 +1,17 @@
+export const checkRequiredKeys = <T extends object>(
+  objectToCheck: T,
+  objectName: string,
+  requiredKeys: Extract<keyof T, string>[]
+): void => {
+  const missingValues = requiredKeys.filter(
+    (key) => objectToCheck[key] === undefined || objectToCheck[key] === null
+  );
+
+  if (missingValues.length > 0) {
+    throw Error(
+      `Required keys missing for ${objectName}: ${[...missingValues].join(
+        ', '
+      )}.\nObject: ${JSON.stringify(objectToCheck)}`
+    );
+  }
+};

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/integrity/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/integrity/index.ts
@@ -1,0 +1,1 @@
+export * from './checkRequiredKeys';

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationItems.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocationItems.ts
@@ -4,6 +4,7 @@ import {
   ListPaginateInput,
   ListOutput,
 } from '../../storage-internal';
+import { checkRequiredKeys } from './integrity';
 import {
   ListHandler,
   ListHandlerInput,
@@ -90,6 +91,17 @@ export const parseResult = (
     prefix
   );
 
+const validateResult = (output: ListOutput) => {
+  checkRequiredKeys(output, `ListOutput`, ['items']);
+  output.items.forEach((item, i) =>
+    checkRequiredKeys(item, `ListOutputItem #${i}`, [
+      'path',
+      'lastModified',
+      'size',
+    ])
+  );
+};
+
 export const listLocationItemsHandler: ListLocationItemsHandler = async (
   input
 ) => {
@@ -143,6 +155,8 @@ export const listLocationItemsHandler: ListLocationItemsHandler = async (
     };
 
     const output = await list(listInput);
+    validateResult(output);
+
     nextNextToken = output.nextToken;
 
     const items = parseResult(output, prefix);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

- Based on [outdated PR from @wuuxigh](https://github.com/wuuxigh/amplify-ui-draft/pull/1)
- Add explicit checks for the *required* data schema we expect from READ APIs. The *required* data is a subset of the response structure, and focuses on what the storage browser uses.
- In most cases, without these checks, missing fields will currently by caught by a [type error](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react-storage/src/components/StorageBrowser/actions/handlers/download.ts#L59) or stricter [value-checks](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react-storage/src/components/StorageBrowser/actions/handlers/utils.ts#L57). Adding explicit checks makes for consistent error modes, and expands coverage to all relevant cases. It would also be possible for implementation refactors to unknowingly remove the code path to the existing errors.
- `checkRequiredKeys` is intentionally forwards-compatible so these checks do not have to be updated every time amplify-js adds properties to the response that storage browser doesn't use. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- Updated unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
