### PR TITLE
Add mocking for file preview

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -208,7 +208,7 @@ module.exports = withNextPluginPreval({
   },
 
   webpack(config) {
-    // Add alias to mock storage-internal for documentation examples
+    // Add alias to mock storage-internal for storage browser examples
     config.resolve.alias = {
       ...config.resolve.alias,
       '@aws-amplify/storage/internals': path.resolve(

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -205,6 +205,15 @@ module.exports = withNextPluginPreval({
   },
 
   webpack(config) {
+    // Add alias to mock storage-internal for documentation examples
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@aws-amplify/storage/internals': path.resolve(
+        __dirname,
+        'src/pages/[platform]/connected-components/storage/storage-browser/examples/mockStorageInternal.ts'
+      ),
+    };
+
     const defaultRehypePlugins = [
       // This is a custom plugin that removes lines that end in `// IGNORE`
       // This allows us to include code necessary for an example to run

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -26,7 +26,7 @@ function createRemarkMdxFrontmatterPlugin(options = {}) {
 
 module.exports = withNextPluginPreval({
   images: {
-    domains: ['images.unsplash.com', 'commondatastorage.googleapis.com'],
+    domains: ['images.unsplash.com'],
   },
   env: {
     BRANCH,

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -25,6 +25,9 @@ function createRemarkMdxFrontmatterPlugin(options = {}) {
 }
 
 module.exports = withNextPluginPreval({
+  images: {
+    domains: ['images.unsplash.com', 'commondatastorage.googleapis.com'],
+  },
   env: {
     BRANCH,
     SITE_URL: process.env.SITE_URL,

--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/CustomFilePreview.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/CustomFilePreview.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Image from 'next/image';
 import { createStorageBrowser } from '@aws-amplify/ui-react-storage/browser';
 import { mockConfig } from './mockConfig'; // IGNORE
+import { defaultActions } from './defaultActions'; // IGNORE
 
 const CustomImageRenderer = ({ fileData, url }: any) => (
   <div style={{ border: '3px solid gray' }}>
@@ -31,6 +32,7 @@ const CustomAudioRenderer = ({ fileData, url }: any) => (
 
 const { StorageBrowser } = createStorageBrowser({
   config: mockConfig, // IGNORE
+  actions: { default: defaultActions }, // IGNORE
   filePreview: {
     fileTypeResolver: (properties) => {
       if (properties.key.endsWith('txt')) return 'text';

--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/defaultActions.ts
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/defaultActions.ts
@@ -135,21 +135,21 @@ export const defaultActions: CreateStorageBrowserInput['actions']['default'] = {
           items: [
             {
               id: uniqueId(),
-              key: `${props.prefix}test-file.txt`,
+              key: `${props.prefix}image-1.jpg`,
               lastModified: new Date(),
               size: 1008,
               type: 'FILE' as const,
             },
             {
               id: uniqueId(),
-              key: `${props.prefix}test-file2.txt`,
+              key: `${props.prefix}image-2.jpg`,
               lastModified: new Date(),
               size: 23456,
               type: 'FILE' as const,
             },
             {
               id: uniqueId(),
-              key: `${props.prefix}test-file3.txt`,
+              key: `${props.prefix}image-3.jpg`,
               lastModified: new Date(),
               size: 43456,
               type: 'FILE' as const,

--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/mockStorageInternal.ts
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/mockStorageInternal.ts
@@ -1,0 +1,38 @@
+// Mock implementation of storage-internal getUrl function for documentation examples
+export const getUrl = async ({ path }: { path: string }) => {
+  const filename = path.split('/').pop() || '';
+
+  let url: string;
+
+  switch (filename) {
+    case 'image-1.jpg':
+      url =
+        'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=2000&h=1333&q=80';
+      break;
+    case 'sample.mp4':
+      url =
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4';
+      break;
+    case 'image-3.jpg':
+      url =
+        'https://images.unsplash.com/photo-1472214103451-9374bd1c798e?w=2000&h=1333&q=80';
+      break;
+    default:
+      url =
+        'https://images.unsplash.com/photo-1518837695005-2083093ee35b?w=800&h=600&q=80';
+  }
+
+  const result = { url };
+  return result;
+};
+
+export const copy = () => Promise.resolve();
+export const getDataAccess = () => Promise.resolve();
+export const list = () => Promise.resolve();
+export const listCallerAccessGrants = () => Promise.resolve();
+export const listPaths = () => Promise.resolve();
+export const remove = () => Promise.resolve();
+export const uploadData = () => Promise.resolve();
+export const StorageValidationErrorCode = {};
+export const assertValidationError = () => {};
+export const validationErrorMap = {};


### PR DESCRIPTION
#### Description of changes
Since we are using mocked data with no actual bucket in the storage browser, the file preview will always return an error. To avoid this, the `getUrl` function will be mocked.

#### Description of how you validated changes
- run the docs locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
