### PR TITLE
fix(react-storage): fix createStorageBrowser type issue

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -36,7 +36,6 @@ import {
   CreateStorageBrowserOutput,
   StorageBrowserProviderProps,
   StorageBrowserType,
-  DerivedCustomViews,
   DerivedActionViewType,
 } from './types';
 import {
@@ -125,10 +124,10 @@ export function createStorageBrowser<
     );
   }
 
-  const StorageBrowser: StorageBrowserType<
-    DerivedActionViewType<RInput>,
-    DerivedCustomViews<RInput>
-  > = ({ views, displayText }) => (
+  const StorageBrowser: StorageBrowserType<RInput> = ({
+    views,
+    displayText,
+  }) => (
     <ErrorBoundary>
       <Provider displayText={displayText} views={views}>
         <StorageBrowserDefault />

--- a/packages/react-storage/src/components/StorageBrowser/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/types.ts
@@ -61,15 +61,19 @@ export interface StorageBrowserProviderProps<V = {}>
   views?: V;
 }
 
-export interface StorageBrowserType<K = string, V = {}> {
-  (props: StorageBrowserProps<K, V>): React.JSX.Element;
+export interface StorageBrowserType<C extends ExtendedActionConfigs> {
+  (
+    props: StorageBrowserProps<DerivedActionViewType<C>, DerivedCustomViews<C>>
+  ): React.JSX.Element;
   displayName: string;
-  Provider: (props: StorageBrowserProviderProps<V>) => React.JSX.Element;
+  Provider: (
+    props: StorageBrowserProviderProps<DerivedCustomViews<C>>
+  ) => React.JSX.Element;
   CopyView: CopyViewType;
   CreateFolderView: CreateFolderViewType;
   DeleteView: DeleteViewType;
   UploadView: UploadViewType;
-  LocationActionView: LocationActionViewType<K>;
+  LocationActionView: LocationActionViewType<DerivedActionViewType<C>>;
   LocationDetailView: LocationDetailViewType;
   LocationsView: LocationsViewType;
 }
@@ -97,10 +101,7 @@ export type DerivedActionViewType<T extends StorageBrowserActions> =
 export interface CreateStorageBrowserOutput<
   C extends ExtendedActionConfigs = ExtendedActionConfigs,
 > {
-  StorageBrowser: StorageBrowserType<
-    DerivedActionViewType<C>,
-    DerivedCustomViews<C>
-  >;
+  StorageBrowser: StorageBrowserType<C>;
   useAction: UseAction<DerivedActionHandlers<C>>;
   useView: UseView;
 }


### PR DESCRIPTION
#### Description of changes
expose [additional storage browser types](https://github.com/aws-amplify/amplify-ui/blob/main/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx#L128)


#### Description of how you validated changes
linked and tested `react-storage` package locally

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
