### PR TITLE
fix: adjust path of types

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -6,7 +6,7 @@
   "module": "dist/index.js",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },


### PR DESCRIPTION
#### Description of changes

In the PR https://github.com/aws-amplify/amplify-ui/pull/6723 a change to the vue `package.json` was made, which references _other_ types.

These are not correct and break the typing of `@aws-amplify/ui-vue`

#### Description of how you validated changes

build the vue package and adjusted the vue-example app for verification

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
