### PR TITLE
chore (ci): update RN build tests with standalone RN 0.78 test

### DIFF
--- a/.github/workflows/reusable-build-system-test-react-native.yml
+++ b/.github/workflows/reusable-build-system-test-react-native.yml
@@ -19,6 +19,7 @@ jobs:
         framework-version: [
             # uncomment to enable
             { formatted: latest, value: latest },
+            { formatted: 078, value: 0.78 },
             { formatted: 077, value: 0.77 },
             { formatted: 076, value: 0.76 },
             { formatted: 075, value: 0.75 },
@@ -38,6 +39,9 @@ jobs:
         exclude:
           - build-tool: expo
             platform: ios
+          - build-tool: expo
+            platform: android
+            framework-version: { formatted: '078', value: '0.78' }
           - build-tool: expo
             platform: android
             framework-version: { formatted: '077', value: '0.77' }
@@ -64,25 +68,9 @@ jobs:
           # https://stackoverflow.com/questions/63463373/create-an-expo-project-with-a-specific-version
           # Only include officially supported Expo SDK versions: https://docs.expo.dev/versions/latest/
           - framework: react-native
-            framework-version: { formatted: 073, value: '0.73' }
+            framework-version: { formatted: 077, value: '0.77' }
             build-tool: expo
-            build-tool-version: 50
-            platform: android
-            pkg-manager: npm
-            node-version: 20
-            logfile: test.log
-          - framework: react-native
-            framework-version: { formatted: 074, value: '0.74' }
-            build-tool: expo
-            build-tool-version: 51
-            platform: android
-            pkg-manager: npm
-            node-version: 20
-            logfile: test.log
-          - framework: react-native
-            framework-version: { formatted: 075, value: '0.75' }
-            build-tool: expo
-            build-tool-version: 51
+            build-tool-version: 52
             platform: android
             pkg-manager: npm
             node-version: 20
@@ -96,9 +84,25 @@ jobs:
             node-version: 20
             logfile: test.log
           - framework: react-native
-            framework-version: { formatted: 077, value: '0.77' }
+            framework-version: { formatted: 075, value: '0.75' }
             build-tool: expo
-            build-tool-version: 52
+            build-tool-version: 51
+            platform: android
+            pkg-manager: npm
+            node-version: 20
+            logfile: test.log
+          - framework: react-native
+            framework-version: { formatted: 074, value: '0.74' }
+            build-tool: expo
+            build-tool-version: 51
+            platform: android
+            pkg-manager: npm
+            node-version: 20
+            logfile: test.log
+          - framework: react-native
+            framework-version: { formatted: 073, value: '0.73' }
+            build-tool: expo
+            build-tool-version: 50
             platform: android
             pkg-manager: npm
             node-version: 20

--- a/build-system-tests/scripts/mega-app-install.sh
+++ b/build-system-tests/scripts/mega-app-install.sh
@@ -118,7 +118,11 @@ else
         echo "npm install $DEPENDENCIES"
         install_dependencies_with_retries npm "$DEPENDENCIES"
         if [[ "$BUILD_TOOL" == "expo" ]]; then
-            if [[ "$FRAMEWORK_VERSION" == "0.75" ]]; then 
+            if [[ "$FRAMEWORK_VERSION" == "0.77" ]]; then
+                # Expo SDK version 52.0.27 supports RN 0.76 and 0.77 but installs 0.76 by default https://expo.dev/changelog/2025-01-21-react-native-0.77#2-install-updated-packages
+                echo "npx expo install react-native@~0.77.1"
+                npx expo install react-native@~0.77.1
+            elif [[ "$FRAMEWORK_VERSION" == "0.75" ]]; then 
                 # Expo SDK version 51.0.0 supports RN 0.74 and 0.75 but installs 0.74 by default https://expo.dev/changelog/2024/08-14-react-native-0.75#2-install-updated-packages
                 echo "npx expo install react-native@~0.75.0"
                 npx expo install react-native@~0.75.0


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

RN 0.79 was recently released and the latest tests are no longer testing RN 0.78 actively. However, Expo has not released or provided stable support for their SDK yet at the time of this writing to support RN 0.78, so 0.78 can only be tested using the RN CLI currently.

Furthermore, it was discovered that there was an extra check missed in order to test RN 0.77 with Expo SDK 52, which meant we were testing RN 0.76 instead of RN 0.77.

- add RN 0.78 test with RN CLI
- add missing check for RN 0.77 when using Expo build tool to address missing 0.77 Expo/RN testing
- **_nit_:** re-order Expo RN tests to be in descending order to follow the RN CLI tests order

#### Description of how you validated changes

Successful action run: https://github.com/aws-amplify/amplify-ui/actions/runs/14393076489/job/40363870986

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
