### PR TITLE
fix: null-check for getSettings

### DIFF
--- a/packages/react-liveness/src/components/FaceLivenessDetector/hooks/useMediaStreamInVideo.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/hooks/useMediaStreamInVideo.ts
@@ -25,12 +25,12 @@ export function useMediaStreamInVideo(
       if (isObject(videoRef.current)) {
         videoRef.current.srcObject = stream;
       }
-      const { height: streamHeight, width: streamWidth } = stream
-        .getTracks()[0]
-        .getSettings();
 
-      setVideoHeight(streamHeight);
-      setVideoWidth(streamWidth);
+      const settings = stream.getTracks()?.[0]?.getSettings();
+      if (settings) {
+        setVideoHeight(settings.height);
+        setVideoWidth(settings.width);
+      }
     }
 
     return () => {


### PR DESCRIPTION
#### Description of changes

We blindly call getSettings on the the stream.getTracks(). This can cause NPEs. This PR adds null-safety to avoid this.

#### Issue [#6601](https://github.com/aws-amplify/amplify-ui/issues/6601)

#### Description of how you validated changes

yarn test
e2e tests: 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x ] PR description included
- [x ] `yarn test` passes and tests are updated/added
- [x ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
