### PR TITLE
chore(docs): adjust wording and clean up React troubleshooting page

### DIFF
--- a/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.react.mdx
+++ b/docs/src/pages/[platform]/getting-started/troubleshooting/troubleshooting.react.mdx
@@ -167,11 +167,11 @@ This is a known problem when using the `jsdom` library (a dependency of Jest) wi
 
 ## Next.js
 
-### Next 13.5+: React Server Components
+### Next 13.4+: React Server Components
 
-Next.js 13.5+ introduces [App Router](https://nextjs.org/docs/13/app/building-your-application/routing#the-app-router) with the usage of [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components). Amplify UI components are intended to be used on the client side. See [here](#attempted-import-error-useform-is-not-exported-from-react-hook-form-imported-as-useform) for solutions.
+Next.js 13.4+ introduces [App Router](https://nextjs.org/docs/13/app/building-your-application/routing#the-app-router) with the usage of [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components). Amplify UI components are intended to be used on the client side. See [here](#attempted-import-error-useform-is-not-exported-from-react-hook-form-imported-as-useform) for solutions.
 
-### Next 13.5+: `Module not found` Errors
+### Next 13.4+: `Module not found` Errors
 
 When you use Amplify with Next.js App Router, you will see the follow errors from `aws-crt` and `encoding` in the server terminal:
 


### PR DESCRIPTION
#### Description of changes
- Adjust certain word usage/terms for Next.js & SSR sections to be more idiomatic based on React/Next.js documentation
- Change Next.js App Router documentation link to the correct version & page
- Do minor formatting of code blocks to remove uneven syntax highlighting and/or align with other markup used elsewhere in the page (a few changes shown in attached table as example reference):

Code block | Before | After |
:--------: | :----: | :----:
CRA4 | ![](https://github.com/user-attachments/assets/9a1c870e-6a26-449c-9e15-8e99ff0c8922) | ![](https://github.com/user-attachments/assets/6692490d-c570-4d3d-b7c1-88308d466ebc)
Next.js module not found | ![](https://github.com/user-attachments/assets/348d4f0f-3a90-4546-a288-1312af1fac83) | ![](https://github.com/user-attachments/assets/5e99472c-f2d5-41cc-8d44-39b89914c5e5)


#### Issue #, if available
Follow up to comment from https://github.com/aws-amplify/amplify-ui/pull/6339#discussion_r1949699422

#### Description of how you validated changes

`yarn docs dev` & `yarn docs test`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
