### PR TITLE
Revert "chore(deps): bump changesets/action from b98cec97583b917ff1dc6179dd4d230d3e439894 to 04d574e831923498156e0b2b93152878063203a3"

### DIFF
--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build packages
         run: yarn build
       - name: Publish to @latest
-        uses: changesets/action@04d574e831923498156e0b2b93152878063203a3
+        uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
         with:
           publish: yarn publish:latest
         env:

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Build packages
         run: yarn build
       - name: Publish to @latest
-        uses: changesets/action@04d574e831923498156e0b2b93152878063203a3
+        uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
         with:
           publish: yarn publish:latest
         env:

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -39,7 +39,7 @@ jobs:
         run: yarn --frozen-lockfile
       - name: Create or update Version Packages PR
         if: ${{ steps.has-changesets.outputs.has-changesets == 'true' }}
-        uses: changesets/action@04d574e831923498156e0b2b93152878063203a3
+        uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
         with:
           version: yarn bumpVersions
           # Use the current branch as the base for the PR


### PR DESCRIPTION
Reverts aws-amplify/amplify-ui#6578 because of a security policy violation since its not allowlisted for the organization and fails the workflow.