### PR TITLE
fix(react): add export.types for internal subpath

### DIFF
--- a/.changeset/fast-pigs-clap.md
+++ b/.changeset/fast-pigs-clap.md
@@ -1,0 +1,6 @@
+---
+"@aws-amplify/ui-react-storage": patch
+"@aws-amplify/ui-react": patch
+---
+
+fix(react): add export.types for internal subpath

--- a/packages/react-storage/src/components/StorageBrowser/components/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/components/index.ts
@@ -14,5 +14,5 @@ export {
   StorageBrowserComponents,
 } from './ComponentsProvider';
 export { componentsDefault } from './defaults';
-export { ViewElement } from './elements';
+export { StorageBrowserIconType, ViewElement } from './elements';
 export { WithKey } from './types';

--- a/packages/react-storage/src/components/StorageBrowser/index.ts
+++ b/packages/react-storage/src/components/StorageBrowser/index.ts
@@ -30,7 +30,11 @@ export {
   CreateManagedAuthAdapterInput,
   StorageBrowserAuthAdapter,
 } from './adapters';
-export { componentsDefault, StorageBrowserComponents } from './components';
+export {
+  componentsDefault,
+  StorageBrowserComponents,
+  StorageBrowserIconType,
+} from './components';
 export {
   createStorageBrowser,
   CreateStorageBrowserInput,

--- a/packages/react-storage/src/components/StorageBrowser/views/hooks/useResolveTableData/__tests__/useResolveTableData.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/hooks/useResolveTableData/__tests__/useResolveTableData.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import useResolveDataTable from '../useResolveTableData';
+import useResolveTableData from '../useResolveTableData';
 import { DataTableResolvers } from '../types';
 
 type Key = (typeof keys)[number];
@@ -27,7 +27,7 @@ describe('useResolveTableData', () => {
     const data = { items, props: {} };
 
     const { result } = renderHook(() =>
-      useResolveDataTable(keys, resolvers, data)
+      useResolveTableData(keys, resolvers, data)
     );
 
     const { headers, rows } = result.current;
@@ -57,7 +57,7 @@ describe('useResolveTableData', () => {
     const data = { props: {} };
 
     const { result } = renderHook(() =>
-      useResolveDataTable(keys, resolvers, data)
+      useResolveTableData(keys, resolvers, data)
     );
 
     expect(result.current.rows).toHaveLength(0);
@@ -67,7 +67,7 @@ describe('useResolveTableData', () => {
     const data = { props: {} };
 
     const { rerender, result } = renderHook(() =>
-      useResolveDataTable(keys, resolvers, data)
+      useResolveTableData(keys, resolvers, data)
     );
 
     const initData = result.current;

--- a/packages/react-storage/src/components/StorageBrowser/views/hooks/useResolveTableData/useResolveTableData.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/hooks/useResolveTableData/useResolveTableData.ts
@@ -4,11 +4,7 @@ import { DataTableProps } from '../../../components';
 
 import { DataTableResolvers } from './types';
 
-export default function useResolveDataTable<
-  K extends string,
-  TItem = {},
-  TProps = {},
->(
+export default function useResolveTableData<K extends string, TItem, TProps>(
   keys: readonly K[] | K[],
   { getCell, getHeader, getRowKey }: DataTableResolvers<K, TProps, TItem>,
   { items, props }: { items?: TItem[]; props: TProps }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,7 +11,8 @@
     },
     "./internal": {
       "import": "./dist/esm/internal.mjs",
-      "require": "./dist/internal.js"
+      "require": "./dist/internal.js",
+      "types": "./dist/types/internal.d.ts"
     },
     "./server": {
       "types": "./dist/types/server.d.ts",

--- a/packages/react/src/primitives/Icon/context/IconsContext.tsx
+++ b/packages/react/src/primitives/Icon/context/IconsContext.tsx
@@ -1,38 +1,5 @@
 import * as React from 'react';
-
-type StorageBrowserIconType =
-  | 'action-canceled'
-  | 'action-error'
-  | 'action-info'
-  | 'action-initial'
-  | 'action-progress'
-  | 'action-queued'
-  | 'action-success'
-  | 'cancel'
-  | 'create-folder'
-  | 'copy-file'
-  | 'delete-file'
-  | 'dismiss'
-  | 'download'
-  | 'error'
-  | 'exit'
-  | 'file'
-  | 'folder'
-  | 'info'
-  | 'loading'
-  | 'menu'
-  | 'paginate-next'
-  | 'paginate-previous'
-  | 'refresh'
-  | 'search'
-  | 'sort-ascending'
-  | 'sort-descending'
-  | 'sort-indeterminate'
-  | 'success'
-  | 'upload-file'
-  | 'upload-folder'
-  | 'vertical-kebab'
-  | 'warning';
+import { StorageBrowserIconType } from './StorageBrowserIcons';
 
 type ComponentIcons<Keys extends string> = {
   [Key in Keys]?: React.ReactNode;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fix `StorageBrowserIconType` resolving to `any` for consumers of _@aws-amplify/ui-react-storage_

**Before**
<img src="https://github.com/user-attachments/assets/c41d9b6a-b197-4a59-b4c3-460e61a6bf3e" alt="app-screen" width="400" />

**After**
<img src="https://github.com/user-attachments/assets/724bde56-3d20-429a-b634-63f685c1b42c" alt="app-screen" width="400" />

**Changes**
- add missing `export.fields` field to _react/package.json_
- remove duplicated `StorageBrowserIconType` type from ui-react
- expose `StorageBrowserIconType` from _@aws-amplify/ui-react-storage/browser_
- fix naming `useResolveDataTable`/`useResolveTableData` naming discrepancy in ui-react-storage

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`yarn build` and validate appropriate typing in vscode

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
