### PR TITLE
chore: change "v#" to "version #" in docs

### DIFF
--- a/docs/src/components/MigrationChanges/MigrationGuideCallout.tsx
+++ b/docs/src/components/MigrationChanges/MigrationGuideCallout.tsx
@@ -19,7 +19,7 @@ export const MigrationGuideCallout = ({ framework }) => {
     <Alert
       role="none"
       variation="info"
-      heading={`@aws-amplify/ui-${framework} v${PREV_MAJOR_VERSIONS[framework]}`}
+      heading={`@aws-amplify/ui-${framework} version ${PREV_MAJOR_VERSIONS[framework]}`}
     >
       The <code>@aws-amplify/ui-{framework}</code> package is currently on
       version {CURRENT_MAJOR_VERSIONS[framework]}. Working with


### PR DESCRIPTION
#### Description of changes
Change "v#" to "version #" in docs to avoid guiding users to install vulnerable package

#### Issue #, if available
https://github.com/aws-amplify/amplify-ui/issues/6654

#### Description of how you validated changes

#### Checklist

- [X] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [X] PR description included
- [X] `yarn test` passes and tests are updated/added
- [X] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
