### PR TITLE
feat(ai-conversation): add conditional autoScroll handling

### DIFF
--- a/.changeset/brave-bears-teach.md
+++ b/.changeset/brave-bears-teach.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-ai": minor
+---
+
+feat(ai-conversation): add conditional autoScroll handling

--- a/packages/react-ai/src/components/AIConversation/AIConversation.tsx
+++ b/packages/react-ai/src/components/AIConversation/AIConversation.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
+
 import { Flex, ScrollView } from '@aws-amplify/ui-react';
 import {
   IconAssistant,
   IconUser,
   useIcons,
 } from '@aws-amplify/ui-react/internal';
+
+import useConversationScrollProps from './useConversationScrollProps';
 import type {
   AIConversation as AIConversationType,
   AIConversationInput,
@@ -29,6 +32,7 @@ interface AIConversationBaseProps
 function AIConversationBase({
   avatars,
   controls,
+  messages,
   ...rest
 }: AIConversationBaseProps): React.JSX.Element {
   useSetUserAgent({
@@ -51,17 +55,12 @@ function AIConversationBase({
 
   const providerProps = {
     ...rest,
-    avatars: {
-      ...defaultAvatars,
-      ...avatars,
-    },
-    controls: {
-      MessageList,
-      PromptList,
-      Form,
-      ...controls,
-    },
+    avatars: { ...defaultAvatars, ...avatars },
+    controls: { MessageList, PromptList, Form, ...controls },
+    messages,
   };
+
+  const scrollProps = useConversationScrollProps(messages);
 
   return (
     <AIConversationProvider {...providerProps}>
@@ -69,7 +68,7 @@ function AIConversationBase({
         className={ComponentClassName.AIConversation}
         testId="ai-conversation"
       >
-        <ScrollView autoScroll="smooth" flex="1">
+        <ScrollView {...scrollProps} flex="1">
           <DefaultMessageControl />
           <MessagesControl />
         </ScrollView>

--- a/packages/react-ai/src/components/AIConversation/__tests__/useConversationScrollProps.test.ts
+++ b/packages/react-ai/src/components/AIConversation/__tests__/useConversationScrollProps.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from '@testing-library/react';
+import useShouldAutoScroll from '../useConversationScrollProps';
+import { ConversationMessage } from '../../../types';
+
+const messages: ConversationMessage[] = [];
+
+type ScrollEvent = React.UIEvent<HTMLDivElement>;
+
+describe('useShouldAutoScroll', () => {
+  it('returns the expected values on mount', () => {
+    const { result } = renderHook(() => useShouldAutoScroll(messages));
+
+    const { autoScroll, onScroll } = result.current;
+
+    expect(autoScroll).toBe('smooth');
+    expect(onScroll).toStrictEqual(expect.any(Function));
+  });
+
+  it('returns the expected values on messages length change', () => {
+    const { result, rerender } = renderHook(
+      (_messages: ConversationMessage[] = messages) =>
+        useShouldAutoScroll(_messages)
+    );
+
+    const { autoScroll: initAutoScroll, onScroll } = result.current;
+
+    expect(initAutoScroll).toBe('smooth');
+
+    const scrollStartEvent = {
+      currentTarget: { scrollTop: 120 },
+    } as ScrollEvent;
+
+    act(() => {
+      onScroll?.(scrollStartEvent);
+    });
+
+    const { autoScroll: startAutoScroll } = result.current;
+    expect(startAutoScroll).toBe('smooth');
+
+    const scrollUpEvent = { currentTarget: { scrollTop: 119 } } as ScrollEvent;
+
+    act(() => {
+      onScroll?.(scrollUpEvent);
+    });
+
+    const { autoScroll: disabledAutoScroll } = result.current;
+
+    expect(disabledAutoScroll).toBeUndefined();
+
+    // increase `messages` length
+    rerender([...messages, {} as ConversationMessage]);
+
+    const { autoScroll: nextMessagesAutoScroll } = result.current;
+
+    expect(nextMessagesAutoScroll).toBe('smooth');
+  });
+});

--- a/packages/react-ai/src/components/AIConversation/useConversationScrollProps.ts
+++ b/packages/react-ai/src/components/AIConversation/useConversationScrollProps.ts
@@ -1,0 +1,44 @@
+import * as React from 'react';
+
+import type { ScrollViewProps } from '@aws-amplify/ui-react';
+import { useHasValueUpdated } from '@aws-amplify/ui-react-core';
+
+import type { ConversationMessage } from '../../types';
+
+interface ConverationScrollProps
+  extends Pick<ScrollViewProps, 'onScroll' | 'autoScroll'> {}
+
+export default function useConversationScrollProps(
+  messages: ConversationMessage[]
+): ConverationScrollProps {
+  const [autoScroll, setAutoScroll] =
+    React.useState<ConverationScrollProps['autoScroll']>('smooth');
+
+  const messagesLength = messages.length;
+  const hasMessagesLengthChanged = useHasValueUpdated(messagesLength, true);
+
+  const lastScrollTop = React.useRef<number | undefined>();
+
+  const onScroll: ConverationScrollProps['onScroll'] = ({ currentTarget }) => {
+    if (autoScroll !== 'smooth') return;
+
+    const { scrollTop } = currentTarget;
+
+    // set `autoScroll` and `lastScrollTop` to `undefined` on user scroll up
+    if (lastScrollTop.current && scrollTop < lastScrollTop.current) {
+      setAutoScroll(undefined);
+      lastScrollTop.current = undefined;
+    } else {
+      lastScrollTop.current = scrollTop;
+    }
+  };
+
+  React.useEffect(() => {
+    // reset `autoScroll` to 'smooth' on new message
+    if (hasMessagesLengthChanged) {
+      setAutoScroll('smooth');
+    }
+  }, [hasMessagesLengthChanged]);
+
+  return { autoScroll, onScroll };
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Updates `AIConversation` streaming message scroll behavior. 

Previously, the underlying `ScrollView` always received an `autoScroll` of "smooth", leading to scenarios where long message streams forced the rendered content above the visible window of the `ScrollView`. With the updates in this PR, `autoScroll` is set conditionally, setting `autoScroll` to `undefined`  on scroll up events and resetting `autoScroll` to "smooth" on the next message received, allowing for end users to control scroll position while a message is streaming

https://github.com/user-attachments/assets/d8f91502-4c72-4b05-9499-3b683111cafa



<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- manual testing
- added unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
