### PR TITLE
feat(storage-browser): add defaultValue, onValueChange, and value props

### DIFF
--- a/examples/next-app-router/src/app/storage-browser/controlled-value/page.tsx
+++ b/examples/next-app-router/src/app/storage-browser/controlled-value/page.tsx
@@ -26,9 +26,8 @@ export default function Page() {
 
   return (
     <StorageBrowser
-      // @ts-expect-error
       onValueChange={handleValueChange}
-      value={value}
+      value={value ? JSON.parse(value) : null}
     />
   );
 }

--- a/examples/react-router/src/App.tsx
+++ b/examples/react-router/src/App.tsx
@@ -10,7 +10,7 @@ const ExampleLinks = () => {
   return (
     <Flex direction="column">
       <Heading level={3}>StorageBrowser</Heading>
-      {SBExamples.map(({ payload, subpath, title }) => (
+      {SBExamples.map(({ payload = '', subpath, title }) => (
         <Link
           key={subpath}
           to={`${pathname}storage-browser/${subpath}${payload}`}

--- a/examples/react-router/src/main.tsx
+++ b/examples/react-router/src/main.tsx
@@ -7,7 +7,6 @@ import App from './App';
 
 scan({
   enabled: import.meta.env.VITE_REACT_SCAN_ENABLED === 'TRUE',
-  trackUnnecessaryRenders: true,
 });
 
 createRoot(document.getElementById('root')!).render(

--- a/examples/react-router/src/storage-browser/controlled-value/index.tsx
+++ b/examples/react-router/src/storage-browser/controlled-value/index.tsx
@@ -23,7 +23,6 @@ export default function App() {
 
   return (
     <StorageBrowser
-      // @ts-expect-error to be updated
       onValueChange={handleValueChange}
       value={value ? JSON.parse(value) : {}}
     />

--- a/examples/react-router/src/storage-browser/default-value/index.tsx
+++ b/examples/react-router/src/storage-browser/default-value/index.tsx
@@ -5,8 +5,5 @@ import { StorageBrowser } from '../storage-browser';
 export default function App() {
   const { value } = useParams<{ value: string }>();
 
-  return (
-    // @ts-expect-error to be updated
-    <StorageBrowser defaultValue={value ? JSON.parse(value) : {}} />
-  );
+  return <StorageBrowser defaultValue={value ? JSON.parse(value) : {}} />;
 }

--- a/examples/react-router/src/storage-browser/index.ts
+++ b/examples/react-router/src/storage-browser/index.ts
@@ -1,23 +1,30 @@
+// apps
 import ControlledValue from './controlled-value';
 import DefaultValue from './default-value';
 import LegacyControlled from './legacy-controlled';
+import PropsValidation from './props-validation';
+
+// utils
 import { PREFIXES, INITIAL_VALUES } from './storage-browser';
 
+// with `location`, `path` search params (`useSearchParams`)
 const LEGACY_CONTROLLED_VALUE_PAYLOAD = `?location=${encodeURIComponent(
   JSON.stringify(INITIAL_VALUES.locations?.[0])
 )}&path=${PREFIXES.nested}`;
 
+// with value `search` params (`useSearchParams`)
 const CONTROLLED_VALUE_PAYLOAD = `?value=${encodeURIComponent(
   JSON.stringify({
     location: INITIAL_VALUES.locations?.[0],
-    path: `${PREFIXES.nested}`,
+    path: PREFIXES.nested,
   })
 )}`;
 
+// dynamic path params (`useParams`)
 const DEFAULT_VALUE_PAYLOAD = `/value/${encodeURIComponent(
   JSON.stringify({
     location: INITIAL_VALUES.locations?.[0],
-    path: `${PREFIXES.nested}`,
+    path: PREFIXES.nested,
   })
 )}`;
 
@@ -42,6 +49,11 @@ const EXAMPLES = [
     params: 'location/:location/path/:path/actionType/:actionType',
     payload: LEGACY_CONTROLLED_VALUE_PAYLOAD,
     title: 'Legacy Controlled',
+  },
+  {
+    Page: PropsValidation,
+    subpath: 'props-validation',
+    title: 'Props Validation',
   },
 ];
 

--- a/examples/react-router/src/storage-browser/props-validation/index.tsx
+++ b/examples/react-router/src/storage-browser/props-validation/index.tsx
@@ -41,8 +41,7 @@ export default function App() {
         }}
       />
 
-      {/* StorageBrowser.Provider: readonly */}
-      <StorageBrowser value={{}} />
+      <StorageBrowser.Provider value={{}} />
 
       {/* StorageBrowser: conflicting controlled/uncontrolled behavior */}
       <StorageBrowser defaultValue={{}} value={{}} />

--- a/examples/react-router/src/storage-browser/props-validation/index.tsx
+++ b/examples/react-router/src/storage-browser/props-validation/index.tsx
@@ -41,6 +41,7 @@ export default function App() {
         }}
       />
 
+      {/* StorageBrowser.Provider: readonly */}
       <StorageBrowser.Provider value={{}} />
 
       {/* StorageBrowser: conflicting controlled/uncontrolled behavior */}

--- a/examples/react-router/src/storage-browser/props-validation/index.tsx
+++ b/examples/react-router/src/storage-browser/props-validation/index.tsx
@@ -1,0 +1,67 @@
+import { LocationData } from '@aws-amplify/ui-react-storage/browser';
+import { StorageBrowser } from '../storage-browser';
+
+const location: LocationData = {
+  bucket: 'my-bucket',
+  id: 'id',
+  permissions: ['delete', 'get', 'list', 'write'],
+  prefix: 'my-prefix',
+  type: 'PREFIX',
+};
+const handleValueChange = () => null;
+
+export default function App() {
+  return (
+    <>
+      {/* StorageBrowser.Provider: deprecated props */}
+      <StorageBrowser.Provider
+        actionType="an-action"
+        location={location}
+        path="a-path"
+      />
+
+      {/* StorageBrowser.Provider: conflicting props w/ deprecated props */}
+      <StorageBrowser.Provider
+        actionType="an-action"
+        location={location}
+        path="a-path"
+        value={{}}
+      />
+
+      {/* StorageBrowser.Provider: controlled - missing required param */}
+      <StorageBrowser.Provider
+        onValueChange={handleValueChange}
+        value={{
+          location: {
+            bucket: 'my-bucket',
+            prefix: 'my-prefix',
+            // @ts-expect-error validate missing required param
+            permissions: undefined,
+          },
+        }}
+      />
+
+      {/* StorageBrowser.Provider: readonly */}
+      <StorageBrowser value={{}} />
+
+      {/* StorageBrowser: conflicting controlled/uncontrolled behavior */}
+      <StorageBrowser defaultValue={{}} value={{}} />
+
+      {/* StorageBrowser: readonly */}
+      <StorageBrowser value={{}} />
+
+      {/* StorageBrowser: controlled - missing required param */}
+      <StorageBrowser
+        onValueChange={handleValueChange}
+        value={{
+          location: {
+            bucket: 'my-bucket',
+            prefix: 'my-prefix',
+            // @ts-expect-error validate missing required param
+            permissions: undefined,
+          },
+        }}
+      />
+    </>
+  );
+}

--- a/packages/react-storage/src/components/StorageBrowser/providers/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/providers/index.ts
@@ -3,4 +3,10 @@ export {
   CredentialsProviderProps,
   RegisterAuthListener,
 } from './configuration';
-export { FileItems, StoreProviderProps, StoreProvider } from './store';
+export {
+  FileItems,
+  StorageBrowserEventValue,
+  StorageBrowserValue,
+  StoreProvider,
+  StoreProviderProps,
+} from './store';

--- a/packages/react-storage/src/components/StorageBrowser/providers/store/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/providers/store/index.ts
@@ -1,3 +1,4 @@
 export { FileItems } from './files';
 export { StoreProvider, StoreProviderProps } from './StoreProvider';
 export { useStore, UseStoreState } from './useStore';
+export { StorageBrowserEventValue, StorageBrowserValue } from './value';

--- a/packages/react-storage/src/components/StorageBrowser/providers/store/value/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/providers/store/value/index.ts
@@ -1,0 +1,6 @@
+export {
+  LocationEventValue,
+  LocationValue,
+  StorageBrowserEventValue,
+  StorageBrowserValue,
+} from './types';

--- a/packages/react-storage/src/components/StorageBrowser/providers/store/value/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/providers/store/value/types.ts
@@ -1,0 +1,42 @@
+import React from 'react';
+import { LocationData } from '../../../actions';
+
+/**
+ * Current `location` data. `bucket`, `prefix` and `permissions` are required
+ */
+export interface LocationValue
+  extends Pick<LocationData, 'bucket' | 'permissions' | 'prefix'> {
+  /**
+   * unique location identifier
+   * @default string - auto-generated
+   */
+  id?: LocationData['id'];
+  /**
+   * breadcrumb navigation `path`
+   * @default string - empty string
+   */
+  path?: string;
+  type?: LocationData['type'];
+}
+
+export interface StorageBrowserValue {
+  // sets action view
+  actionType?: string;
+  location?: LocationValue;
+}
+
+export interface LocationEventValue extends Required<LocationValue> {}
+
+export interface StorageBrowserEventValue {
+  // `undefined` on no `actionType` selected
+  actionType: string | undefined;
+  // `undefined` on no `location` selected
+  location: LocationEventValue | undefined;
+}
+
+export interface ValueProviderProps {
+  children?: React.ReactNode;
+  value?: StorageBrowserValue;
+  defaultValue?: StorageBrowserValue;
+  onValueChange?: (event: StorageBrowserEventValue) => void;
+}

--- a/packages/react-storage/src/components/StorageBrowser/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/types.ts
@@ -11,7 +11,12 @@ import { StorageBrowserComponents } from './ComponentsProvider';
 import { GetLocationCredentials } from './credentials';
 import { StorageBrowserDisplayText } from './displayText';
 import { ErrorBoundaryType } from './ErrorBoundary';
-import { RegisterAuthListener, StoreProviderProps } from './providers';
+import {
+  RegisterAuthListener,
+  StorageBrowserEventValue,
+  StorageBrowserValue,
+  StoreProviderProps,
+} from './providers';
 import { DerivedActionHandlers, UseAction } from './useAction';
 import {
   CopyViewType,
@@ -145,6 +150,24 @@ export interface CreateStorageBrowserInput {
  */
 export interface StorageBrowserProps<K = string, V = {}> {
   /**
+   * provide to initialize the `StorageBrowser` with a default location, `actionType`
+   * or pagination values as an uncontrolled component
+   */
+  defaultValue?: StorageBrowserValue;
+
+  /**
+   * called on location, pagination or action change events. Provide with `value`
+   * prop for controlled component behavior or as a standalone prop
+   */
+  onValueChange?: (value: StorageBrowserEventValue) => void;
+
+  /**
+   * provide with `onValueChange` to use the `StorageBrowser` as a controlled
+   * component
+   */
+  value?: StorageBrowserValue;
+
+  /**
    * Overrides default display string values. Supports resolving of static and dynamic text
    * values and error messages
    *
@@ -180,7 +203,10 @@ export interface StorageBrowserProps<K = string, V = {}> {
  */
 export interface StorageBrowserProviderProps<V = {}>
   extends StoreProviderProps,
-    Pick<StorageBrowserProps, 'displayText'> {
+    Pick<
+      StorageBrowserProps,
+      'defaultValue' | 'displayText' | 'onValueChange' | 'value'
+    > {
   // note: `views` intentionally scoped to custom slots to prevent conflicts with composability
   /**
    * Accepts custom action views rendered by `LocationActionView`
@@ -188,10 +214,25 @@ export interface StorageBrowserProviderProps<V = {}>
   views?: V;
 
   /**
-   * Sets initial `location` data. Provide to initialize the `StorageBrowser` with an initial
-   * `location`
+   * @deprecated will be removed in a future major verison. Prefer `value` for controlled behavior or `defaultValue` for initializng `actionType`
+   *
+   *  initial `actionType`, does not update
+   */
+  actionType?: string;
+
+  /**
+   * @deprecated will be removed in a future major verison. Prefer `value` for controlled behavior or `defaultValue` for initializng `actionType`
+   *
+   * initial `location` data, does not update
    */
   location?: LocationData;
+
+  /**
+   * @deprecated will be removed in a future major verison. Prefer `value` for controlled behavior or `defaultValue` for initializng `actionType`
+   *
+   * initial `location` subpath to establish navigation state, does not update
+   */
+  path?: string;
 }
 
 /**

--- a/packages/react-storage/src/components/StorageBrowser/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/types.ts
@@ -31,36 +31,34 @@ import {
 } from './views';
 
 /**
- * Configuration properties
+ * @description configuration properties
  */
 export interface StorageBrowserConfig {
   /**
-   * AWS account Id
+   * @description AWS account Id
    */
   accountId?: string;
 
   /**
-   * Custom S3 endpoint used in action handler calls
+   * @description custom S3 endpoint used in action handler calls
    */
   customEndpoint?: string;
 
   /**
-   * Location credentials retrieval handler
+   * @description location credentials retrieval handler
    */
   getLocationCredentials: GetLocationCredentials;
 
   /**
+   * @description locations list handler
    * @required
-   *
-   * Locations list handler
    */
   listLocations: ListLocations;
 
   /**
-   * @required
    *
-   * Provided handler receives an `onStateChange` callback to be called from
-   * the consumer on auth status changes to clear in-memory credentials
+   * @description provided handler receives an `onStateChange` callback to be called from the consumer on auth status changes to clear in-memory credentials
+   * @required
    *
    * @example
    * ```tsx
@@ -107,9 +105,8 @@ export interface StorageBrowserConfig {
   registerAuthListener: RegisterAuthListener;
 
   /**
+   * @description AWS account region
    * @required
-   *
-   * AWS account region
    */
   region: string;
 }
@@ -120,27 +117,27 @@ export interface StorageBrowserActions {
 }
 
 /**
- * Configuration and options for `createStorageBrowser`
+ * @description configuration and options for `createStorageBrowser`
  */
 export interface CreateStorageBrowserInput {
   /**
-   * Override and default `StorageBrowser` actions and action view configs
+   * @description override and default `StorageBrowser` actions and action view configs
    */
   actions?: StorageBrowserActions;
 
   /**
-   * `StorageBrowser` configuration properties
+   * @description `StorageBrowser` configuration properties
+   * @required
    */
   config: StorageBrowserConfig;
 
   /**
-   * Custom ErrorBoundary class. If omitted, a default ErrorBoundary is provided.
-   * To disable ErrorBoundary, set to `null`.
+   * @description custom ErrorBoundary class. If omitted, a default ErrorBoundary is provided. To disable ErrorBoundary, set to `null`.
    */
   ErrorBoundary?: ErrorBoundaryType | null;
 
   /**
-   * Overrides default `components` used within `StorageBrowser`
+   * @description Overrides default `components` used within `StorageBrowser`
    */
   components?: StorageBrowserComponents;
 }
@@ -150,27 +147,22 @@ export interface CreateStorageBrowserInput {
  */
 export interface StorageBrowserProps<K = string, V = {}> {
   /**
-   * provide to initialize the `StorageBrowser` with a default location, `actionType`
-   * or pagination values as an uncontrolled component
+   * @description provide to initialize the `StorageBrowser` with a default location, `actionType` or pagination values as an uncontrolled component
    */
-  defaultValue?: StorageBrowserValue;
+  defaultValue?: StorageBrowserValue | null;
 
   /**
-   * called on location, pagination or action change events. Provide with `value`
-   * prop for controlled component behavior or as a standalone prop
+   * @description called on location and action change events. Provide with `value` prop for controlled component behavior or as a standalone prop
    */
   onValueChange?: (value: StorageBrowserEventValue) => void;
 
   /**
-   * provide with `onValueChange` to use the `StorageBrowser` as a controlled
-   * component
+   * @description provide with `onValueChange` to use the `StorageBrowser` as a controlled component
    */
-  value?: StorageBrowserValue;
+  value?: StorageBrowserValue | null;
 
   /**
-   * Overrides default display string values. Supports resolving of static and dynamic text
-   * values and error messages
-   *
+   * @description Overrides default display string values. Supports resolving of static and dynamic text values and error messages
    * @example
    * ```tsx
    * const myDisplayText = {
@@ -192,14 +184,13 @@ export interface StorageBrowserProps<K = string, V = {}> {
   displayText?: StorageBrowserDisplayText;
 
   /**
-   * Accepts default top level `views` overrides and custom `views` defined by the `actions`
-   * parameter of `createStorageBrowser`
+   * @description accepts default top level `views` overrides and custom `views` defined by the `actions` parameter of `createStorageBrowser`
    */
   views?: StorageBrowserViews<K, V>;
 }
 
 /**
- * `StorageBrowser.Provider` component properties
+ * @description `StorageBrowser.Provider` component properties
  */
 export interface StorageBrowserProviderProps<V = {}>
   extends StoreProviderProps,
@@ -209,42 +200,37 @@ export interface StorageBrowserProviderProps<V = {}>
     > {
   // note: `views` intentionally scoped to custom slots to prevent conflicts with composability
   /**
-   * Accepts custom action views rendered by `LocationActionView`
+   * @description accepts custom action views rendered by `LocationActionView`
    */
   views?: V;
 
   /**
    * @deprecated will be removed in a future major verison. Prefer `value` for controlled behavior or `defaultValue` for initializng `actionType`
-   *
-   *  initial `actionType`, does not update
+   * @description initial `actionType`, does not update
    */
   actionType?: string;
 
   /**
    * @deprecated will be removed in a future major verison. Prefer `value` for controlled behavior or `defaultValue` for initializng `actionType`
-   *
-   * initial `location` data, does not update
+   * @description initial `location` data, does not update
    */
   location?: LocationData;
 
   /**
    * @deprecated will be removed in a future major verison. Prefer `value` for controlled behavior or `defaultValue` for initializng `actionType`
-   *
-   * initial `location` subpath to establish navigation state, does not update
+   * @description initial `location` subpath to establish navigation state, does not update
    */
   path?: string;
 }
 
 /**
- * `StorageBrowser` component, provider and view components
+ * @description `StorageBrowser` component, provider and view components
  */
 export interface StorageBrowserType<K = string, V = {}> {
   (props: StorageBrowserProps<K, V>): React.JSX.Element;
   displayName: string;
   /**
-   * `StorageBrowser` React.Context provider. Composed `StorageBrowser` components
-   * must be a descendant of a `Provider` element
-   *
+   * @description `StorageBrowser` React.Context provider. Composed `StorageBrowser` components must be a descendant of a `Provider` element
    * @example
    * ```tsx
    * <StorageBrowser.Provider>
@@ -255,9 +241,7 @@ export interface StorageBrowserType<K = string, V = {}> {
   Provider: (props: StorageBrowserProviderProps<V>) => React.JSX.Element;
 
   /**
-   * Utility view aggregating all action views. Can be used to render a standalone
-   * action view
-   *
+   * @description utility view aggregating all action views. Can be used to render a standalone action view
    * @example
    * ```tsx
    * <StorageBrowser.LocationActionView type="copy" />
@@ -266,18 +250,17 @@ export interface StorageBrowserType<K = string, V = {}> {
   LocationActionView: LocationActionViewType<K>;
 
   /**
-   * Displays data related to the selected or provided `location` and action
-   * selection
+   * @description displays data related to the selected or provided `location` and action selection
    */
   LocationDetailView: LocationDetailViewType;
 
   /**
-   * Entry point view displaying `locations` returned from `listLocations`
+   * @description entry point view displaying `locations` returned from `listLocations`
    */
   LocationsView: LocationsViewType;
 
   /**
-   * Standalone composable default action view components
+   * @description standalone composable default action view components
    */
   CopyView: CopyViewType;
   CreateFolderView: CreateFolderViewType;
@@ -288,9 +271,9 @@ export interface StorageBrowserType<K = string, V = {}> {
 type DefaultActionType<T = string> = Exclude<T, keyof DefaultActionConfigs>;
 
 /**
- * @internal @unstable interface subject to change, not recommended for public use
- *
- * Utility type resolving available custom action view component slots
+ * @internal
+ * @unstable interface subject to change, not recommended for public use
+ * @description utility type resolving available custom action view component slots
  */
 export type DerivedActionViews<T extends StorageBrowserActions> = {
   [K in keyof T['custom'] as K extends DefaultActionType<K>
@@ -302,15 +285,13 @@ export type DerivedActionViews<T extends StorageBrowserActions> = {
 
 /**
  * @internal @unstable interface subject to change, not recommended for public use
- *
- * Utility type of excluded action keys that do not have a corresponding action view
+ * @description utility type of excluded action keys that do not have a corresponding action view
  */
 type DefaultActionWithoutViewType = 'download';
 
 /**
  * @internal @unstable interface subject to change, not recommended for public use
- *
- * Utility type resolving available location action view types
+ * @description utility type resolving available location action view types
  */
 export type DerivedActionViewType<T extends StorageBrowserActions> =
   | keyof {
@@ -323,13 +304,13 @@ export type DerivedActionViewType<T extends StorageBrowserActions> =
   | Exclude<keyof DefaultActionConfigs, DefaultActionWithoutViewType>;
 
 /**
- * Return values of `createStorageBrowser`
+ * @description return values of `createStorageBrowser`
  */
 export interface CreateStorageBrowserOutput<
   C extends ExtendedActionConfigs = ExtendedActionConfigs,
 > {
   /**
-   * `StorageBrowser` component and subcomponents
+   * @description `StorageBrowser` component and subcomponents
    */
   StorageBrowser: StorageBrowserType<
     DerivedActionViewType<C>,
@@ -337,12 +318,12 @@ export interface CreateStorageBrowserOutput<
   >;
 
   /**
-   * Action handler utility hook
+   * @description action handler utility hook
    */
   useAction: UseAction<DerivedActionHandlers<C>>;
 
   /**
-   * View state utility hook
+   * @description view state utility hook
    */
   useView: UseView;
 }

--- a/packages/react-storage/src/components/StorageBrowser/useAction/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/useAction/types.ts
@@ -129,29 +129,36 @@ export type UseActionState<TTask extends Task> = [
 ];
 
 /**
- * `StorageBrowser` utility hook used to run default and custom action handlers
- * from within a parent `StorageBrowser.Provider`. `useAction` provides the
- * action handler with the current `location` state and credentials values,
- * as well as any parameters provided as `data` at the `useAction` call site
+ * @description `StorageBrowser` utility hook used to run default and custom action handlers from within a parent `StorageBrowser.Provider`. `useAction` provides the action handler with the current `location` state and credentials values, as well as any parameters provided as `data` at the `useAction` call site. accepts `handler` key to be run as initial argument and `options` with `items` as second. Returns batch tasks or atomic task state and `handler` accepting optional input allowing for location override
+ * @example
+ * batch actions - Returns batch task state and `handler` accepting optional input allowing for location override
+ * ```tsx
+ * // provide array of `items` to intialize `useAction` with batch handling behavior
+ * const items = [];
+ * const [{ tasks }, dispatchActions] = useAction('upload', { items })
+ *
+ * <button onClick={() => dispatchActions()}>start uploads</button>
+ * ```
+ *
+ * @example
+ * atomic action - returns atomic task `state` and `handler``input`, `handler` requires `input` containing `data` and `options`
+ * ```tsx
+ * // handler data
+ * const data = {}
+ * // do not provide `items` for atomic handling behavior
+ * const [{ task }, dispatchAction] = useAction('upload')
+ *
+ * <button onClick={() => dispatchAction({ data })}>start upload</button>
+ * ```
  */
 export interface UseAction<
   Handlers extends Record<keyof Handlers, ActionHandler>,
 > {
-  /**
-   * accepts `handler` to be run as initial argument and `options` with `items`
-   * as second. Returns batch task state and `handler` accoeting optional input
-   * allowing for location override
-   */
   <K extends keyof Handlers, TTask extends InferTask<Handlers[K]>>(
     key: K,
     options: UseActionOptionsWithItems<TTask>
   ): UseActionsState<TTask>;
 
-  /**
-   * * accepts `handler` to be run as initial argument and `options` as second.
-   * Returns atomic task `state` and `handler``input`, `handler`  requires `input`
-   * containing `data` and `options`
-   */
   <K extends keyof Handlers, TTask extends InferTask<Handlers[K]>>(
     key: K,
     options?: UseActionOptions<TTask>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

- add `defaultValue`, `onValueChange` and `value` to `StorageBrowserProps` and `StorageBrowserProviderProps` interfaces
- add initial controlled property related interfaces in _react-storage/src/components/StorageBrowser/providers/store/value/index.ts_
- add props validation examples in `react-router` example app

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
NA

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
