### PR TITLE
e2e(storage-browser): add tests for upload pagination

### DIFF
--- a/packages/e2e/cypress/integration/common/shared.ts
+++ b/packages/e2e/cypress/integration/common/shared.ts
@@ -460,6 +460,16 @@ Then('the {string} button is disabled', (name: string) => {
   }).should('be.disabled');
 });
 
+Then('the {string} button is enabled', (name: string) => {
+  cy.findByRole('button', {
+    name: new RegExp(`^${escapeRegExp(name)}$`, 'i'),
+  }).should('not.be.disabled');
+});
+
+Then('the table should have {string} rows', (value: string) => {
+  cy.get('table').find('tbody tr').should('have.length', value);
+});
+
 Then('the {string} field is invalid', (name: string) => {
   cy.findInputField(name)
     .then(($el) => $el.get(0).checkValidity())

--- a/packages/e2e/features/ui/components/storage/storage-browser/action-menu.feature
+++ b/packages/e2e/features/ui/components/storage/storage-browser/action-menu.feature
@@ -106,6 +106,38 @@ Feature: Create folder with Storage Browser
     Then I see "All files deleted"
 
   @react
+  Scenario: upload a lot of files with pagination
+    When I click the first button containing "public"
+    Then I see the "Menu Toggle" button
+    When I click the "Menu Toggle" button
+    # upload file
+    Then I see the "Upload" menuitem
+    When I click the "Upload" menuitem
+    Then the "Upload" button is disabled
+    When I upload "250" files with random names
+    Then I see "Not started"
+    And the table should have "100" rows
+    And I see the "Go to page 2" button
+    And the "Go to page 2" button is enabled
+    And I see the "Go to page 3" button
+    And the "Go to page 3" button is enabled
+    And the "Go to next page" button is enabled
+    And the "Go to previous page" button is disabled
+    When I click the "Go to page 2" button
+    Then I see the "Go to page 1" button
+    And the table should have "100" rows
+    And the "Go to page 1" button is enabled
+    And the "Go to next page" button is enabled
+    And I see the "Go to page 3" button
+    And the "Go to previous page" button is enabled
+    When I click the "Go to page 3" button
+    Then the table should have "50" rows
+    And I see the "Go to page 1" button
+    And the "Go to page 1" button is enabled
+    And I see the "Go to page 2" button
+    And the "Go to page 2" button is enabled
+    And the "Go to next page" button is disabled
+  @react
   Scenario: upload a folder
     When I click the first button containing "public"
     Then I see the "Menu Toggle" button


### PR DESCRIPTION
#### Description of changes
This PR adds missing e2e test for the pagination on the UploadView

#### Description of how you validated changes

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
