### PR TITLE
fix: resolve React Native build test failure

### DIFF
--- a/.github/workflows/build-system-test-react-native.yml
+++ b/.github/workflows/build-system-test-react-native.yml
@@ -6,8 +6,9 @@ permissions:
   id-token: write # This is required for aws-actions/configure-aws-credentials
 
 on:
-  schedule:
-    - cron: '0 * * * *' # Run at the first minute of every hour
+  pull_request:
+    branches: [main, hotfix]
+    types: [opened, synchronize, labeled]
 
 jobs:
   build:

--- a/.github/workflows/build-system-test-react-native.yml
+++ b/.github/workflows/build-system-test-react-native.yml
@@ -6,9 +6,8 @@ permissions:
   id-token: write # This is required for aws-actions/configure-aws-credentials
 
 on:
-  pull_request:
-    branches: [main, hotfix]
-    types: [opened, synchronize, labeled]
+  schedule:
+    - cron: '0 * * * *' # Run at the first minute of every hour
 
 jobs:
   build:

--- a/build-system-tests/scripts/mega-app-install.sh
+++ b/build-system-tests/scripts/mega-app-install.sh
@@ -105,7 +105,7 @@ if [ "$PKG_MANAGER" == 'yarn' ]; then
     yarn add $DEPENDENCIES
 else
     if [[ "$FRAMEWORK" == "react-native" ]]; then
-        DEPENDENCIES="$TAGGED_UI_FRAMEWORK @aws-amplify/react-native aws-amplify react-native-safe-area-context@4.14.0 @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill"
+        DEPENDENCIES="$TAGGED_UI_FRAMEWORK @aws-amplify/react-native aws-amplify react-native-safe-area-context@^4.14.0 @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill"
         echo "npm install $DEPENDENCIES"
         npm install $DEPENDENCIES
         if [[ "$BUILD_TOOL" == "expo" ]]; then

--- a/build-system-tests/scripts/mega-app-install.sh
+++ b/build-system-tests/scripts/mega-app-install.sh
@@ -105,7 +105,7 @@ if [ "$PKG_MANAGER" == 'yarn' ]; then
     yarn add $DEPENDENCIES
 else
     if [[ "$FRAMEWORK" == "react-native" ]]; then
-        DEPENDENCIES="$TAGGED_UI_FRAMEWORK @aws-amplify/react-native aws-amplify react-native-safe-area-context @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill"
+        DEPENDENCIES="$TAGGED_UI_FRAMEWORK @aws-amplify/react-native aws-amplify react-native-safe-area-context@4.14.0 @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill"
         echo "npm install $DEPENDENCIES"
         npm install $DEPENDENCIES
         if [[ "$BUILD_TOOL" == "expo" ]]; then


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Background
* The mega app used in cli React Native canary build tests uses the dependency `react-native-safe-area-context`
  * Currently, the workflow to run the build test is set to use the latest version of `react-native-safe-area-context`
  * The release of version 5.0.0 increased the minimum required version of React Native to 0.75.0+, while support for lower versions is still being included in tests
  * This caused an incompatibility on tests using versions of React Native below 0.75.0, resulting in test failure.
* Build test was confirmed to pass with this change

#### Description of changes
* Set version of `react-native-safe-area-context` used in pipeline build tests to latest minor change within v4, as v5 includes breaking changes to React Native versions required in testing process.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
