### PR TITLE
fix: explicitly set webpack for next

### DIFF
--- a/build-system-tests/scripts/mega-app-create-app.sh
+++ b/build-system-tests/scripts/mega-app-create-app.sh
@@ -70,8 +70,8 @@ echo "echo "{}" >package.json"
 echo "{}" >package.json
 
 if [ "$BUILD_TOOL" == 'next' ]; then
-    echo "npx create-next-app ${MEGA_APP_NAME} --ts --no-src-dir --no-experimental-app --no-eslint --no-app --no-tailwind --no-turbopack"
-    npx create-next-app ${MEGA_APP_NAME} --ts --no-src-dir --no-experimental-app --no-eslint --no-app --no-tailwind --no-turbopack
+    echo "npx create-next-app@${BUILD_TOOL_VERSION} ${MEGA_APP_NAME} --yes --ts --no-src-dir --no-experimental-app --no-eslint --no-app --no-tailwind --no-turbopack --webpack"
+    npx create-next-app@${BUILD_TOOL_VERSION} ${MEGA_APP_NAME} --yes --ts --no-src-dir --no-experimental-app --no-eslint --no-app --no-tailwind --no-turbopack --webpack
 fi
 
 if [ "$BUILD_TOOL" == 'vite' ]; then


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Currently the canaries are failing, due to next releasing v16 and defaulting to turbopack.

This PR is supposed to mitigate the issue.
A deeper investigation and some more changes might be needed to allow for a smoother transition to turbopack

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

none 
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
