### PR TITLE
fix(docs): use public package exports for StorageBrowser types

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -38,8 +38,6 @@ module.exports = withNextPluginPreval({
   // Differentiate pages with frontmatter & layout vs. normal MD(X)
   pageExtensions: ['page.mdx', 'page.tsx'],
 
-  swcMinify: true,
-
   async headers() {
     return [
       {

--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/locations.ts
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/locations.ts
@@ -1,4 +1,4 @@
-import { ListLocationsOutput } from '@aws-amplify/ui-react-storage/dist/types/components/StorageBrowser/actions';
+import { ListLocationsOutput } from '@aws-amplify/ui-react-storage/browser';
 
 export const locations: ListLocationsOutput['items'] = [
   {

--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/mockConfig.ts
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/examples/mockConfig.ts
@@ -1,4 +1,4 @@
-import { CreateStorageBrowserInput } from '@aws-amplify/ui-react-storage/dist/types/components/StorageBrowser';
+import { CreateStorageBrowserInput } from '@aws-amplify/ui-react-storage/browser';
 import { locations } from './locations';
 
 export const mockConfig: CreateStorageBrowserInput['config'] = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Fixes the docs build failure introduced by the Next.js 16.2.x upgrade in #6951.

Next.js 16.2.x now forcibly overrides `moduleResolution` to `"bundler"` during `next build`. Under bundler resolution, deep imports into a package's internal `dist/` paths (bypassing the `exports` map in `package.json`) no longer resolve.

Two docs example files were importing StorageBrowser types via internal paths:

```ts
// Before (broken under bundler resolution)
import { ListLocationsOutput } from '@aws-amplify/ui-react-storage/dist/types/components/StorageBrowser/actions';
import { CreateStorageBrowserInput } from '@aws-amplify/ui-react-storage/dist/types/components/StorageBrowser';

// After (uses the public ./browser subpath export)
import { ListLocationsOutput } from '@aws-amplify/ui-react-storage/browser';
import { CreateStorageBrowserInput } from '@aws-amplify/ui-react-storage/browser';
```

Both types are already publicly exported through the `./browser` subpath defined in `@aws-amplify/ui-react-storage`'s `package.json` `exports` field, so no library changes are needed.

Also removes the deprecated `swcMinify` option from `docs/next.config.js`, which Next.js 16.2.x flags as unrecognized.

#### Issue #, if available

Unblocks #6951

#### Description of how you validated changes

- Verified `ListLocationsOutput` and `CreateStorageBrowserInput` are both exported from the `./browser` subpath entry point (`packages/react-storage/src/components/StorageBrowser/index.ts`)
- Confirmed no other files import from `@aws-amplify/ui-react-storage/dist/` internal paths

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
