### PR TITLE
Add services override for forcing new password

### DIFF
--- a/.changeset/seven-flies-judge.md
+++ b/.changeset/seven-flies-judge.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui': minor
+---
+
+Added services.handleForceChangePassword hook

--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -1,7 +1,6 @@
 import { createMachine, sendUpdate } from 'xstate';
 import type { ConfirmSignInInput } from 'aws-amplify/auth';
 import {
-  confirmSignIn,
   fetchUserAttributes,
   resetPassword,
   signInWithRedirect,
@@ -345,7 +344,7 @@ export function signInActor({ services }: SignInMachineOptions) {
             options: { userAttributes },
           };
 
-          return confirmSignIn(input);
+          return services.handleForceChangePassword(input);
         },
         signInWithRedirect(_, { data }) {
           return signInWithRedirect(data);

--- a/packages/ui/src/machines/authenticator/defaultServices.ts
+++ b/packages/ui/src/machines/authenticator/defaultServices.ts
@@ -92,6 +92,7 @@ export const defaultServices = {
   handleForgotPasswordSubmit: confirmResetPassword,
   handleForgotPassword: resetPassword,
   handleResendSignUpCode: resendSignUpCode,
+  handleForceChangePassword: confirmSignIn,
 
   // Validation hooks for overriding
   async validateCustomSignUp(


### PR DESCRIPTION
#### Description of changes

Adds a way to override/extend the confirmSignIn call done when the new password dialog is done.


#### Description of how you validated changes

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
