### PR TITLE
chore(deps): downgrade react-icons

### DIFF
--- a/.github/workflows/test-internal-prs.yml
+++ b/.github/workflows/test-internal-prs.yml
@@ -13,7 +13,8 @@ concurrency:
 
 on:
   pull_request:
-    branches: [main, hotfix]
+    # branches: [main, hotfix]
+    branches: feat-expose-sb-types/main
     types: [opened, synchronize, labeled]
 
 jobs:

--- a/examples/next-app-router/package.json
+++ b/examples/next-app-router/package.json
@@ -14,7 +14,7 @@
     "react": "^18.3.0",
     "next": "^14.2.25",
     "react-dom": "^18",
-    "react-icons": "^5.5.0"
+    "react-icons": "^4.3.1"
   },
   "devDependencies": {
     "@types/node": "^14.14.31",

--- a/examples/next-app-router/src/components/ThemeToggle.tsx
+++ b/examples/next-app-router/src/components/ThemeToggle.tsx
@@ -2,7 +2,7 @@
 // https://github.com/vercel/next.js/discussions/53063
 import { Button, ColorMode } from '@aws-amplify/ui-react';
 import { useEffect, useState } from 'react';
-import { LuMoon, LuSun } from 'react-icons/lu';
+import { MdDarkMode, MdLightMode } from 'react-icons/md';
 
 function ThemeToggle({ initialValue }: { initialValue: ColorMode }) {
   const [colorMode, setColorMode] = useState(initialValue);
@@ -26,7 +26,7 @@ function ThemeToggle({ initialValue }: { initialValue: ColorMode }) {
     <Button
       onClick={() => setColorMode(colorMode === 'dark' ? 'light' : 'dark')}
     >
-      {colorMode === 'dark' ? <LuSun /> : <LuMoon />}
+      {colorMode === 'dark' ? <MdLightMode /> : <MdDarkMode />}
     </Button>
   );
 }

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -22,7 +22,7 @@
     "react": "^18.3.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.3.0",
-    "react-icons": "^5.5.0",
+    "react-icons": "^4.3.1",
     "react-map-gl": "7.0.23",
     "swr": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     ],
     "nohoist": [
       "**/@react-native-community/**",
-      "**/react-icons",
       "**/react-native",
       "**/react-native-paper",
       "**/react-native-safe-area-context",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24270,11 +24270,6 @@ react-icons@^4.3.1:
   resolved "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz#621e900caa23b912f737e41be57f27f6b2bff445"
   integrity sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==
 
-react-icons@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.5.0.tgz#8aa25d3543ff84231685d3331164c00299cdfaf2"
-  integrity sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==
-
 "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Downgrade `react-icons`
- update `next-app-router` example app to use material icons in place of missing lucide icons
- reapply changes to allow CI to run against feature branch
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
