### PR TITLE
fix(react-storage): enable default checksum algorithm for create folder action 

### DIFF
--- a/.changeset/large-swans-repair.md
+++ b/.changeset/large-swans-repair.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui-react-storage': patch
+---
+
+fix(react-storage): enable default checksum algorithm for create folder action #6305
+

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/createFolder.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/createFolder.spec.ts
@@ -1,6 +1,7 @@
 import { createFolderHandler, CreateFolderHandlerInput } from '../createFolder';
 
 import { uploadData, UploadDataInput } from '../../../storage-internal';
+import { DEFAULT_CHECKSUM_ALGORITHM } from '../constants';
 
 jest.mock('../../../storage-internal');
 
@@ -70,6 +71,7 @@ describe('createFolderHandler', () => {
         locationCredentialsProvider: credentials,
         onProgress: expect.any(Function),
         preventOverwrite: true,
+        checksumAlgorithm: DEFAULT_CHECKSUM_ALGORITHM,
       },
       path: baseInput.data.key,
     };

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/constants.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_CHECKSUM_ALGORITHM = 'crc-32';

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/createFolder.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/createFolder.ts
@@ -9,6 +9,7 @@ import {
   TaskHandlerOptions,
 } from './types';
 import { constructBucket, getProgress } from './utils';
+import { DEFAULT_CHECKSUM_ALGORITHM } from './constants';
 
 export interface CreateFolderHandlerData extends TaskData {
   preventOverwrite?: boolean;
@@ -48,6 +49,7 @@ export const createFolderHandler: CreateFolderHandler = (input) => {
         if (isFunction(onProgress)) onProgress(data, getProgress(event));
       },
       preventOverwrite,
+      checksumAlgorithm: DEFAULT_CHECKSUM_ALGORITHM,
     },
   });
 

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/upload.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/upload.ts
@@ -12,6 +12,7 @@ import {
 } from './types';
 
 import { constructBucket, getProgress } from './utils';
+import { DEFAULT_CHECKSUM_ALGORITHM } from './constants';
 
 export interface UploadHandlerOptions
   extends TaskHandlerOptions<{ key: string }> {}
@@ -33,8 +34,6 @@ export interface UploadHandler
 // 5MB for multipart upload
 // https://github.com/aws-amplify/amplify-js/blob/1a5366d113c9af4ce994168653df3aadb142c581/packages/storage/src/providers/s3/utils/constants.ts#L16
 export const MULTIPART_UPLOAD_THRESHOLD_BYTES = 5 * 1024 * 1024;
-
-export const DEFAULT_CHECKSUM_ALGORITHM = 'crc-32';
 
 export const UNDEFINED_CALLBACKS = {
   cancel: undefined,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
The purpose of this change is to add the default checksum algorithm header to create folder requests originating from storage browser. This allows the create folder action to be compatible with S3 buckets that have object lock enabled and a default retention set.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- manual testing
- unit testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [X] PR description included
- [X] `yarn test` passes and tests are updated/added
- [X] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [X] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
