### PR TITLE
fix: restore angular project

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@react-native-community/cli": "^17.0.1",
     "**/@react-native-community/**/fast-xml-parser": "^5.3.6",
     "**/@aws-*/**/fast-xml-parser": "^5.3.6",
-    "**/@aws-amplify/ui-angular-example/**/codelyzer/**/@angular/core": "19.2.18",
+    "**/@aws-amplify/ui-angular-example/**/codelyzer/**/@angular/core": "19.2.19",
     "**/@angular-devkit/build-angular/minimatch": "3.1.4",
     "**/@angular-devkit/build-angular/webpack": "^5.76.0",
     "**/@angular-devkit/build-angular/webpack-dev-server/express/path-to-regexp": "0.1.12",

--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -14,8 +14,8 @@
     "directory": "packages/angular/projects/ui-angular"
   },
   "peerDependencies": {
-    "@angular/core": "^19.2.19",
-    "@angular/common": "^19.2.19",
+    "@angular/core": ">= 19.0.0",
+    "@angular/common": ">= 19.0.0",
     "aws-amplify": "^6.14.3",
     "rxjs": "^6.5.3 || ^7.4.0 || ^8.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,16 +455,9 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/core@19.2.18":
-  version "19.2.18"
-  resolved "https://registry.npmjs.org/@angular/core/-/core-19.2.18.tgz#50e561c20e98e5339ce351f207d6d7aeecf10f85"
-  integrity sha512-+QRrf0Igt8ccUWXHA+7doK5W6ODyhHdqVyblSlcQ8OciwkzIIGGEYNZom5OZyWMh+oI54lcSeyV2O3xaDepSrQ==
-  dependencies:
-    tslib "^2.3.0"
-
-"@angular/core@^19.2.19":
+"@angular/core@19.2.19", "@angular/core@^19.2.19":
   version "19.2.19"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-19.2.19.tgz#a2c35dfc5254a2d1e32b75bbf5f7b3bd07883d03"
+  resolved "https://registry.npmjs.org/@angular/core/-/core-19.2.19.tgz#a2c35dfc5254a2d1e32b75bbf5f7b3bd07883d03"
   integrity sha512-VZAzpxBoQgyy7AOlhxbAHxPQWo0nk8xsnrD36PLCZeTZA/5GNzO3lLVaX2N5BCUgpgiCBjNBKq9kVo6ZkAls9g==
   dependencies:
     tslib "^2.3.0"
@@ -24228,10 +24221,10 @@ jest-pnp-resolver@^1.2.2:
   resolved "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz"
   integrity sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==
 
-jest-preset-angular@^16.1.1:
-  version "16.1.1"
-  resolved "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-16.1.1.tgz#5177c48bec73d26e586391b18363d81f2d93e15e"
-  integrity sha512-yrvV/86IO2mj3H33xWVEPwmLW9CJIOM7YcMBcwDWa9OXEAW9XM+47no8R06oine9+wH+QWXfFzFR3TG6nX7QRA==
+jest-preset-angular@^15.0.0:
+  version "15.0.3"
+  resolved "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-15.0.3.tgz#34f6552d703bd5d889bf788a9f75cb13f21e2ded"
+  integrity sha512-W1OpeQ/tq72ZSGXRvUDktL02QBAWIM5SZPK4KI0zoXNvRGiGhNMbxuaFF7anLi27cojmWHm+TewJQI1Dsm9s6A==
   dependencies:
     "@jest/environment-jsdom-abstract" "^30.0.0"
     bs-logger "^0.2.6"
@@ -34314,12 +34307,7 @@ zod@^3.24.1:
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.5.tgz#aeb269a6f9fc259b1212c348c7c5432aaa474d2a"
   integrity sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==
 
-zone.js@^0.16.1:
-  version "0.16.1"
-  resolved "https://registry.npmjs.org/zone.js/-/zone.js-0.16.1.tgz#ca91f0889e46b1c252aab6c75332e36840916227"
-  integrity sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==
-
-zone.js@~0.15.0:
+zone.js@^0.15.0, zone.js@~0.15.0:
   version "0.15.1"
   resolved "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz"
   integrity sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

followup of https://github.com/aws-amplify/amplify-ui/pull/6886

the previous PR restricted the peerDependencies of the ui project for angular.
This PR resets the versions to the previous ones.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
