### PR TITLE
fix(authenticator): hide Resend Code button during password-based MFA

### DIFF
--- a/.changeset/fix-resend-code-password-mfa.md
+++ b/.changeset/fix-resend-code-password-mfa.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react": patch
+---
+
+fix(authenticator): hide Resend Code button during password-based MFA sign-in

--- a/packages/react/src/components/Authenticator/shared/ConfirmSignInFooter.tsx
+++ b/packages/react/src/components/Authenticator/shared/ConfirmSignInFooter.tsx
@@ -33,7 +33,7 @@ export const ConfirmSignInFooter = (): React.JSX.Element => {
   // Only show "Resend Code" for passwordless (USER_AUTH) flows.
   // Password-based sign-in does not support resending MFA codes.
   const hasPasswordlessMethod =
-    !!selectedAuthMethod ||
+    (!!selectedAuthMethod && selectedAuthMethod !== 'PASSWORD') ||
     !!availableAuthMethods?.some((m) => m !== 'PASSWORD');
   const showResendCode =
     isOtpChallenge(challengeName) && hasPasswordlessMethod && resendCode;

--- a/packages/react/src/components/Authenticator/shared/ConfirmSignInFooter.tsx
+++ b/packages/react/src/components/Authenticator/shared/ConfirmSignInFooter.tsx
@@ -14,16 +14,29 @@ const {
 } = authenticatorTextUtil;
 
 export const ConfirmSignInFooter = (): React.JSX.Element => {
-  const { isPending, toSignIn, challengeName, resendCode } = useAuthenticator(
-    (context) => [
-      context.isPending,
-      context.toSignIn,
-      context.challengeName,
-      context.resendCode,
-    ]
-  );
+  const {
+    isPending,
+    toSignIn,
+    challengeName,
+    resendCode,
+    selectedAuthMethod,
+    availableAuthMethods,
+  } = useAuthenticator((context) => [
+    context.isPending,
+    context.toSignIn,
+    context.challengeName,
+    context.resendCode,
+    context.selectedAuthMethod,
+    context.availableAuthMethods,
+  ]);
 
-  const showResendCode = isOtpChallenge(challengeName) && resendCode;
+  // Only show "Resend Code" for passwordless (USER_AUTH) flows.
+  // Password-based sign-in does not support resending MFA codes.
+  const hasPasswordlessMethod =
+    !!selectedAuthMethod ||
+    !!availableAuthMethods?.some((m) => m !== 'PASSWORD');
+  const showResendCode =
+    isOtpChallenge(challengeName) && hasPasswordlessMethod && resendCode;
 
   return (
     <Flex direction="column">


### PR DESCRIPTION
   Description of changes

   The "Resend Code" button was incorrectly displayed during password-based MFA sign-in (e.g., SMSMFA, EMAILOTP
   challenges triggered after a traditional password sign-in). Clicking it resulted in the error password is
   required to signIn because the underlying resendSignInCode service attempts to re-initiate sign-in via
   USER_AUTH flow without a password.

   This PR updates ConfirmSignInFooter to only show the "Resend Code" button when the sign-in was initiated via a
   passwordless (USER_AUTH) flow (e.g., EMAIL_OTP, SMS_OTP, WEB_AUTHN). The button is now hidden when
   availableAuthMethods only contains PASSWORD, which indicates a traditional password-based sign-in.

   Changes:

   - ConfirmSignInFooter.tsx: Added selectedAuthMethod and availableAuthMethods to the useAuthenticator selector.
   The showResendCode condition now checks that a non-password auth method exists before rendering the button.

   Issue #, if available

   Fixes #6954

   Description of how you validated changes

   - Reproduced the bug using a Vite + React app with SMS MFA enabled (password-based sign-in)
   - Verified the "Resend Code" button no longer appears during password-based MFA sign-in
   - Confirmed the button still appears correctly during passwordless (USER_AUTH) sign-in flows

   Checklist

   - [x] Have read the Pull Request Guidelines
   - [x] PR description included
   - [ ] yarn test passes and tests are updated/added
   - [x] PR title and commit messages follow conventional commit
   (https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
   - [ ] If this change should result in a version bump, changeset added
   (https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after
   creating the PR.) This does not apply to changes made to docs, e2e, examples, or other private packages.

   By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0
   license.