### PR TITLE
fix(react): export dist CSS entrypoints for Metro compatibility

### DIFF
--- a/.changeset/warm-dogs-return.md
+++ b/.changeset/warm-dogs-return.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/ui-react-liveness': patch
+'@aws-amplify/ui-react': patch
+---
+
+Fix Metro warnings by explicitly exporting dist CSS entrypoints in package.json. Added `./dist/styles.css` export aliases to prevent Metro from implicitly falling back to file-based resolution.

--- a/packages/react-liveness/package.json
+++ b/packages/react-liveness/package.json
@@ -9,10 +9,12 @@
       "import": "./dist/esm/index.mjs",
       "require": "./dist/index.js"
     },
-    "./styles.css": "./dist/styles.css"
+    "./styles.css": "./dist/styles.css",
+    "./dist/styles.css": "./dist/styles.css"
   },
   "browser": {
-    "./styles.css": "./dist/styles.css"
+    "./styles.css": "./dist/styles.css",
+    "./dist/styles.css": "./dist/styles.css"
   },
   "types": "dist/types/index.d.ts",
   "sideEffects": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,12 +20,14 @@
       "require": "./dist/server.js"
     },
     "./styles.css": "./dist/styles.css",
+    "./dist/styles.css": "./dist/styles.css",
     "./styles.layer.css": "./dist/styles.layer.css",
     "./styles/*": "./dist/styles/*",
     "./primitives.json": "./dist/primitives.json"
   },
   "browser": {
-    "./styles.css": "./dist/styles.css"
+    "./styles.css": "./dist/styles.css",
+    "./dist/styles.css": "./dist/styles.css"
   },
   "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Resolves #6956

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Metro warns when resolving Amplify UI CSS from React Native Web or Expo DOM components usage because it probes the dist subpath `./dist/styles.css`, which was not listed in package `exports`. Add explicit `./dist/styles.css` export aliases for `@aws-amplify/ui-react` and `@aws-amplify/ui-react-liveness` so Metro no longer have to implicitly fallback to file-based resolution.

*In Detail explanation*:-
When using React Liveness packages in Expo React native apps via Expo DOM components, we need to import Amplify UI CSS files in our DOM component as shown below:-
```ts
// These are the documented CSS entrypoints:
import '@aws-amplify/ui-react/styles.css';
import '@aws-amplify/ui-react-liveness/styles.css';
```

Metro internally resolves these to ./dist/styles.css as a fallback and the styles get imported correctly because of Metro's fallback
But since metro bundler had to use fallback. it emits warnings because those dist subpaths are not listed in the packages' `exports` field:

```
WARN  Attempted to import the module "…/node_modules/styles.css" which is not listed
in the "exports" of "…/@aws-amplify/ui-react" under the requested subpath
"./dist/styles.css". Falling back to file-based resolution. Consider updating the
call site or asking the package maintainer(s) to expose this API.

WARN  Attempted to import the module "…/node_modules/styles.css" which is not listed
in the "exports" of "…/@aws-amplify/ui-react-liveness" under the requested subpath
"./dist/styles.css". Falling back to file-based resolution. …
```



#### Description of how you validated changes

I have tested this locally by directly making changes to the package.json in my react native app's node_modules and verified that the metro bundler is no longer emitting those warnings. The styles are imported as expected

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
