### PR TITLE
chore(docs): update storage browser to include components override section

### DIFF
--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/ComponentOverride.tsx
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/ComponentOverride.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {
+  createStorageBrowser,
+  CreateStorageBrowserInput,
+} from '@aws-amplify/ui-react-storage/browser';
+import { Breadcrumbs, View, Text, Loader } from '@aws-amplify/ui-react';
+import { mockConfig } from './mockConfig';
+import { defaultActions } from './defaultActions';
+
+const components: CreateStorageBrowserInput['components'] = {
+  Navigation: ({ items }) => (
+    <Breadcrumbs.Container>
+      {items.map(({ isCurrent, name, onNavigate }) => (
+        <Breadcrumbs.Item key={name}>
+          <Breadcrumbs.Link isCurrent={isCurrent} onClick={onNavigate}>
+            🏠 {name}
+          </Breadcrumbs.Link>
+        </Breadcrumbs.Item>
+      ))}
+    </Breadcrumbs.Container>
+  ),
+
+  LoadingIndicator: ({ isLoading }) =>
+    isLoading ? (
+      <View textAlign="center" padding="large">
+        <Loader size="large" />
+        <Text>⏳ Loading your files...</Text>
+      </View>
+    ) : null,
+
+  Title: ({ title }) => (
+    <Text fontSize="xl" fontWeight="bold" color="brand.primary.80">
+      📁 {title}
+    </Text>
+  ),
+};
+
+const { StorageBrowser } = createStorageBrowser({
+  config: mockConfig,
+  actions: { default: defaultActions },
+  components, // Pass custom components here
+});
+
+export default function Example() {
+  return <StorageBrowser />;
+}

--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/index.ts
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/index.ts
@@ -8,3 +8,4 @@ export { default as Theming } from './Theming';
 export { default as Icons } from './Icons';
 export { default as Default } from './Default';
 export { default as GenerateUrlViewComposed } from './GenerateUrlViewComposed';
+export { default as ComponentOverride } from './ComponentOverride';

--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/react.mdx
@@ -11,6 +11,7 @@ import {
   Theming,
   Icons,
   GenerateUrlViewComposed,
+  ComponentOverride,
 } from './examples'
 
 
@@ -312,6 +313,43 @@ You can use the `<IconsProvider>` to customize the icons used in the `StorageBro
     ```
   </ExampleCode>
 </Example>
+
+### Component Override
+
+You can override any of the default components used in Storage Browser by passing custom components to the `components` prop of `createStorageBrowser`. When you provide a component (e.g., `Navigation`, `DataTable`, `SearchField`), it will completely replace the default implementation.
+
+
+<Example>
+  <ComponentOverride />
+  <ExampleCode>
+    ```jsx file=./examples/ComponentOverride.tsx
+    ```
+  </ExampleCode>
+</Example>
+
+**Available Components to Override:**
+- `ActionCancel`
+- `ActionDestination`
+- `ActionExit`
+- `ActionStart`
+- `ActionsList`
+- `AddFiles`
+- `AddFolder`
+- `DataRefresh`
+- `DataTable`
+- `DropZone`
+- `FolderNameField`
+- `LoadingIndicator`
+- `Message`
+- `Navigation`
+- `OverwriteToggle`
+- `Pagination`
+- `SearchField`
+- `SearchSubfoldersToggle`
+- `StatusDisplay`
+- `Title`
+
+Each component receives the same props as the default implementation, so you can access all the data and callbacks.
 
 ### Display Text
 


### PR DESCRIPTION
#### Description of changes
Add a new section "Component Override" to the storage browser component. 


#### Issue #6658 , if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Run the docs locally 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
