### PR TITLE
fix(docs): use correct listLocation attribute names in Storage Browser auth example 

### DIFF
--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/react.mdx
@@ -195,20 +195,20 @@ export const { StorageBrowser } = createStorageBrowser({
     listLocations: async (input = {}) => {
       const { nextToken, pageSize } = input;
       return {
-        locations: [
+        items: [
           {
-            bucketName: '[bucket name]',
+            bucket: '[bucket name]',
             prefix: '', // empty path means bucket root
             id: 'XXXXXXX', // unique identifier 
             type: 'BUCKET',
-            permission: ['delete', 'get', 'list', 'write'],
+            permissions: ['delete', 'get', 'list', 'write'],
           },
           {
-            bucketName: '[bucket name]',
+            bucket: '[bucket name]',
             prefix: 'some/path',
             id: 'XXXXXXX', // unique identifier 
             type: 'PREFIX',
-            permission: ['delete', 'get', 'list', 'write'],
+            permissions: ['delete', 'get', 'list', 'write'],
           }
         ]
       }


### PR DESCRIPTION
#### Description of changes
Fix Storage Browser docs example where "Customer Managed Auth" section uses incorrect `listLocations` attribute names.

#### Issue #, if available

#### Description of how you validated changes
local docs, comparison against stobro types

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
