### PR TITLE
chore(react-native): update allowed peerDep to >=0.70

### DIFF
--- a/.changeset/many-feet-appear.md
+++ b/.changeset/many-feet-appear.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-native": minor
+---
+
+chore(react-native): update allowed peerDep to >=0.70

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "aws-amplify": "^6.9.0",
     "react": "*",
-    "react-native": "^0.70 || ^0.71 || ^0.72 || ^0.73 || ^0.74 || ^0.75",
+    "react-native": ">=0.70",
     "react-native-safe-area-context": "^4.2.5"
   },
   "files": [


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update `@aws-amplify/ui-react-native` to support v0.76
- update `react-native` peerDep to allow all versions >=0.70
```diff
-   "react-native": "^0.70 || ^0.71 || ^0.72 || ^0.73 || ^0.74 || ^0.75",
+   "react-native": ">=0.70",
```
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Resolves https://github.com/aws-amplify/amplify-ui/issues/5973
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual verification of installation and smoke testing of `@aws-amplify/ui-react-native` in a `react-native@0.76` example app (thanks @jordanvn)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
