### PR TITLE
chore(gh-action): bump install-with-retry backoff in build tests

### DIFF
--- a/.github/actions/install-with-retries/action.yml
+++ b/.github/actions/install-with-retries/action.yml
@@ -1,5 +1,5 @@
 name: 'Install with retries'
-description: 'Runs yarn install with up to 2 retries'
+description: 'Runs yarn install with up to 3 retries'
 inputs:
   skip-cypress-binary:
     description: 'Whether to skip binary installation for cypress'

--- a/.github/actions/install-with-retries/install-with-retries.sh
+++ b/.github/actions/install-with-retries/install-with-retries.sh
@@ -36,9 +36,9 @@ for i in {1..4}; do
   # Don't add delay at end of last attempt if last attempt fails
   if [ "$i" -le 3 ]; then
     # NPM publish can be flaky causing failed installs
-    # Add exponential backoff between retries: [4/16/64]s ~= [5/15/60]s
-    echo "[ERROR]: yarn install failed with exit code $return_value, waiting to retry in $((4 * i)) seconds..."
-    sleep $((4 ** i))
+    # Add exponential backoff between retries: 5s/25s/125s ~= 3min total
+    echo "[ERROR]: yarn install failed with exit code $return_value, waiting to retry in $((5 ** i)) seconds..."
+    sleep $((5 ** i))
   fi
 done
 

--- a/build-system-tests/scripts/install-dependencies-with-retries.sh
+++ b/build-system-tests/scripts/install-dependencies-with-retries.sh
@@ -21,8 +21,8 @@ install_dependencies_with_retries() {
             break
         fi
         # Add exponential backoff delay between failed attempts 
-        # [4/16/64]s ~= [5/15/60]s
-        local wait=$((4 ** attempt))
+        # [5/25/125]s ~= 3min total
+        local wait=$((5 ** attempt))
         attempt=$((attempt + 1))
         if [ $attempt -le $retries ]; then
             echo "$1 install failed. Retrying in $wait seconds..."


### PR DESCRIPTION
#### Description of changes
Finally got a NPM flaky tag publish hit on the retry backoff strategy during release publishing that affected the Publish/Next workflow, which unfortunately proved that the retry time used was too small. (https://github.com/aws-amplify/amplify-ui/actions/runs/13319459666/job/37201331321) 

Doing another small nudge to the time, which brings total time used from ~1.4min to ~3min

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
