### PR TITLE
fix(slider): remounted controlled value not updating

### DIFF
--- a/packages/react/src/primitives/SliderField/SliderField.tsx
+++ b/packages/react/src/primitives/SliderField/SliderField.tsx
@@ -90,16 +90,17 @@ const SliderFieldPrimitive: Primitive<SliderFieldProps, 'span'> = (
     [onChange]
   );
 
+  const realValue = isControlled ? value : currentValue;
   const renderedValue = React.useMemo(() => {
     const formattedValue = isFunction(formatValue)
-      ? formatValue(currentValue)
-      : currentValue;
+      ? formatValue(realValue)
+      : realValue;
     return typeof formatValue === 'string' ? (
       <View as="span">{formattedValue}</View>
     ) : (
       formattedValue
     );
-  }, [currentValue, formatValue]);
+  }, [realValue, formatValue]);
 
   const isVertical = orientation === 'vertical';
   const componentClasses = classNames(

--- a/packages/react/src/primitives/SliderField/SliderField.tsx
+++ b/packages/react/src/primitives/SliderField/SliderField.tsx
@@ -91,16 +91,9 @@ const SliderFieldPrimitive: Primitive<SliderFieldProps, 'span'> = (
   );
 
   const realValue = isControlled ? value : currentValue;
-  const renderedValue = React.useMemo(() => {
-    const formattedValue = isFunction(formatValue)
-      ? formatValue(realValue)
-      : realValue;
-    return typeof formatValue === 'string' ? (
-      <View as="span">{formattedValue}</View>
-    ) : (
-      formattedValue
-    );
-  }, [realValue, formatValue]);
+  const formattedValue = isFunction(formatValue)
+    ? formatValue(realValue)
+    : realValue;
 
   const isVertical = orientation === 'vertical';
   const componentClasses = classNames(
@@ -138,7 +131,13 @@ const SliderFieldPrimitive: Primitive<SliderFieldProps, 'span'> = (
         visuallyHidden={labelHidden}
       >
         <View as="span">{label}</View>
-        {!isValueHidden ? renderedValue : null}
+        {!isValueHidden ? (
+          typeof formatValue === 'string' ? (
+            <View as="span">{formattedValue}</View>
+          ) : (
+            formattedValue
+          )
+        ) : null}
       </Label>
       <FieldDescription
         id={descriptionId}

--- a/packages/react/src/primitives/SliderField/__tests__/SliderField.test.tsx
+++ b/packages/react/src/primitives/SliderField/__tests__/SliderField.test.tsx
@@ -17,6 +17,7 @@ import {
 import { ComponentClassName } from '@aws-amplify/ui';
 import { AUTO_GENERATED_ID_PREFIX } from '../../utils/useStableId';
 import { ERROR_SUFFIX, DESCRIPTION_SUFFIX } from '../../../helpers/constants';
+import { Button } from '../../Button';
 
 // Jest uses JSDom, which apparently doesn't support the ResizeObserver API
 // This will get around that API reference error in Jest
@@ -131,7 +132,14 @@ describe('SliderField:', () => {
   describe('Slider', () => {
     const ControlledSliderField = () => {
       const [value, setValue] = React.useState(5);
-      return <SliderField label="slider" value={value} onChange={setValue} />;
+      return (
+        <>
+          <SliderField label="slider" value={value} onChange={setValue} />
+          <Button testId="test-button" onClick={() => setValue(10)}>
+            Set to 10
+          </Button>
+        </>
+      );
     };
 
     it('should work as uncontrolled component', async () => {
@@ -151,15 +159,27 @@ describe('SliderField:', () => {
     it('should work as controlled component', async () => {
       render(<ControlledSliderField />);
       const slider = await screen.findByRole('slider');
+      const label = await screen.findByTestId(SLIDER_LABEL_TEST_ID);
       expect(slider).toHaveAttribute('aria-valuenow', '5');
+      expect(label).toHaveTextContent('5');
       fireEvent.keyDown(slider, { key: 'ArrowUp', code: 'ArrowUp' });
       expect(slider).toHaveAttribute('aria-valuenow', '6');
+      expect(label).toHaveTextContent('6');
       fireEvent.keyDown(slider, { key: 'ArrowUp', code: 'ArrowUp' });
       expect(slider).toHaveAttribute('aria-valuenow', '7');
+      expect(label).toHaveTextContent('7');
       fireEvent.keyDown(slider, { key: 'ArrowDown', code: 'ArrowDown' });
       expect(slider).toHaveAttribute('aria-valuenow', '6');
+      expect(label).toHaveTextContent('6');
       fireEvent.keyDown(slider, { key: 'ArrowDown', code: 'ArrowDown' });
       expect(slider).toHaveAttribute('aria-valuenow', '5');
+      expect(label).toHaveTextContent('5');
+
+      // External update (remount) should work as well
+      const button = await screen.findByTestId('test-button');
+      fireEvent.click(button);
+      expect(slider).toHaveAttribute('aria-valuenow', '10');
+      expect(label).toHaveTextContent('10');
     });
 
     it('should set step', async () => {
@@ -206,6 +226,8 @@ describe('SliderField:', () => {
         `${ComponentClassName['Field']}--large`
       );
     });
+
+    it('should work as controlled', async () => {});
 
     describe('Root', () => {
       it('should render default and custom classname', async () => {

--- a/packages/react/src/primitives/SliderField/__tests__/SliderField.test.tsx
+++ b/packages/react/src/primitives/SliderField/__tests__/SliderField.test.tsx
@@ -227,8 +227,6 @@ describe('SliderField:', () => {
       );
     });
 
-    it('should work as controlled', async () => {});
-
     describe('Root', () => {
       it('should render default and custom classname', async () => {
         const className = 'class-test';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fixes an issue where the label value for the slider was not updating on external update. TBH there might be a cleaner way to do this, but I'm rusty. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

To repro:
1. set a value via props
2. unmount the component
3. mount the component again with a different value
4. Observe the slider bar has repositioned while the label still reports the original value

#### Description of how you validated changes

Added a test and built a test page to validate with my own 👁️ 

(the top slider is controlled, bottom one uncontrolled, the button just sets a random value)

Previous:

![CleanShot 2025-01-16 at 13 27 03](https://github.com/user-attachments/assets/7ed588d2-6b32-4687-aede-e0cedf02b4fe)


With the fix:

![CleanShot 2025-01-16 at 13 25 53](https://github.com/user-attachments/assets/bee664ae-54f7-4b3d-8435-c119bebdb510)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
