### PR TITLE
chore: remove unused SessionInformation import

### DIFF
--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/__tests__/liveness.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/__tests__/liveness.test.ts
@@ -25,7 +25,6 @@ import {
   IlluminationState,
   LivenessErrorState,
 } from '../../types';
-import { SessionInformation } from '@aws-sdk/client-rekognitionstreaming';
 
 const context = getMockContext();
 


### PR DESCRIPTION
#### Description of changes

This PR removes the unused import found in [Code-Scan-644](https://github.com/aws-amplify/amplify-ui/security/code-scanning/644).

#### Issue #, if available

#### Description of how you validated changes

#### Checklist

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
