### PR TITLE
fix: init nuxt app with template

### DIFF
--- a/build-system-tests/scripts/mega-app-create-app.sh
+++ b/build-system-tests/scripts/mega-app-create-app.sh
@@ -91,8 +91,8 @@ if [[ "$FRAMEWORK" == 'vue' ]]; then
         echo "vue create --preset ../templates/components/vue/preset-${FRAMEWORK_VERSION}.json $MEGA_APP_NAME"
         echo 'Y' | vue create --preset ../templates/components/vue/preset-${FRAMEWORK_VERSION}.json $MEGA_APP_NAME
     elif [ "$BUILD_TOOL" == 'nuxt' ]; then
-        echo "npx nuxi@latest init $MEGA_APP_NAME -t v4-compat"
-        npx nuxi@latest init $MEGA_APP_NAME -t v4-compat
+        echo "npx nuxi@latest init $MEGA_APP_NAME -t v4"
+        npx nuxi@latest init $MEGA_APP_NAME -t v4
     fi
 fi
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

[Build System Test](https://github.com/aws-amplify/amplify-ui/actions/runs/19958757620/job/57233803231) is failing because `npx nuxt init` has changed to be interactive - it prompts for template selection. In GitHub Actions (non-interactive environment), it likely defaults to a different template, and failed to satisfy the project structure.

Changing to nuxi which allows setting template to be the minimal template for nuxt v4.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Run app locally with the updated script.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
