### PR TITLE
chore: temporarily set react@latest to 18 in build tests

### DIFF
--- a/.github/workflows/reusable-build-system-test-react-native.yml
+++ b/.github/workflows/reusable-build-system-test-react-native.yml
@@ -16,8 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         framework: [react-native]
-        framework-version:
-          [
+        framework-version: [
             # uncomment to enable
             # { formatted: latest, value: latest },
             { formatted: 075, value: 0.75 },
@@ -53,8 +52,8 @@ jobs:
             platform: android
             framework-version: { formatted: '071', value: '0.71' }
         include:
-          # Expo makes you specify a version of the SDK that supports that a particular version of React Native 
-          # https://stackoverflow.com/questions/63463373/create-an-expo-project-with-a-specific-version 
+          # Expo makes you specify a version of the SDK that supports a specific version of React Native
+          # https://stackoverflow.com/questions/63463373/create-an-expo-project-with-a-specific-version
           - framework: react-native
             framework-version: { formatted: 070, value: '0.70' }
             build-tool: expo

--- a/.github/workflows/reusable-build-system-test.yml
+++ b/.github/workflows/reusable-build-system-test.yml
@@ -28,7 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         framework: [react]
-        framework-version: [latest]
+        # temporarily pointing all react tests to v18
+        # framework-version: [latest]
+        framework-version: [18]
         build-tool: [next, vite]
         build-tool-version: [latest]
         pkg-manager: [npm]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Temporarily point `latest` react build tests to version 18 to unblock pipeline while `react@19` support is added to the monorepo in https://github.com/aws-amplify/amplify-ui/pull/5826

Impacted build tests:
- https://github.com/aws-amplify/amplify-ui/actions/runs/12188594424/job/34006682978
- https://github.com/aws-amplify/amplify-ui/actions/runs/12188594424/job/34006683451


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
NA

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
