### PR TITLE
chore: add v0.76 and latest to React Native build system tests

### DIFF
--- a/.github/workflows/test-internal-prs.yml
+++ b/.github/workflows/test-internal-prs.yml
@@ -138,11 +138,6 @@ jobs:
       DOCSEARCH_DOCS_API_KEY: ${{ secrets.DOCSEARCH_DOCS_API_KEY }}
       DOCSEARCH_DOCS_INDEX_NAME: ${{ secrets.DOCSEARCH_DOCS_INDEX_NAME }}
 
-  build:
-    uses: ./.github/workflows/reusable-build-system-test-react-native.yml
-    with:
-      dist-tag: latest
-
   update-success-status:
     if: ${{ success() }}
     needs: [setup, e2e, codeql, dependency-review]


### PR DESCRIPTION
#### Description of changes
- Specify `0.76` and `latest` to be run as part of React Native build system tests workflow

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- adding and running `build-system-tests-react-native` workflow on internal PR checks for this PR before removing the workflow

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
