### PR TITLE
chore(deps): bump tar to 7.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "send": "^0.19.0",
     "serialize-javascript": "^6.0.2",
     "socks": "^2.7.3",
-    "tar": "7.5.7",
+    "tar": "7.5.8",
     "tar-fs": "^3.1.1",
     "undici": "^6.23.0",
     "webpack-dev-middleware": "^5.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -31779,10 +31779,10 @@ tar-stream@^3.0.0, tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@7.5.7, tar@^6.1.11, tar@^7.4.3:
-  version "7.5.7"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.7.tgz#adf99774008ba1c89819f15dbd6019c630539405"
-  integrity sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==
+tar@7.5.8, tar@^6.1.11, tar@^7.4.3:
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.8.tgz#6bbdfdb487914803d401bab6a2abb100aaa253d5"
+  integrity sha512-SYkBtK99u0yXa+IWL0JRzzcl7RxNpvX/U08Z+8DKnysfno7M+uExnTZH8K+VGgShf2qFPKtbNr9QBl8n7WBP6Q==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Bumps `tar` package from version 7.5.7 to 7.5.8

#### Issue #, if available

N/A

#### Description of how you validated changes

- Verified `tar` package is now at version 7.5.8 using `yarn why tar`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.