### PR TITLE
fix(storage-browser): hotfix move useProcessTasks concurrency option to dispatch handler

### DIFF
--- a/.changeset/nasty-months-teach.md
+++ b/.changeset/nasty-months-teach.md
@@ -1,5 +1,0 @@
----
-"@aws-amplify/ui-react-storage": patch
----
-
-fix(storage-browser): move useProcessTasks concurrency option to dispatch handler

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-react": "6.11.1",
-    "@aws-amplify/ui-react-storage": "3.10.1",
+    "@aws-amplify/ui-react-storage": "3.10.2",
     "@docsearch/react": "3",
     "@mdx-js/loader": "^2.1.0",
     "@mdx-js/mdx": "^2.1.0",

--- a/examples/next-app-router/package.json
+++ b/examples/next-app-router/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-react": "6.11.1",
-    "@aws-amplify/ui-react-storage": "3.10.1",
+    "@aws-amplify/ui-react-storage": "3.10.2",
     "react": "^18.3.0",
     "next": "^14.2.25",
     "react-dom": "^18",

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -15,7 +15,7 @@
     "@aws-amplify/ui-react-geo": "^2.2.8",
     "@aws-amplify/ui-react-liveness": "^3.3.8",
     "@aws-amplify/ui-react-notifications": "^2.2.8",
-    "@aws-amplify/ui-react-storage": "^3.10.1",
+    "@aws-amplify/ui-react-storage": "^3.10.2",
     "@aws-sdk/credential-providers": "^3.370.0",
     "next": "^14.2.25",
     "next-global-css": "^1.1.1",

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui-react": "6.11.1",
-    "@aws-amplify/ui-react-storage": "3.10.1",
+    "@aws-amplify/ui-react-storage": "3.10.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.3"

--- a/packages/react-storage/CHANGELOG.md
+++ b/packages/react-storage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aws-amplify/ui-react-storage
 
+## 3.10.2
+
+### Patch Changes
+
+- [`cf63046c171b5dd349121d0d8bbf2282fb71aae4`](https://github.com/aws-amplify/amplify-ui/commit/cf63046c171b5dd349121d0d8bbf2282fb71aae4) Thanks [@calebpollman](https://github.com/calebpollman)! - fix(storage-browser): move useProcessTasks concurrency option to dispatch handler
+
 ## 3.10.1
 
 ### Patch Changes

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/ui-react-storage",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "main": "dist/index.js",
   "module": "dist/esm/index.mjs",
   "exports": {
@@ -66,7 +66,7 @@
       "name": "createStorageBrowser",
       "path": "dist/esm/browser.mjs",
       "import": "{ createStorageBrowser }",
-      "limit": "64.13 kB",
+      "limit": "64.19 kB",
       "ignore": [
         "@aws-amplify/storage"
       ]

--- a/packages/react-storage/src/version.ts
+++ b/packages/react-storage/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '3.10.1';
+export const VERSION = '3.10.2';

--- a/packages/test-utils/CHANGELOG.md
+++ b/packages/test-utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aws-amplify/ui-test-utils
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies [[`cf63046c171b5dd349121d0d8bbf2282fb71aae4`](https://github.com/aws-amplify/amplify-ui/commit/cf63046c171b5dd349121d0d8bbf2282fb71aae4)]:
+  - @aws-amplify/ui-react-storage@3.10.2
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-amplify/ui-test-utils",
   "private": true,
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Test utils for Amplify Connected Component e2e tests",
   "exports": {
     "./*": {
@@ -26,7 +26,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@aws-amplify/ui-react-storage": "3.10.1",
+    "@aws-amplify/ui-react-storage": "3.10.2",
     "tslib": "^2.5.2"
   }
 }


### PR DESCRIPTION
#### Description of changes
- Merging HotFix branch back to main. This is after we released a hotFix for https://github.com/aws-amplify/amplify-ui/pull/6525.
- Since we had merged the hotFix PR to main first, we need to manually remove it's changeSet since this is already released by the hotFix branch  

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
…atch handler (#6528)

* fix(storage-browser): move useProcessTasks concurrency option to dispatch handler (#6525)

* chore: fix publish-hotfix actions (#6527)

* Version Packages

* chore: bump size limit

---------

Co-authored-by: Caleb Pollman <cpollman@amazon.com>