### PR TITLE
fix(react-storage): upload status not annouced to AT users

### DIFF
--- a/packages/react-storage/src/components/StorageManager/StorageManager.tsx
+++ b/packages/react-storage/src/components/StorageManager/StorageManager.tsx
@@ -183,7 +183,9 @@ const StorageManagerBase = React.forwardRef(function StorageManager(
   };
 
   const onUploadAll = () => {
-    queueFiles();
+    setTimeout(() => {
+      queueFiles();
+    }, 5000);
   };
 
   const onPauseUpload: TaskHandler = ({ id, uploadTask }) => {

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/FileStatusMessage.tsx
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/FileStatusMessage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { classNames } from '@aws-amplify/ui';
 
 import { ComponentClassName } from '@aws-amplify/ui';
-import { Text, View } from '@aws-amplify/ui-react';
+import { Text, View, VisuallyHidden } from '@aws-amplify/ui-react';
 import { IconCheck, IconError, useIcons } from '@aws-amplify/ui-react/internal';
 import { classNameModifier } from '@aws-amplify/ui';
 import { FileStatus } from '../../../FileUploader/types';
@@ -17,55 +17,83 @@ export const FileStatusMessage = ({
   uploadSuccessfulText,
 }: FileStatusMessageProps): React.JSX.Element | null => {
   const icons = useIcons('storageManager');
-  switch (status) {
-    case FileStatus.UPLOADING: {
-      return (
-        <Text className={ComponentClassName.StorageManagerFileStatus}>
-          {getUploadingText(percentage)}
-        </Text>
-      );
+
+  // Generate the screen reader announcement text
+  const announcementText = () => {
+    switch (status) {
+      case FileStatus.UPLOADING:
+        return `File upload status changed: Uploading ${percentage}%`;
+      case FileStatus.PAUSED:
+        return `File upload status changed: Paused at ${percentage}%`;
+      case FileStatus.UPLOADED:
+        return `File upload status changed: Upload completed successfully`;
+      case FileStatus.ERROR:
+        return `File upload status changed: Error`;
+      case FileStatus.QUEUED:
+        return `File upload status changed: Queued`;
+      default:
+        return '';
     }
-    case FileStatus.PAUSED:
-      return (
-        <Text className={ComponentClassName.StorageManagerFileStatus}>
-          {getPausedText(percentage)}
-        </Text>
-      );
-    case FileStatus.UPLOADED:
-      return (
-        <Text
-          className={classNames(
-            ComponentClassName.StorageManagerFileStatus,
-            classNameModifier(
+  };
+
+  const renderStatusMessage = () => {
+    switch (status) {
+      case FileStatus.UPLOADING: {
+        return (
+          <Text className={ComponentClassName.StorageManagerFileStatus}>
+            {getUploadingText(percentage)}
+          </Text>
+        );
+      }
+      case FileStatus.PAUSED:
+        return (
+          <Text className={ComponentClassName.StorageManagerFileStatus}>
+            {getPausedText(percentage)}
+          </Text>
+        );
+      case FileStatus.UPLOADED:
+        return (
+          <Text
+            className={classNames(
               ComponentClassName.StorageManagerFileStatus,
-              'success'
-            )
-          )}
-        >
-          <View as="span" fontSize="xl">
-            {icons?.success ?? <IconCheck />}
-          </View>
-          {uploadSuccessfulText}
-        </Text>
-      );
-    case FileStatus.ERROR:
-      return (
-        <Text
-          className={classNames(
-            ComponentClassName.StorageManagerFileStatus,
-            classNameModifier(
+              classNameModifier(
+                ComponentClassName.StorageManagerFileStatus,
+                'success'
+              )
+            )}
+          >
+            <View as="span" fontSize="xl">
+              {icons?.success ?? <IconCheck />}
+            </View>
+            {uploadSuccessfulText}
+          </Text>
+        );
+      case FileStatus.ERROR:
+        return (
+          <Text
+            className={classNames(
               ComponentClassName.StorageManagerFileStatus,
-              'error'
-            )
-          )}
-        >
-          <View as="span" fontSize="xl">
-            {icons?.error ?? <IconError />}
-          </View>
-          {errorMessage}
-        </Text>
-      );
-    default:
-      return null;
-  }
+              classNameModifier(
+                ComponentClassName.StorageManagerFileStatus,
+                'error'
+              )
+            )}
+          >
+            <View as="span" fontSize="xl">
+              {icons?.error ?? <IconError />}
+            </View>
+            {errorMessage}
+          </Text>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <>
+      <VisuallyHidden role="status">{announcementText()}</VisuallyHidden>
+      {renderStatusMessage()}
+    </>
+  );
 };

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/FileStatusMessage.test.tsx
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/FileStatusMessage.test.tsx
@@ -105,4 +105,51 @@ describe('FileStatusMessage', () => {
     expect(screen.getByTestId('error')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
+
+  it('announces upload progress when status is uploading', () => {
+    render(
+      <FileStatusMessage {...defaultProps} status={FileStatus.UPLOADING} />
+    );
+
+    const announcement = screen.getByRole('status');
+    expect(announcement).toHaveTextContent(
+      'File upload status changed: Uploading 50%'
+    );
+  });
+
+  it('announces paused status with progress', () => {
+    render(<FileStatusMessage {...defaultProps} status={FileStatus.PAUSED} />);
+
+    const announcement = screen.getByRole('status');
+    expect(announcement).toHaveTextContent(
+      'File upload status changed: Paused at 50%'
+    );
+  });
+
+  it('announces successful upload completion', () => {
+    render(
+      <FileStatusMessage {...defaultProps} status={FileStatus.UPLOADED} />
+    );
+
+    const announcement = screen.getByRole('status');
+    expect(announcement).toHaveTextContent(
+      'File upload status changed: Upload completed successfully'
+    );
+  });
+
+  it('announces error status', () => {
+    render(<FileStatusMessage {...defaultProps} status={FileStatus.ERROR} />);
+
+    const announcement = screen.getByRole('status');
+    expect(announcement).toHaveTextContent('File upload status changed: Error');
+  });
+
+  it('has no announcement for queued status', () => {
+    render(<FileStatusMessage {...defaultProps} status={FileStatus.QUEUED} />);
+
+    const announcement = screen.getByRole('status');
+    expect(announcement).toHaveTextContent(
+      'File upload status changed: Queued'
+    );
+  });
 });

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileControl.test.tsx.snap
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileControl.test.tsx.snap
@@ -75,6 +75,12 @@ exports[`FileControl renders as expected when file is uploading 1`] = `
         </span>
       </button>
     </div>
+    <span
+      class="amplify-visually-hidden"
+      role="status"
+    >
+      File upload status changed: Uploading 0%
+    </span>
     <p
       class="amplify-text amplify-storagemanager__file__status"
     >
@@ -137,6 +143,12 @@ exports[`FileControl renders as expected when uploading is paused 1`] = `
         </span>
       </button>
     </div>
+    <span
+      class="amplify-visually-hidden"
+      role="status"
+    >
+      File upload status changed: Paused at 0%
+    </span>
     <p
       class="amplify-text amplify-storagemanager__file__status"
     >
@@ -242,6 +254,12 @@ exports[`FileControl renders thumbnails 1`] = `
         </span>
       </button>
     </div>
+    <span
+      class="amplify-visually-hidden"
+      role="status"
+    >
+      File upload status changed: Uploading 0%
+    </span>
     <p
       class="amplify-text amplify-storagemanager__file__status"
     >
@@ -347,6 +365,12 @@ exports[`FileControl should default to showThumbnails being true 1`] = `
         </span>
       </button>
     </div>
+    <span
+      class="amplify-visually-hidden"
+      role="status"
+    >
+      File upload status changed: Uploading 0%
+    </span>
     <p
       class="amplify-text amplify-storagemanager__file__status"
     >

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileList.test.tsx.snap
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileList.test.tsx.snap
@@ -85,6 +85,12 @@ exports[`FileList renders an alert in case of error 1`] = `
           </span>
         </button>
       </div>
+      <span
+        class="amplify-visually-hidden"
+        role="status"
+      >
+        File upload status changed: Uploading 0%
+      </span>
       <p
         class="amplify-text amplify-storagemanager__file__status"
       >
@@ -219,6 +225,12 @@ exports[`FileList renders as expected 1`] = `
           </span>
         </button>
       </div>
+      <span
+        class="amplify-visually-hidden"
+        role="status"
+      >
+        File upload status changed: Uploading 0%
+      </span>
       <p
         class="amplify-text amplify-storagemanager__file__status"
       >
@@ -311,6 +323,12 @@ exports[`FileList renders as expected when upload is resumable 1`] = `
           </span>
         </button>
       </div>
+      <span
+        class="amplify-visually-hidden"
+        role="status"
+      >
+        File upload status changed: Uploading 0%
+      </span>
       <p
         class="amplify-text amplify-storagemanager__file__status"
       >

--- a/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileStatusMessage.test.tsx.snap
+++ b/packages/react-storage/src/components/StorageManager/ui/FileList/__tests__/__snapshots__/FileStatusMessage.test.tsx.snap
@@ -2,6 +2,12 @@
 
 exports[`FileStatusMessage renders as expected when file is uploaded 1`] = `
 <div>
+  <span
+    class="amplify-visually-hidden"
+    role="status"
+  >
+    File upload status changed: Upload completed successfully
+  </span>
   <p
     class="amplify-text amplify-storagemanager__file__status amplify-storagemanager__file__status--success"
   >
@@ -31,6 +37,12 @@ exports[`FileStatusMessage renders as expected when file is uploaded 1`] = `
 
 exports[`FileStatusMessage renders as expected when file is uploading 1`] = `
 <div>
+  <span
+    class="amplify-visually-hidden"
+    role="status"
+  >
+    File upload status changed: Uploading 50%
+  </span>
   <p
     class="amplify-text amplify-storagemanager__file__status"
   >
@@ -41,6 +53,12 @@ exports[`FileStatusMessage renders as expected when file is uploading 1`] = `
 
 exports[`FileStatusMessage renders as expected when file uploading is paused 1`] = `
 <div>
+  <span
+    class="amplify-visually-hidden"
+    role="status"
+  >
+    File upload status changed: Paused at 50%
+  </span>
   <p
     class="amplify-text amplify-storagemanager__file__status"
   >
@@ -51,6 +69,12 @@ exports[`FileStatusMessage renders as expected when file uploading is paused 1`]
 
 exports[`FileStatusMessage renders as expected when there is an error uploading 1`] = `
 <div>
+  <span
+    class="amplify-visually-hidden"
+    role="status"
+  >
+    File upload status changed: Error
+  </span>
   <p
     class="amplify-text amplify-storagemanager__file__status amplify-storagemanager__file__status--error"
   >
@@ -80,6 +104,12 @@ exports[`FileStatusMessage renders as expected when there is an error uploading 
 
 exports[`FileStatusMessage renders custom icons from IconProvider 1`] = `
 <div>
+  <span
+    class="amplify-visually-hidden"
+    role="status"
+  >
+    File upload status changed: Error
+  </span>
   <p
     class="amplify-text amplify-storagemanager__file__status amplify-storagemanager__file__status--error"
   >
@@ -90,6 +120,12 @@ exports[`FileStatusMessage renders custom icons from IconProvider 1`] = `
     </span>
     Error
   </p>
+  <span
+    class="amplify-visually-hidden"
+    role="status"
+  >
+    File upload status changed: Upload completed successfully
+  </span>
   <p
     class="amplify-text amplify-storagemanager__file__status amplify-storagemanager__file__status--success"
   >
@@ -103,4 +139,13 @@ exports[`FileStatusMessage renders custom icons from IconProvider 1`] = `
 </div>
 `;
 
-exports[`FileStatusMessage renders nothing when status is queued 1`] = `<div />`;
+exports[`FileStatusMessage renders nothing when status is queued 1`] = `
+<div>
+  <span
+    class="amplify-visually-hidden"
+    role="status"
+  >
+    File upload status changed: Queued
+  </span>
+</div>
+`;


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adding a new VisuallyHidden Text, that will announce the file upload status changes to screen reader. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Manual testing with VoiceOver

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
