### PR TITLE
chore: update build-system-tests to only run for supported react-nati…

### DIFF
--- a/.github/workflows/reusable-build-system-test-react-native.yml
+++ b/.github/workflows/reusable-build-system-test-react-native.yml
@@ -18,14 +18,8 @@ jobs:
         framework-version:
           [
             { formatted: latest, value: latest },
-            { formatted: 078, value: 0.78 },
-            { formatted: 077, value: 0.77 },
-            { formatted: 076, value: 0.76 },
-            { formatted: 075, value: 0.75 },
-            { formatted: 074, value: 0.74 },
-            { formatted: 073, value: 0.73 },
-            { formatted: 072, value: 0.72 },
-            { formatted: 071, value: 0.71 },
+            { formatted: 083, value: 0.83.2 },
+            { formatted: 082, value: 0.82.1 },
           ]
         build-tool: [cli, expo]
         build-tool-version: [latest]
@@ -35,77 +29,6 @@ jobs:
         # platform: [ios, android]
         platform: [android]
         logfile: [test.log]
-        exclude:
-          - build-tool: expo
-            platform: ios
-          - build-tool: expo
-            platform: android
-            framework-version: { formatted: '078', value: '0.78' }
-          - build-tool: expo
-            platform: android
-            framework-version: { formatted: '077', value: '0.77' }
-          - build-tool: expo
-            platform: android
-            framework-version: { formatted: '076', value: '0.76' }
-          - build-tool: expo
-            platform: android
-            framework-version: { formatted: '075', value: '0.75' }
-          - build-tool: expo
-            platform: android
-            framework-version: { formatted: '074', value: '0.74' }
-          - build-tool: expo
-            platform: android
-            framework-version: { formatted: '073', value: '0.73' }
-          - build-tool: expo
-            platform: android
-            framework-version: { formatted: '072', value: '0.72' }
-          - build-tool: expo
-            platform: android
-            framework-version: { formatted: '071', value: '0.71' }
-        include:
-          # Expo makes you specify a version of the SDK that supports a specific version of React Native
-          # https://stackoverflow.com/questions/63463373/create-an-expo-project-with-a-specific-version
-          # Only include officially supported Expo SDK versions: https://docs.expo.dev/versions/latest/
-          - framework: react-native
-            framework-version: { formatted: 077, value: '0.77' }
-            build-tool: expo
-            build-tool-version: 52
-            platform: android
-            pkg-manager: npm
-            node-version: 20
-            logfile: test.log
-          - framework: react-native
-            framework-version: { formatted: 076, value: '0.76' }
-            build-tool: expo
-            build-tool-version: 52
-            platform: android
-            pkg-manager: npm
-            node-version: 20
-            logfile: test.log
-          - framework: react-native
-            framework-version: { formatted: 075, value: '0.75' }
-            build-tool: expo
-            build-tool-version: 51
-            platform: android
-            pkg-manager: npm
-            node-version: 20
-            logfile: test.log
-          - framework: react-native
-            framework-version: { formatted: 074, value: '0.74' }
-            build-tool: expo
-            build-tool-version: 51
-            platform: android
-            pkg-manager: npm
-            node-version: 20
-            logfile: test.log
-          - framework: react-native
-            framework-version: { formatted: 073, value: '0.73' }
-            build-tool: expo
-            build-tool-version: 50
-            platform: android
-            pkg-manager: npm
-            node-version: 20
-            logfile: test.log
 
     env:
       MEGA_APP_NAME: rn${{ matrix.framework-version.formatted }}${{ matrix.build-tool }}${{ matrix.build-tool-version }}${{ matrix.platform }}ui${{ inputs.dist-tag }}


### PR DESCRIPTION
#### Description of changes

Updates the React Native build system test matrix to only include currently supported React Native versions (0.82., 0.83.2, and latest), removing end-of-life versions 0.71 through 0.78. This also removes the associated Expo SDK `exclude`/`include` matrix entries that were tied to those older versions, significantly simplifying the workflow configuration.

#### Issue #, if available

N/A

#### Description of how you validated changes

- https://github.com/aws-amplify/amplify-ui/actions/runs/22406674148/job/64868410051

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
