### PR TITLE
fix(docs): remove non-visible header rendering in TOC

### DIFF
--- a/docs/src/components/Layout/index.tsx
+++ b/docs/src/components/Layout/index.tsx
@@ -46,12 +46,22 @@ export default function Page({
           ...document.querySelectorAll(
             `${nextRootSelector} h2[id], ${nextRootSelector} h3[id]`
           ),
-        ].map((node: HTMLElement) => ({
-          id: node.id,
-          label: node.innerText,
-          level: node.nodeName,
-          top: node.offsetTop,
-        }))
+        ].reduce(
+          (
+            acc: { id: string; label: string; level: string; top: number }[],
+            node: HTMLElement
+          ) =>
+            // remove non-visible nodes that are excluded from rendering by `FilterChildren`
+            !node.checkVisibility()
+              ? acc
+              : acc.concat({
+                  id: node.id,
+                  label: node.innerText,
+                  level: node.nodeName,
+                  top: node.offsetTop,
+                }),
+          []
+        )
       );
     });
     updateHeaders(); // with static rendering the mutation observer is no longer triggered on initial page view because the content has already been rendered


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fix rendering of Table of Contents links that are not visible in the current page

**Before**
![CleanShot 2025-02-19 at 15 49 06@2x](https://github.com/user-attachments/assets/2419b1b8-c58a-4eb7-babc-caced54cf081)

**After**
![CleanShot 2025-02-19 at 15 52 13@2x](https://github.com/user-attachments/assets/23cf4102-71b0-4130-bc5e-4cfe1a3b34dc)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manual test
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
