### PR TITLE
fix (FileUploader): update FileUploader prop docs for defaultFiles

### DIFF
--- a/docs/src/pages/[platform]/connected-components/storage/fileuploader/props.ts
+++ b/docs/src/pages/[platform]/connected-components/storage/fileuploader/props.ts
@@ -88,7 +88,7 @@ export const FILE_UPLOADER = [
   {
     name: `defaultFiles?`,
     description: 'An array of files that already exist in the cloud.',
-    type: 'Array<{s3key: string}>',
+    type: 'Array<{key: string}>',
   },
   {
     name: `displayText?`,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fix a bug in the FileUploader props docs where it takes a key instead of "s3key".

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
