### PR TITLE
fix(storage-browser): remove key parsing in useDeleteView

### DIFF
--- a/.changeset/metal-dogs-attack.md
+++ b/.changeset/metal-dogs-attack.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-storage": patch
+---
+
+fix(storage-browser): remove key parsing in useDeleteView

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/CopyViewProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/CopyViewProvider.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { MessageProps } from '../../../composables/Message';
 import { ControlsContextProvider } from '../../../controls/context';
 import { useDisplayText } from '../../../displayText';
 
@@ -9,7 +10,7 @@ import { FoldersMessageProvider } from './FoldersMessageControl';
 import { FoldersPaginationProvider } from './FoldersPaginationControl';
 import { FoldersTableProvider } from './FoldersTableControl';
 import { CopyViewProviderProps } from './types';
-import { MessageProps } from '../../../composables/Message';
+import { getFolderText } from './utils';
 
 export function CopyViewProvider({
   children,
@@ -65,8 +66,7 @@ export function CopyViewProvider({
   } = folders;
 
   const tableData = getActionViewTableData({
-    getFolderText: ({ data: { fileKey, sourceKey } }) =>
-      sourceKey.slice(0, -fileKey.length),
+    getFolderText,
     tasks,
     isProcessing,
     displayText,

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/CopyViewProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/CopyViewProvider.tsx
@@ -30,6 +30,7 @@ export function CopyViewProvider({
     statusDisplayCompletedLabel,
     statusDisplayFailedLabel,
     statusDisplayQueuedLabel,
+    title,
   } = displayText;
 
   const {
@@ -37,7 +38,6 @@ export function CopyViewProvider({
     folders,
     isProcessing,
     isProcessingComplete,
-    location,
     statusCounts,
     tasks,
     onActionCancel,
@@ -64,11 +64,10 @@ export function CopyViewProvider({
     onSelectFolder,
   } = folders;
 
-  const { key: locationKey } = location ?? {};
-
   const tableData = getActionViewTableData({
+    getFolderText: ({ data: { fileKey, sourceKey } }) =>
+      sourceKey.slice(0, -fileKey.length),
     tasks,
-    locationKey,
     isProcessing,
     displayText,
     onTaskRemove,
@@ -110,6 +109,7 @@ export function CopyViewProvider({
         statusDisplayFailedLabel,
         statusDisplayQueuedLabel,
         tableData,
+        title,
       }}
       onActionCancel={onActionCancel}
       onActionExit={onActionExit}

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/__tests__/CopyViewProvider.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/__tests__/CopyViewProvider.spec.tsx
@@ -32,9 +32,10 @@ jest.spyOn(Config, 'useGetActionInput').mockReturnValue(() => ({
 
 const getActionCompleteMessage = jest.fn();
 const getListFoldersResultsMessage = jest.fn();
+const title = 'Copy';
 jest.mock('../../../../displayText', () => ({
   useDisplayText: () => ({
-    CopyView: { getActionCompleteMessage, getListFoldersResultsMessage },
+    CopyView: { getActionCompleteMessage, getListFoldersResultsMessage, title },
   }),
 }));
 
@@ -174,6 +175,7 @@ describe('CopyViewProvider', () => {
         isActionExitDisabled: true,
         isActionDestinationNavigable: false,
         statusCounts: processingViewState.statusCounts,
+        title,
       },
       ...actionCallbacks,
     });

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/__tests__/utils.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/__tests__/utils.spec.ts
@@ -1,0 +1,28 @@
+import { CopyHandlerData } from '../../../../actions';
+import { Task } from '../../../../tasks';
+
+import { getFolderText } from '../utils';
+
+describe('getFolderText', () => {
+  it('returns the expected value', () => {
+    const expected = 'my-prefix/';
+    const fileKey = 'my-key.jpg';
+    const sourceKey = `${expected}${fileKey}`;
+
+    const task: Task<CopyHandlerData> = {
+      data: {
+        fileKey,
+        key: `my-destination/${fileKey}`,
+        sourceKey,
+        id: 'id',
+        lastModified: new Date(),
+      },
+      message: undefined,
+      progress: undefined,
+      status: 'QUEUED',
+    };
+    const output = getFolderText(task);
+
+    expect(output).toBe(expected);
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/utils.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/CopyView/utils.ts
@@ -1,0 +1,6 @@
+import { CopyHandlerData } from '../../../actions';
+import { Task } from '../../../tasks';
+
+export const getFolderText = ({
+  data: { fileKey, sourceKey },
+}: Task<CopyHandlerData>): string => sourceKey.slice(0, -fileKey.length);

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/DeleteViewProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/DeleteViewProvider.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 
 import { ControlsContextProvider } from '../../../controls/context';
 import { useDisplayText } from '../../../displayText';
+
 import { getActionViewTableData } from '../getActionViewTableData';
 import { DeleteViewProviderProps } from './types';
+import { getFolderText } from './utils';
 
 export function DeleteViewProvider({
   children,
@@ -41,7 +43,7 @@ export function DeleteViewProvider({
     tasks,
     isProcessing,
     displayText,
-    getFolderText: ({ data }) => data.key.slice(0, -data.fileKey.length),
+    getFolderText,
     onTaskRemove,
   });
 

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/DeleteViewProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/DeleteViewProvider.tsx
@@ -25,7 +25,6 @@ export function DeleteViewProvider({
   const {
     isProcessing,
     isProcessingComplete,
-    location,
     statusCounts,
     tasks,
     onActionCancel,
@@ -40,9 +39,9 @@ export function DeleteViewProvider({
 
   const tableData = getActionViewTableData({
     tasks,
-    locationKey: location.key,
     isProcessing,
     displayText,
+    getFolderText: ({ data }) => data.key.slice(0, -data.fileKey.length),
     onTaskRemove,
   });
 

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/__tests__/useDeleteView.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/__tests__/useDeleteView.spec.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react';
 
 import { useStore } from '../../../../providers/store';
 import { useAction } from '../../../../useAction';
+import { FileDataItem } from '../../../../actions';
 
 import { useDeleteView } from '../useDeleteView';
 import { INITIAL_STATUS_COUNTS } from '../../../../tasks';
@@ -9,16 +10,35 @@ import { INITIAL_STATUS_COUNTS } from '../../../../tasks';
 jest.mock('../../../../providers/store');
 jest.mock('../../../../useAction');
 
+const fileDataItems: FileDataItem[] = [
+  {
+    key: 'pretend-prefix/test-file.txt',
+    fileKey: 'test-file.txt',
+    lastModified: new Date(),
+    id: 'id-1',
+    size: 10,
+    type: 'FILE',
+  },
+  {
+    key: 'pretend-prefix/deeply-nested/test-file.txt',
+    fileKey: 'test-file.txt',
+    lastModified: new Date(),
+    id: 'id-2',
+    size: 10,
+    type: 'FILE',
+  },
+];
+
 describe('useDeleteView', () => {
-  const mockeUseAction = jest.mocked(useAction);
-  const mockeUseStore = jest.mocked(useStore);
+  const mockUseAction = jest.mocked(useAction);
+  const mockUseStore = jest.mocked(useStore);
   const mockCancel = jest.fn();
   const mockDispatchStoreAction = jest.fn();
   const mockHandleDelete = jest.fn();
   const mockReset = jest.fn();
 
   beforeEach(() => {
-    mockeUseStore.mockReturnValue([
+    mockUseStore.mockReturnValue([
       {
         actionType: 'DELETE',
         files: [],
@@ -33,23 +53,12 @@ describe('useDeleteView', () => {
           path: '',
           key: 'test-prefix/',
         },
-        locationItems: {
-          fileDataItems: [
-            {
-              key: 'pretend-prefix/test-file.txt',
-              fileKey: 'test-file.txt',
-              lastModified: new Date(),
-              id: 'id',
-              size: 10,
-              type: 'FILE',
-            },
-          ],
-        },
+        locationItems: { fileDataItems },
       },
       mockDispatchStoreAction,
     ]);
 
-    mockeUseAction.mockReturnValue([
+    mockUseAction.mockReturnValue([
       {
         isProcessing: false,
         isProcessingComplete: false,
@@ -88,8 +97,8 @@ describe('useDeleteView', () => {
     mockDispatchStoreAction.mockClear();
     mockHandleDelete.mockClear();
     mockReset.mockClear();
-    mockeUseAction.mockReset();
-    mockeUseStore.mockReset();
+    mockUseAction.mockReset();
+    mockUseStore.mockReset();
   });
 
   it('should return the correct initial state', () => {
@@ -150,5 +159,15 @@ describe('useDeleteView', () => {
     expect(mockDispatchStoreAction).toHaveBeenCalledWith({
       type: 'RESET_ACTION_TYPE',
     });
+  });
+
+  it('provides the unmodified value of `fileDataItems` to `useAction` as `items`', () => {
+    renderHook(() => useDeleteView());
+
+    expect(mockUseAction).toHaveBeenCalledTimes(1);
+    expect(mockUseAction).toHaveBeenCalledWith(
+      'delete',
+      expect.objectContaining({ items: fileDataItems })
+    );
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/__tests__/utils.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/__tests__/utils.spec.ts
@@ -1,0 +1,26 @@
+import { DeleteHandlerData } from '../../../../actions';
+import { Task } from '../../../../tasks';
+
+import { getFolderText } from '../utils';
+
+describe('getFolderText', () => {
+  it('returns the expected value', () => {
+    const expected = 'my-prefix/';
+    const fileKey = 'my-key.jpg';
+    const key = `${expected}${fileKey}`;
+
+    const task: Task<DeleteHandlerData> = {
+      data: {
+        fileKey,
+        key,
+        id: 'id',
+      },
+      message: undefined,
+      progress: undefined,
+      status: 'QUEUED',
+    };
+    const output = getFolderText(task);
+
+    expect(output).toBe(expected);
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/useDeleteView.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/useDeleteView.ts
@@ -1,11 +1,15 @@
 import React from 'react';
 import { isFunction } from '@aws-amplify/ui';
 
+import { FileDataItem } from '../../../actions';
 import { useStore } from '../../../providers/store';
 import { Task } from '../../../tasks';
 import { useAction } from '../../../useAction';
 
 import { DeleteViewState, UseDeleteViewOptions } from './types';
+
+// assign to constant to ensure referential equality
+const EMPTY_ITEMS: FileDataItem[] = [];
 
 export const useDeleteView = (
   options?: UseDeleteViewOptions
@@ -13,12 +17,10 @@ export const useDeleteView = (
   const { onExit: _onExit } = options ?? {};
 
   const [{ location, locationItems }, dispatchStoreAction] = useStore();
-  const { fileDataItems } = locationItems;
   const { current } = location;
+  const { fileDataItems: items = EMPTY_ITEMS } = locationItems;
 
-  const [processState, handleProcess] = useAction('delete', {
-    items: fileDataItems ?? [],
-  });
+  const [processState, handleProcess] = useAction('delete', { items });
 
   const { isProcessing, isProcessingComplete, statusCounts, tasks } =
     processState;

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/useDeleteView.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/useDeleteView.ts
@@ -14,20 +14,11 @@ export const useDeleteView = (
 
   const [{ location, locationItems }, dispatchStoreAction] = useStore();
   const { fileDataItems } = locationItems;
-  const { current, key } = location;
+  const { current } = location;
 
-  const data = React.useMemo(
-    () =>
-      !fileDataItems
-        ? []
-        : fileDataItems.map((item) => ({
-            ...item,
-            key: `${key}${item.fileKey}`,
-          })),
-    [fileDataItems, key]
-  );
-
-  const [processState, handleProcess] = useAction('delete', { items: data });
+  const [processState, handleProcess] = useAction('delete', {
+    items: fileDataItems ?? [],
+  });
 
   const { isProcessing, isProcessingComplete, statusCounts, tasks } =
     processState;

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/utils.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DeleteView/utils.ts
@@ -1,0 +1,6 @@
+import { DeleteHandlerData } from '../../../actions';
+import { Task } from '../../../tasks';
+
+export const getFolderText = ({
+  data: { fileKey, key },
+}: Task<DeleteHandlerData>): string => key.slice(0, -fileKey.length);

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/UploadView/UploadViewProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/UploadView/UploadViewProvider.tsx
@@ -89,6 +89,17 @@ export function UploadViewProvider({
         statusDisplayFailedLabel,
         statusDisplayQueuedLabel,
         tableData: getActionViewTableData({
+          getFolderText: ({
+            data: {
+              file: { webkitRelativePath },
+            },
+          }) =>
+            webkitRelativePath
+              ? webkitRelativePath.slice(
+                  0,
+                  webkitRelativePath.lastIndexOf('/') + 1
+                )
+              : '-',
           tasks,
           shouldDisplayProgress: true,
           displayText,

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/UploadView/UploadViewProvider.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/UploadView/UploadViewProvider.tsx
@@ -6,6 +6,7 @@ import { useDisplayText } from '../../../displayText';
 import { getActionViewTableData } from '../getActionViewTableData';
 
 import { UploadViewProviderProps } from './types';
+import { getFolderText } from './utils';
 
 export function UploadViewProvider({
   children,
@@ -89,17 +90,7 @@ export function UploadViewProvider({
         statusDisplayFailedLabel,
         statusDisplayQueuedLabel,
         tableData: getActionViewTableData({
-          getFolderText: ({
-            data: {
-              file: { webkitRelativePath },
-            },
-          }) =>
-            webkitRelativePath
-              ? webkitRelativePath.slice(
-                  0,
-                  webkitRelativePath.lastIndexOf('/') + 1
-                )
-              : '-',
+          getFolderText,
           tasks,
           shouldDisplayProgress: true,
           displayText,

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/UploadView/__tests__/utils.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/UploadView/__tests__/utils.spec.ts
@@ -1,0 +1,46 @@
+import { UploadHandlerData } from '../../../../actions';
+import { Task } from '../../../../tasks';
+
+import { getFolderText } from '../utils';
+
+describe('getFolderText', () => {
+  it('returns the expected value when `file` contains a `webkitRelativePath` value', () => {
+    const expected = 'local-folder/';
+    const mockFile = { webkitRelativePath: expected } as File;
+    const key = 'my-key.jpg';
+
+    const task: Task<UploadHandlerData> = {
+      data: {
+        key,
+        file: mockFile,
+        id: 'id',
+      },
+      message: undefined,
+      progress: undefined,
+      status: 'QUEUED',
+    };
+    const output = getFolderText(task);
+
+    expect(output).toBe(expected);
+  });
+
+  it('returns the expected value when `file` does not contain a `webkitRelativePath` value', () => {
+    const expected = '-';
+    const mockFile = {} as File;
+    const key = 'my-key.jpg';
+
+    const task: Task<UploadHandlerData> = {
+      data: {
+        key,
+        file: mockFile,
+        id: 'id',
+      },
+      message: undefined,
+      progress: undefined,
+      status: 'QUEUED',
+    };
+    const output = getFolderText(task);
+
+    expect(output).toBe(expected);
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/UploadView/utils.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/UploadView/utils.ts
@@ -1,0 +1,11 @@
+import { UploadHandlerData } from '../../../actions';
+import { Task } from '../../../tasks';
+
+export const getFolderText = ({
+  data: {
+    file: { webkitRelativePath },
+  },
+}: Task<UploadHandlerData>): string =>
+  webkitRelativePath
+    ? webkitRelativePath.slice(0, webkitRelativePath.lastIndexOf('/') + 1)
+    : '-';

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/__tests__/__snapshots__/getActionViewTableData.spec.ts.snap
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/__tests__/__snapshots__/getActionViewTableData.spec.ts.snap
@@ -123,7 +123,7 @@ exports[`getActionViewTableData should have remove handler on queued files 1`] =
       },
       {
         "content": {
-          "text": "folder/subfolder/",
+          "text": "/",
         },
         "key": "folder-1",
         "type": "text",

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/__tests__/getActionViewTableData.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/__tests__/getActionViewTableData.spec.ts
@@ -150,7 +150,6 @@ describe('getActionViewTableData', () => {
 
     const result = getActionViewTableData({
       tasks,
-      locationKey: 'folder/subfolder/',
       displayText: DEFAULT_UPLOAD_VIEW_DISPLAY_TEXT,
       isProcessing: false,
       onTaskRemove: jest.fn(),
@@ -216,7 +215,6 @@ describe('getActionViewTableData', () => {
 
     const result = getActionViewTableData({
       tasks,
-      locationKey: 'folder/subfolder/',
       displayText: DEFAULT_UPLOAD_VIEW_DISPLAY_TEXT,
       isProcessing: false,
       onTaskRemove: jest.fn(),

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/getActionViewTableData.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/getActionViewTableData.ts
@@ -57,15 +57,15 @@ const getProgressHeader = (label: string): ActionViewHeaders[0] => ({
 export const getActionViewTableData = <T extends TaskData = TaskData>({
   tasks,
   displayText,
+  getFolderText,
   isProcessing,
-  locationKey,
   shouldDisplayProgress = false,
   onTaskRemove,
 }: {
   tasks: Task<T>[];
   isProcessing: boolean;
-  locationKey?: string;
   shouldDisplayProgress?: boolean;
+  getFolderText?: (task: Task<T>) => string;
   displayText: Omit<
     DefaultActionViewDisplayText,
     'getActionCompleteMessage'
@@ -110,27 +110,9 @@ export const getActionViewTableData = <T extends TaskData = TaskData>({
             };
           }
           case 'folder': {
-            if (locationKey) {
-              return { key, type: 'text', content: { text: locationKey } };
-            }
+            const text = getFolderText?.(task) ?? '/';
 
-            if (isFileItem(data)) {
-              const { webkitRelativePath } = data.file;
-              return {
-                key,
-                type: 'text',
-                content: {
-                  text: webkitRelativePath
-                    ? webkitRelativePath.slice(
-                        0,
-                        webkitRelativePath.lastIndexOf('/') + 1
-                      )
-                    : '-',
-                },
-              };
-            }
-
-            return { key, type: 'text', content: { text: '/' } };
+            return { key, type: 'text', content: { text } };
           }
           case 'type': {
             return {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Fix passing of invalid item `key` provided to `delete` handler from `LocationDetailView` search results:
- remove `key` parsing in `useDeleteView`
- refactor "Folder" column value extraction in action views
- add missing `title` value to `CopyViewProvider`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
fixes #6449
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- manual testng
- unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
