### PR TITLE
chore(ci): specify react-native-safe-area-context version

### DIFF
--- a/build-system-tests/scripts/mega-app-install.sh
+++ b/build-system-tests/scripts/mega-app-install.sh
@@ -106,7 +106,15 @@ if [ "$PKG_MANAGER" == 'yarn' ]; then
 else
     if [[ "$FRAMEWORK" == "react-native" ]]; then
         # react-native-safe-area-context v5.0.0+ does not support RN 0.74 and lower
-        DEPENDENCIES="$TAGGED_UI_FRAMEWORK @aws-amplify/react-native aws-amplify react-native-safe-area-context@^4.2.5 @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill"
+        DEPENDENCIES="$TAGGED_UI_FRAMEWORK @aws-amplify/react-native aws-amplify @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill"
+
+        # react-native-safe-area-context v5 is required for >= 0.78
+        if [[ "$FRAMEWORK_VERSION" == "latest" || $FRAMEWORK_VERSION > "0.77" ]]; then
+            DEPENDENCIES="$DEPENDENCIES react-native-safe-area-context@^5.2.0 --force"
+        else
+            DEPENDENCIES="$DEPENDENCIES react-native-safe-area-context@^4.2.5"
+        fi;
+
         echo "npm install $DEPENDENCIES"
         install_dependencies_with_retries npm "$DEPENDENCIES"
         if [[ "$BUILD_TOOL" == "expo" ]]; then


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
React Native v0.78 was released last night and `react-native-safe-area-context` v5.2.0 is explicitly required to support this version. The purpose of this pull request is to update the build test script to install the correct version of this package depending on the target RN version.

Sample Run:
https://github.com/aws-amplify/amplify-ui/actions/runs/13425426394

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [X] PR description included
- [X] `yarn test` passes and tests are updated/added
- [X] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
