### PR TITLE
feat(storage-browser): add refactored store context

### DIFF
--- a/packages/react-storage/src/components/StorageBrowser/store/__tests__/context.spec.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/store/__tests__/context.spec.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+
+import { DEFAULT_STATE } from '../constants';
+import { StoreProvider, useStore } from '../context';
+
+describe('useStore', () => {
+  it('provides the expected values when wrapped with a `StoreProvider`', () => {
+    const { result } = renderHook(useStore, {
+      wrapper: ({ children }) => <StoreProvider>{children}</StoreProvider>,
+    });
+
+    const [state, handler] = result.current;
+
+    expect(state).toBe(DEFAULT_STATE);
+    expect(handler).toStrictEqual(expect.any(Function));
+  });
+
+  it('provides the expected values when not wrapped with a `StoreProvider`', () => {
+    const { result } = renderHook(useStore);
+
+    const [state, handler] = result.current;
+
+    expect(state).toBe(DEFAULT_STATE);
+    expect(handler).toStrictEqual(expect.any(Function));
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/store/__tests__/storeReducer.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/store/__tests__/storeReducer.spec.ts
@@ -1,0 +1,134 @@
+import { LocationData } from '../../actions';
+
+import { DEFAULT_STATE } from '../constants';
+import storeReducer from '../storeReducer';
+
+const location: LocationData = {
+  bucket: 'bucket',
+  id: 'id',
+  permissions: ['delete', 'get', 'list', 'write'],
+  prefix: 'prefix/',
+  type: 'PREFIX',
+};
+
+describe('storeReducer', () => {
+  it('returns the expected state on change `location` event', () => {
+    const output = storeReducer(DEFAULT_STATE, {
+      type: 'CHANGE_LOCATION',
+      location,
+    });
+
+    const expected = {
+      actionType: undefined,
+      location: { current: location, path: '', key: location.prefix },
+    };
+
+    expect(output).toStrictEqual(expected);
+  });
+
+  it('returns the expected state on change `location` event if `state.location` is unchanged', () => {
+    const initialOutput = storeReducer(DEFAULT_STATE, {
+      type: 'CHANGE_LOCATION',
+      location,
+    });
+
+    expect(initialOutput).toStrictEqual({
+      actionType: undefined,
+      location: { current: location, path: '', key: location.prefix },
+    });
+
+    const nextOutput = storeReducer(initialOutput, {
+      type: 'CHANGE_LOCATION',
+      location,
+    });
+
+    // assert referential equality
+    expect(initialOutput).toBe(nextOutput);
+  });
+
+  it('returns the expected state on reset `location` event', () => {
+    const state = {
+      ...DEFAULT_STATE,
+      location: { ...DEFAULT_STATE.location, current: location },
+    };
+
+    const output = storeReducer(state, { type: 'RESET_LOCATION' });
+
+    expect(output).toStrictEqual(DEFAULT_STATE);
+  });
+
+  it('returns the expected state on reset `location` event if `state.location` is unchanged', () => {
+    const state = {
+      ...DEFAULT_STATE,
+      location: { ...DEFAULT_STATE.location, current: location },
+    };
+
+    const initialOutput = storeReducer(state, { type: 'RESET_LOCATION' });
+
+    expect(initialOutput).toStrictEqual(DEFAULT_STATE);
+
+    const nextOutput = storeReducer(initialOutput, { type: 'RESET_LOCATION' });
+
+    // assert referential equality
+    expect(nextOutput).toBe(initialOutput);
+  });
+
+  it('returns the expected state on change `actionType` event', () => {
+    const actionType = 'some-action';
+
+    const output = storeReducer(DEFAULT_STATE, {
+      type: 'CHANGE_ACTION_TYPE',
+      actionType,
+    });
+
+    expect(output).toStrictEqual({ ...DEFAULT_STATE, actionType });
+  });
+
+  it('returns the expected state on change `actionType` event if `state.actionType` is unchanged', () => {
+    const actionType = 'some-action';
+
+    const initialOutput = storeReducer(DEFAULT_STATE, {
+      type: 'CHANGE_ACTION_TYPE',
+      actionType,
+    });
+
+    expect(initialOutput).toStrictEqual({ ...DEFAULT_STATE, actionType });
+
+    const nextOutput = storeReducer(initialOutput, {
+      type: 'CHANGE_ACTION_TYPE',
+      actionType,
+    });
+
+    // assert referential equality
+    expect(nextOutput).toBe(initialOutput);
+  });
+
+  it('returns the expected state on reset `actionType` event', () => {
+    const actionType = 'some-action';
+
+    const output = storeReducer(
+      { ...DEFAULT_STATE, actionType },
+      { type: 'RESET_ACTION_TYPE' }
+    );
+
+    expect(output).toStrictEqual(DEFAULT_STATE);
+  });
+
+  it('returns the same state on reset `actionType` event if `state.actionType` is `undefined`', () => {
+    const actionType = 'some-action';
+
+    const initialOutput = storeReducer(
+      { ...DEFAULT_STATE, actionType },
+      { type: 'RESET_ACTION_TYPE' }
+    );
+
+    expect(initialOutput).toStrictEqual(DEFAULT_STATE);
+
+    const nextOutput = storeReducer(initialOutput, {
+      type: 'RESET_ACTION_TYPE',
+    });
+
+    // assert referential equality
+    expect(nextOutput).toBe(initialOutput);
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/store/__tests__/useStoreReducer.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/store/__tests__/useStoreReducer.spec.ts
@@ -1,0 +1,139 @@
+import { act, renderHook } from '@testing-library/react';
+import { useControlledReducer } from '@aws-amplify/ui-react-core';
+
+import { DEFAULT_STATE } from '../constants';
+import {
+  StorageBrowserEventValue,
+  StoreActionType,
+  StoreState,
+} from '../types';
+import { getState, getInitialState } from '../utils';
+
+import storeReducer from '../storeReducer';
+import useStoreReducer from '../useStoreReducer';
+import { LocationData } from '../../actions';
+
+jest.mock('@aws-amplify/ui-react-core');
+jest.mock('../utils');
+jest.mock('../validateStoreProps');
+
+const mockGetState = jest.mocked(getState);
+const mockGetInitialState = jest.mocked(getInitialState);
+const mockUseControlledReducer = jest.mocked(useControlledReducer);
+
+describe('useStoreReducer', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('provides the expected values to `mockUseControlledReducer` when provided empty props', () => {
+    mockGetInitialState.mockReturnValue(DEFAULT_STATE);
+
+    renderHook(() => useStoreReducer({}));
+
+    expect(mockGetState).not.toHaveBeenCalled();
+
+    expect(mockGetInitialState).toHaveBeenCalledTimes(1);
+    expect(mockGetInitialState).toHaveBeenCalledWith(undefined, {});
+
+    expect(mockUseControlledReducer).toHaveBeenCalledWith(
+      storeReducer,
+      DEFAULT_STATE,
+      { controlledState: undefined, onStateChange: expect.any(Function) }
+    );
+  });
+
+  it('provides the expected values to `mockUseControlledReducer` when provided `value` prop', () => {
+    mockGetInitialState.mockReturnValue(DEFAULT_STATE);
+    mockGetState.mockReturnValue(DEFAULT_STATE);
+
+    renderHook(() => useStoreReducer({ value: null }));
+
+    expect(mockGetState).toHaveBeenCalledTimes(1);
+    expect(mockGetState).toHaveBeenCalledWith(null);
+
+    expect(mockGetInitialState).toHaveBeenCalledTimes(1);
+    expect(mockGetInitialState).toHaveBeenCalledWith(undefined, {});
+
+    expect(mockUseControlledReducer).toHaveBeenCalledWith(
+      storeReducer,
+      DEFAULT_STATE,
+      { controlledState: DEFAULT_STATE, onStateChange: expect.any(Function) }
+    );
+  });
+
+  it('provides the expected shape of `value` to `onValueChange` on `state` change', () => {
+    let mockState: StoreState;
+    mockUseControlledReducer.mockImplementation(
+      (_, state: StoreState, options) => {
+        const { onStateChange } = options ?? {};
+
+        mockState = state;
+
+        return [
+          state,
+          (action: StoreActionType) => {
+            mockState = storeReducer(mockState, action);
+
+            onStateChange?.(mockState);
+          },
+        ];
+      }
+    );
+
+    const onValueChange = jest.fn();
+
+    const { result } = renderHook(() => useStoreReducer({ onValueChange }));
+
+    const dispatch = result.current[1];
+
+    const nextLocation: LocationData = {
+      bucket: 'next-bucket',
+      id: 'next-id',
+      permissions: ['delete'],
+      prefix: 'next-prefix',
+      type: 'PREFIX',
+    };
+
+    // set next location
+    act(() => {
+      dispatch({ type: 'CHANGE_LOCATION', location: nextLocation });
+    });
+
+    const locationChangeEvent: StorageBrowserEventValue = {
+      actionType: undefined,
+      location: { ...nextLocation, path: '' },
+    };
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenCalledWith(locationChangeEvent);
+
+    const nextActionType = 'some-action';
+
+    // set next action type
+    act(() => {
+      dispatch({ type: 'CHANGE_ACTION_TYPE', actionType: nextActionType });
+    });
+
+    const actionTypeChangeEvent: StorageBrowserEventValue = {
+      actionType: nextActionType,
+      location: { ...nextLocation, path: '' },
+    };
+
+    expect(onValueChange).toHaveBeenCalledTimes(2);
+    expect(onValueChange).toHaveBeenCalledWith(actionTypeChangeEvent);
+
+    // reset location type
+    act(() => {
+      dispatch({ type: 'RESET_LOCATION' });
+    });
+
+    const resetLocationChangeEvent: StorageBrowserEventValue = {
+      actionType: nextActionType,
+      location: undefined,
+    };
+
+    expect(onValueChange).toHaveBeenCalledTimes(3);
+    expect(onValueChange).toHaveBeenCalledWith(resetLocationChangeEvent);
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/store/__tests__/utils.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/store/__tests__/utils.spec.ts
@@ -1,0 +1,164 @@
+import { LocationData } from '../../actions';
+
+import { DEFAULT_STATE } from '../constants';
+import { LocationValue } from '../types';
+import {
+  getState,
+  getInitialState,
+  getLocationData,
+  parseLocationType,
+} from '../utils';
+
+const location: LocationData = {
+  bucket: 'bucket',
+  id: 'id',
+  permissions: ['delete', 'get', 'list', 'write'],
+  prefix: 'prefix/',
+  type: 'OBJECT' as const,
+};
+
+Object.defineProperty(globalThis, 'crypto', {
+  value: { randomUUID: () => 'intentionally-static-test-id' },
+});
+
+describe('getInitialState', () => {
+  it('returns the expected state when `defaultValue` is `null`', () => {
+    const output = getInitialState(null);
+    expect(output).toBe(DEFAULT_STATE);
+  });
+
+  it('returns the expected state when `defaultValue` has a `location` missing `id` and `type` values', () => {
+    const location: LocationValue = {
+      bucket: 'bucket',
+      permissions: ['delete', 'get', 'list', 'write'],
+      prefix: 'prefix/',
+    };
+
+    const output = getInitialState({ location });
+
+    expect(output).toStrictEqual({
+      actionType: undefined,
+      location: {
+        current: {
+          ...location,
+          id: 'intentionally-static-test-id',
+          type: 'PREFIX',
+        },
+        key: 'prefix/',
+        path: '',
+      },
+    });
+  });
+
+  it('returns the expected state when `defaultValue` is `undefined`', () => {
+    const output = getInitialState(undefined);
+    expect(output).toBe(DEFAULT_STATE);
+  });
+
+  it('returns the expected state when `defaultValue` is `undefined` and provided `legacyProps`', () => {
+    const output = getInitialState(undefined, { location });
+    expect(output).toStrictEqual({
+      actionType: undefined,
+      location: { current: location, key: 'prefix/', path: '' },
+    });
+  });
+
+  it('returns the expected state when `defaultValue` is `undefined` and provided `legacyProps` with an empty `location`', () => {
+    const output = getInitialState(undefined, { location: undefined });
+    expect(output).toStrictEqual(DEFAULT_STATE);
+  });
+
+  it('returns the expected state when both `defaultValue` and `legacyProps` are explicitly `undefined``', () => {
+    const output = getInitialState(undefined, undefined);
+    expect(output).toStrictEqual(DEFAULT_STATE);
+  });
+});
+
+describe('getLocationData', () => {
+  it('returns the expected value when value is `undefined`', () => {
+    const output = getLocationData();
+
+    expect(output).toBeUndefined();
+  });
+
+  it('returns the expected value when value is a fully formed location', () => {
+    const output = getLocationData(location);
+
+    expect(output).toStrictEqual(location);
+  });
+
+  it('provides default values for `id` and `type` when not included in value', () => {
+    const value: LocationValue = {
+      bucket: 'bucket',
+      permissions: ['delete', 'get', 'list', 'write'],
+      prefix: 'prefix/',
+    };
+    const output = getLocationData(value);
+
+    expect(output?.type).toBe('PREFIX');
+    expect(output?.id).toBe('intentionally-static-test-id');
+  });
+});
+
+describe('getState', () => {
+  it('returns the expected state when value is `undefined`', () => {
+    const output = getState(undefined);
+
+    expect(output).toBe(DEFAULT_STATE);
+  });
+
+  it('returns the expected state when value is `null`', () => {
+    const output = getState(null);
+
+    expect(output).toBe(DEFAULT_STATE);
+  });
+
+  it('returns the expected state when value includes a `location` resolving to `undefined`', () => {
+    const output = getState({ location: undefined });
+
+    expect(output).toBe(DEFAULT_STATE);
+  });
+
+  it('returns the expected state when value includes a `location` missing `id` and `type` values', () => {
+    const output = getState({
+      location: {
+        bucket: 'bucket',
+        permissions: ['delete', 'get', 'list', 'write'],
+        prefix: 'prefix/',
+      },
+    });
+
+    expect(output).toStrictEqual({
+      actionType: undefined,
+      location: {
+        current: {
+          ...location,
+          id: 'intentionally-static-test-id',
+          type: 'PREFIX',
+        },
+        key: 'prefix/',
+        path: '',
+      },
+    });
+  });
+});
+
+describe('parseLocationType', () => {
+  it('returns a `type` of `PREFIX` as expected', () => {
+    const output = parseLocationType({ ...location, prefix: 'some-prefix/' });
+    expect(output).toBe('PREFIX');
+  });
+
+  it('returns a `type` of `OBJECT` as expected', () => {
+    const output = parseLocationType({
+      ...location,
+      prefix: 'some-object-key',
+    });
+    expect(output).toBe('OBJECT');
+  });
+
+  it('returns a `type` of `BUCKET` as expected', () => {
+    const output = parseLocationType({ ...location, prefix: '' });
+    expect(output).toBe('BUCKET');
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/store/__tests__/validateStoreProps.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/store/__tests__/validateStoreProps.spec.ts
@@ -1,0 +1,168 @@
+import { LocationData } from '../../actions';
+import { StoreProviderProps } from '../types';
+import {
+  CHANGED_MODE,
+  CONLICTING_PROPS,
+  DEPRECATED_PROPS,
+  DEPRECATED_PROPS_AND_CONFLICTING,
+  DEPRECATED_SUFFIX,
+  MISSING_REQUIRED,
+  READONLY,
+} from '../validateStoreProps';
+
+// mock implementation to disable terminal output
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+const location: LocationData = {
+  bucket: 'my-bucket',
+  prefix: 'my-prefix',
+  permissions: ['delete'],
+  id: '',
+  type: 'BUCKET',
+};
+
+describe('validateStoreProps', () => {
+  let validateStoreProps: (props: StoreProviderProps) => void;
+
+  beforeEach(() => {
+    // use `jest.isolateModules` to reset module state between tests
+    jest.isolateModules(() => {
+      // disable the below linting rules as they do not play well with `require` statements
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access
+      validateStoreProps = require('../validateStoreProps').default;
+    });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockClear();
+  });
+
+  it('logs the expected error message when provided multiple deprecated props once', () => {
+    validateStoreProps({ actionType: 'some-action', location });
+
+    const expected = [
+      DEPRECATED_PROPS,
+      '`actionType`, `location`',
+      DEPRECATED_SUFFIX,
+    ];
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(...expected);
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(...expected);
+  });
+
+  it('logs the expected error message when provided a single deprecated prop once', () => {
+    validateStoreProps({ actionType: 'some-action' });
+
+    const expected = [DEPRECATED_PROPS, '`actionType`', DEPRECATED_SUFFIX];
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(...expected);
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(...expected);
+  });
+
+  it('logs the expected error message when provided both `value` and `defaultValue` props once', () => {
+    validateStoreProps({ value: {}, defaultValue: {} });
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(CONLICTING_PROPS);
+
+    validateStoreProps({ value: {}, defaultValue: {} });
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(CONLICTING_PROPS);
+  });
+
+  it('logs the expected message when provided a `value.location` with missing required parameters once', () => {
+    validateStoreProps({
+      // @ts-expect-error force invalid location
+      value: { location: { ...location, bucket: undefined } },
+      onValueChange: jest.fn(),
+    });
+
+    const expected = [MISSING_REQUIRED, '`bucket`'];
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(...expected);
+
+    validateStoreProps({
+      // @ts-expect-error force invalid location
+      value: { location: { ...location, bucket: undefined } },
+      onValueChange: jest.fn(),
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(...expected);
+  });
+
+  it('logs the expected messages when provided a deprecated `location` with missing required parameters once', () => {
+    validateStoreProps({
+      // @ts-expect-error force invalid location
+      location: { ...location, bucket: undefined, prefix: undefined },
+    });
+
+    const expectedOne = [DEPRECATED_PROPS, '`location`', DEPRECATED_SUFFIX];
+    const expectedTwo = [MISSING_REQUIRED, '`bucket`, `prefix`'];
+
+    // scenario logs both deprecated and missing messages
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(...expectedOne);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(...expectedTwo);
+
+    validateStoreProps({
+      // @ts-expect-error force invalid location
+      location: { ...location, bucket: undefined, prefix: undefined },
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(...expectedOne);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(...expectedTwo);
+  });
+
+  it('logs the expected message when provided only a `value` prop once', () => {
+    validateStoreProps({ value: { location } });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(READONLY);
+
+    validateStoreProps({ value: { location } });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(READONLY);
+  });
+
+  it('logs the expected messages when provided a deprecated prop and a `value` prop once', () => {
+    validateStoreProps({
+      value: { location },
+      location,
+      onValueChange: jest.fn(),
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      DEPRECATED_PROPS_AND_CONFLICTING,
+      '`location`',
+      DEPRECATED_SUFFIX
+    );
+
+    validateStoreProps({
+      value: { location },
+      location,
+      onValueChange: jest.fn(),
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      DEPRECATED_PROPS_AND_CONFLICTING,
+      '`location`',
+      DEPRECATED_SUFFIX
+    );
+  });
+
+  it('logs the expected message on change between controlled and uncontrolled mode once', () => {
+    validateStoreProps({ value: null });
+    validateStoreProps({});
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(CHANGED_MODE);
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/store/constants.ts
+++ b/packages/react-storage/src/components/StorageBrowser/store/constants.ts
@@ -1,0 +1,6 @@
+import { StoreState } from './types';
+
+export const DEFAULT_STATE: StoreState = {
+  actionType: undefined,
+  location: { current: undefined, path: '', key: '' },
+};

--- a/packages/react-storage/src/components/StorageBrowser/store/context.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/store/context.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { noop } from '@aws-amplify/ui';
+import { createContextUtilities } from '@aws-amplify/ui-react-core';
+
+import { DEFAULT_STATE } from './constants';
+import { StoreProviderProps, StoreContextType } from './types';
+import useStoreReducer from './useStoreReducer';
+
+const DEFAULT_VALUE: StoreContextType = [DEFAULT_STATE, noop];
+export const { StoreContext, useStore } = createContextUtilities({
+  contextName: 'Store',
+  defaultValue: DEFAULT_VALUE,
+});
+
+export function StoreProvider({
+  children,
+  ...props
+}: StoreProviderProps): React.JSX.Element {
+  const value = useStoreReducer(props);
+
+  return (
+    <StoreContext.Provider value={value}>{children}</StoreContext.Provider>
+  );
+}

--- a/packages/react-storage/src/components/StorageBrowser/store/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/store/index.ts
@@ -1,0 +1,10 @@
+export { StoreProvider, useStore } from './context';
+export {
+  LocationEventValue,
+  LocationState,
+  LocationValue,
+  StorageBrowserEventValue,
+  StorageBrowserValue,
+  StoreProviderProps,
+  StoreState,
+} from './types';

--- a/packages/react-storage/src/components/StorageBrowser/store/storeReducer.ts
+++ b/packages/react-storage/src/components/StorageBrowser/store/storeReducer.ts
@@ -1,0 +1,43 @@
+import { DEFAULT_STATE } from './constants';
+import { StoreActionType, StoreState } from './types';
+
+export default function storeReducer(
+  state: StoreState,
+  action: StoreActionType
+): StoreState {
+  switch (action.type) {
+    case 'CHANGE_LOCATION': {
+      const { location, path = '' } = action;
+
+      if (
+        state.location.current?.id === location.id &&
+        state.location.path === path
+      ) {
+        return state;
+      }
+
+      const key = `${location.prefix}${path}`;
+
+      return { ...state, location: { current: location, path, key } };
+    }
+    case 'RESET_LOCATION': {
+      if (state.location.current === undefined) return state;
+
+      return { ...state, location: DEFAULT_STATE.location };
+    }
+    case 'CHANGE_ACTION_TYPE': {
+      const { actionType } = action;
+
+      if (state.actionType === actionType) {
+        return state;
+      }
+
+      return { ...state, actionType };
+    }
+    case 'RESET_ACTION_TYPE': {
+      if (state.actionType === undefined) return state;
+
+      return { ...state, actionType: DEFAULT_STATE.actionType };
+    }
+  }
+}

--- a/packages/react-storage/src/components/StorageBrowser/store/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/store/types.ts
@@ -1,0 +1,128 @@
+import React from 'react';
+import { LocationData, LocationType } from '../actions';
+
+/**
+ * @see {@link LocationData}
+ */
+export interface LocationValue
+  extends Pick<LocationData, 'bucket' | 'permissions' | 'prefix'> {
+  /**
+   * @see {@link LocationData.id} defaults to auto-generated uuid
+   */
+  id?: LocationData['id'];
+
+  /**
+   * @description string following `location.prefix` in forming an object key. defaults to empty string
+   * @example
+   * ```ts
+   * const path = "my-path/my-nested-path/";
+   *
+   * const prefix = "my-prefix/";
+   * const bucket = "my-bucket";
+   *
+   * // "my-bucket/my-prefix/my-path/my-nested-path/"
+   * const key = `${bucket}/${prefix}${path}`
+   *```
+   */
+  path?: string;
+
+  /**
+   * @see {@link LocationType}
+   */
+  type?: LocationType;
+}
+
+export interface StorageBrowserValue {
+  actionType?: string;
+  location?: LocationValue;
+}
+
+export interface LocationEventValue extends Required<LocationValue> {}
+
+export interface StorageBrowserEventValue {
+  // `undefined` on no `actionType` selected
+  actionType: string | undefined;
+  // `undefined` on no `location` selected
+  location: LocationEventValue | undefined;
+}
+
+export interface StoreProviderProps {
+  children?: React.ReactNode;
+
+  // include `null` for improved flexibility for consumers
+  defaultValue?: StorageBrowserValue | null;
+
+  // include `null` for improved flexibility for consumers
+  value?: StorageBrowserValue | null;
+
+  onValueChange?: (event: StorageBrowserEventValue) => void;
+
+  /**
+   * @deprecated
+   */
+  actionType?: string;
+
+  /**
+   * @deprecated
+   */
+  location?: LocationData;
+
+  /**
+   * @deprecated
+   */
+  path?: string;
+}
+
+export type StoreActionType =
+  | { type: 'CHANGE_ACTION_TYPE'; actionType: string }
+  | { type: 'RESET_ACTION_TYPE' }
+  | {
+      type: 'CHANGE_LOCATION';
+      location: LocationData;
+      path?: string;
+    }
+  | { type: 'RESET_LOCATION' };
+
+/**
+ * Stores current `location` and nested `path` values set on
+ * navigate events.
+ *
+ * @example
+ *`"s3://my-bucket/my-prefix/a-path/a-nested-path/"`
+ *
+ * ```
+ * const state: LocationState = {
+ *   location: {
+ *     bucket: 'my-bucket',
+ *     permisson: 'READWRITE',
+ *     prefix: 'my/prefix/',
+ *     type: 'PREFIX',
+ *   },
+ *   path: 'a-path/a-nested-path/',
+ *   key: 'my/prefix/a-path/a-nested-path/',
+ * }
+ *
+ */
+export interface LocationState {
+  /**
+   * current `location` metadata
+   */
+  current: LocationData | undefined;
+
+  /**
+   * current `location` subpath within a `location`
+   */
+  path: string;
+
+  /**
+   * fully qualified string consisting of `location` prefix and path
+   */
+  key: string;
+}
+
+export interface StoreState {
+  actionType: string | undefined;
+  location: LocationState;
+}
+
+export type StoreContextType = [StoreState, React.Dispatch<StoreActionType>];

--- a/packages/react-storage/src/components/StorageBrowser/store/useStoreReducer.ts
+++ b/packages/react-storage/src/components/StorageBrowser/store/useStoreReducer.ts
@@ -1,0 +1,31 @@
+import { useControlledReducer } from '@aws-amplify/ui-react-core';
+
+import storeReducer from './storeReducer';
+import { StoreProviderProps, StoreState, StoreContextType } from './types';
+import { getState, getInitialState } from './utils';
+import validateStoreProps from './validateStoreProps';
+
+export default function useStoreReducer(
+  props: StoreProviderProps
+): StoreContextType {
+  validateStoreProps(props);
+
+  const { defaultValue, onValueChange, value, ...legacyProps } = props;
+
+  const initialState = getInitialState(defaultValue, legacyProps);
+  const controlledState = value !== undefined ? getState(value) : undefined;
+
+  const onStateChange = ({
+    actionType,
+    location: { current, path },
+  }: StoreState) => {
+    const location = !current ? undefined : { ...current, path };
+
+    onValueChange?.({ actionType, location });
+  };
+
+  return useControlledReducer(storeReducer, initialState, {
+    controlledState,
+    onStateChange,
+  });
+}

--- a/packages/react-storage/src/components/StorageBrowser/store/utils.ts
+++ b/packages/react-storage/src/components/StorageBrowser/store/utils.ts
@@ -1,0 +1,66 @@
+import { isObject } from '@aws-amplify/ui';
+
+import { LocationData } from '../actions';
+
+import { DEFAULT_STATE } from './constants';
+import {
+  LocationValue,
+  StorageBrowserValue,
+  StoreProviderProps,
+  StoreState,
+} from './types';
+
+export const parseLocationType = ({
+  prefix,
+}: LocationData | LocationValue): LocationData['type'] =>
+  prefix?.endsWith('/') ? 'PREFIX' : prefix?.length ? 'OBJECT' : 'BUCKET';
+
+export function getLocationData(
+  location?: LocationData | LocationValue
+): LocationData | undefined {
+  if (location === undefined) return;
+
+  const { bucket, permissions, prefix, id: _id, type: _type } = location;
+
+  const id = _id ?? crypto.randomUUID();
+  const type = _type ?? parseLocationType(location);
+
+  return { bucket, permissions, prefix, id, type };
+}
+
+export function getState(
+  value: StorageBrowserValue | null | undefined
+): StoreState {
+  if (value === undefined || value === null) return DEFAULT_STATE;
+
+  const current = getLocationData(value.location);
+
+  if (!current) return DEFAULT_STATE;
+
+  const actionType = value?.actionType;
+  const path = value?.location?.path ?? '';
+  const key = `${current.prefix}${path}`;
+
+  return { actionType, location: { current, key, path } };
+}
+
+export function getInitialState(
+  defaultValue: StorageBrowserValue | null | undefined,
+  legacyProps?: Pick<StoreProviderProps, 'actionType' | 'location' | 'path'>
+): StoreState {
+  // prefer `defaultValue` if provided
+  if (isObject(defaultValue) || defaultValue === null) {
+    return getState(defaultValue);
+  }
+
+  const legacyValue = legacyProps
+    ? {
+        actionType: legacyProps.actionType,
+        location: legacyProps.location
+          ? { ...legacyProps.location, path: legacyProps.path }
+          : undefined,
+      }
+    : undefined;
+
+  return getState(legacyValue);
+}

--- a/packages/react-storage/src/components/StorageBrowser/store/validateStoreProps.ts
+++ b/packages/react-storage/src/components/StorageBrowser/store/validateStoreProps.ts
@@ -1,0 +1,112 @@
+import { templateJoin } from '@aws-amplify/ui';
+
+import { LocationData } from '../actions';
+import { LocationValue, StoreProviderProps } from './types';
+
+export const CONLICTING_PROPS =
+  '`StorageBrowser` has been been provided with both `value` and `defaultValue` props. StorageBrowser must be either controlled or uncontrolled (specify either the `value` prop, or the `defaultValue` prop, but not both). Decide between using a controlled or uncontrolled `StorageBrowser` and remove one of these props.';
+
+export const READONLY =
+  'A `value` prop has been provided to `StorageBrowser` without `onValueChange`. This will render a read-only `StorageBrowser`. If the `StorageBrowser` should be mutable use `defaultValue`, otherwise set `onValueChange`.';
+
+export const MISSING_REQUIRED =
+  'A `value` prop has been provided to `StorageBrowser` without all required `location` parameters. `StorageBrowser` will ignore the provided `location`. Missing `location` parameters: %s.';
+
+export const DEPRECATED_SUFFIX =
+  '`actionType`, `location` and `path` props have been deprecated amd will be removed in a future major version. For controlled behavior provide the `value` prop or for uncontrolled behavior provide the `defaultValue` prop.';
+export const DEPRECATED_PROPS =
+  '`StorageBrowser` has been provided with one or more deprecated props: %s. %s';
+export const DEPRECATED_PROPS_AND_CONFLICTING =
+  '`StorageBrowser` has been provided with deprecated props of %s that conflict with the `value` and `defaultValue` props. %s';
+
+export const CHANGED_MODE =
+  '`StorageBrowser` has changed from controlled to uncontrolled due to the `value` prop resolving to type `%s`. Switching between controlled and uncontrolled behaviors is not supported and may lead to unexpected behaviors.';
+
+const REQUIRED_LOCATION_KEYS = ['bucket', 'permissions', 'prefix'] as const;
+
+const DEPRECATED_PROP_KEYS = ['actionType', 'location', 'path'] as const;
+
+const template = (key: string, index: number, values: string[]) =>
+  `\`${key}\`${index < values.length - 1 ? ', ' : ''}`;
+
+const getMissingLocationKeys = (
+  location: LocationData | LocationValue | null
+) =>
+  location === null
+    ? []
+    : REQUIRED_LOCATION_KEYS.filter((key) => !location[key]);
+
+let didWarnConflictingBehavior = false;
+let didWarnDeprecatedAndConflictingProps = false;
+let didWarnDeprecatedProps = false;
+let didWarnMissingParameters = false;
+let didWarnReadonly = false;
+let didWarnChangedMode = false;
+let initialMode: string;
+
+export default function validateStoreProps(props: StoreProviderProps): void {
+  // eslint-disable-next-line no-console
+  const logError = console.error;
+
+  const { defaultValue, location, onValueChange, value } = props;
+
+  const deprecatedProps = templateJoin(
+    DEPRECATED_PROP_KEYS.filter((key) => !!props[key]),
+    template
+  );
+
+  if (
+    !didWarnDeprecatedAndConflictingProps &&
+    deprecatedProps &&
+    (!!value || !!defaultValue)
+  ) {
+    logError(
+      DEPRECATED_PROPS_AND_CONFLICTING,
+      deprecatedProps,
+      DEPRECATED_SUFFIX
+    );
+    didWarnDeprecatedAndConflictingProps = true;
+  }
+
+  if (
+    !didWarnDeprecatedAndConflictingProps &&
+    !didWarnDeprecatedProps &&
+    deprecatedProps
+  ) {
+    logError(DEPRECATED_PROPS, deprecatedProps, DEPRECATED_SUFFIX);
+    didWarnDeprecatedProps = true;
+  }
+
+  const hasConflictingProps = value && defaultValue;
+
+  if (!didWarnConflictingBehavior && hasConflictingProps) {
+    logError(CONLICTING_PROPS);
+    didWarnConflictingBehavior = true;
+  }
+
+  const isReadonly = !hasConflictingProps && value && !onValueChange;
+
+  if (!didWarnReadonly && isReadonly) {
+    logError(READONLY);
+    didWarnReadonly = true;
+  }
+
+  const missingParameters = value?.location
+    ? templateJoin(getMissingLocationKeys(value.location), template)
+    : location
+    ? templateJoin(getMissingLocationKeys(location), template)
+    : undefined;
+
+  if (!didWarnMissingParameters && missingParameters) {
+    logError(MISSING_REQUIRED, missingParameters);
+    didWarnMissingParameters = true;
+  }
+
+  const mode = value === undefined ? 'uncontrolled' : 'controlled';
+  if (!initialMode) initialMode = mode;
+
+  if (!didWarnChangedMode && initialMode !== mode) {
+    logError(CHANGED_MODE);
+    didWarnChangedMode = true;
+  }
+}

--- a/packages/ui/src/utils/utils.ts
+++ b/packages/ui/src/utils/utils.ts
@@ -219,10 +219,11 @@ export const classNameModifierByFlag = (
  */
 export function templateJoin(
   values: string[],
-  template: (value: string) => string
+  template: (value: string, index: number, values: string[]) => string
 ): string {
   return values.reduce(
-    (acc, curr) => `${acc}${isString(curr) ? template(curr) : ''}`,
+    (acc, curr, index) =>
+      `${acc}${isString(curr) ? template(curr, index, values) : ''}`,
     ''
   );
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Add refactored `StoreProvider` responsible for state management of `location`, `actionType`, `path` and `key` values
- add `StoreProvider`/`useStore` and unit tests
- add `useStoreProvider` and unit tests
- add `validateStoreProps` and unit tests
- add `storeReducer` and unit tests
- add related utils and unit tests
- add/update related types

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- manual testing and e2e testing on _feat-sb-controllled/dev_ branch
- unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
