### PR TITLE
chore(deps): bump node-forge to v1.3.2

### DIFF
--- a/.github/dependency-review/config.yml
+++ b/.github/dependency-review/config.yml
@@ -34,3 +34,5 @@ allow-licenses:
   - 'X11'
   - 'zlib-acknowledgement'
   - 'Zlib'
+allow-dependencies-licenses:
+  - 'pkg:npm/node-forge@1.3.2'

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "json5": "^2.2.1",
     "loader-utils": "2.0.4",
     "nanoid": "3.3.8",
-    "node-forge": "1.3.0",
+    "node-forge": "1.3.2",
     "node-gyp": "11.5.0",
     "nth-check": "^2.0.1",
     "postcss": "^8.4.31",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23328,10 +23328,10 @@ node-fetch@^2.6.1, node-fetch@^2.6.12:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@1.3.0, node-forge@^1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.0.tgz#37a874ea723855f37db091e6c186e5b67a01d4b2"
-  integrity sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==
+node-forge@1.3.2, node-forge@^1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.2.tgz#d0d2659a26eef778bf84d73e7f55c08144ee7750"
+  integrity sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==
 
 node-gyp-build@^4.2.2:
   version "4.6.0"


### PR DESCRIPTION
#### Description of changes

* Resolves a dependabot issue by bumping `node-forge@1.3.0` to `node-forge@1.3.2`
* Adds `node-forge` to `allow-dependencies-licenses` for the dependency license check since it uses an incompatible license. Since `node-forge` is introduced by `selfsigned` which is used by `webpack-dev-server` its only used as a dev dependency and not shipped. Unfortunately, we need webpack-dev-server for Angular and can not replace it.

#### Issue #, if available

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
