### PR TITLE
feat(ui-react-storage): allow custom error boundary

### DIFF
--- a/examples/next/pages/ui/components/storage/storage-browser/custom-actions/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-browser/custom-actions/index.page.tsx
@@ -121,9 +121,7 @@ const { StorageBrowser, useView } = createStorageBrowser({
       },
     },
   },
-  components: {
-    ErrorBoundary: CustomErrorBoundary,
-  },
+  ErrorBoundary: CustomErrorBoundary,
   config: {
     getLocationCredentials: () =>
       Promise.resolve({

--- a/examples/next/pages/ui/components/storage/storage-browser/custom-actions/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-browser/custom-actions/index.page.tsx
@@ -1,11 +1,11 @@
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 import { createStorageBrowser } from '@aws-amplify/ui-react-storage/browser';
 import { Flex, Message } from '@aws-amplify/ui-react';
 import './styles.css';
 
 import '@aws-amplify/ui-react-storage/styles.css';
 
-class CustomErrorBoundary extends React.Component<Required<PropsWithChildren>> {
+class CustomErrorBoundary extends React.Component<React.PropsWithChildren> {
   state = {
     hasError: false,
   };

--- a/examples/next/pages/ui/components/storage/storage-browser/custom-actions/styles.css
+++ b/examples/next/pages/ui/components/storage/storage-browser/custom-actions/styles.css
@@ -1,4 +1,4 @@
-// Intentionally to test error boundary. No effect in prod mode.
+/* Intentionally to test error boundary. No effect in prod mode. */
 nextjs-portal {
   display: none;
 }

--- a/examples/next/pages/ui/components/storage/storage-browser/custom-actions/styles.css
+++ b/examples/next/pages/ui/components/storage/storage-browser/custom-actions/styles.css
@@ -1,0 +1,4 @@
+// Intentionally to test error boundary. No effect in prod mode.
+nextjs-portal {
+  display: none;
+}

--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -231,6 +231,12 @@ Given(
   }
 );
 
+Given('I expect an exception', () => {
+  Cypress.on('uncaught:exception', () => {
+    return false;
+  });
+});
+
 When('Sign in was called with {string}', (username: string) => {
   let tempStub = stub.calledWith(username, Cypress.env('VALID_PASSWORD'));
   stub = null;

--- a/packages/e2e/features/ui/components/storage/storage-browser/observability.feature
+++ b/packages/e2e/features/ui/components/storage/storage-browser/observability.feature
@@ -1,0 +1,14 @@
+Feature: Monitoring errors
+
+  Background:
+    Given I'm running the example "ui/components/storage/storage-browser/custom-actions"
+
+  @react
+  Scenario: Shows custom error boundary when unexpected error happens
+    Given I expect an exception
+    When I click the first button containing "my-prefix"
+    Then I see the "Menu Toggle" button
+    When I click the "Menu Toggle" button
+    Then I see the "Mock unexpected error" menuitem
+    When I click the "Mock unexpected error" menuitem
+    Then I see "An unexpected error has happened."

--- a/packages/react-storage/src/components/StorageBrowser/ComponentsProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/ComponentsProvider.tsx
@@ -4,8 +4,11 @@ import { ElementsProvider } from '@aws-amplify/ui-react-core/elements';
 
 import { ComposablesProvider, Composables } from './composables';
 import { StorageBrowserElements } from './context/elements';
+import { ErrorBoundaryProps } from './ErrorBoundary';
 
-export interface Components extends Partial<Composables> {}
+export interface Components extends Partial<Composables> {
+  ErrorBoundary?: React.ComponentClass<ErrorBoundaryProps>;
+}
 
 export interface ComponentsProviderProps {
   children?: React.ReactNode;

--- a/packages/react-storage/src/components/StorageBrowser/ComponentsProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/ComponentsProvider.tsx
@@ -4,11 +4,8 @@ import { ElementsProvider } from '@aws-amplify/ui-react-core/elements';
 
 import { ComposablesProvider, Composables } from './composables';
 import { StorageBrowserElements } from './context/elements';
-import { ErrorBoundaryProps } from './ErrorBoundary';
 
-export interface Components extends Partial<Composables> {
-  ErrorBoundary?: React.ComponentClass<ErrorBoundaryProps>;
-}
+export interface Components extends Partial<Composables> {}
 
 export interface ComponentsProviderProps {
   children?: React.ReactNode;

--- a/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { STORAGE_BROWSER_BLOCK_TO_BE_UPDATED } from '../constants';
 
-interface ErrorBoundaryProps {
+export interface ErrorBoundaryProps {
   children: React.ReactNode;
 }
 

--- a/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
@@ -18,6 +18,8 @@ const Fallback = (): React.JSX.Element => (
   </div>
 );
 
+export type ErrorBoundaryType = React.ComponentClass<ErrorBoundaryProps>;
+
 export class ErrorBoundary extends React.Component<
   ErrorBoundaryProps,
   ErrorBoundaryState

--- a/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 
 import { STORAGE_BROWSER_BLOCK_TO_BE_UPDATED } from '../constants';
 
-interface ErrorBoundaryProps {
-  children: React.ReactNode;
-}
-
 interface ErrorBoundaryState {
   hasError: boolean;
 }
@@ -18,13 +14,13 @@ const Fallback = (): React.JSX.Element => (
   </div>
 );
 
-export type ErrorBoundaryType = React.ComponentClass<ErrorBoundaryProps>;
+export type ErrorBoundaryType = React.ComponentType<React.PropsWithChildren>;
 
 export class ErrorBoundary extends React.Component<
-  ErrorBoundaryProps,
+  React.PropsWithChildren,
   ErrorBoundaryState
 > {
-  constructor(props: ErrorBoundaryProps) {
+  constructor(props: React.PropsWithChildren) {
     super(props);
     this.state = { hasError: false };
   }

--- a/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { STORAGE_BROWSER_BLOCK_TO_BE_UPDATED } from '../constants';
 
-export interface ErrorBoundaryProps {
+interface ErrorBoundaryProps {
   children: React.ReactNode;
 }
 

--- a/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/index.ts
@@ -1,1 +1,1 @@
-export { ErrorBoundary } from './ErrorBoundary';
+export { ErrorBoundary, ErrorBoundaryProps } from './ErrorBoundary';

--- a/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/index.ts
@@ -1,1 +1,1 @@
-export { ErrorBoundary } from './ErrorBoundary';
+export { ErrorBoundary, ErrorBoundaryType } from './ErrorBoundary';

--- a/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/ErrorBoundary/index.ts
@@ -1,1 +1,1 @@
-export { ErrorBoundary, ErrorBoundaryProps } from './ErrorBoundary';
+export { ErrorBoundary } from './ErrorBoundary';

--- a/packages/react-storage/src/components/StorageBrowser/__tests__/createStorageBrowser.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/__tests__/createStorageBrowser.spec.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 
 import * as ProvidersModule from '../providers';
@@ -101,8 +101,10 @@ describe('createStorageBrowser', () => {
   });
 
   it('should accept custom error boundary', async () => {
-    class CustomErrorBoundary extends React.Component<PropsWithChildren> {
-      constructor(props: PropsWithChildren) {
+    class CustomErrorBoundary extends React.Component<{
+      children: React.ReactNode;
+    }> {
+      constructor(props: { children: React.ReactNode }) {
         super(props);
       }
 

--- a/packages/react-storage/src/components/StorageBrowser/__tests__/createStorageBrowser.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/__tests__/createStorageBrowser.spec.tsx
@@ -101,10 +101,8 @@ describe('createStorageBrowser', () => {
   });
 
   it('should accept custom error boundary', async () => {
-    class CustomErrorBoundary extends React.Component<{
-      children: React.ReactNode;
-    }> {
-      constructor(props: { children: React.ReactNode }) {
+    class CustomErrorBoundary extends React.Component<React.PropsWithChildren> {
+      constructor(props: React.PropsWithChildren) {
         super(props);
       }
 
@@ -129,5 +127,29 @@ describe('createStorageBrowser', () => {
     });
 
     expect(screen.getByText('Custom Error Boundary')).toBeInTheDocument();
+  });
+
+  it('should support disabling error boundary', () => {
+    const { StorageBrowser } = createStorageBrowser({
+      config: input.config,
+      ErrorBoundary: null,
+    });
+
+    const LocationsViewWithError = () => {
+      React.useEffect(() => {
+        throw new Error('Unexpected Error');
+      }, []);
+      return <StorageBrowser.LocationsView />;
+    };
+
+    expect(() => {
+      render(
+        <StorageBrowser
+          views={{
+            LocationsView: LocationsViewWithError,
+          }}
+        />
+      );
+    }).toThrow('Unexpected Error');
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/__tests__/createStorageBrowser.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/__tests__/createStorageBrowser.spec.tsx
@@ -6,6 +6,7 @@ import * as UIModule from '@aws-amplify/ui';
 
 import { createStorageBrowser } from '../createStorageBrowser';
 import { StorageBrowserDisplayText } from '../displayText/types';
+import { ErrorBoundaryProps } from '../ErrorBoundary';
 
 const createConfigurationProviderSpy = jest.spyOn(
   ProvidersModule,
@@ -98,5 +99,36 @@ describe('createStorageBrowser', () => {
       // prefer non-static string - `version` field is updated on each package bump
       version: expect.any(String),
     });
+  });
+
+  it('should accept custom error boundary', async () => {
+    class CustomErrorBoundary extends React.Component<ErrorBoundaryProps> {
+      constructor({ children }: ErrorBoundaryProps) {
+        super({ children });
+      }
+
+      render() {
+        const { children } = this.props;
+        return (
+          <div>
+            <p>Custom Error Boundary</p>
+            {children}
+          </div>
+        );
+      }
+    }
+
+    const { StorageBrowser } = createStorageBrowser({
+      config: input.config,
+      components: {
+        ErrorBoundary: CustomErrorBoundary,
+      },
+    });
+
+    await waitFor(() => {
+      render(<StorageBrowser />);
+    });
+
+    expect(screen.getByText('Custom Error Boundary')).toBeInTheDocument();
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/__tests__/createStorageBrowser.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/__tests__/createStorageBrowser.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 
 import * as ProvidersModule from '../providers';
@@ -6,7 +6,6 @@ import * as UIModule from '@aws-amplify/ui';
 
 import { createStorageBrowser } from '../createStorageBrowser';
 import { StorageBrowserDisplayText } from '../displayText/types';
-import { ErrorBoundaryProps } from '../ErrorBoundary';
 
 const createConfigurationProviderSpy = jest.spyOn(
   ProvidersModule,
@@ -102,9 +101,9 @@ describe('createStorageBrowser', () => {
   });
 
   it('should accept custom error boundary', async () => {
-    class CustomErrorBoundary extends React.Component<ErrorBoundaryProps> {
-      constructor({ children }: ErrorBoundaryProps) {
-        super({ children });
+    class CustomErrorBoundary extends React.Component<PropsWithChildren> {
+      constructor(props: PropsWithChildren) {
+        super(props);
       }
 
       render() {
@@ -120,9 +119,7 @@ describe('createStorageBrowser', () => {
 
     const { StorageBrowser } = createStorageBrowser({
       config: input.config,
-      components: {
-        ErrorBoundary: CustomErrorBoundary,
-      },
+      ErrorBoundary: CustomErrorBoundary,
     });
 
     await waitFor(() => {

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -131,22 +131,21 @@ export function createStorageBrowser<
     );
   }
 
+  const ErrorBoundary =
+    input.ErrorBoundary === null
+      ? React.Fragment
+      : input.ErrorBoundary ?? DefaultErrorBoundary;
+
   const StorageBrowser: StorageBrowserType<
     DerivedActionViewType<RInput>,
     DerivedActionViews<RInput>
-  > = ({ views, displayText }) => {
-    const OptionalErrorBoundary =
-      input.ErrorBoundary === null
-        ? React.Fragment
-        : input.ErrorBoundary ?? DefaultErrorBoundary;
-    return (
-      <OptionalErrorBoundary>
-        <Provider displayText={displayText} views={views}>
-          <StorageBrowserDefault />
-        </Provider>
-      </OptionalErrorBoundary>
-    );
-  };
+  > = ({ views, displayText }) => (
+    <ErrorBoundary>
+      <Provider displayText={displayText} views={views}>
+        <StorageBrowserDefault />
+      </Provider>
+    </ErrorBoundary>
+  );
 
   StorageBrowser.LocationActionView =
     LocationActionView as LocationActionViewType<DerivedActionViewType<RInput>>;

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -15,7 +15,7 @@ import { elementsDefault } from './context/elements';
 import { ComponentsProvider } from './ComponentsProvider';
 import { componentsDefault } from './componentsDefault';
 import { DisplayTextProvider } from './displayText';
-import { ErrorBoundary } from './ErrorBoundary';
+import { ErrorBoundary as DefaultErrorBoundary } from './ErrorBoundary';
 import { createConfigurationProvider, StoreProvider } from './providers';
 import { StorageBrowserDefault } from './StorageBrowserDefault';
 import {
@@ -131,6 +131,7 @@ export function createStorageBrowser<
     );
   }
 
+  const ErrorBoundary = input.components?.ErrorBoundary ?? DefaultErrorBoundary;
   const StorageBrowser: StorageBrowserType<
     DerivedActionViewType<RInput>,
     DerivedActionViews<RInput>

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -131,7 +131,7 @@ export function createStorageBrowser<
     );
   }
 
-  const ErrorBoundary = input.components?.ErrorBoundary ?? DefaultErrorBoundary;
+  const ErrorBoundary = input.ErrorBoundary ?? DefaultErrorBoundary;
   const StorageBrowser: StorageBrowserType<
     DerivedActionViewType<RInput>,
     DerivedActionViews<RInput>

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -131,17 +131,22 @@ export function createStorageBrowser<
     );
   }
 
-  const ErrorBoundary = input.ErrorBoundary ?? DefaultErrorBoundary;
   const StorageBrowser: StorageBrowserType<
     DerivedActionViewType<RInput>,
     DerivedActionViews<RInput>
-  > = ({ views, displayText }) => (
-    <ErrorBoundary>
-      <Provider displayText={displayText} views={views}>
-        <StorageBrowserDefault />
-      </Provider>
-    </ErrorBoundary>
-  );
+  > = ({ views, displayText }) => {
+    const OptionalErrorBoundary =
+      input.ErrorBoundary === null
+        ? React.Fragment
+        : input.ErrorBoundary ?? DefaultErrorBoundary;
+    return (
+      <OptionalErrorBoundary>
+        <Provider displayText={displayText} views={views}>
+          <StorageBrowserDefault />
+        </Provider>
+      </OptionalErrorBoundary>
+    );
+  };
 
   StorageBrowser.LocationActionView =
     LocationActionView as LocationActionViewType<DerivedActionViewType<RInput>>;

--- a/packages/react-storage/src/components/StorageBrowser/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/types.ts
@@ -45,7 +45,11 @@ export interface CreateStorageBrowserInput {
   actions?: StorageBrowserActions;
   config: Config;
   components?: Components;
-  ErrorBoundary?: ErrorBoundaryType;
+  /**
+   * Custom ErrorBoundary class. If omitted, a default ErrorBoundary is provided.
+   * To disable ErrorBoundary, set to `null`.
+   */
+  ErrorBoundary?: ErrorBoundaryType | null;
 }
 
 export interface StorageBrowserProps<K = string, V = {}> {

--- a/packages/react-storage/src/components/StorageBrowser/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/types.ts
@@ -44,6 +44,7 @@ export interface CreateStorageBrowserInput {
   actions?: StorageBrowserActions;
   config: Config;
   components?: Components;
+  ErrorBoundary?: React.ComponentClass;
 }
 
 export interface StorageBrowserProps<K = string, V = {}> {

--- a/packages/react-storage/src/components/StorageBrowser/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/types.ts
@@ -8,6 +8,7 @@ import {
 } from './actions';
 import { GetLocationCredentials } from './credentials/types';
 import { Components } from './ComponentsProvider';
+import { ErrorBoundaryType } from './ErrorBoundary';
 import { RegisterAuthListener, StoreProviderProps } from './providers';
 
 import {
@@ -44,7 +45,7 @@ export interface CreateStorageBrowserInput {
   actions?: StorageBrowserActions;
   config: Config;
   components?: Components;
-  ErrorBoundary?: React.ComponentClass;
+  ErrorBoundary?: ErrorBoundaryType;
 }
 
 export interface StorageBrowserProps<K = string, V = {}> {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Allow overwriting the default ErrorBoundary to catch the potential unexpected errors.

```jsx
createStorageBrowser({
  ErrorBoundary: MyErrorBoundaryClass
})
```

Or disable the default error boundary
```jsx
createStorageBrowser({
  ErrorBoundary: null
})
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available


<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Unit test, Integ test,

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
