### PR TITLE
chore(ci): add configurable resource-path to e2e example start

### DIFF
--- a/.github/workflow-samples/tagged-release.yml
+++ b/.github/workflow-samples/tagged-release.yml
@@ -29,16 +29,16 @@ jobs:
       commit: ${{ github.sha }}
       repository: ${{ github.repository }}
 
-  unit:
-    uses: ./.github/workflows/reusable-unit.yml
-    needs: setup-cache
-    with:
-      commit: ${{ github.sha }}
-      repository: ${{ github.repository }}
+  # unit:
+  #   uses: ./.github/workflows/reusable-unit.yml
+  #   needs: setup-cache
+  #   with:
+  #     commit: ${{ github.sha }}
+  #     repository: ${{ github.repository }}
 
   e2e:
     uses: ./.github/workflows/reusable-e2e.yml
-    needs: unit
+    # needs: unit
     with:
       commit: ${{ github.sha }}
       repository: ${{ github.repository }}

--- a/.github/workflow-samples/tagged-release.yml
+++ b/.github/workflow-samples/tagged-release.yml
@@ -29,16 +29,16 @@ jobs:
       commit: ${{ github.sha }}
       repository: ${{ github.repository }}
 
-  # unit:
-  #   uses: ./.github/workflows/reusable-unit.yml
-  #   needs: setup-cache
-  #   with:
-  #     commit: ${{ github.sha }}
-  #     repository: ${{ github.repository }}
+  unit:
+    uses: ./.github/workflows/reusable-unit.yml
+    needs: setup-cache
+    with:
+      commit: ${{ github.sha }}
+      repository: ${{ github.repository }}
 
   e2e:
     uses: ./.github/workflows/reusable-e2e.yml
-    # needs: unit
+    needs: unit
     with:
       commit: ${{ github.sha }}
       repository: ${{ github.repository }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -69,18 +69,25 @@ jobs:
         include:
           - example: angular
             package: angular
+            resource-path: ui/components/authenticator/sign-in-with-username
             tags: '@angular and not @todo-angular'
 
           - example: next
             package: react
+            resource-path: ui/components/authenticator/sign-in-with-username
             tags: '@react and not @todo-react'
 
           - example: react-router
             package: react
             tags: '@react-router and not @todo-react-router'
 
+          - example: next-app-router
+            package: react
+            tags: '@next-app-router and not @todo-next-app-router'
+
           - example: vue
             package: vue
+            resource-path: ui/components/authenticator/sign-in-with-username
             tags: '@vue and not @todo-vue'
 
     steps:
@@ -318,7 +325,7 @@ jobs:
         run: yarn ${{ matrix.example }}-example build
 
       - name: Start ${{ matrix.example }} example
-        run: yarn ${{ matrix.example }}-example start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000/ui/components/authenticator/sign-in-with-username
+        run: yarn ${{ matrix.example }}-example start & npx wait-on -c waitOnConfig.json -t 20000 http-get://localhost:3000/${{ matrix.resource-path || '' }}
         env:
           # Setting this value temporarily since the beta liveness sample app hits the gamma endpoint
           NEXT_PUBLIC_STREAMING_API_URL: wss://streaming-rekognition-gamma.us-east-1.amazonaws.com


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Update _.github/workflows/reusable-e2e.yml_ to include configurable `resource-path` provided to e2e example app on start to allow running of example apps that do not include `Authenticator` tests

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- validate commands locally
- CI

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
