### PR TITLE
fix(ui-react): Loader primitive accessibility role

### DIFF
--- a/.changeset/five-pandas-wash.md
+++ b/.changeset/five-pandas-wash.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react-storage": patch
+"@aws-amplify/ui-react": patch
+---
+
+fix(ui-react): Loader primitive accessibility role

--- a/packages/react-storage/src/components/FileUploader/ui/FileList/__tests__/__snapshots__/FileControl.test.tsx.snap
+++ b/packages/react-storage/src/components/FileUploader/ui/FileList/__tests__/__snapshots__/FileControl.test.tsx.snap
@@ -292,7 +292,7 @@ exports[`FileControl should default to showThumbnails being true 1`] = `
       <span
         class="amplify-text amplify-fileuploader__file__size"
       />
-        aria-valuenow="0"
+      <svg
         class="amplify-loader amplify-loader--linear amplify-fileuploader__loader"
         role="progressbar"
       >

--- a/packages/react-storage/src/components/FileUploader/ui/FileList/__tests__/__snapshots__/FileControl.test.tsx.snap
+++ b/packages/react-storage/src/components/FileUploader/ui/FileList/__tests__/__snapshots__/FileControl.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`FileControl renders as expected when file is uploading 1`] = `
       />
       <svg
         class="amplify-loader amplify-loader--linear amplify-fileuploader__loader"
-        role="img"
+        role="progressbar"
       >
         <g>
           <line
@@ -189,7 +189,7 @@ exports[`FileControl renders thumbnails 1`] = `
       />
       <svg
         class="amplify-loader amplify-loader--linear amplify-fileuploader__loader"
-        role="img"
+        role="progressbar"
       >
         <g>
           <line
@@ -292,9 +292,9 @@ exports[`FileControl should default to showThumbnails being true 1`] = `
       <span
         class="amplify-text amplify-fileuploader__file__size"
       />
-      <svg
+        aria-valuenow="0"
         class="amplify-loader amplify-loader--linear amplify-fileuploader__loader"
-        role="img"
+        role="progressbar"
       >
         <g>
           <line

--- a/packages/react-storage/src/components/FileUploader/ui/FileList/__tests__/__snapshots__/FileList.test.tsx.snap
+++ b/packages/react-storage/src/components/FileUploader/ui/FileList/__tests__/__snapshots__/FileList.test.tsx.snap
@@ -22,8 +22,9 @@ exports[`FileList renders an alert in case of error 1`] = `
           class="amplify-text amplify-fileuploader__file__size"
         />
         <svg
+          aria-valuenow="0"
           class="amplify-loader amplify-loader--linear amplify-loader--determinate amplify-fileuploader__loader"
-          role="img"
+          role="progressbar"
         >
           <g>
             <line
@@ -156,8 +157,9 @@ exports[`FileList renders as expected 1`] = `
           class="amplify-text amplify-fileuploader__file__size"
         />
         <svg
+          aria-valuenow="0"
           class="amplify-loader amplify-loader--linear amplify-loader--determinate amplify-fileuploader__loader"
-          role="img"
+          role="progressbar"
         >
           <g>
             <line
@@ -252,7 +254,7 @@ exports[`FileList renders as expected when upload is resumable 1`] = `
         />
         <svg
           class="amplify-loader amplify-loader--linear amplify-fileuploader__loader"
-          role="img"
+          role="progressbar"
         >
           <g>
             <line

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileControl.test.tsx.snap
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileControl.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`FileControl renders as expected when file is uploading 1`] = `
       />
       <svg
         class="amplify-loader amplify-loader--linear amplify-storagemanager__loader"
-        role="img"
+        role="progressbar"
       >
         <g>
           <line
@@ -189,7 +189,7 @@ exports[`FileControl renders thumbnails 1`] = `
       />
       <svg
         class="amplify-loader amplify-loader--linear amplify-storagemanager__loader"
-        role="img"
+        role="progressbar"
       >
         <g>
           <line
@@ -294,7 +294,7 @@ exports[`FileControl should default to showThumbnails being true 1`] = `
       />
       <svg
         class="amplify-loader amplify-loader--linear amplify-storagemanager__loader"
-        role="img"
+        role="progressbar"
       >
         <g>
           <line

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileList.test.tsx.snap
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileList.test.tsx.snap
@@ -22,8 +22,9 @@ exports[`FileList renders an alert in case of error 1`] = `
           class="amplify-text amplify-storagemanager__file__size"
         />
         <svg
+          aria-valuenow="0"
           class="amplify-loader amplify-loader--linear amplify-loader--determinate amplify-storagemanager__loader"
-          role="img"
+          role="progressbar"
         >
           <g>
             <line
@@ -156,8 +157,9 @@ exports[`FileList renders as expected 1`] = `
           class="amplify-text amplify-storagemanager__file__size"
         />
         <svg
