### PR TITLE
chore: revert build system override for peer dep installation

### DIFF
--- a/build-system-tests/scripts/mega-app-install.sh
+++ b/build-system-tests/scripts/mega-app-install.sh
@@ -110,8 +110,7 @@ else
 
         # react-native-safe-area-context v5 is required for >= 0.74
         if [[ "$FRAMEWORK_VERSION" == "latest" || $FRAMEWORK_VERSION > "0.74" ]]; then
-            # build system test uses latest tag, will need to remove force after release
-            DEPENDENCIES="$DEPENDENCIES react-native-safe-area-context --force"
+            DEPENDENCIES="$DEPENDENCIES react-native-safe-area-context"
         else
             DEPENDENCIES="$DEPENDENCIES react-native-safe-area-context@^4.2.5"
         fi;
@@ -120,12 +119,6 @@ else
         install_dependencies_with_retries npm "$DEPENDENCIES"
         if [[ "$BUILD_TOOL" == "expo" ]]; then
             if [[ "$FRAMEWORK_VERSION" == "0.75" ]]; then 
-                # Prevent Expo from "fixing" force installed dependency
-                # Can be removed once peer dependency is available with latest tag
-                tmp=$(mktemp)
-                jq '.overrides."@aws-amplify/ui-react-native"."react-native-safe-area-context" = "$react-native-safe-area-context"' package.json > "$tmp"
-                mv "$tmp" package.json
-
                 # Expo SDK version 51.0.0 supports RN 0.74 and 0.75 but installs 0.74 by default https://expo.dev/changelog/2024/08-14-react-native-0.75#2-install-updated-packages
                 echo "npx expo install react-native@~0.75.0"
                 npx expo install react-native@~0.75.0


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
The purpose of this pull request is to remove an override in the build system test now that the updated peer dependency version for `react-native-safe-area-context` has been released to the `latest` tag.

Force installation override in build system test. was first introduced with release of `react-native@0.78` which requires `react-native-safe-area-context@5.x`, leading to a conflict with the peer dependency version specified by `ui-react-native` of `^4.2.5`. This peer dependency conflict has been resolved with latest release.

- https://github.com/aws-amplify/amplify-ui/pull/6383
- https://github.com/aws-amplify/amplify-ui/pull/6372

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- [Successful Build Test](https://github.com/aws-amplify/amplify-ui/actions/runs/13974840006)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [X] PR description included
- [X] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
