### PR TITLE
chore: pin webpack version in vue-cli build test

### DIFF
--- a/build-system-tests/scripts/mega-app-install.sh
+++ b/build-system-tests/scripts/mega-app-install.sh
@@ -92,6 +92,14 @@ elif [ "$FRAMEWORK" == 'angular' ]; then
     # We've install @amplify/cli when creating the app
     DEPENDENCIES="$TAGGED_UI_FRAMEWORK aws-amplify"
     echo "DEPENDENCIES=$DEPENDENCIES"
+
+elif [ "$FRAMEWORK" == 'vue' ]; then
+    if [ "$BUILD_TOOL" == 'vue-cli' ]; then
+        # override webpack version
+        tmp=$(mktemp)
+        jq '."resolutions"."webpack" = "5.98.0"' package.json > "$tmp"
+        mv "$tmp" package.json
+    fi
 fi
 
 if [ "$PKG_MANAGER" == 'yarn' ]; then


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Temporarily pin webpack version to bypass build test failures.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- https://github.com/aws-amplify/amplify-ui/actions/runs/14318033966/job/40128570900

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [X] PR description included
- [X] `yarn test` passes and tests are updated/added
- [X] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
