### PR TITLE
chore: remove temporary use of react 18 in react@latest build tests

### DIFF
--- a/.github/workflows/reusable-build-system-test.yml
+++ b/.github/workflows/reusable-build-system-test.yml
@@ -28,9 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         framework: [react]
-        # temporarily pointing all react tests to v18
-        # framework-version: [latest]
-        framework-version: [18]
+        framework-version: [latest]
         build-tool: [next, vite]
         build-tool-version: [latest]
         pkg-manager: [npm]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
* Removes temporary pinning of React version to 18 in testing of latest React version
  * This was originally done due to a lack of React 19 support, but that support has now been added

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
