### PR TITLE
fix: disable turbopack for next build

### DIFF
--- a/build-system-tests/scripts/mega-app-create-app.sh
+++ b/build-system-tests/scripts/mega-app-create-app.sh
@@ -70,8 +70,8 @@ echo "echo "{}" >package.json"
 echo "{}" >package.json
 
 if [ "$BUILD_TOOL" == 'next' ]; then
-    echo "npx create-next-app ${MEGA_APP_NAME} --ts --no-src-dir --no-experimental-app --no-eslint --no-app --no-tailwind"
-    npx create-next-app ${MEGA_APP_NAME} --ts --no-src-dir --no-experimental-app --no-eslint --no-app --no-tailwind
+    echo "npx create-next-app ${MEGA_APP_NAME} --ts --no-src-dir --no-experimental-app --no-eslint --no-app --no-tailwind --no-turbopack"
+    npx create-next-app ${MEGA_APP_NAME} --ts --no-src-dir --no-experimental-app --no-eslint --no-app --no-tailwind --no-turbopack
 fi
 
 if [ "$BUILD_TOOL" == 'vite' ]; then


### PR DESCRIPTION
#### Description of changes

Build with next consistently fails since new release of next@15.5.0. With the new version create-next-app enables turbopack by default which breaks the build. This PR disables turbopack for the next build.

#### Issue #, if available

#### Description of how you validated changes
Local build

#### Checklist

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
