### PR TITLE
fix(email-mfa): remove select-mfa-type from form fields union

### DIFF
--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/select-mfa-type/select-mfa-type.component.spec.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/select-mfa-type/select-mfa-type.component.spec.ts
@@ -18,14 +18,6 @@ const totpFieldInput = { name: fieldName, value: 'TOTP' };
 
 const mockContext: Partial<AuthActorContext> = {
   challengeName: 'MFA_SETUP',
-  formFields: {
-    selectMfaType: {
-      mfa_type: {
-        label: 'Select MFA Type',
-        type: 'radio',
-      },
-    },
-  },
   allowedMfaTypes: ['EMAIL', 'TOTP'],
 };
 

--- a/packages/ui/src/helpers/authenticator/formFields/defaults.ts
+++ b/packages/ui/src/helpers/authenticator/formFields/defaults.ts
@@ -166,17 +166,6 @@ const getForceNewPasswordFormFields = (state: AuthMachineState): FormFields => {
   return formField;
 };
 
-const getSelectMfaTypeFormFields = (_: AuthMachineState): FormFields => {
-  return {
-    mfa_type: {
-      label: 'Select MFA Type',
-      placeholder: 'Please select desired MFA type',
-      type: 'radio',
-      isRequired: true,
-    },
-  };
-};
-
 const getSetupEmailFormFields = (_: AuthMachineState): FormFields => ({
   email: getDefaultFormField('email'),
 });
@@ -194,7 +183,6 @@ export const defaultFormFieldsGetters: Record<
   forgotPassword: getForgotPasswordFormFields,
   confirmResetPassword: getConfirmResetPasswordFormFields,
   confirmVerifyUser: getConfirmationCodeFormFields,
-  selectMfaType: getSelectMfaTypeFormFields,
   setupEmail: getSetupEmailFormFields,
   setupTotp: getConfirmationCodeFormFields,
 };

--- a/packages/ui/src/types/authenticator/form.ts
+++ b/packages/ui/src/types/authenticator/form.ts
@@ -19,7 +19,6 @@ export type FormFieldComponents =
   | 'confirmSignUp'
   | 'confirmVerifyUser'
   | 'forgotPassword'
-  | 'selectMfaType'
   | 'setupEmail'
   | 'setupTotp';
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
This should have been removed as part of an earlier refactor. There is no functional impact but it affects the exposed interface when overriding form fields for customization.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
