### PR TITLE
ci: increase gradle download timeout

### DIFF
--- a/.github/workflows/reusable-build-system-test-react-native.yml
+++ b/.github/workflows/reusable-build-system-test-react-native.yml
@@ -110,6 +110,7 @@ jobs:
     env:
       MEGA_APP_NAME: rn${{ matrix.framework-version.formatted }}${{ matrix.build-tool }}${{ matrix.build-tool-version }}${{ matrix.platform }}ui${{ inputs.dist-tag }}
       EMULATOR_PORT: 5554
+      GRADLE_OPTS: '-Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000'
     steps:
       - name: Checkout Amplify UI
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.1.3 https://github.com/actions/checkout/commit/cd7d8d697e10461458bc61a30d094dc601a8b017


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Increases Gradle network timeout from 10s (default) to 60s for React Native build system tests.

The CI was intermittently failing with SocketTimeoutException: Read timed out when downloading Gradle distributions. This happens when the Gradle server is slow to respond during the HTTP header phase of the download - the connection establishes but the server stalls before completing the response headers.

Since the React Native apps are created dynamically, we set GRADLE_OPTS at the workflow level rather than modifying gradle-wrapper.properties.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-ui/actions/runs/20144640800/job/57821547307
#### Description of how you validated changes


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
