### PR TITLE
fix(ui-react-liveness): oval ratio multiplier

### DIFF
--- a/.changeset/twelve-bags-watch.md
+++ b/.changeset/twelve-bags-watch.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react-liveness': patch
+---
+
+fix(ui-react-liveness): oval ratio multiplier

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/liveness.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/liveness.ts
@@ -277,7 +277,7 @@ export function drawStaticOval(
   const ovalDetails = getStaticLivenessOvalDetails({
     width: width!,
     height: height!,
-    ratioMultiplier: 0.3,
+    ratioMultiplier: 0.5,
   });
   ovalDetails.flippedCenterX = width! - ovalDetails.centerX;
 


### PR DESCRIPTION
#### Description of changes
Fix the oval size by increase the ratio to original value. The original value gets accidentally decreased previously in a previous [PR](https://github.com/aws-amplify/amplify-ui/pull/6599) 

#### Issue #6649 , if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
