### PR TITLE
chore(deps): bump changesets/action from b98cec97583b917ff1dc6179dd4d230d3e439894 to changesets/action@f2660aa7e78365f53dbeb4cfa774c1499ec6483a

### DIFF
--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build packages
         run: yarn build
       - name: Publish to @latest
-        uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
+        uses: changesets/action@f2660aa7e78365f53dbeb4cfa774c1499ec6483a
         with:
           publish: yarn publish:latest
         env:

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Build packages
         run: yarn build
       - name: Publish to @latest
-        uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
+        uses: changesets/action@f2660aa7e78365f53dbeb4cfa774c1499ec6483a
         with:
           publish: yarn publish:latest
         env:

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -39,7 +39,7 @@ jobs:
         run: yarn --frozen-lockfile
       - name: Create or update Version Packages PR
         if: ${{ steps.has-changesets.outputs.has-changesets == 'true' }}
-        uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
+        uses: changesets/action@f2660aa7e78365f53dbeb4cfa774c1499ec6483a
         with:
           version: yarn bumpVersions
           # Use the current branch as the base for the PR


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
Bumps [changesets/action](https://github.com/changesets/action) from b98cec97583b917ff1dc6179dd4d230d3e439894 to changesets/action@f2660aa7e78365f53dbeb4cfa774c1499ec6483a.

Related dependabot PR: https://github.com/aws-amplify/amplify-ui/pull/6741
The new version introduced by the dependabot is too high: https://github.com/aws-amplify/amplify-ui/actions/runs/18041019454. We're using the highest acceptable version.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
