### PR TITLE
chore: run production build for nuxt build system tests

### DIFF
--- a/build-system-tests/scripts/mega-app-start.sh
+++ b/build-system-tests/scripts/mega-app-start.sh
@@ -56,9 +56,12 @@ echo "###########################"
 echo "cd ./mega-apps/${MEGA_APP_NAME}"
 cd ./mega-apps/${MEGA_APP_NAME}
 
-if [ "$BUILD_TOOL" == 'vite' ] || [ "$BUILD_TOOL" == 'nuxt' ]; then
+if [ "$BUILD_TOOL" == 'vite' ]; then
     echo "npm run dev -- --port 3000 &"
     npm run dev -- --port 3000 &
+elif [ "$BUILD_TOOL" == 'nuxt' ]; then
+    echo "npm run preview -- --port 3000 &"
+    npm run preview -- --port 3000 &
 elif [ "$FRAMEWORK" == 'vue' ]; then
     echo "npm run serve -- --port 3000 &"
     npm run serve -- --port 3000 &


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The build system test([build / build (vue, latest, nuxt, latest, npm, 20)](https://github.com/aws-amplify/amplify-ui/actions/runs/17296163700/job/49094772655#logs)) failed regularly due to failure to fetch dynamically imported module.

Therefore, we're running the tests in production mode to avoid the impact from such flaky error.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Run build system tests locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
