### PR TITLE
fix(authenticator-react-native): password manager autofill validation

### DIFF
--- a/.changeset/young-avocados-talk.md
+++ b/.changeset/young-avocados-talk.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react-native': patch
+---
+
+fix(authenticator-react-native): password manager autofill validation

--- a/packages/react-native/src/Authenticator/hooks/useFieldValues/useFieldValues.ts
+++ b/packages/react-native/src/Authenticator/hooks/useFieldValues/useFieldValues.ts
@@ -112,17 +112,18 @@ export default function useFieldValues<FieldType extends TypedField>({
     const { name, label, labelHidden, ...rest } = field;
 
     const onBlur: TextFieldOnBlur = (event) => {
+      const textValue = values[name] || event?.nativeEvent?.text;
       setTouched({ ...touched, [name]: true });
 
       // call `onBlur` passed as text `field` option
       field.onBlur?.(event);
 
       // call machine blur handler
-      handleBlur({ name, value: values[name] });
+      handleBlur({ name, value: textValue });
 
       setFieldValidationErrors({
         ...fieldValidationErrors,
-        [name]: runFieldValidation(field, values[name], validationErrors),
+        [name]: runFieldValidation(field, textValue, validationErrors),
       });
     };
 


### PR DESCRIPTION
#### Description of changes

Fixed password manager autofill validation issue in React Native Authenticator. When using password managers like Dashlane, the email field was incorrectly marked as invalid even when containing a valid email address.

The issue occurred because the `onBlur` handler in `useFieldValues` was using stale React state (`values[name]`) instead of the actual field value from the native event. This caused validation to run against empty state rather than the autofilled value.

**Changes:**
- Modified `onBlur` handler to use `values[name] || event?.nativeEvent?.text`
- Ensures validation uses actual field value for both manual input and autofilled values
- Maintains backward compatibility with existing functionality

#### Issue #, if available

#6648

#### Description of how you validated changes

- Tested with IOS native password manger that autofill the Authenticator fields on a physical iPhone
   - Create an Amplify react-native sample app
   - Linked amplify-ui react native package locally to the sample app
   -  Apply the fix on `@aws-amplify/ui-react-native`
   - Run the app on a physical iPhone `npx expo run:ios --configuration Release --device` or ` RCT_USE_PREBUILT_RNCORE=0 RCT_USE_RN_DEP=0  npx expo run:ios --configuration Release --device`
  

Verified the followings 
- Verified that autofilled email fields now validate correctly without requiring manual interaction
- Confirmed that manual typing still works as expected
- Ensured no regression in existing validation behavior

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.