### PR TITLE
chore: bump activesupport gem version

### DIFF
--- a/examples/react-native/Gemfile
+++ b/examples/react-native/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 ruby '>= 2.6.10'
 
 gem 'cocoapods', '>= 1.11.3'
-gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'
+gem 'activesupport', '>= 7.2.3.1'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes
this PR bumps the vulnerable version of the activesupport gem in the `react-native` workspace to a fixed version

this fixes CVE-2026-33169, CVE-2026-33176 and CVE-2026-33170

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
