### PR TITLE
fix: explicitly install expo-asset for expo mega app

### DIFF
--- a/build-system-tests/scripts/mega-app-install.sh
+++ b/build-system-tests/scripts/mega-app-install.sh
@@ -24,6 +24,10 @@ while [[ $# -gt 0 ]]; do
         BUILD_TOOL=$2
         shift
         ;;
+    -b | --build-tool-version)
+        BUILD_TOOL_VERSION=$2
+        shift
+        ;;
     -n | --name)
         MEGA_APP_NAME=$2
         shift
@@ -114,6 +118,11 @@ else
         else
             DEPENDENCIES="$DEPENDENCIES react-native-safe-area-context@^4.2.5"
         fi;
+
+        # expo-asset is nested under expo/node_modules in expo 52, causing Metro resolution issues
+        if [[ "$BUILD_TOOL" == "expo" && $BUILD_TOOL_VERSION > "51" ]]; then
+            DEPENDENCIES="$DEPENDENCIES expo-asset"
+        fi
 
         echo "npm install $DEPENDENCIES"
         install_dependencies_with_retries npm "$DEPENDENCIES"

--- a/build-system-tests/scripts/setup-mega-app.sh
+++ b/build-system-tests/scripts/setup-mega-app.sh
@@ -91,7 +91,7 @@ BASE_OPTIONS="--build-tool $BUILD_TOOL --name $MEGA_APP_NAME --framework $FRAMEW
 ./scripts/mega-app-copy-files.sh $BASE_OPTIONS
 
 # Install dependencies
-./scripts/mega-app-install.sh $BASE_OPTIONS --pkg-manager $PKG_MANAGER --tag $TAG
+./scripts/mega-app-install.sh $BASE_OPTIONS --pkg-manager $PKG_MANAGER --tag $TAG --build-tool-version $BUILD_TOOL_VERSION 
 
 # Build mega app
 ./scripts/mega-app-build.sh $BASE_OPTIONS --platform $PLATFORM


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
expo-asset are installed in node_modules/expo/node_modules/ instead of in the node_modules/, causing Metro resolution issues:
```
Error: The required package `expo-asset` cannot be found
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Build and run mega app locally for both expo 51 and expo 52.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
