### PR TITLE
chore(storage-browser): add type definitions and exports

### DIFF
--- a/examples/next/pages/ui/components/storage/storage-browser/managed-auth/index.page.tsx
+++ b/examples/next/pages/ui/components/storage/storage-browser/managed-auth/index.page.tsx
@@ -20,7 +20,10 @@ import {
 
 import '@aws-amplify/ui-react-storage/styles.css';
 
-type GetLink = ActionHandler<{ duration: number; fileKey: string }, string>;
+type GetLink = ActionHandler<
+  { duration: number; fileKey: string },
+  { link: string }
+>;
 
 const getLink: GetLink = ({ data, config }) => {
   const result = getUrl({
@@ -33,7 +36,7 @@ const getLink: GetLink = ({ data, config }) => {
     },
   }).then((res) => ({
     status: 'COMPLETE' as const,
-    value: res.url.toString(),
+    value: { link: res.url.toString() },
   }));
 
   return { result };
@@ -57,8 +60,7 @@ const { StorageBrowser, useAction, useView } = createStorageBrowser({
 const LinkActionView = () => {
   const [duration, setDuration] = React.useState(60);
 
-  const locationDetailState = useView('LocationDetail');
-  const { onActionExit, fileDataItems } = locationDetailState;
+  const { onActionExit, fileDataItems } = useView('LocationDetail');
 
   const items = React.useMemo(
     () =>
@@ -79,9 +81,7 @@ const LinkActionView = () => {
         value={duration}
         min={15}
         max={300}
-        onStepChange={(value) => {
-          setDuration(value);
-        }}
+        onStepChange={setDuration}
       />
       <Button onClick={() => handleCreate()}>Start</Button>
       {!tasks
@@ -90,7 +90,7 @@ const LinkActionView = () => {
             return (
               <Flex direction="row" key={data.fileKey}>
                 <Text>{data.fileKey}</Text>
-                {value ? <Link href={value}>link</Link> : null}
+                {value.link ? <Link href={value.link}>link</Link> : null}
                 <Text>{status}</Text>
               </Flex>
             );

--- a/examples/next/pages/ui/components/storage/storage-browser/managed-auth/routed/StorageBrowser.ts
+++ b/examples/next/pages/ui/components/storage/storage-browser/managed-auth/routed/StorageBrowser.ts
@@ -2,6 +2,7 @@ import { Auth } from '../../managedAuthAdapter';
 import {
   createManagedAuthAdapter,
   createStorageBrowser,
+  defaultActionConfigs,
 } from '@aws-amplify/ui-react-storage/browser';
 
 export const routedAuth = new Auth({ persistCredentials: true });

--- a/packages/react-storage/src/__tests__/__snapshots__/exports.spec.ts.snap
+++ b/packages/react-storage/src/__tests__/__snapshots__/exports.spec.ts.snap
@@ -16,5 +16,7 @@ exports[`@aws-amplify/ui-react-storage/browser exports should match snapshot 1`]
   "createAmplifyAuthAdapter",
   "createManagedAuthAdapter",
   "createStorageBrowser",
+  "defaultActionConfigs",
+  "defaultActionHandlers",
 ]
 `;

--- a/packages/react-storage/src/__tests__/exports.spec.ts
+++ b/packages/react-storage/src/__tests__/exports.spec.ts
@@ -1,5 +1,5 @@
 import * as exported from '../';
-import * as browser from '../../browser';
+import * as browser from '../components/StorageBrowser';
 
 describe('@aws-amplify/ui-react-storage', () => {
   describe('exports', () => {

--- a/packages/react-storage/src/components/StorageBrowser/ComponentsProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/ComponentsProvider.tsx
@@ -5,7 +5,10 @@ import { ElementsProvider } from '@aws-amplify/ui-react-core/elements';
 import { ComposablesProvider, Composables } from './composables';
 import { StorageBrowserElements } from './context/elements';
 
-export interface Components extends Partial<Composables> {}
+/**
+ * Override/Custom component slots
+ */
+export interface StorageBrowserComponents extends Partial<Composables> {}
 
 export interface ComponentsProviderProps {
   children?: React.ReactNode;

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/defaults.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/defaults.tsx
@@ -1,11 +1,4 @@
-import {
-  listLocationItemsHandler,
-  createFolderHandler,
-  uploadHandler,
-  copyHandler,
-  deleteHandler,
-  downloadHandler,
-} from '../handlers';
+import { defaultActionHandlers } from '../handlers';
 
 import {
   CopyActionConfig,
@@ -22,7 +15,7 @@ export const copyActionConfig: CopyActionConfig = {
     icon: 'copy-file',
     label: 'Copy',
   },
-  handler: copyHandler,
+  handler: defaultActionHandlers.copy,
 };
 
 export const deleteActionConfig: DeleteActionConfig = {
@@ -33,7 +26,7 @@ export const deleteActionConfig: DeleteActionConfig = {
     icon: 'delete-file',
     label: 'Delete',
   },
-  handler: deleteHandler,
+  handler: defaultActionHandlers.delete,
 };
 
 export const createFolderActionConfig: CreateFolderActionConfig = {
@@ -43,7 +36,7 @@ export const createFolderActionConfig: CreateFolderActionConfig = {
     icon: 'create-folder',
     label: 'Create folder',
   },
-  handler: createFolderHandler,
+  handler: defaultActionHandlers.createFolder,
 };
 
 export const uploadActionConfig: UploadActionConfig = {
@@ -53,13 +46,15 @@ export const uploadActionConfig: UploadActionConfig = {
     icon: 'upload-file',
     label: 'Upload',
   },
-  handler: uploadHandler,
+  handler: defaultActionHandlers.upload,
 };
 
+// Action view configs only, does not include `listLocationItems`
 export const defaultActionViewConfigs = {
   copy: copyActionConfig,
   createFolder: createFolderActionConfig,
-  download: downloadHandler,
+  // provide `download` handler only; `download` does not have a dedicated view/config
+  download: defaultActionHandlers.download,
   delete: deleteActionConfig,
   upload: uploadActionConfig,
 };
@@ -77,5 +72,5 @@ export const isDefaultActionViewType = (
 
 export const defaultActionConfigs = {
   ...defaultActionViewConfigs,
-  listLocationItems: listLocationItemsHandler,
+  listLocationItems: defaultActionHandlers.listLocationItems,
 };

--- a/packages/react-storage/src/components/StorageBrowser/actions/configs/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/configs/types.ts
@@ -16,6 +16,41 @@ import {
   UploadHandler,
 } from '../handlers';
 
+/**
+ * Utility type representing the function signature of `StorageBrowser` action handlers. First
+ * positional generic adds additional properties to `data` parameter, second positional
+ * generic specifies optional return value provided to `options.onSuccess` callback and
+ * `Task.value`.
+ *
+ * @example
+ * ```ts
+ * interface MyData {
+ *   user: {
+ *     name: string
+ *     id: string
+ *   };
+ * }
+ *
+ * interface MyReturnValue {
+ *   link: string;
+ * }
+ *
+ * type CreateDownloadLink = ActionHandler<MyData, MyReturnValue>;
+ *
+ * const createDownloadLink: CreateDownloadLink = (input) => {
+ *   // `config` is provided to handler, includes location data, credentials
+ *   const { config, data } = input;
+ *   const { user } = data;
+ *
+ *   const result = generatePresignedUrl(user, credentials).then((res) => ({
+ *     status: 'COMPLETE' as const,
+ *     value: { link: res.url.toString() },
+ *   }));
+ *
+ *   return { result };
+ * }
+ * ```
+ */
 export type ActionHandler<TData = any, RValue = any> = TaskHandler<
   TaskHandlerInput<TData & TaskData>,
   TaskHandlerOutput<RValue>
@@ -112,6 +147,10 @@ export interface ExtendedDefaultActionConfigs
   listLocations: ListLocations;
 }
 
+/**
+ * Accepts either an `ActionViewConfig` for creation of an action list item and corresponding
+ * view slot or an action handler for standalone action usage
+ */
 export type CustomActionConfigs = Record<
   ActionName,
   ActionViewConfig | ActionHandler

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/defaults.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/defaults.ts
@@ -1,0 +1,15 @@
+import { copyHandler } from './copy';
+import { createFolderHandler } from './createFolder';
+import { deleteHandler } from './delete';
+import { downloadHandler } from './download';
+import { listLocationItemsHandler } from './listLocationItems';
+import { uploadHandler } from './upload';
+
+export const defaultActionHandlers = {
+  copy: copyHandler,
+  createFolder: createFolderHandler,
+  delete: deleteHandler,
+  download: downloadHandler,
+  listLocationItems: listLocationItemsHandler,
+  upload: uploadHandler,
+};

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/index.ts
@@ -1,5 +1,6 @@
 export * from './copy';
 export * from './createFolder';
+export * from './defaults';
 export * from './delete';
 export * from './download';
 export * from './listLocationItems';

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocations.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/listLocations.ts
@@ -1,7 +1,4 @@
-import {
-  listCallerAccessGrants,
-  LocationCredentialsProvider,
-} from '../../storage-internal';
+import { listCallerAccessGrants } from '../../storage-internal';
 import { assertAccountId } from '../../validators';
 
 import {
@@ -9,6 +6,7 @@ import {
   ListHandler,
   ListLocationsExcludeOptions,
   LocationData,
+  ActionInputConfig,
 } from './types';
 import { getFilteredLocations } from './utils';
 
@@ -37,18 +35,10 @@ export interface ListLocationsHandlerOptions
 
 export interface ListLocationsHandlerInput {
   options?: ListLocationsHandlerOptions;
-  config: {
-    accountId?: string;
-    credentials: LocationCredentialsProvider;
-    customEndpoint?: string;
-    region: string;
-  };
+  config: Omit<ActionInputConfig, 'bucket'>;
 }
 
-export interface ListLocationsHandlerOutput {
-  items: LocationData[];
-  nextToken: string | undefined;
-}
+export interface ListLocationsHandlerOutput extends ListLocationsOutput {}
 
 export interface ListLocationsHandler
   extends ListHandler<ListLocationsHandlerInput, ListLocationsHandlerOutput> {}

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/types.ts
@@ -88,7 +88,8 @@ export interface TaskHandlerOptions<V = any> {
   onSuccess?: (data: { key: string; id: string }, value: V) => void;
   onError?: (
     data: { key: string; id: string },
-    message: string | undefined
+    message: string | undefined,
+    error: Error
   ) => void;
 }
 

--- a/packages/react-storage/src/components/StorageBrowser/actions/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/index.ts
@@ -12,6 +12,7 @@ export {
   CreateFolderHandlerInput,
   CreateFolderHandlerOptions,
   CreateFolderHandlerOutput,
+  defaultActionHandlers,
   downloadHandler,
   DownloadHandler,
   DownloadHandlerData,

--- a/packages/react-storage/src/components/StorageBrowser/componentsDefault.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/componentsDefault.tsx
@@ -12,11 +12,11 @@ import {
   View,
   Heading,
 } from '@aws-amplify/ui-react';
-import { Components } from './ComponentsProvider';
+import { StorageBrowserComponents } from './ComponentsProvider';
 import { IconElement } from './context/elements';
 import { STORAGE_BROWSER_BLOCK } from './constants';
 
-const OverwriteToggle: Components['OverwriteToggle'] = ({
+const OverwriteToggle: StorageBrowserComponents['OverwriteToggle'] = ({
   isDisabled,
   isOverwritingEnabled,
   label = '',
@@ -36,25 +36,22 @@ const OverwriteToggle: Components['OverwriteToggle'] = ({
   );
 };
 
-const SearchSubfoldersToggle: Components['SearchSubfoldersToggle'] = ({
-  isSearchingSubfolders,
-  label = '',
-  onToggle,
-}) => {
-  return (
-    <CheckboxField
-      name={label}
-      label={label}
-      labelPosition="end"
-      checked={isSearchingSubfolders}
-      onChange={() => {
-        onToggle?.();
-      }}
-    />
-  );
-};
+const SearchSubfoldersToggle: StorageBrowserComponents['SearchSubfoldersToggle'] =
+  ({ isSearchingSubfolders, label = '', onToggle }) => {
+    return (
+      <CheckboxField
+        name={label}
+        label={label}
+        labelPosition="end"
+        checked={isSearchingSubfolders}
+        onChange={() => {
+          onToggle?.();
+        }}
+      />
+    );
+  };
 
-const Pagination: Components['Pagination'] = ({
+const Pagination: StorageBrowserComponents['Pagination'] = ({
   page = 1,
   onPaginate,
   hasNextPage,
@@ -79,7 +76,7 @@ const Pagination: Components['Pagination'] = ({
   );
 };
 
-const SearchField: Components['SearchField'] = ({
+const SearchField: StorageBrowserComponents['SearchField'] = ({
   onQueryChange,
   onSearch,
   onClear,
@@ -107,7 +104,7 @@ const SearchField: Components['SearchField'] = ({
   );
 };
 
-const Navigation: Components['Navigation'] = ({ items }) => {
+const Navigation: StorageBrowserComponents['Navigation'] = ({ items }) => {
   return (
     <Breadcrumbs.Container>
       {items.map((item, i) => {
@@ -128,7 +125,9 @@ const Navigation: Components['Navigation'] = ({ items }) => {
   );
 };
 
-const LoadingIndicator: Components['LoadingIndicator'] = ({ isLoading }) => {
+const LoadingIndicator: StorageBrowserComponents['LoadingIndicator'] = ({
+  isLoading,
+}) => {
   if (isLoading) {
     return (
       <Loader
@@ -140,7 +139,7 @@ const LoadingIndicator: Components['LoadingIndicator'] = ({ isLoading }) => {
   }
 };
 
-const FolderNameField: Components['FolderNameField'] = ({
+const FolderNameField: StorageBrowserComponents['FolderNameField'] = ({
   onChange,
   label,
   placeholder,
@@ -170,7 +169,9 @@ const FolderNameField: Components['FolderNameField'] = ({
   );
 };
 
-const DataRefresh: Components['DataRefresh'] = ({ onRefresh }) => {
+const DataRefresh: StorageBrowserComponents['DataRefresh'] = ({
+  onRefresh,
+}) => {
   return (
     <Button
       onClick={() => {
@@ -183,7 +184,7 @@ const DataRefresh: Components['DataRefresh'] = ({ onRefresh }) => {
   );
 };
 
-const ActionsList: Components['ActionsList'] = ({
+const ActionsList: StorageBrowserComponents['ActionsList'] = ({
   items,
   onActionSelect,
   isDisabled,
@@ -219,7 +220,10 @@ const ActionsList: Components['ActionsList'] = ({
   );
 };
 
-const StatusDisplay: Components['StatusDisplay'] = ({ statuses, total }) => {
+const StatusDisplay: StorageBrowserComponents['StatusDisplay'] = ({
+  statuses,
+  total,
+}) => {
   if (!statuses?.length) {
     return null;
   }
@@ -241,7 +245,7 @@ const StatusDisplay: Components['StatusDisplay'] = ({ statuses, total }) => {
   );
 };
 
-const ActionDestination: Components['ActionDestination'] = ({
+const ActionDestination: StorageBrowserComponents['ActionDestination'] = ({
   isNavigable,
   items,
   label,
@@ -282,7 +286,7 @@ const ActionDestination: Components['ActionDestination'] = ({
   );
 };
 
-const Title: Components['Title'] = ({ title }) => {
+const Title: StorageBrowserComponents['Title'] = ({ title }) => {
   return (
     <Heading className={`${STORAGE_BROWSER_BLOCK}__title`} level={2}>
       {title}
@@ -290,7 +294,7 @@ const Title: Components['Title'] = ({ title }) => {
   );
 };
 
-export const componentsDefault: Components = {
+export const componentsDefault: StorageBrowserComponents = {
   ActionDestination,
   ActionsList,
   DataRefresh,

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -46,10 +46,10 @@ import {
 } from './views';
 
 /**
- * Creates a `StoraageBrowser` component and utility hooks from provided configuration `input`.
+ * Creates a `StorageBrowser` component and utility hooks from provided configuration `input`.
  *
- * @param input - `StoraageBrowser` auth, actions and ui configuration values
- * @returns `StoraageBrowser` component, `useAction` and `useView` hooks
+ * @param input - `StorageBrowser` auth, actions and ui configuration values
+ * @returns `StorageBrowser` component, `useAction` and `useView` hooks
  */
 export function createStorageBrowser<
   Input extends CreateStorageBrowserInput,

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser.tsx
@@ -45,6 +45,12 @@ import {
   ViewsProvider,
 } from './views';
 
+/**
+ * Creates a `StoraageBrowser` component and utility hooks from provided configuration `input`.
+ *
+ * @param input - `StoraageBrowser` auth, actions and ui configuration values
+ * @returns `StoraageBrowser` component, `useAction` and `useView` hooks
+ */
 export function createStorageBrowser<
   Input extends CreateStorageBrowserInput,
   RInput extends Input['actions'] extends ExtendedActionConfigs

--- a/packages/react-storage/src/components/StorageBrowser/displayText/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/displayText/types.ts
@@ -171,6 +171,9 @@ export interface LocationDetailViewDisplayText
 export interface UploadViewDisplayText
   extends Partial<DefaultUploadViewDisplayText> {}
 
+/**
+ * `StorageBrowser` display text strings/resolver functions
+ */
 export interface StorageBrowserDisplayText {
   LocationsView?: LocationsViewDisplayText;
   LocationDetailView?: LocationDetailViewDisplayText;

--- a/packages/react-storage/src/components/StorageBrowser/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/index.ts
@@ -1,10 +1,29 @@
 export { componentsDefault } from './componentsDefault';
 export { createStorageBrowser } from './createStorageBrowser';
 export {
-  ActionViewConfig,
   ActionHandler,
-  FileDataItem,
+  ActionViewConfig,
+  CopyHandlerInput,
+  CopyHandlerOutput,
+  CreateFolderHandlerInput,
+  CreateFolderHandlerOutput,
+  defaultActionConfigs,
+  defaultActionHandlers,
+  DeleteHandlerInput,
+  DeleteHandlerOutput,
+  DownloadHandlerInput,
+  DownloadHandlerOutput,
   ExtendedActionConfigs,
+  ListLocations,
+  ListLocationsInput,
+  ListLocationsOutput,
+  LocationData,
+  ListLocationItemsHandlerInput,
+  ListLocationItemsHandlerOutput,
+  ListLocationsHandlerInput,
+  ListLocationsHandlerOutput,
+  UploadHandlerInput,
+  UploadHandlerOutput,
 } from './actions';
 export {
   createAmplifyAuthAdapter,
@@ -12,11 +31,19 @@ export {
   CreateManagedAuthAdapterInput,
   StorageBrowserAuthAdapter,
 } from './adapters';
-export { DefaultStorageBrowserDisplayText } from './displayText';
+export { StorageBrowserComponents } from './ComponentsProvider';
+export {
+  DefaultStorageBrowserDisplayText,
+  StorageBrowserDisplayText,
+} from './displayText';
 export {
   CreateStorageBrowserInput,
-  StorageBrowserType,
-  DerivedActionViewType,
+  CreateStorageBrowserOutput,
   DerivedActionViews,
+  DerivedActionViewType,
+  StorageBrowserConfig,
+  StorageBrowserProps,
+  StorageBrowserProviderProps,
+  StorageBrowserType,
 } from './types';
 export { UseView } from './views';

--- a/packages/react-storage/src/components/StorageBrowser/providers/configuration/createConfigurationProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/providers/configuration/createConfigurationProvider.tsx
@@ -13,9 +13,12 @@ const Passthrough = ({ children }: { children?: React.ReactNode }) => (
   <>{children}</>
 );
 
-export function createConfigurationProvider<T extends React.ComponentType<any>>(
+export function createConfigurationProvider<
+  T extends React.ComponentType<any>,
+  P extends React.ComponentProps<T>,
+>(
   input: CreateConfigurationProviderInput<T>
-): ConfigurationProviderComponent<T> {
+): ConfigurationProviderComponent<P> {
   const {
     accountId,
     ChildComponent,

--- a/packages/react-storage/src/components/StorageBrowser/providers/configuration/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/providers/configuration/types.ts
@@ -13,18 +13,15 @@ export interface GetActionInputProviderProps {
   customEndpoint?: string;
 }
 
-export interface CreateConfigurationProviderInput<
-  T extends React.ComponentType<any>,
-> extends GetActionInputProviderProps,
+export interface CreateConfigurationProviderInput<T>
+  extends GetActionInputProviderProps,
     CredentialsProviderProps {
   ChildComponent?: T;
   displayName: string;
   region: string;
 }
 
-export interface ConfigurationProviderComponent<
-  T extends React.ComponentType<any>,
-> {
-  (props: React.ComponentProps<T>): React.JSX.Element;
+export interface ConfigurationProviderComponent<P> {
+  (props: P): React.JSX.Element;
   displayName: string;
 }

--- a/packages/react-storage/src/components/StorageBrowser/providers/store/actionType/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/providers/store/actionType/types.ts
@@ -10,6 +10,10 @@ export type ActionTypeStateContext = [
 ];
 
 export interface ActionTypeProviderProps {
+  /**
+   *  Sets initial `actionType`. Provide to initialize the `StorageBrowser` with an initial
+   * `actionType`
+   */
   actionType?: string;
   children?: React.ReactNode;
 }

--- a/packages/react-storage/src/components/StorageBrowser/providers/store/location/context.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/providers/store/location/context.tsx
@@ -67,7 +67,14 @@ export type LocationStateContext = [
 
 export interface LocationProviderProps {
   children?: React.ReactNode;
+  /**
+   * Sets initial `location` data
+   */
   location?: LocationData;
+
+  /**
+   * Sets initial `location` subpath to establish initial navigation state
+   */
   path?: string;
 }
 

--- a/packages/react-storage/src/components/StorageBrowser/tasks/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/tasks/index.ts
@@ -1,3 +1,3 @@
 export { INITIAL_STATUS_COUNTS } from './constants';
 export { useProcessTasks } from './useProcessTasks';
-export { StatusCounts, Task, Tasks, TaskStatus } from './types';
+export { StatusCounts, Task, Tasks, TaskStatus, TasksState } from './types';

--- a/packages/react-storage/src/components/StorageBrowser/tasks/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/tasks/types.ts
@@ -39,12 +39,12 @@ export type HandleProcessTasks<T extends TaskData, U> = (
   input: U extends T[] ? Omit<TaskHandlerInput<T>, 'data'> : TaskHandlerInput<T>
 ) => void;
 
-export interface TasksState<T extends TaskData = TaskData> {
+export interface TasksState<T extends TaskData = TaskData, V = any> {
   isProcessing: boolean;
   isProcessingComplete: boolean;
   reset: () => void;
   statusCounts: StatusCounts;
-  tasks: Tasks<T>;
+  tasks: Tasks<T, V>;
 }
 export type UseProcessTasksState<T extends TaskData, D> = [
   TasksState<T>,

--- a/packages/react-storage/src/components/StorageBrowser/tasks/useProcessTasks.ts
+++ b/packages/react-storage/src/components/StorageBrowser/tasks/useProcessTasks.ts
@@ -28,16 +28,16 @@ const isTaskHandlerInput = <T extends TaskData>(
 ): input is TaskHandlerInput<T> => !!(input as TaskHandlerInput<T>).data;
 
 export const useProcessTasks = <
-  TData extends TaskData = TaskData,
-  RValue = any,
+  TData extends TaskData,
+  TResult,
   // infered value of `items` for conditional typing of `concurrency`
   D extends TData[] | undefined = undefined,
 >(
-  handler: ActionHandler<TData, RValue>,
+  handler: ActionHandler<TData, TResult>,
   items?: D,
   options?: ProcessTasksOptions<
     TData,
-    RValue,
+    TResult,
     D extends TData[] ? number : never
   >
 ): UseProcessTasksState<TData, D> => {
@@ -153,7 +153,7 @@ export const useProcessTasks = <
     const getTask = () => tasksRef.current.get(data.id);
 
     const { options } = _input;
-    const { onProgress: _onProgress, onSuccess, onError } = options ?? {};
+    const { onProgress: _onProgress } = options ?? {};
 
     const onProgress = ({ id }: TData, progress?: number) => {
       const task = getTask();
@@ -191,15 +191,11 @@ export const useProcessTasks = <
           onTaskSuccess(task, output?.value);
         }
 
-        if (task && isFunction(onSuccess)) onSuccess(data, output?.value);
-
         updateTask(data.id, output);
       })
       .catch((e: Error) => {
         const task = getTask();
         if (task && isFunction(onTaskError)) onTaskError(task, e);
-
-        if (task && isFunction(onError)) onError(data, e?.message);
 
         updateTask(data.id, { message: e.message, status: 'FAILED' });
       })

--- a/packages/react-storage/src/components/StorageBrowser/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/types.ts
@@ -5,9 +5,12 @@ import {
   DefaultActionConfigs,
   ExtendedActionConfigs,
   ListLocations,
+  LocationData,
 } from './actions';
 import { GetLocationCredentials } from './credentials/types';
-import { Components } from './ComponentsProvider';
+
+import { StorageBrowserComponents } from './ComponentsProvider';
+
 import { RegisterAuthListener, StoreProviderProps } from './providers';
 
 import {
@@ -18,20 +21,95 @@ import {
   LocationActionViewType,
   LocationDetailViewType,
   LocationsViewType,
-  Views,
   UseView,
+  StorageBrowserViews,
 } from './views';
 
 import { StorageBrowserDisplayText } from './displayText';
 
 import { DerivedActionHandlers, UseAction } from './useAction';
 
-export interface Config {
+/**
+ * Configuration properties
+ */
+export interface StorageBrowserConfig {
+  /**
+   * AWS account Id
+   */
   accountId?: string;
+
+  /**
+   * Custom S3 endpoint used in action handler calls
+   */
   customEndpoint?: string;
+
+  /**
+   * Location credentials retrieval handler
+   */
   getLocationCredentials: GetLocationCredentials;
+
+  /**
+   * @required
+   *
+   * Locations list handler
+   */
   listLocations: ListLocations;
+
+  /**
+   * @required
+   *
+   * Provided handler receives an `onStateChange` callback to be called from
+   * the consumer on auth status changes to clear in-memory credentials
+   *
+   * @example
+   * ```tsx
+   * // src/auth.ts
+   * class MyAuth {
+   *   // ...other private fields
+   *   private onStateChange: () => void | undefined;
+   *
+   *   registerAuthListener = (onStateChange: () => void) => {
+   *     // set `onStateChange` callback
+   *     this.onStateChange = onStateChange;
+   *   };
+   *
+   *   signOut() {
+   *     // ...do sign out stuff
+   *
+   *     // run `onStateChange` callback
+   *     this.onStateChange?.();
+   *   }
+   * }
+   *
+   * export const myAuth = new MyAuth();
+   *
+   * // src/storage-browser.ts
+   * import {
+   *   createStorageBrowser,
+   *   createManagedAuthAdapter
+   * } from '@aws-amplify/ui-react-storage/browser';
+   *
+   * import { myAuth } from './auth.ts';
+   *
+   * const managedAuthAdapter = createManagedAuthAdapter({
+   *   accountId: myAuth.accountId,
+   *   credentialsProvider: myAuth.credentialsProvider,
+   *   region: myAuth.region,
+   *   registerAuthListener: myAuth.registerAuthListener,
+   * });
+   *
+   * export const { StorageBrowser } = createStorageBrowser({
+   *   config: managedAuthAdapter,
+   * });
+   * ```
+   */
   registerAuthListener: RegisterAuthListener;
+
+  /**
+   * @required
+   *
+   * AWS account region
+   */
   region: string;
 }
 
@@ -40,41 +118,136 @@ export interface StorageBrowserActions {
   custom?: CustomActionConfigs;
 }
 
+/**
+ * Configuration and options for `createStorageBrowser`
+ */
 export interface CreateStorageBrowserInput {
+  /**
+   * Override and default `StorageBrowser` actions and action view configs
+   */
   actions?: StorageBrowserActions;
-  config: Config;
-  components?: Components;
+
+  /**
+   * `StorageBrowser` configuration properties
+   */
+  config: StorageBrowserConfig;
+
+  /**
+   * Overrides default `components` used within `StorageBrowser`
+   */
+  components?: StorageBrowserComponents;
 }
 
+/**
+ * `StorageBrowser` component properties
+ */
 export interface StorageBrowserProps<K = string, V = {}> {
+  /**
+   * Overrides default display string values. Supports resolving of static and dynamic text
+   * values and error messages
+   *
+   * @example
+   * ```tsx
+   * const myDisplayText = {
+   *   CreateFolderView: {
+   *     // static text
+   *     // default: "Create folder"
+   *     title: 'Add subfolder",
+   *
+   *     // dynamic text
+   *     // default: () => 'Folder name cannot contain "/", nor start or end with "."'
+   *     getValidationMessage?: (folderName) =>
+   *       `Folder name "${folderName}" cannot contain "/", nor start or end with "."`
+   *   }
+   * }
+   *
+   * <StorageBrowser displayText={{ displayText: myDisplayText }} />
+   * ```
+   */
   displayText?: StorageBrowserDisplayText;
-  views?: Views<K, V>;
+
+  /**
+   * Accepts default top level `views` overrides and custom `views` defined by the `actions`
+   * parameter of `createStorageBrowser`
+   */
+  views?: StorageBrowserViews<K, V>;
 }
 
+/**
+ * `StorageBrowser.Provider` component properties
+ */
 export interface StorageBrowserProviderProps<V = {}>
-  extends StoreProviderProps {
-  displayText?: StorageBrowserDisplayText;
-  // `views` intentionally scoped to custom slots to prevent conflicts with composability
+  extends StoreProviderProps,
+    Pick<StorageBrowserProps, 'displayText'> {
+  // note: `views` intentionally scoped to custom slots to prevent conflicts with composability
+  /**
+   * Accepts custom action views rendered by `LocationActionView`
+   */
   views?: V;
+
+  /**
+   * Sets initial `location` data. Provide to initialize the `StorageBrowser` with an initial
+   * `location`
+   */
+  location?: LocationData;
 }
 
+/**
+ * `StorageBrowser` component, provider and view components
+ */
 export interface StorageBrowserType<K = string, V = {}> {
   (props: StorageBrowserProps<K, V>): React.JSX.Element;
   displayName: string;
+  /**
+   * `StorageBrowser` React.Context provider. Composed `StorageBrowser` components
+   * must be a descendant of a `Provider` element
+   *
+   * @example
+   * ```tsx
+   * <StorageBrowser.Provider>
+   *   <Modal content={<StorageBrowser.UploadView />}>
+   * </StorageBrowser.Provider>
+   * ```
+   */
   Provider: (props: StorageBrowserProviderProps<V>) => React.JSX.Element;
+
+  /**
+   * Utility view aggregating all action views. Can be used to render a standalone
+   * action view
+   *
+   * @example
+   * ```tsx
+   * <StorageBrowser.LocationActionView type="copy" />
+   * ```
+   */
+  LocationActionView: LocationActionViewType<K>;
+
+  /**
+   * Displays data related to the selected or provided `location` and action
+   * selection
+   */
+  LocationDetailView: LocationDetailViewType;
+
+  /**
+   * Entry point view displaying `locations` returned from `listLocations`
+   */
+  LocationsView: LocationsViewType;
+
+  /**
+   * Standalone composable default action view components
+   */
   CopyView: CopyViewType;
   CreateFolderView: CreateFolderViewType;
   DeleteView: DeleteViewType;
   UploadView: UploadViewType;
-  LocationActionView: LocationActionViewType<K>;
-  LocationDetailView: LocationDetailViewType;
-  LocationsView: LocationsViewType;
 }
 
 type DefaultActionType<T = string> = Exclude<T, keyof DefaultActionConfigs>;
 
 /**
- * @internal @unstable
+ * @internal @unstable interface subject to change, not recommended for public use
+ *
+ * Utility type resolving available custom action view component slots
  */
 export type DerivedActionViews<T extends StorageBrowserActions> = {
   [K in keyof T['custom'] as K extends DefaultActionType<K>
@@ -85,7 +258,16 @@ export type DerivedActionViews<T extends StorageBrowserActions> = {
 };
 
 /**
- * @internal @unstable
+ * @internal @unstable interface subject to change, not recommended for public use
+ *
+ * Utility type of excluded action keys that do not have a corresponding action view
+ */
+type DefaultActionWithoutViewType = 'download';
+
+/**
+ * @internal @unstable interface subject to change, not recommended for public use
+ *
+ * Utility type resolving available location action view types
  */
 export type DerivedActionViewType<T extends StorageBrowserActions> =
   | keyof {
@@ -95,15 +277,29 @@ export type DerivedActionViewType<T extends StorageBrowserActions> =
           : never
         : never]?: any;
     }
-  | Exclude<keyof DefaultActionConfigs, 'download'>;
+  | Exclude<keyof DefaultActionConfigs, DefaultActionWithoutViewType>;
 
+/**
+ * Return values of `createStorageBrowser`
+ */
 export interface CreateStorageBrowserOutput<
   C extends ExtendedActionConfigs = ExtendedActionConfigs,
 > {
+  /**
+   * `StorageBrowser` component and subcomponents
+   */
   StorageBrowser: StorageBrowserType<
     DerivedActionViewType<C>,
     DerivedActionViews<C>
   >;
+
+  /**
+   * Action handler utility hook
+   */
   useAction: UseAction<DerivedActionHandlers<C>>;
+
+  /**
+   * View state utility hook
+   */
   useView: UseView;
 }

--- a/packages/react-storage/src/components/StorageBrowser/useAction/useAction.ts
+++ b/packages/react-storage/src/components/StorageBrowser/useAction/useAction.ts
@@ -1,30 +1,42 @@
 import { ActionHandler } from '../actions';
 import { useActionHandlers } from './context';
-import { DefaultActionHandlers, UseAction } from './types';
 import { useHandler } from './useHandler';
+import { DefaultActionHandlers, UseAction } from './types';
 
 type ListHandlerKeys = 'listLocations' | 'listLocationItems';
 
 export const ERROR_MESSAGE =
   '`useAction` must be called from within `StorageBrowser.Provider`';
 
-export const useAction: UseAction<DefaultActionHandlers> = (key, options) => {
-  if (
-    (key as ListHandlerKeys) === 'listLocations' ||
-    (key as ListHandlerKeys) === 'listLocationItems'
-  ) {
+function assertActionHandlerKey(
+  key: string
+): asserts key is Exclude<keyof DefaultActionHandlers, ListHandlerKeys> {
+  if (key === 'listLocations' || key === 'listLocationItems') {
     throw new Error(`Value of \`${key}\` cannot be provided to \`useAction\``);
   }
+}
+
+function assertActionHandler<I, R>(
+  handler: unknown,
+  key: string
+): asserts handler is ActionHandler<I, R> {
+  if (typeof handler !== 'function') {
+    throw new Error(
+      `No handler found for value of \`${key}\` provided to \`useAction\``
+    );
+  }
+}
+
+export const useAction: UseAction<DefaultActionHandlers> = ((key, options) => {
+  assertActionHandlerKey(key);
 
   const { handlers } = useActionHandlers({ errorMessage: ERROR_MESSAGE });
 
   const handler = handlers?.[key];
 
-  if (!handler) {
-    throw new Error(
-      `No handler found for value of \`${key}\` provided to \`useAction\``
-    );
-  }
+  assertActionHandler(handler, key);
 
-  return useHandler(handler as ActionHandler, options);
-};
+  return useHandler(handler, options);
+  // casting to allow usage of `UseAction` interface which ensures that
+  // the `options` param receives the correct typing
+}) as UseAction<DefaultActionHandlers>;

--- a/packages/react-storage/src/components/StorageBrowser/useAction/useList.ts
+++ b/packages/react-storage/src/components/StorageBrowser/useAction/useList.ts
@@ -1,31 +1,42 @@
-import { useListLocations } from './useListLocations';
-import { useListLocationItems } from './useListLocationItems';
-import { useListFolderItems } from './useListFolderItems';
+import { useListLocations, UseListLocationsState } from './useListLocations';
+import {
+  useListLocationItems,
+  UseListLocationItemsState,
+} from './useListLocationItems';
+import {
+  useListFolderItems,
+  UseListFolderItemsState,
+} from './useListFolderItems';
 
-const LIST_ACTION_HOOKS = {
+interface DefaultUseListStates {
+  folderItems: UseListFolderItemsState;
+  locationItems: UseListLocationItemsState;
+  locations: UseListLocationsState;
+}
+
+type UseListHooks = {
+  [K in keyof DefaultUseListStates]: () => DefaultUseListStates[K];
+};
+
+const LIST_ACTION_HOOKS: UseListHooks = {
   folderItems: useListFolderItems,
   locationItems: useListLocationItems,
   locations: useListLocations,
 };
 
-type ListActionHooks = typeof LIST_ACTION_HOOKS;
+type UseListType = keyof DefaultUseListStates;
 
-type ListActionType = keyof ListActionHooks;
-
-export type UseList = <
-  K extends keyof ListActionHooks,
-  S extends ListActionHooks[K],
->(
+export type UseList = <K extends UseListType>(
   type: K
-) => ReturnType<S>;
+) => DefaultUseListStates[K];
 
-const isListActionViewType = (value: unknown): value is ListActionType =>
-  Object.keys(LIST_ACTION_HOOKS).includes(value as ListActionType);
+const isListActionViewType = (value: unknown): value is UseListType =>
+  Object.keys(LIST_ACTION_HOOKS).includes(value as UseListType);
 
-// @ts-expect-error
 export const useList: UseList = (type) => {
   if (!isListActionViewType(type)) {
     throw new Error(`Value of \`${type}\` cannot be used to index \`useList\``);
   }
+
   return LIST_ACTION_HOOKS[type]();
 };

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/types.ts
@@ -53,3 +53,9 @@ export interface FoldersState {
   onSearchClear: () => void;
   onSelectFolder: (id: string, folderLocationPath: string) => void;
 }
+
+export interface CopyViewState extends ActionViewState<CopyHandlerData> {
+  folders: FoldersState;
+  destination: LocationState;
+  onSelectDestination: (location: LocationData, path?: string) => void;
+}

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/useFolders.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/useFolders.ts
@@ -5,7 +5,6 @@ import { useList } from '../../../useAction';
 
 import { usePaginate } from '../../hooks/usePaginate';
 import { useSearch } from '../../hooks/useSearch';
-
 import { FoldersState } from './types';
 
 const DEFAULT_PAGE_SIZE = 100;
@@ -41,10 +40,10 @@ export const useFolders = ({
     });
   }, [handleList, key]);
 
-  const hasNextToken = !!nextToken;
+  const hasNextPage = !!nextToken;
 
-  const paginateCallback = () => {
-    if (!nextToken) return;
+  const onPaginate = () => {
+    if (!hasNextPage) return;
 
     handleList({
       prefix: key,
@@ -54,15 +53,14 @@ export const useFolders = ({
 
   const {
     currentPage: page,
-    onPaginate,
+    handlePaginate,
     highestPageVisited,
     pageItems,
     handleReset,
   } = usePaginate({
     items,
-    paginateCallback,
+    onPaginate,
     pageSize: DEFAULT_PAGE_SIZE,
-    hasNextToken,
   });
 
   const onSearch = (query: string) => {
@@ -98,7 +96,7 @@ export const useFolders = ({
 
   return {
     hasError,
-    hasNextPage: hasNextToken,
+    hasNextPage,
     highestPageVisited,
     isLoading,
     message,
@@ -107,7 +105,7 @@ export const useFolders = ({
     pageItems,
     query,
     hasExhaustedSearch,
-    onPaginate,
+    onPaginate: handlePaginate,
     onQuery,
     onSearch: onSearchSubmit,
     onSearchClear: () => {

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/index.ts
@@ -1,3 +1,7 @@
 export { LocationDetailView } from './LocationDetailView';
-export { LocationDetailViewProps, LocationDetailViewType } from './types';
+export {
+  LocationDetailViewProps,
+  LocationDetailViewState,
+  LocationDetailViewType,
+} from './types';
 export { useLocationDetailView } from './useLocationDetailView';

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/useLocationDetailView.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationDetailView/useLocationDetailView.ts
@@ -62,8 +62,8 @@ export const useLocationDetailView = (
   // set up pagination
   const { items, nextToken, search } = data;
   const { hasExhaustedSearch = false } = search ?? {};
-  const hasNextToken = !!nextToken;
-  const paginateCallback = () => {
+
+  const onPaginate = () => {
     if (hasInvalidPrefix || !nextToken) return;
     dispatchStoreAction({ type: 'RESET_LOCATION_ITEMS' });
     handleList({
@@ -74,15 +74,14 @@ export const useLocationDetailView = (
 
   const {
     currentPage,
-    onPaginate,
+    handlePaginate,
     handleReset,
     highestPageVisited,
     pageItems,
   } = usePaginate({
     items,
-    paginateCallback,
+    onPaginate,
     pageSize: listOptions.pageSize,
-    hasNextToken,
   });
 
   const onSearch = (query: string, includeSubfolders?: boolean) => {
@@ -167,13 +166,13 @@ export const useLocationDetailView = (
     fileDataItems,
     hasError,
     hasDownloadError: task?.status === 'FAILED',
-    hasNextPage: hasNextToken,
+    hasNextPage: !!nextToken,
     highestPageVisited,
     message,
     downloadErrorMessage: getDownloadErrorMessageFromFailedDownloadTask(task),
     isLoading,
     isSearchSubfoldersEnabled,
-    onPaginate,
+    onPaginate: handlePaginate,
     searchQuery,
     hasExhaustedSearch,
     onRefresh,
@@ -236,10 +235,7 @@ export const useLocationDetailView = (
     onSearchClear: () => {
       resetSearch();
       if (hasInvalidPrefix) return;
-      handleList({
-        prefix: key,
-        options: { ...listOptions, refresh: true },
-      });
+      handleList({ prefix: key, options: { ...listOptions, refresh: true } });
       handleReset();
     },
     onSearchQueryChange,

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationsView/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationsView/index.ts
@@ -1,3 +1,7 @@
 export { LocationsView } from './LocationsView';
-export { LocationsViewProps, LocationsViewType } from './types';
+export {
+  LocationsViewProps,
+  LocationsViewState,
+  LocationsViewType,
+} from './types';
 export { useLocationsView } from './useLocationsView';

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationsView/useLocationsView.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationsView/useLocationsView.ts
@@ -45,22 +45,21 @@ export const useLocationsView = (
   }, [handleList, listOptions]);
 
   // set up pagination
-  const paginateCallback = () => {
+  const onPaginate = () => {
     if (!nextToken) return;
     handleList({ options: { ...listOptions, nextToken } });
   };
 
   const {
     currentPage,
-    onPaginate,
+    handlePaginate,
     handleReset,
     highestPageVisited,
     pageItems,
   } = usePaginate({
     items,
-    paginateCallback,
+    onPaginate,
     pageSize: listOptions.pageSize,
-    hasNextToken,
   });
 
   const onSearch = (query: string) => {
@@ -111,7 +110,7 @@ export const useLocationsView = (
       handleReset();
       handleList({ options: { ...listOptions, refresh: true } });
     },
-    onPaginate,
+    onPaginate: handlePaginate,
     onSearch: onSearchSubmit,
     onSearchQueryChange,
     onSearchClear: () => {

--- a/packages/react-storage/src/components/StorageBrowser/views/__tests__/useView.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/__tests__/useView.spec.ts
@@ -1,12 +1,12 @@
 import { renderHook } from '@testing-library/react';
-import { useView, DEFAULT_VIEW_HOOKS, UseViewType } from '../useView';
+import { USE_VIEW_HOOKS, useView, UseViewType } from '../useView';
 
 jest.mock('../LocationActionView');
 jest.mock('../LocationsView');
 jest.mock('../LocationDetailView');
 
 describe('useView', () => {
-  it.each(Object.entries(DEFAULT_VIEW_HOOKS))(
+  it.each(Object.entries(USE_VIEW_HOOKS))(
     'calls the expected hook when provided a %s type key',
     (type, hook) => {
       renderHook(() => useView(type as UseViewType));

--- a/packages/react-storage/src/components/StorageBrowser/views/context/getViews.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/context/getViews.ts
@@ -4,18 +4,20 @@ import { capitalize, isFunction, isObject } from '@aws-amplify/ui';
 import { CustomActionConfigs } from '../../actions';
 import { DEFAULT_ACTION_VIEWS } from './actionViews';
 import { DEFAULT_PRIMARY_VIEWS } from './primaryViews';
-import { DefaultActionViewsByActionName, Views } from '../types';
+import { DefaultActionViewsByActionName, StorageBrowserViews } from '../types';
 import { ViewsContextType } from './types';
 
 export const getViews = (
-  views?: Views,
+  views?: StorageBrowserViews,
   customConfigs?: CustomActionConfigs
 ): ViewsContextType => {
   const resolvedDefaultActionViews = Object.entries(
     DEFAULT_ACTION_VIEWS
   ).reduce((output, [actionName, component]) => {
     // use viewName to lookup overrides for default action views
-    const viewName = capitalize(`${actionName}View` as keyof Views);
+    const viewName = capitalize(
+      `${actionName}View` as keyof StorageBrowserViews
+    );
     return {
       ...output,
       [actionName]: (views?.[viewName] ?? component) as React.ComponentType,
@@ -28,7 +30,10 @@ export const getViews = (
         // ignore custom actions that are only handlers
         return !isObject(config) || isFunction(config)
           ? acc
-          : { ...acc, [key]: views?.[config.viewName as keyof Views] };
+          : {
+              ...acc,
+              [key]: views?.[config.viewName as keyof StorageBrowserViews],
+            };
       }, {});
 
   return {

--- a/packages/react-storage/src/components/StorageBrowser/views/context/views.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/context/views.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ExtendedActionConfigs } from '../../actions';
-import { Views } from '../types';
+import { StorageBrowserViews } from '../types';
 import { ViewsContextType } from './types';
 import { getViews } from './getViews';
 import { ActionViewsContext } from './actionViews';
@@ -13,7 +13,7 @@ export function ViewsProvider({
 }: {
   children?: React.ReactNode;
   actions?: ExtendedActionConfigs;
-  views?: Views;
+  views?: StorageBrowserViews;
 }): React.JSX.Element {
   const { custom } = actions ?? {};
 

--- a/packages/react-storage/src/components/StorageBrowser/views/hooks/__tests__/usePaginate.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/hooks/__tests__/usePaginate.spec.ts
@@ -1,64 +1,65 @@
-import { usePaginate } from '../usePaginate';
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 
-jest.mock('../../../controls/context');
+import { LocationItemData } from '../../../actions';
+import { usePaginate } from '../usePaginate';
 
 describe('usePaginate', () => {
-  const data: Parameters<typeof usePaginate>[0] = {
-    paginateCallback: jest.fn(),
-    pageSize: 1,
-    hasNextToken: false,
-    items: [
-      {
-        key: 'key1',
-        id: 'id1',
-        type: 'FOLDER',
-      },
-      {
-        key: 'key2',
-        id: 'id2',
-        type: 'FOLDER',
-      },
-    ],
-  };
+  const onPaginate = jest.fn();
+  const items: LocationItemData[] = [
+    {
+      key: 'key1',
+      id: 'id1',
+      type: 'FOLDER',
+    },
+    {
+      key: 'key2',
+      id: 'id2',
+      type: 'FOLDER',
+    },
+  ];
+
+  const data = { onPaginate, pageSize: 1, items };
+
+  afterEach(jest.clearAllMocks);
 
   it('returns the expected values on initial call', () => {
-    const { result } = renderHook(() => usePaginate({ ...data }));
+    const { result } = renderHook(() => usePaginate(data));
 
     const { current } = result ?? {};
 
     expect(current?.currentPage).toBe(1);
-    expect(typeof current?.onPaginate).toBe('function');
+    expect(current?.highestPageVisited).toBe(1);
+
+    expect(typeof current?.handlePaginate).toBe('function');
     expect(typeof current?.handleReset).toBe('function');
-    expect(typeof current?.highestPageVisited).toBe('number');
   });
 
   it('returns the expected value of `highestPageVisited` on paginate when not on the last page', () => {
-    const { result } = renderHook(() => usePaginate({ ...data }));
+    const { result } = renderHook(() => usePaginate(data));
 
     const expectedHighestPage = Math.ceil(data.items.length / data.pageSize);
 
     act(() => {
-      result?.current?.onPaginate(expectedHighestPage);
+      result?.current?.handlePaginate(expectedHighestPage);
     });
 
     expect(result?.current?.highestPageVisited).toBe(2);
   });
 
   it('returns the expected value of `currentPage` on paginate', () => {
-    const { result } = renderHook(() => usePaginate({ ...data }));
+    const { result } = renderHook(() => usePaginate(data));
 
     expect(result?.current?.currentPage).toBe(1);
 
     act(() => {
-      result?.current?.onPaginate(2);
+      result?.current?.handlePaginate(2);
     });
 
     expect(result?.current?.currentPage).toBe(2);
   });
 
   it('returns the expected value of pageItems', () => {
-    const { result } = renderHook(() => usePaginate({ ...data }));
+    const { result } = renderHook(() => usePaginate(data));
 
     const expectedPageItems = data.items.slice(0, data.pageSize);
 
@@ -66,12 +67,15 @@ describe('usePaginate', () => {
   });
 
   it('calls `onPaginate` as expected', () => {
-    const { result } = renderHook(() => usePaginate({ ...data }));
+    const { result } = renderHook(() => usePaginate(data));
+
+    const page = 2;
 
     act(() => {
-      result?.current?.onPaginate(2);
+      result?.current?.handlePaginate(page);
     });
 
-    expect(data.paginateCallback).toHaveBeenCalled();
+    expect(data.onPaginate).toHaveBeenCalledTimes(1);
+    expect(data.onPaginate).toHaveBeenCalledWith(page);
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/views/hooks/usePaginate.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/hooks/usePaginate.ts
@@ -2,61 +2,62 @@ import React from 'react';
 
 import { isFunction } from '@aws-amplify/ui';
 
-interface UsePaginate<T> {
+const DEFAULT_PAGE_SIZE = 100;
+
+interface UsePaginateState<T> {
   currentPage: number;
   highestPageVisited: number;
-  onPaginate: (page: number) => void;
+  handlePaginate: (page: number) => void;
   handleReset: () => void;
   pageItems: T[];
 }
 
-interface UsePaginateProps<T> {
-  hasNextToken: boolean;
-  items: T[];
-  paginateCallback?: () => void;
-  pageSize: number;
+interface UsePaginateInput<T> {
+  items?: T[];
+  onPaginate?: (page?: number) => void;
+  page?: number;
+  pageSize?: number;
 }
 
 export const usePaginate = <T>({
-  hasNextToken,
   items,
-  paginateCallback,
-  pageSize,
-}: UsePaginateProps<T>): UsePaginate<T> => {
-  const [currentPage, setCurrentPage] = React.useState(1);
+  onPaginate,
+  page = 1,
+  pageSize = DEFAULT_PAGE_SIZE,
+}: UsePaginateInput<T>): UsePaginateState<T> => {
+  const [currentPage, setCurrentPage] = React.useState(page);
+  const visitedRef = React.useRef(page);
 
   const handleReset = React.useRef(() => {
-    setCurrentPage(1);
+    setCurrentPage(page);
+    // set `visitedRef` to initially provided `page`
+    visitedRef.current = page;
   }).current;
 
-  return React.useMemo((): UsePaginate<T> => {
-    const resultCount = Array.isArray(items) ? items.length : 0;
-    const highestPageVisited = Math.ceil(resultCount / pageSize);
+  return React.useMemo((): UsePaginateState<T> => {
+    const hasItems = Array.isArray(items);
+
+    const highestPageVisited = visitedRef.current;
+
     const isFirstPage = currentPage === 1;
     const start = isFirstPage ? 0 : (currentPage - 1) * pageSize;
     const end = isFirstPage ? pageSize : currentPage * pageSize;
-    const pageItems = Array.isArray(items) ? items.slice(start, end) : [];
+    const pageItems = hasItems ? items.slice(start, end) : [];
 
     return {
       currentPage,
-      onPaginate: (page) => {
-        const shouldPaginate =
-          page >= 1 && (page <= highestPageVisited || hasNextToken);
-        if (shouldPaginate) {
-          if (isFunction(paginateCallback)) paginateCallback();
-          setCurrentPage(page);
-        }
+      handlePaginate: (page) => {
+        if (page < 1) return;
+
+        if (isFunction(onPaginate)) onPaginate(page);
+
+        if (page > currentPage) visitedRef.current = page;
+
+        setCurrentPage(page);
       },
       handleReset,
       highestPageVisited,
       pageItems,
     };
-  }, [
-    currentPage,
-    handleReset,
-    hasNextToken,
-    items,
-    paginateCallback,
-    pageSize,
-  ]);
+  }, [currentPage, handleReset, items, onPaginate, pageSize]);
 };

--- a/packages/react-storage/src/components/StorageBrowser/views/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/types.ts
@@ -26,6 +26,10 @@ export interface ListViewProps
   extends ActionViewProps,
     Partial<ListViewState> {}
 
+export type StorageBrowserViews<T = string, K = {}> = Partial<
+  PrimaryViews<T> & DefaultActionViews & K
+>;
+
 export interface PrimaryViews<T = string> {
   LocationActionView: (
     props: LocationActionViewProps<T>
@@ -49,7 +53,3 @@ export interface DefaultActionViewsByActionName {
   delete: (props: DeleteViewProps) => React.JSX.Element | null;
   upload: (props: UploadViewProps) => React.JSX.Element | null;
 }
-
-export type Views<T = string, K = {}> = Partial<
-  PrimaryViews<T> & DefaultActionViews & K
->;

--- a/packages/react-storage/src/components/StorageBrowser/views/useView.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/useView.ts
@@ -1,13 +1,33 @@
 import {
   useCopyView,
+  UploadViewState,
+  CreateFolderViewState,
+  DeleteViewState,
+  CopyViewState,
   useCreateFolderView,
   useUploadView,
   useDeleteView,
 } from './LocationActionView';
-import { useLocationsView } from './LocationsView';
-import { useLocationDetailView } from './LocationDetailView';
+import {
+  useLocationDetailView,
+  LocationDetailViewState,
+} from './LocationDetailView';
+import { useLocationsView, LocationsViewState } from './LocationsView';
 
-export const DEFAULT_VIEW_HOOKS = {
+interface DefaultUseViewStates {
+  Copy: CopyViewState;
+  CreateFolder: CreateFolderViewState;
+  Delete: DeleteViewState;
+  LocationDetail: LocationDetailViewState;
+  Locations: LocationsViewState;
+  Upload: UploadViewState;
+}
+
+type UseViewHooks = {
+  [K in keyof DefaultUseViewStates]: () => DefaultUseViewStates[K];
+};
+
+export const USE_VIEW_HOOKS: UseViewHooks = {
   Copy: useCopyView,
   CreateFolder: useCreateFolderView,
   Delete: useDeleteView,
@@ -16,33 +36,19 @@ export const DEFAULT_VIEW_HOOKS = {
   Upload: useUploadView,
 };
 
-type DefaultViewHooks = typeof DEFAULT_VIEW_HOOKS;
-export type UseViewType = keyof DefaultViewHooks;
+export type UseViewType = keyof DefaultUseViewStates;
 
-export type ViewKey<T> = T extends Record<
-  string,
-  { componentName?: `${infer U}View` }
->
-  ? U
-  : T extends Record<infer K, any>
-  ? K
-  : never;
-
-const isUseViewType = (value: unknown): value is UseViewType =>
-  !!DEFAULT_VIEW_HOOKS?.[value as UseViewType];
-
-export type UseView = <
-  K extends UseViewType,
-  S extends ReturnType<DefaultViewHooks[K]>,
->(
+export type UseView = <K extends UseViewType>(
   type: K
-) => S;
+) => DefaultUseViewStates[K];
 
-// @ts-expect-error
+const isUseViewType = <T extends UseViewType>(value: T | unknown): value is T =>
+  !!USE_VIEW_HOOKS?.[value as T];
+
 export const useView: UseView = (type) => {
   if (!isUseViewType(type)) {
     throw new Error(`Value of \`${type}\` cannot be used to index \`useView\``);
   }
 
-  return DEFAULT_VIEW_HOOKS[type]();
+  return USE_VIEW_HOOKS[type]();
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
- add type definitions for configuration interfaces
- expose configuration and handler public interfaces
- general type cleanup
- address `page` handling issues in `usePaginate` hook
- fix `UseAction` typing

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- ran linting, tyep checking
- manual testing
- updated unit tests for `usePaginate` changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
