### PR TITLE
fix: Numeric 0 can be set in the property

### DIFF
--- a/.changeset/eight-socks-approve.md
+++ b/.changeset/eight-socks-approve.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix: Numeric 0 can be set in the property

--- a/packages/react/src/primitives/shared/__tests__/styleUtils.test.tsx
+++ b/packages/react/src/primitives/shared/__tests__/styleUtils.test.tsx
@@ -67,6 +67,7 @@ describe('convertStylePropsToStyleObj:', () => {
       // cast to `undefined` to allow robustness testing
       color: null as unknown as undefined,
       border: '',
+      borderWidth: 0,
       borderRadius: '6px',
       ariaLabel: 'important section',
       as: 'section',
@@ -80,6 +81,7 @@ describe('convertStylePropsToStyleObj:', () => {
     expect(propStyles['backgroundColor']).toBeUndefined();
     expect(propStyles['color']).toBeUndefined();
     expect(propStyles['border']).toBeUndefined();
+    expect(propStyles['borderWidth']).toBe(props.borderWidth);
     expect(propStyles['borderRadius']).toBe(props.borderRadius);
     expect(propStyles['as']).toBeUndefined();
   });

--- a/packages/react/src/primitives/shared/styleUtils.ts
+++ b/packages/react/src/primitives/shared/styleUtils.ts
@@ -128,7 +128,8 @@ export const convertStylePropsToStyleObj: ConvertStylePropsToStyleObj = ({
     .forEach((propKey) => {
       if (isComponentStyleProp(propKey)) {
         const values = props[propKey];
-        if (!values || isEmptyString(values)) return;
+        if (values === null || values === undefined || isEmptyString(values))
+          return;
 
         const reactStyleProp = ComponentPropsToStylePropsMap[propKey];
         // short circuit the style prop here if it is a string or design token


### PR DESCRIPTION
#### Description of changes

Set a property on a primitive component to Numeric 0, the property will be set to 0 in the browser.

#### Issue #, if available

#6380

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
