### PR TITLE
chore: ignore HMR exceptions in cypress

### DIFF
--- a/build-system-tests/e2e/cypress/support/e2e.ts
+++ b/build-system-tests/e2e/cypress/support/e2e.ts
@@ -16,5 +16,11 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 
+Cypress.on('uncaught:exception', (err) => {
+  if (err.message.includes('Hot Module Replacement is disabled')) {
+    return false;
+  }
+});
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
with a recent change to webpack/cypress HMR issues (HMR client is present, but HMR is not enabled) become exceptions and cypress bails on any uncaught exception.

is is a change to the behavior of cypress to ignore HMR issues (as they are not critical) and continue testing.

#### Issue #, if available
_- none -_
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
ran the build-system-test locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
