### PR TITLE
feat(ui-react-storage): export default handler configs and types

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/index.ts
@@ -1,25 +1,18 @@
 export { componentsDefault } from './componentsDefault';
 export { createStorageBrowser } from './createStorageBrowser';
 export {
-  CopyHandler,
   CopyHandlerInput,
   CopyHandlerOutput,
-  CreateFolderHandler,
   CreateFolderHandlerInput,
   CreateFolderHandlerOutput,
-  DeleteHandler,
   DeleteHandlerInput,
   DeleteHandlerOutput,
-  DownloadHandler,
   DownloadHandlerInput,
   DownloadHandlerOutput,
-  ListLocationItemsHandler,
   ListLocationItemsHandlerInput,
   ListLocationItemsHandlerOutput,
-  UploadHandler,
   UploadHandlerInput,
   UploadHandlerOutput,
-  ListLocationsHandler,
   ListLocationsHandlerInput,
   ListLocationsHandlerOutput,
   ActionViewConfig,
@@ -35,7 +28,6 @@ export {
   StorageBrowserAuthAdapter,
 } from './adapters';
 export {
-  GetLocationCredentials,
   GetLocationCredentialsInput,
   GetLocationCredentialsOutput,
 } from './credentials/types';

--- a/packages/react-storage/src/components/StorageBrowser/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/index.ts
@@ -1,10 +1,32 @@
 export { componentsDefault } from './componentsDefault';
 export { createStorageBrowser } from './createStorageBrowser';
 export {
+  CopyHandler,
+  CopyHandlerInput,
+  CopyHandlerOutput,
+  CreateFolderHandler,
+  CreateFolderHandlerInput,
+  CreateFolderHandlerOutput,
+  DeleteHandler,
+  DeleteHandlerInput,
+  DeleteHandlerOutput,
+  DownloadHandler,
+  DownloadHandlerInput,
+  DownloadHandlerOutput,
+  ListLocationItemsHandler,
+  ListLocationItemsHandlerInput,
+  ListLocationItemsHandlerOutput,
+  UploadHandler,
+  UploadHandlerInput,
+  UploadHandlerOutput,
+  ListLocationsHandler,
+  ListLocationsHandlerInput,
+  ListLocationsHandlerOutput,
   ActionViewConfig,
   ActionHandler,
   FileDataItem,
   ExtendedActionConfigs,
+  defaultActionConfigs,
 } from './actions';
 export {
   createAmplifyAuthAdapter,
@@ -12,6 +34,11 @@ export {
   CreateManagedAuthAdapterInput,
   StorageBrowserAuthAdapter,
 } from './adapters';
+export {
+  GetLocationCredentials,
+  GetLocationCredentialsInput,
+  GetLocationCredentialsOutput,
+} from './credentials/types';
 export { DefaultStorageBrowserDisplayText } from './displayText';
 export {
   CreateStorageBrowserInput,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Export the default configs for the StoBro action handlers. With it, users can extend the action handlers whereas keeping the default behavior. Normal use case includes addtional verification before sending requests; 3rd-party observability integration etc.

Also export the handler input & output types to make it easy for users to build wrapper utitlities around the action handlers. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
