### PR TITLE
docs(storage-browser): update documentation for folder deletion feature

### DIFF
--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/react.mdx
@@ -1085,6 +1085,17 @@ Folder deletion functionality requires aws-amplify package version 6.16.0 or lat
 #### Delete view state
 
 ```ts
+interface ActionConfirmationModalProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  content?: React.ReactNode;
+  onConfirm: () => void;
+  onCancel: () => void;
+  confirmLabel: string;
+  cancelLabel: string;
+}
+
 interface DeleteViewState {
   isProcessing: boolean;
   isProcessingComplete: boolean;


### PR DESCRIPTION
#### Description of changes

Updates StorageBrowser documentation to reflect the new folder deletion feature introduced in #6834.

**Changes include:**
- Updated Overview section to mention folder deletion capability alongside file deletion
- Added `ConfirmationModal` component to Delete view components list
- Added `ActionConfirmationModal` to component override list
- Updated LocationDetailView state interface:
  - Added `dataItems` property for mixed file/folder selections
  - Updated `onSelect` method signature to support `LocationItemData`
- Updated DeleteView state interface:
  - Added `onConfirmDelete`, `onCancelConfirmation` handlers
  - Added `confirmationModal` property

#### Issue #, if available

Related to folder deletion feature implementation in #6834

#### Description of how you validated changes

- Reviewed all type changes in the `feat/SB-folder-deletion` branch
- Cross-referenced component implementations with documentation
- Verified interface updates match actual implementation
- Ensured all new properties and methods are documented

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.