### PR TITLE
chore: remove node-forge from allowed dependencies

### DIFF
--- a/.github/dependency-review/config.yml
+++ b/.github/dependency-review/config.yml
@@ -34,5 +34,3 @@ allow-licenses:
   - 'X11'
   - 'zlib-acknowledgement'
   - 'Zlib'
-allow-dependencies-licenses:
-  - 'pkg:npm/node-forge@1.3.2'


### PR DESCRIPTION
#### Description of changes

`node-forge` is licensed under BSD-3-Clause OR GPL-2.0. Our license is compatible with BSD-3-Clause so we can remove it from the allowed dependencies.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
