### PR TITLE
chore(examples): add missing prefix to storage initial values

### DIFF
--- a/examples/next-app-router/src/app/storage-browser/storage-browser.ts
+++ b/examples/next-app-router/src/app/storage-browser/storage-browser.ts
@@ -4,8 +4,8 @@ import {
 } from '@aws-amplify/ui-react-storage/browser';
 import '@aws-amplify/ui-react-storage/styles.css';
 import {
-  MockHandlers,
   InitialValues,
+  MockHandlers,
 } from '@aws-amplify/ui-test-utils/storage-browser';
 
 export const PREFIXES = {
@@ -39,6 +39,7 @@ export const INITIAL_VALUES: InitialValues = {
         type: 'FOLDER',
       },
     ],
+    [`${PREFIXES.base}${PREFIXES.nested}${PREFIXES.deeplyNested}`]: [],
   },
 };
 

--- a/examples/react-router/src/storage-browser/storage-browser.ts
+++ b/examples/react-router/src/storage-browser/storage-browser.ts
@@ -4,8 +4,8 @@ import {
 } from '@aws-amplify/ui-react-storage/browser';
 import '@aws-amplify/ui-react-storage/styles.css';
 import {
-  MockHandlers,
   InitialValues,
+  MockHandlers,
 } from '@aws-amplify/ui-test-utils/storage-browser';
 
 export const PREFIXES = {
@@ -39,6 +39,7 @@ export const INITIAL_VALUES: InitialValues = {
         type: 'FOLDER',
       },
     ],
+    [`${PREFIXES.base}${PREFIXES.nested}${PREFIXES.deeplyNested}`]: [],
   },
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
A prefix value was missing from the folder structure defined in `INITIAL_VALUES` for the example apps, which caused issues when interacting with the prefix folder (e.g. uploading files)

- fix `deeply-nested-prefix/` to have a folder initial value

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
manual testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
