### PR TITLE
chore(ci): reduce angular e2e flakiness

### DIFF
--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-phone.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-phone.feature
@@ -56,9 +56,9 @@ Feature: Sign In with Phone Number
     When I update my country code from "+82" to "+20"
     Then I type my "phone number" with status "UNCONFIRMED"
     Then I type my password
-    Then I click the "Sign in" button
     Then I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth" } }' with error fixture "user-not-confirmed-exception"
     Then I intercept '{ "headers": { "X-Amz-Target": "AWSCognitoIdentityProviderService.ResendConfirmationCode" } }' with fixture "resend-confirmation-code-email"
+    Then I click the "Sign in" button
     Then I see "Confirmation Code"
 
   @angular @react @vue @react-native
@@ -89,9 +89,9 @@ Feature: Sign In with Phone Number
 
   @angular @react @vue
   Scenario: Phone number field autocompletes username
-  
-  On sign in form, autocomplete prefers usage of username instead of phone number. 
-  See https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/.
+
+    On sign in form, autocomplete prefers usage of username instead of phone number.
+    See https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/.
 
     Then "Phone Number" field autocompletes "username"
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
The purpose of this change is to reduce flakiness associated with E2E tests by initializing intercept listeners earlier in test execution step (prior to firing intercept target).

Sample run:
https://github.com/aws-amplify/amplify-ui/actions/runs/13442552437?pr=6373
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- e2e tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [X] PR description included
- [X] `yarn test` passes and tests are updated/added
- [X] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
