### PR TITLE
fix(ui-react-ai): Addressing cross-browser inconsistencies in AIConversation IME input handling

### DIFF
--- a/.changeset/clean-suits-own.md
+++ b/.changeset/clean-suits-own.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-ai": patch
+---
+
+fix(ui-react-ai): Addressing cross-browser inconsistencies in AIConversation IME input handling

--- a/packages/react-ai/src/components/AIConversation/views/default/Form.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/default/Form.tsx
@@ -107,8 +107,16 @@ export const Form: Required<ControlsContextProps>['Form'] = ({
           rows={1}
           value={input?.text ?? ''}
           testId="text-input"
-          onCompositionStart={() => setComposing(true)}
-          onCompositionEnd={() => setComposing(false)}
+          onCompositionStart={() => {
+            setComposing(true);
+          }}
+          onCompositionEnd={(e) => {
+            setComposing(false);
+            setInput?.((prevValue) => ({
+              ...prevValue,
+              text: (e.target as HTMLTextAreaElement).value,
+            }));
+          }}
           onKeyDown={(e) => {
             // Submit on enter key if shift is not pressed also
             const shouldSubmit = !e.shiftKey && e.key === 'Enter' && !composing;
@@ -120,7 +128,7 @@ export const Form: Required<ControlsContextProps>['Form'] = ({
           onChange={(e) => {
             setInput?.((prevValue) => ({
               ...prevValue,
-              text: e.target.value,
+              text: (e.target as HTMLTextAreaElement).value,
             }));
           }}
         />


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Address the issue AIConversation component was not able to properly update Chinese pinyin IME suggestion

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
- https://github.com/aws-amplify/amplify-ui/issues/6378
#### Description of how you validated changes

- Manual testing with local copy of AIConversation

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
