### PR TITLE
changeset: null-check for getSettings in UseMediaStreamInVideo

### DIFF
--- a/.changeset/tough-radios-reply.md
+++ b/.changeset/tough-radios-reply.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react-liveness': patch
+---
+
+fix(liveness): null-check for getSettings in UseMediaStreamInVideo


### PR DESCRIPTION

#### Description of changes

Adds missing changeset for https://github.com/aws-amplify/amplify-ui/pull/6611

