### PR TITLE
fix(storage-browser): update task statuses before passing to callbacks, add error to TaskResult

### DIFF
--- a/.changeset/forty-hotels-tan.md
+++ b/.changeset/forty-hotels-tan.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-storage": patch
+---
+
+fix(storage-browser): update task statuses before passing to callbacks, add error to TaskResult

--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/react.mdx
@@ -487,39 +487,12 @@ The following `default` actions are invoked by the default UI views:
 
 <Example>
 <ExampleCode>
-```ts
-import { createStorageBrowser, defaultActionConfigs } from '@aws-amplify/ui-react-storage/browser';
-
-const { StorageBrowser } = createStorageBrowser({
-  actions: {
-    default: {
-      upload: {
-        ...defaultActionConfigs.upload,
-        handler: ({ config, data, options }) =>
-          defaultActionConfigs.upload.handler({
-            config,
-            data,
-            options: {
-              ...options,
-              onSuccess: (...input) => {
-                options?.onSuccess?.(...input);
-                fileUploadCounter.add(1); // Your custom counter metrics.
-              },
-              onError: (data, message, error) => {
-                options?.onError?.(data, message, error);
-                fileUploadError.recordError(error); // Your custom error metrics.
-              },
-            },
-          }),
-      }
-    }
-  }
-});
+```tsx file=../../../../../../../examples/next/pages/ui/components/storage/storage-browser/default-auth/routed/StorageBrowser.ts
 ```
 </ExampleCode>
 </Example>
 
-#### New custom actions
+#### Add Custom actions
 
 `custom` actions can be provided to add entirely new functionality to `StorageBrowser` which can be used by custom UI views. 
 

--- a/examples/next/pages/ui/components/storage/storage-browser/default-auth/routed/StorageBrowser.ts
+++ b/examples/next/pages/ui/components/storage/storage-browser/default-auth/routed/StorageBrowser.ts
@@ -3,6 +3,8 @@ import { Amplify } from 'aws-amplify';
 import {
   createAmplifyAuthAdapter,
   createStorageBrowser,
+  defaultHandlers,
+  defaultActionConfigs,
 } from '@aws-amplify/ui-react-storage/browser';
 import '@aws-amplify/ui-react-storage/styles.css';
 
@@ -10,6 +12,45 @@ import config from './aws-exports';
 
 Amplify.configure(config);
 
+const uploads = [];
+const errors = [];
+const fileUploadCounter = {
+  add: (value: { key: string }) => {
+    uploads.push(value);
+
+    console.log('uploads', uploads);
+  },
+  recordError: (error: Error) => {
+    errors.push(error);
+
+    console.log('errors', errors);
+  },
+};
+
 export const { StorageBrowser } = createStorageBrowser({
   config: createAmplifyAuthAdapter(),
+  actions: {
+    default: {
+      upload: {
+        ...defaultActionConfigs.upload,
+        handler: (input) => {
+          const output = defaultHandlers.upload(input);
+
+          output.result.then((result) => {
+            const { error, status, value } = result;
+            if (status === 'COMPLETE') {
+              fileUploadCounter.add(value);
+            } else if (
+              status === 'FAILED' ||
+              status === 'OVERWRITE_PREVENTED'
+            ) {
+              fileUploadCounter.recordError(error);
+            }
+          });
+
+          return output;
+        },
+      },
+    },
+  },
 });

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/copy.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/copy.spec.ts
@@ -113,13 +113,15 @@ describe('copyHandler', () => {
   });
 
   it('returns failed status', async () => {
-    const errorMessage = 'error-message';
-    mockCopy.mockRejectedValue(new Error(errorMessage));
+    const error = new Error('No copy!');
+
+    mockCopy.mockRejectedValue(error);
     const { result } = copyHandler(baseInput);
 
     expect(await result).toEqual({
+      error,
+      message: error.message,
       status: 'FAILED',
-      message: errorMessage,
     });
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/createFolder.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/createFolder.spec.ts
@@ -122,37 +122,38 @@ describe('createFolderHandler', () => {
   });
 
   it('handles a failure as expected', async () => {
-    const errorMessage = 'error-message';
+    const error = new Error('No new folder!');
 
     mockUploadData.mockReturnValue({
       ...mockUploadDataReturnValue,
-      result: Promise.reject(new Error(errorMessage)),
+      result: Promise.reject(error),
       state: 'ERROR',
     });
 
     const { result } = createFolderHandler(baseInput);
 
     expect(await result).toStrictEqual({
-      message: errorMessage,
+      error,
+      message: error.message,
       status: 'FAILED',
     });
   });
 
   it('returns "OVERWRITE_PREVENTED" on `PreconditionFailed` error', async () => {
-    const message = 'No overwrite!';
-    const overwritePreventedError = new Error(message);
-    overwritePreventedError.name = 'PreconditionFailed';
+    const error = new Error('No overwrite!');
+    error.name = 'PreconditionFailed';
 
     mockUploadData.mockReturnValue({
       ...mockUploadDataReturnValue,
-      result: Promise.reject(overwritePreventedError),
+      result: Promise.reject(error),
       state: 'ERROR',
     });
 
     const { result } = createFolderHandler(baseInput);
 
     expect(await result).toStrictEqual({
-      message,
+      error,
+      message: error.message,
       status: 'OVERWRITE_PREVENTED',
     });
   });

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/delete.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/delete.spec.ts
@@ -61,13 +61,14 @@ describe('deleteHandler', () => {
   });
 
   it('returns failed status', async () => {
-    const errorMessage = 'error-message';
-    mockRemove.mockRejectedValue(new Error(errorMessage));
+    const error = new Error('No delete!');
+    mockRemove.mockRejectedValue(error);
     const { result } = deleteHandler(baseInput);
 
     expect(await result).toEqual({
+      error,
+      message: error.message,
       status: 'FAILED',
-      message: errorMessage,
     });
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/download.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/download.spec.ts
@@ -61,13 +61,14 @@ describe('downloadHandler', () => {
   });
 
   it('returns failed status', async () => {
-    const errorMessage = 'error-message';
-    mockGetUrl.mockRejectedValue(new Error(errorMessage));
+    const error = new Error('No download!');
+    mockGetUrl.mockRejectedValue(error);
     const { result } = downloadHandler(baseInput);
 
     expect(await result).toEqual({
+      error,
+      message: error.message,
       status: 'FAILED',
-      message: errorMessage,
     });
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/upload.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/upload.spec.ts
@@ -178,6 +178,7 @@ describe('uploadHandler', () => {
     const { result } = uploadHandler(baseInput);
 
     expect(await result).toStrictEqual({
+      error,
       message: error.message,
       status: 'FAILED',
     });
@@ -196,18 +197,19 @@ describe('uploadHandler', () => {
     const { result } = uploadHandler(baseInput);
 
     expect(await result).toStrictEqual({
-      message: 'Failed!',
+      error,
+      message: error.message,
       status: 'CANCELED',
     });
   });
 
   it('handles an overwrite failure as expected', async () => {
-    const preconditionError = new Error('Failed!');
-    preconditionError.name = 'PreconditionFailed';
+    const error = new Error('Failed!');
+    error.name = 'PreconditionFailed';
 
     mockUploadData.mockReturnValue({
       ...mockUploadDataReturnValue,
-      result: Promise.reject(preconditionError),
+      result: Promise.reject(error),
       state: 'ERROR',
     });
 
@@ -217,7 +219,8 @@ describe('uploadHandler', () => {
     });
 
     expect(await result).toStrictEqual({
-      message: 'Failed!',
+      error,
+      message: error.message,
       status: 'OVERWRITE_PREVENTED',
     });
   });

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/copy.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/copy.ts
@@ -67,6 +67,9 @@ export const copyHandler: CopyHandler = (input) => {
         status: 'COMPLETE' as const,
         value: { key: path },
       }))
-      .catch(({ message }: Error) => ({ message, status: 'FAILED' })),
+      .catch((error: Error) => {
+        const { message } = error;
+        return { error, message, status: 'FAILED' };
+      }),
   };
 };

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/createFolder.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/createFolder.ts
@@ -58,11 +58,12 @@ export const createFolderHandler: CreateFolderHandler = (input) => {
         status: 'COMPLETE' as const,
         value: { key: path },
       }))
-      .catch(({ message, name }: Error) => {
+      .catch((error: Error) => {
+        const { message, name } = error;
         if (name === 'PreconditionFailed') {
-          return { message, status: 'OVERWRITE_PREVENTED' };
+          return { error, message, status: 'OVERWRITE_PREVENTED' };
         }
-        return { message, status: 'FAILED' };
+        return { error, message, status: 'FAILED' };
       }),
   };
 };

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/delete.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/delete.ts
@@ -46,7 +46,10 @@ export const deleteHandler: DeleteHandler = ({
       status: 'COMPLETE' as const,
       value: { key: path },
     }))
-    .catch(({ message }: Error) => ({ message, status: 'FAILED' as const }));
+    .catch((error: Error) => {
+      const { message } = error;
+      return { error, message, status: 'FAILED' as const };
+    });
 
   return { result };
 };

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/download.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/download.ts
@@ -58,7 +58,10 @@ export const downloadHandler: DownloadHandler = ({
       downloadFromUrl(key, url.toString());
       return { status: 'COMPLETE' as const, value: { url } };
     })
-    .catch(({ message }: Error) => ({ message, status: 'FAILED' as const }));
+    .catch((error: Error) => {
+      const { message } = error;
+      return { error, message, status: 'FAILED' as const };
+    });
 
   return { result };
 };

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/types.ts
@@ -107,7 +107,12 @@ export type TaskResultStatus =
 
 export interface TaskResult<TStatus, TValue> {
   /**
-   * optional result message
+   * result error (if any)
+   */
+  error?: Error;
+
+  /**
+   * result message (if any)
    */
   message?: string;
 
@@ -117,7 +122,7 @@ export interface TaskResult<TStatus, TValue> {
   status: TStatus;
 
   /**
-   * task result value
+   * task result value (if any)
    */
   value?: TValue;
 }

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/upload.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/upload.ts
@@ -38,7 +38,6 @@ export const UNDEFINED_CALLBACKS = {
 
 export const uploadHandler: UploadHandler = ({ config, data, options }) => {
   const { accountId, credentials, customEndpoint } = config;
-  // const { id, key, file, preventOverwrite } = data;
   const { key, file, preventOverwrite } = data;
   // const { onProgress, onError } = options ?? {};
   const { onProgress } = options ?? {};

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/upload.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/upload.ts
@@ -39,7 +39,6 @@ export const UNDEFINED_CALLBACKS = {
 export const uploadHandler: UploadHandler = ({ config, data, options }) => {
   const { accountId, credentials, customEndpoint } = config;
   const { key, file, preventOverwrite } = data;
-  // const { onProgress, onError } = options ?? {};
   const { onProgress } = options ?? {};
 
   const input: UploadDataInput = {

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/upload.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/upload.ts
@@ -38,7 +38,9 @@ export const UNDEFINED_CALLBACKS = {
 
 export const uploadHandler: UploadHandler = ({ config, data, options }) => {
   const { accountId, credentials, customEndpoint } = config;
+  // const { id, key, file, preventOverwrite } = data;
   const { key, file, preventOverwrite } = data;
+  // const { onProgress, onError } = options ?? {};
   const { onProgress } = options ?? {};
 
   const input: UploadDataInput = {
@@ -71,12 +73,11 @@ export const uploadHandler: UploadHandler = ({ config, data, options }) => {
       .catch((error: Error) => {
         const { message } = error;
         if (error.name === 'PreconditionFailed') {
-          return { message, status: 'OVERWRITE_PREVENTED' };
+          return { error, message, status: 'OVERWRITE_PREVENTED' };
         }
-        return {
-          message,
-          status: isCancelError(error) ? 'CANCELED' : 'FAILED',
-        };
+
+        const status = isCancelError(error) ? 'CANCELED' : 'FAILED';
+        return { error, message, status };
       }),
   };
 };

--- a/packages/test-utils/src/storage-browser/mock-handlers.ts
+++ b/packages/test-utils/src/storage-browser/mock-handlers.ts
@@ -126,7 +126,10 @@ export class MockHandlers {
     ) {
       return {
         ...UNDEFINED_CALLBACKS,
-        result: Promise.resolve({ status: 'OVERWRITE_PREVENTED' }),
+        result: Promise.resolve({
+          error: new Error('cannot overwrite existing file'),
+          status: 'OVERWRITE_PREVENTED',
+        }),
       };
     }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Update `useProcessTasks` to include `error` in `task` result, update on status callback handling logic to update `task` before providing to callbacks
- return `error` from all handlers in error cases ('FAILED', 'OVERWRITE_PREVENTED', 'CANCELED')
- refactor `updateTask` in `useProcessTasks` to return updated `task` for providing to on status callbacks

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Unit tests, manual tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
