### PR TITLE
fix(authenticator): exclude username from user attributes in force change password flow

### DIFF
--- a/.changeset/nice-buses-train.md
+++ b/.changeset/nice-buses-train.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui': patch
+'@aws-amplify/ui-react': patch
+---
+
+fix(authenticator): exclude username from user attributes in force change password flow

--- a/packages/ui/src/machines/authenticator/actors/signIn.ts
+++ b/packages/ui/src/machines/authenticator/actors/signIn.ts
@@ -490,6 +490,7 @@ export function signInActor({ services }: SignInMachineOptions) {
             // destructure and toss UI confirm_password field
             // to prevent error from sending to confirmSignIn
             confirm_password,
+            username,
             ...userAttributes
           } = formValues;
 


### PR DESCRIPTION
<!--Please make sure to read the Pull Request Guidelines:https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md-->

#### Description of changes

This PR fixes a bug in the Authenticator's force change password flow where the `username` field was being incorrectly sent as a user attribute to AWS Cognito's `confirmSignIn` API.

**Changes:**
- Modified `handleForceChangePassword` service in `signIn.ts` to explicitly exclude `username` from the destructured `userAttributes` object
- Added comprehensive unit tests to verify that `username`, `confirm_password`, and `country_code` are properly excluded from user attributes
- Tests also verify proper phone number formatting with country codes

**Impact:**
This prevents potential API errors when username is present in form values during the force change password flow. The username field is not a valid user attribute for the `confirmSignIn` operation and should be filtered out along with other UI-only fields.

#### Issue #6849 

#### Description of how you validated changes

1. Verified in a sample app that reproduces the issue. 

2. **Unit Tests**: Added 3 new test cases in `signIn.test.ts` that verify:
   - Username is excluded from userAttributes when calling confirmSignIn
   - Phone number formatting works correctly and country_code is excluded
   - Empty userAttributes are handled when only password fields are provided

2. **Test Execution**: All tests pass successfully
   ```bash
   npm test -- --testPathPattern=signIn.test.ts --testNamePattern="handleForceChangePassword"