### PR TITLE
fix(authenticator): apply default checked to select mfa type

### DIFF
--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/select-mfa-type/select-mfa-type.component.html
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/select-mfa-type/select-mfa-type.component.html
@@ -16,7 +16,7 @@
             <h3 [class]="classNames(ComponentClassName.Heading, 'amplify-heading--3')">{{ headerText }}</h3>
         </amplify-slot>
         <div
-            *ngFor="let mfaType of allowedMfaTypes"
+            *ngFor="let mfaType of allowedMfaTypes; index as i"
             [class]="classNames(ComponentClassName.Flex, ComponentClassName.Field, ComponentClassName.RadioGroupField)"
             role="radiogroup"
         >
@@ -31,6 +31,7 @@
                     [class]="classNames(ComponentClassName.Input, ComponentClassName.FieldGroupControl, ComponentClassName.VisuallyHidden, ComponentClassName.RadioInput)"
                     [attr.data-amplify-radio-control-input]
                     [value]="mfaType"
+                    [checked]="i === 0"
                     name="mfa_type"
                     type="radio"
                     required

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-email-mfa-selection.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-email-mfa-selection.feature
@@ -51,3 +51,16 @@ Feature: Sign In with Email MFA Selection
         Then I click the "Confirm" button
         Then I click the "Sign out" button
         Then I see "Sign In"
+
+    @react @vue @angular
+    Scenario: Sign In, Use Default Mfa Selection, Enter Valid Confirmation Code
+        When I type my "username" with status "CONFIRMED"
+        Then I type my password
+        Then I click the "Sign in" button
+        Then I click the "Confirm" button
+        Then I see "Confirm Email Code"
+        Then I type a valid confirmation code
+        Then I click the "Confirm" button
+        Then I click the "Sign out" button
+        Then I see "Sign In"
+

--- a/packages/e2e/features/ui/components/authenticator/sign-in-with-email-mfa-setup-selection.feature
+++ b/packages/e2e/features/ui/components/authenticator/sign-in-with-email-mfa-setup-selection.feature
@@ -97,3 +97,19 @@ Feature: Sign In with Email MFA Setup Selection
         Then I click the "Confirm" button
         Then I click the "Sign out" button
         Then I see "Sign In"
+
+    @react @vue @angular
+    Scenario: Sign In, Use Default Mfa Selection, Enter Valid Confirmation Code
+        When I type my "username" with status "CONFIRMED"
+        Then I type my password
+        Then I click the "Sign in" button
+        Then I see "Multi-Factor Authentication Setup"
+        Then I click the "Confirm" button
+        Then I see "Setup Email"
+        Then I type my "email" with status "CONFIRMED"
+        Then I click the "Confirm" button
+        Then I see "Confirm Email Code"
+        Then I type a valid confirmation code
+        Then I click the "Confirm" button
+        Then I click the "Sign out" button
+        Then I see "Sign In"

--- a/packages/react/src/components/Authenticator/SelectMfaType/SelectMfaType.tsx
+++ b/packages/react/src/components/Authenticator/SelectMfaType/SelectMfaType.tsx
@@ -59,8 +59,13 @@ export const SelectMfaType = ({
               isDisabled={isPending}
               isRequired
             >
-              {allowedMfaTypes.map((value) => (
-                <Radio name="mfa_type" key={value} value={value}>
+              {allowedMfaTypes.map((value, index) => (
+                <Radio
+                  name="mfa_type"
+                  key={value}
+                  value={value}
+                  defaultChecked={index === 0}
+                >
                   {getMfaTypeLabelByValue(value)}
                 </Radio>
               ))}

--- a/packages/vue/src/components/select-mfa-type.vue
+++ b/packages/vue/src/components/select-mfa-type.vue
@@ -77,7 +77,7 @@ const onBackToSignInClicked = () => {
                             :aria-labelledby="`amplify-field-${random}`"
                         >
                             <template
-                                v-for="mfaType in allowedMfaTypes"
+                                v-for="(mfaType, index) in allowedMfaTypes"
                                 :key="mfaType"
                             >
                                 <base-label
@@ -94,6 +94,7 @@ const onBackToSignInClicked = () => {
                                         name="mfa_type"
                                         type="radio"
                                         :value="mfaType"
+                                        :checked="index === 0"
                                     >
                                     </base-input>
                                     <base-text


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
The purpose of this PR is apply default checked behavior to the radio groups on the select mfa type screen. We automatically select the first radio option.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [X] PR description included
- [X] `yarn test` passes and tests are updated/added
- [X] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