+          aria-valuenow="0"
           class="amplify-loader amplify-loader--linear amplify-loader--determinate amplify-storagemanager__loader"
-          role="img"
+          role="progressbar"
         >
           <g>
             <line
@@ -252,7 +254,7 @@ exports[`FileList renders as expected when upload is resumable 1`] = `
         />
         <svg
           class="amplify-loader amplify-loader--linear amplify-storagemanager__loader"
-          role="img"
+          role="progressbar"
         >
           <g>
             <line

--- a/packages/react/src/primitives/Button/__tests__/Button.test.tsx
+++ b/packages/react/src/primitives/Button/__tests__/Button.test.tsx
@@ -263,21 +263,21 @@ describe('Button test suite', () => {
     const loaderWrapper = await screen.findByText('loading');
     expect(loaderWrapper).toHaveClass(ComponentClassName.ButtonLoaderWrapper);
 
-    const loader = await screen.findByRole('img');
+    const loader = await screen.findByRole('progressbar');
     expect(loader).toHaveClass(ComponentClassName.Loader);
   });
 
   it('should pass size to Loader correctly if size is set', async () => {
     render(<Button loadingText="loading" size="small" isLoading />);
 
-    const loader = await screen.findByRole('img');
+    const loader = await screen.findByRole('progressbar');
     expect(loader).toHaveClass('amplify-loader--small');
   });
 
   it('should render Loader correctly without loadingText and isLoading is set to true', async () => {
     render(<Button isLoading />);
 
-    const loader = await screen.findByRole('img');
+    const loader = await screen.findByRole('progressbar');
     expect(loader).toHaveClass(ComponentClassName.Loader);
   });
 

--- a/packages/react/src/primitives/Loader/Loader.tsx
+++ b/packages/react/src/primitives/Loader/Loader.tsx
@@ -139,6 +139,8 @@ const LoaderPrimitive: Primitive<LoaderProps, 'svg'> = (
     <View
       as="svg"
       aria-valuenow={isDeterminate ? percentage : undefined}
+      aria-valuemax={isDeterminate ? 100 : undefined}
+      aria-valuemin={isDeterminate ? 0 : undefined}
       className={componentClasses}
       ref={ref}
       role="progressbar"

--- a/packages/react/src/primitives/Loader/Loader.tsx
+++ b/packages/react/src/primitives/Loader/Loader.tsx
@@ -136,7 +136,15 @@ const LoaderPrimitive: Primitive<LoaderProps, 'svg'> = (
   );
 
   return (
-    <View as="svg" className={componentClasses} ref={ref} role="img" {...rest}>
+    <View
+      as="svg"
+      aria-valuenow={isDeterminate ? percentage : undefined}
+      aria-hidden={!isDeterminate}
+      className={componentClasses}
+      ref={ref}
+      role="progressbar"
+      {...rest}
+    >
       {variation === 'linear' ? linearLoader : circularLoader}
     </View>
   );

--- a/packages/react/src/primitives/Loader/Loader.tsx
+++ b/packages/react/src/primitives/Loader/Loader.tsx
@@ -139,8 +139,6 @@ const LoaderPrimitive: Primitive<LoaderProps, 'svg'> = (
     <View
       as="svg"
       aria-valuenow={isDeterminate ? percentage : undefined}
-      aria-valuemax={isDeterminate ? 100 : undefined}
-      aria-valuemin={isDeterminate ? 0 : undefined}
       className={componentClasses}
       ref={ref}
       role="progressbar"

--- a/packages/react/src/primitives/Loader/Loader.tsx
+++ b/packages/react/src/primitives/Loader/Loader.tsx
@@ -139,7 +139,6 @@ const LoaderPrimitive: Primitive<LoaderProps, 'svg'> = (
     <View
       as="svg"
       aria-valuenow={isDeterminate ? percentage : undefined}
-      aria-hidden={!isDeterminate}
       className={componentClasses}
       ref={ref}
       role="progressbar"

--- a/packages/react/src/primitives/Loader/__tests__/Loader.test.tsx
+++ b/packages/react/src/primitives/Loader/__tests__/Loader.test.tsx
@@ -167,21 +167,15 @@ describe('Loader:', () => {
   });
 
   it('should render without aria-valuenow if not determinate state', async () => {
-    expect.assertions(3);
     render(<Loader />);
 
     const loader = await screen.findByRole('progressbar');
     expect(loader).not.toHaveAttribute('aria-valuenow');
-    expect(loader).not.toHaveAttribute('aria-valuemin');
-    expect(loader).not.toHaveAttribute('aria-valuemax');
   });
 
   it('should render with aria-valuenow attribute if in determinate state', async () => {
-    expect.assertions(3);
     render(<Loader isDeterminate percentage={50} />);
     const loader = await screen.findByRole('progressbar');
     expect(loader).toHaveAttribute('aria-valuenow', '50');
-    expect(loader).toHaveAttribute('aria-valuemin', '0');
-    expect(loader).toHaveAttribute('aria-valuemax', '100');
   });
 });

--- a/packages/react/src/primitives/Loader/__tests__/Loader.test.tsx
+++ b/packages/react/src/primitives/Loader/__tests__/Loader.test.tsx
@@ -165,4 +165,23 @@ describe('Loader:', () => {
     const percentageText = await screen.findByText(textContent);
     expect(percentageText).toHaveClass(ComponentClassName.VisuallyHidden);
   });
+
+  it('should render without aria-valuenow if not determinate state', async () => {
+    expect.assertions(3);
+    render(<Loader />);
+
+    const loader = await screen.findByRole('progressbar');
+    expect(loader).not.toHaveAttribute('aria-valuenow');
+    expect(loader).not.toHaveAttribute('aria-valuemin');
+    expect(loader).not.toHaveAttribute('aria-valuemax');
+  });
+
+  it('should render with aria-valuenow attribute if in determinate state', async () => {
+    expect.assertions(3);
+    render(<Loader isDeterminate percentage={50} />);
+    const loader = await screen.findByRole('progressbar');
+    expect(loader).toHaveAttribute('aria-valuenow', '50');
+    expect(loader).toHaveAttribute('aria-valuemin', '0');
+    expect(loader).toHaveAttribute('aria-valuemax', '100');
+  });
 });

--- a/packages/react/src/primitives/Loader/__tests__/Loader.test.tsx
+++ b/packages/react/src/primitives/Loader/__tests__/Loader.test.tsx
@@ -16,7 +16,7 @@ describe('Loader:', () => {
   it('should render default and custom classname', async () => {
     const className = 'class-test';
     render(<Loader className={className} />);
-    const loader = await screen.findByRole('img');
+    const loader = await screen.findByRole('progressbar');
     expect(loader).toHaveClass(ComponentClassName.Loader, className);
   });
 
@@ -53,26 +53,26 @@ describe('Loader:', () => {
     const ref = React.createRef<SVGSVGElement>();
     render(<Loader ref={ref} />);
 
-    await screen.findByRole('img');
+    await screen.findByRole('progressbar');
     expect(ref.current?.nodeName).toBe('svg');
   });
 
   it('should set size attribute', async () => {
     render(<Loader size="large" />);
-    const loader = await screen.findByRole('img');
+    const loader = await screen.findByRole('progressbar');
     expect(loader).toHaveClass(`${ComponentClassName.Loader}--large`);
   });
 
   it('should set variation attribute', async () => {
     render(<Loader variation="linear" />);
-    const loader = await screen.findByRole('img');
+    const loader = await screen.findByRole('progressbar');
     expect(loader).toHaveClass(`${ComponentClassName.Loader}--linear`);
   });
 
   it('should set ariaLabel', async () => {
     const ariaLabel = 'This is a label.';
     render(<Loader ariaLabel={ariaLabel} />);
-    const loader = await screen.findByRole('img');
+    const loader = await screen.findByRole('progressbar');
     expect(loader).toHaveAttribute('aria-label', ariaLabel);
   });
 
@@ -106,7 +106,7 @@ describe('Loader:', () => {
     const percentage = 80;
     render(<Loader percentage={percentage} isDeterminate />);
 
-    const loader = await screen.findByRole('img');
+    const loader = await screen.findByRole('progressbar');
     expect(loader).toHaveClass(`${ComponentClassName.Loader}--determinate`);
 
     const circularFilled = await screen.findByTestId(CIRCULAR_FILLED);
@@ -137,7 +137,7 @@ describe('Loader:', () => {
     const percentage = 80;
     render(<Loader percentage={percentage} variation="linear" isDeterminate />);
 
-    const loader = await screen.findByRole('img');
+    const loader = await screen.findByRole('progressbar');
     expect(loader).toHaveClass(`${ComponentClassName.Loader}--determinate`);
 
     const linearFilled = await screen.findByTestId(LINEAR_FILLED);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Change the accessibility role of an loader to `progressbar` instead of an `img`, and accessibly hide the `Loader` when  in `indeterminate` state. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

The changes was validated using manual testing through VoiceOver. The VoiceOver now identifies the Loader with 20% determinate value as `20% loading indicator` instead of an `image`. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
