### PR TITLE
chore: denote react native safe area dep limitation and update quickstart commands

### DIFF
--- a/build-system-tests/scripts/mega-app-install.sh
+++ b/build-system-tests/scripts/mega-app-install.sh
@@ -105,7 +105,7 @@ if [ "$PKG_MANAGER" == 'yarn' ]; then
     yarn add $DEPENDENCIES
 else
     if [[ "$FRAMEWORK" == "react-native" ]]; then
-        # react-native-safe-area-context versions 5.0.0+ do no support RN 0.74 and lower
+        # react-native-safe-area-context v5.0.0+ does not support RN 0.74 and lower
         DEPENDENCIES="$TAGGED_UI_FRAMEWORK @aws-amplify/react-native aws-amplify react-native-safe-area-context@^4.2.5 @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill"
         echo "npm install $DEPENDENCIES"
         npm install $DEPENDENCIES

--- a/build-system-tests/scripts/mega-app-install.sh
+++ b/build-system-tests/scripts/mega-app-install.sh
@@ -105,7 +105,8 @@ if [ "$PKG_MANAGER" == 'yarn' ]; then
     yarn add $DEPENDENCIES
 else
     if [[ "$FRAMEWORK" == "react-native" ]]; then
-        DEPENDENCIES="$TAGGED_UI_FRAMEWORK @aws-amplify/react-native aws-amplify react-native-safe-area-context@^4.14.0 @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill"
+        # react-native-safe-area-context versions 5.0.0+ do no support RN 0.74 and lower
+        DEPENDENCIES="$TAGGED_UI_FRAMEWORK @aws-amplify/react-native aws-amplify react-native-safe-area-context@^4.2.5 @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill"
         echo "npm install $DEPENDENCIES"
         npm install $DEPENDENCIES
         if [[ "$BUILD_TOOL" == "expo" ]]; then
@@ -115,7 +116,7 @@ else
                 npx expo install react-native@~0.75.0
             fi
             echo "npx expo install --fix"
-            npx expo install --fix # fix the dependencies that are incompatible with the installed expo versio
+            npx expo install --fix # fix the dependencies that are incompatible with the installed expo version
         fi
     else
         install_dependencies_with_retries npm "$DEPENDENCIES"

--- a/docs/src/components/ExpoSnack.tsx
+++ b/docs/src/components/ExpoSnack.tsx
@@ -35,7 +35,7 @@ const defaultOptions: SnackOptions = {
     '@aws-amplify/rtn-web-browser',
     '@aws-amplify/ui-react-native',
     'aws-amplify@5.3.11',
-    'react-native-safe-area-context',
+    'react-native-safe-area-context@^4.2.5',
     '@react-native-community/netinfo',
     '@react-native-async-storage/async-storage',
     'react-native-get-random-values',

--- a/docs/src/data/frameworks.ts
+++ b/docs/src/data/frameworks.ts
@@ -54,7 +54,7 @@ export const AMPLIFY_5_UI_VERSIONS: Record<string, number> = {
 
 // React Native requires direct installation of dependencies with native modules
 export const REACT_NATIVE_DEPENDENCIES =
-  '@aws-amplify/react-native react-native-safe-area-context @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values';
+  '@aws-amplify/react-native react-native-safe-area-context@^4.2.5 @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values';
 
 export const FRAMEWORK_INSTALL_SCRIPTS = {
   react: 'npm i @aws-amplify/ui-react aws-amplify',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
* Update hard-coded version of `react-native-safe-area-context` to `^4.2.5` to match other usage within repo
* Add comment explaining why the latest version is not used
* Update commands in docs to install correct version
* Fix minor typo

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
