### PR TITLE
fix(liveness): cypress/e2e liveness test issue

### DIFF
--- a/packages/e2e/cypress/integration/common/liveness.ts
+++ b/packages/e2e/cypress/integration/common/liveness.ts
@@ -12,3 +12,10 @@ Then('I see the {string} timeout error', (message: string) => {
     })
     .should('exist');
 });
+
+Then(
+  'I click the {string} selectfield and select the {string} option',
+  (selectFieldName: string, optionValue: string) => {
+    cy.get('select').scrollIntoView().select(optionValue);
+  }
+);

--- a/packages/e2e/cypress/integration/common/liveness.ts
+++ b/packages/e2e/cypress/integration/common/liveness.ts
@@ -16,6 +16,6 @@ Then('I see the {string} timeout error', (message: string) => {
 Then(
   'I click the {string} selectfield and select the {string} option',
   (selectFieldName: string, optionValue: string) => {
-    cy.get('select').scrollIntoView().select(optionValue);
+    cy.findByDisplayValue(selectFieldName).select(optionValue);
   }
 );


### PR DESCRIPTION
#### Description of changes
Currently multiple liveness e2e test fails due file definition lacking (error details below). This PR will fix that by adding a step definition to handle the selection element. 

```
     Error: 
Step implementation missing for "I click the "FaceMovementAndLightChallenge" selectfield and select the "FaceMovementChallenge" option".

We tried searching for files containing step definitions using the following search pattern templates:

```

#### Description of how you validated changes
- By running the liveness e2e test successfully `yarn test:liveness `

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
