### PR TITLE
fix: pin `react-native-get-random-values`

### DIFF
--- a/build-system-tests/scripts/mega-app-install.sh
+++ b/build-system-tests/scripts/mega-app-install.sh
@@ -86,7 +86,7 @@ if [ "$FRAMEWORK" == 'react' ]; then
 
     if [ "$BUILD_TOOL" == 'vite' ]; then
         # https://vite.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility
-        # Fixes `EventEmitter is not a constructor`` error with geocoder package 
+        # Fixes `EventEmitter is not a constructor`` error with geocoder package
         DEPENDENCIES="$DEPENDENCIES events"
         echo "DEPENDENCIES=$DEPENDENCIES"
     fi
@@ -110,7 +110,7 @@ if [ "$PKG_MANAGER" == 'yarn' ]; then
 else
     if [[ "$FRAMEWORK" == "react-native" ]]; then
         # react-native-safe-area-context v5.0.0+ does not support RN 0.74 and lower
-        DEPENDENCIES="$TAGGED_UI_FRAMEWORK @aws-amplify/react-native aws-amplify @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill"
+        DEPENDENCIES="$TAGGED_UI_FRAMEWORK @aws-amplify/react-native aws-amplify @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values@1.11.0 react-native-url-polyfill"
 
         # react-native-safe-area-context v5 is required for >= 0.74
         if [[ "$FRAMEWORK_VERSION" == "latest" || $FRAMEWORK_VERSION > "0.74" ]]; then
@@ -131,7 +131,7 @@ else
                 # Expo SDK version 52.0.27 supports RN 0.76 and 0.77 but installs 0.76 by default https://expo.dev/changelog/2025-01-21-react-native-0.77#2-install-updated-packages
                 echo "npx expo install react-native@~0.77.1"
                 npx expo install react-native@~0.77.1
-            elif [[ "$FRAMEWORK_VERSION" == "0.75" ]]; then 
+            elif [[ "$FRAMEWORK_VERSION" == "0.75" ]]; then
                 # Expo SDK version 51.0.0 supports RN 0.74 and 0.75 but installs 0.74 by default https://expo.dev/changelog/2024/08-14-react-native-0.75#2-install-updated-packages
                 echo "npx expo install react-native@~0.75.0"
                 npx expo install react-native@~0.75.0


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
react-native tests fail for [Test and Publish / next](https://github.com/aws-amplify/amplify-ui/actions/workflows/publish-next.yml)

this happens since a new major release of `react-native-get-random-values` requires a minimum react-native version.

this pins the version of the package.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

_- none -_

#### Description of how you validated changes

build the testing application locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
