### PR TITLE
fix(ui-react-storage): StorageImage showing fallback text while the image is still fetching

### DIFF
--- a/packages/react-storage/src/components/StorageImage/StorageImage.tsx
+++ b/packages/react-storage/src/components/StorageImage/StorageImage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { classNames, ComponentClassName } from '@aws-amplify/ui';
-import { Image } from '@aws-amplify/ui-react';
+import { Image, View } from '@aws-amplify/ui-react';
 import { useDeprecationWarning } from '@aws-amplify/ui-react/internal';
 import { useGetUrl, useSetUserAgent } from '@aws-amplify/ui-react-core';
 
@@ -53,6 +53,7 @@ export const StorageImage = ({
   onStorageGetError,
   onGetUrlError,
   validateObjectExistence = true,
+  style,
   ...rest
 }: StorageImageProps | StorageImagePathProps): React.JSX.Element => {
   const hasImgkey = !!imgKey;
@@ -99,11 +100,16 @@ export const StorageImage = ({
     ]
   );
 
-  const { url } = useGetUrl(input);
+  const { url, isLoading } = useGetUrl(input);
+
+  if (isLoading) {
+    return <View style={{ ...style }}></View>;
+  }
 
   return (
     <Image
       {...rest}
+      style={{ ...style }}
       className={classNames(ComponentClassName.StorageImage, className)}
       src={url?.toString() ?? fallbackSrc}
     />


### PR DESCRIPTION
#### Description of changes

Currently, when using `StorageImage`, the user would see the fallback text while the image is still being fetched. The issue is more prominent when the network is throttled. 

This PR uses the loading state exposed by `useGetUrl` and returns a `View` with the provided styles while the image is being fetched. 

#### Issue #6254 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
