### PR TITLE
Fix/bobbor/i18n texts

### DIFF
--- a/.changeset/wise-masks-buy.md
+++ b/.changeset/wise-masks-buy.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui": patch
+---
+
+Fix/bobbor/i18n texts

--- a/packages/ui/src/helpers/authenticator/__tests__/textUtil.test.ts
+++ b/packages/ui/src/helpers/authenticator/__tests__/textUtil.test.ts
@@ -71,9 +71,7 @@ describe('authenticatorTextUtil', () => {
 
       expect(
         authenticatorTextUtil.getDeliveryMessageText(codeDeliveryDetails)
-      ).toEqual(
-        'Your code is on the way. To log in, enter the code we sent you. It may take a minute to arrive.'
-      );
+      ).toEqual('Your code is on the way. It may take a minute to arrive.');
     });
   });
 

--- a/packages/ui/src/helpers/authenticator/textUtil.ts
+++ b/packages/ui/src/helpers/authenticator/textUtil.ts
@@ -37,14 +37,14 @@ const getDeliveryMessageText = (
   const arrivalMessage = translate(DefaultTexts.CODE_ARRIVAL);
 
   if (!(isEmailMessage || isTextMessage)) {
-    return `${translate(DefaultTexts.CODE_SENT)}. ${arrivalMessage}.`;
+    return translate(DefaultTexts.DELIVERY_MESSAGE_UNKNOWN, { arrivalMessage });
   }
 
-  const instructionMessage = isEmailMessage
-    ? translate(DefaultTexts.CODE_EMAILED)
-    : translate(DefaultTexts.CODE_TEXTED);
+  const key = isEmailMessage
+    ? DefaultTexts.DELIVERY_MESSAGE_EMAIL
+    : DefaultTexts.DELIVERY_MESSAGE_PHONE;
 
-  return `${instructionMessage} ${Destination}. ${arrivalMessage}.`;
+  return translate(key, { destination: Destination, arrivalMessage });
 };
 
 const getDeliveryMethodText = (
@@ -181,13 +181,9 @@ export const authenticatorTextUtil = {
 
   /** SetupTotp */
   getSetupTotpText: () => translate(DefaultTexts.SETUP_TOTP),
-  // TODO: add defaultText for below
   getSetupTotpInstructionsText: () =>
-    translate(
-      'Copy and paste the secret key below into an authenticator app and then enter the code in the text field below.'
-    ),
-  // TODO: add defaultText for "COPIED"
-  getCopiedText: () => translate('COPIED'),
+    translate(DefaultTexts.SETUP_TOTP_INSTRUCTIONS),
+  getCopiedText: () => translate(DefaultTexts.COPIED),
 
   /** FederatedSignIn */
   getSignInWithFederationText,
@@ -232,8 +228,6 @@ export const authenticatorTextUtil = {
   getUsernameLabelByLoginMechanism,
 
   /** Validations */
-  // TODO: add defaultText
-  getInvalidEmailText: () => translate('Please enter a valid email'),
-  // TODO: add defaultText
-  getRequiredFieldText: () => translate('This field is required'),
+  getInvalidEmailText: () => translate(DefaultTexts.INVALID_EMAIL),
+  getRequiredFieldText: () => translate(DefaultTexts.FIELD_REQUIRED),
 } as const; // using `as const` so that keys are strongly typed

--- a/packages/ui/src/i18n/dictionaries/authenticator/de.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/de.ts
@@ -86,8 +86,16 @@ export const deDict: AuthenticatorDictionary = {
     'Ihr Bestätigungscode ist unterwegs. Um sich einzuloggen geben Sie den Code ein, den wir per E-Mail verschickt haben',
   'Your code is on the way. To log in, enter the code we sent you':
     'Ihr Code ist unterwegs. Um sich anzumelden, geben Sie den Code ein, den wir Ihnen gesendet haben',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Ihr Code ist unterwegs. Um sich anzumelden, geben Sie den Code ein, den wir Ihnen gesendet haben.',
   'Your code is on the way. To log in, enter the code we texted to':
     'Ihr Bestätigungscode ist unterwegs. Um sich einzuloggen geben Sie den Code ein, den wir per SMS verschickt haben',
+  'Your code is on the way. {arrivalMessage}':
+    'Ihr Code ist unterwegs. Um sich anzumelden, geben Sie den Code ein, den wir Ihnen gesendet haben. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Ihr Bestätigungscode ist unterwegs. Um sich einzuloggen geben Sie den Code ein, den wir per E-Mail verschickt haben {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Ihr Bestätigungscode ist unterwegs. Um sich einzuloggen geben Sie den Code ein, den wir per SMS verschickt haben {destination}. {arrivalMessage}',
 
   // Additional translations provided by customers
   'An account with the given email already exists.':
@@ -118,5 +126,6 @@ export const deDict: AuthenticatorDictionary = {
   'Sign Up': 'Registrieren',
   'User already exists': 'Dieser Benutzer existiert bereits',
   'User does not exist': 'Dieser Benutzer existiert nicht',
+  'User does not exist.': 'Dieser Benutzer existiert nicht',
   'Username cannot be empty': 'Benutzername darf nicht leer sein',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/defaultTexts.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/defaultTexts.ts
@@ -6,12 +6,17 @@ export const defaultTexts = {
   CHANGE_PASSWORD: 'Change Password',
   CHANGING_PASSWORD: 'Changing',
   CODE: 'Code',
-  CODE_ARRIVAL: 'It may take a minute to arrive',
+  CODE_ARRIVAL: 'It may take a minute to arrive.',
   CODE_EMAILED:
     'Your code is on the way. To log in, enter the code we emailed to',
-  CODE_SENT: 'Your code is on the way. To log in, enter the code we sent you',
+  CODE_SENT: 'Your code is on the way. To log in, enter the code we sent you.',
   CODE_TEXTED:
     'Your code is on the way. To log in, enter the code we texted to',
+  DELIVERY_MESSAGE_UNKNOWN: 'Your code is on the way. {arrivalMessage}',
+  DELIVERY_MESSAGE_EMAIL:
+    'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}',
+  DELIVERY_MESSAGE_PHONE:
+    'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}',
   CONFIRM_PASSWORD: 'Confirm Password',
   CONFIRM_PASSWORD_PLACEHOLDER: 'Please confirm your Password',
   CONFIRM_RESET_PASSWORD_HEADING: 'Reset your Password',
@@ -24,6 +29,7 @@ export const defaultTexts = {
   CONFIRM: 'Confirm',
   CONFIRMATION_CODE: 'Confirmation Code',
   CONFIRMING: 'Confirming',
+  COPIED: 'COPIED',
   CONTINUE: 'Continue',
   CONTINUE_WITHOUT_PASSKEY: 'Continue without a Passkey',
   CREATE_ACCOUNT: 'Create Account',
@@ -50,10 +56,12 @@ export const defaultTexts = {
   ENTER_USERNAME_FIRST: 'Please enter your username first',
   EXISTING_PASSKEYS: 'Existing Passkeys',
   FAMILY_NAME: 'Family Name',
+  FIELD_REQUIRED: 'This field is required',
   GIVEN_NAME: 'Given Name',
   FORGOT_PASSWORD: 'Forgot Password?',
   FORGOT_YOUR_PASSWORD: 'Forgot your password?',
   HIDE_PASSWORD: 'Hide password',
+  INVALID_EMAIL: 'Please enter a valid email',
   LOADING: 'Loading',
   LOGIN_NAME: 'Username',
   MIDDLE_NAME: 'Middle Name',
@@ -85,6 +93,8 @@ export const defaultTexts = {
   RESET_PASSWORD: 'Reset Password',
   SEND_CODE: 'Send code',
   CODE_DELIVERY_FAILED: 'Unable to send verification code. Please try again.',
+  CONFIGURATION_ERROR:
+    'Configuration error (see console) - please contact the administrator',
   VERIFICATION_CODE_EXPIRED:
     'Your verification code has expired. Please request a new code.',
   VERIFICATION_CODE_INVALID:
@@ -94,6 +104,8 @@ export const defaultTexts = {
   SETUP_ANOTHER_PASSKEY: 'Setup another Passkey',
   SETUP_EMAIL: 'Setup Email',
   SETUP_TOTP: 'Setup TOTP',
+  SETUP_TOTP_INSTRUCTIONS:
+    'Copy and paste the secret key below into an authenticator app and then enter the code in the text field below.',
   SHOW_PASSWORD: 'Show password',
   SIGN_IN_BUTTON: 'Sign in',
   SIGN_IN_TAB: 'Sign In',

--- a/packages/ui/src/i18n/dictionaries/authenticator/en.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/en.ts
@@ -42,6 +42,7 @@ export const enDict: AuthenticatorDictionary = {
   'Forgot your password?': 'Forgot your password?',
   'Hide password': 'Hide password',
   'It may take a minute to arrive': 'It may take a minute to arrive',
+  'It may take a minute to arrive.': 'It may take a minute to arrive.',
   Loading: 'Loading',
   'Multi-Factor Authentication': 'Multi-Factor Authentication',
   'Multi-Factor Authentication Setup': 'Multi-Factor Authentication Setup',
@@ -82,6 +83,14 @@ export const enDict: AuthenticatorDictionary = {
     'Your code is on the way. To log in, enter the code we emailed to',
   'Your code is on the way. To log in, enter the code we sent you':
     'Your code is on the way. To log in, enter the code we sent you',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Your code is on the way. To log in, enter the code we sent you.',
   'Your code is on the way. To log in, enter the code we texted to':
     'Your code is on the way. To log in, enter the code we texted to',
+  'Your code is on the way. {arrivalMessage}':
+    'Your code is on the way. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/es.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/es.ts
@@ -34,6 +34,8 @@ export const esDict: AuthenticatorDictionary = {
   'Forgot your password?': '¿Olvidó su contraseña?',
   'Hide password': 'Ocultar contraseña',
   'It may take a minute to arrive': 'Es posible que tarde un minuto en llegar',
+  'It may take a minute to arrive.':
+    'Es posible que tarde un minuto en llegar.',
   Loading: 'Cargando',
   'Multi-Factor Authentication': 'Autenticación multifactor',
   'Multi-Factor Authentication Setup':
@@ -74,8 +76,16 @@ export const esDict: AuthenticatorDictionary = {
     'El código está en camino. Para iniciar sesión, escriba el código que hemos enviado por correo electrónico a',
   'Your code is on the way. To log in, enter the code we sent you':
     'El código está en camino. Para iniciar sesión, escriba el código que le hemos enviado',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'El código está en camino. Para iniciar sesión, escriba el código que le hemos enviado.',
   'Your code is on the way. To log in, enter the code we texted to':
     'El código está en camino. Para iniciar sesión, escriba el código que hemos enviado por mensaje de texto a',
+  'Your code is on the way. {arrivalMessage}':
+    'El código está en camino. Para iniciar sesión, escriba el código que le hemos enviado. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'El código está en camino. Para iniciar sesión, escriba el código que hemos enviado por correo electrónico a {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'El código está en camino. Para iniciar sesión, escriba el código que hemos enviado por mensaje de texto a {destination}. {arrivalMessage}',
 
   // Additional translations provided by customers
   'An account with the given email already exists.':
@@ -85,6 +95,7 @@ export const esDict: AuthenticatorDictionary = {
   'Forgot Password': 'Olvidé mi contraseña',
   'Incorrect username or password.':
     'Nombre de usuario o contraseña incorrecta',
+  'Incorrect username or password': 'Nombre de usuario o contraseña incorrecta',
   'Enter your Family Name': 'Escriba su apellido',
   'Enter your Given Name': 'Escriba su nombre',
   'Given Name': 'Nombre',
@@ -104,6 +115,7 @@ export const esDict: AuthenticatorDictionary = {
   'Sign Up': 'Crear cuenta',
   'User already exists': 'El usuario ya existe',
   'User does not exist.': 'El usuario no existe',
+  'User does not exist': 'El usuario no existe',
   'Username/client id combination not found.': 'El usuario no existe',
   'Username cannot be empty': 'El nombre de usuario no puede estar vacío',
   'Your passwords must match': 'Las contraseñas deben coincidir',

--- a/packages/ui/src/i18n/dictionaries/authenticator/fr.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/fr.ts
@@ -68,6 +68,7 @@ export const frDict: AuthenticatorDictionary = {
   'We Sent A Code': 'Nous avons envoyé un code',
   'We Texted You': 'Nous vous avons envoyé un SMS',
   'Your code is on the way. To log in, enter the code we sent you': `Votre code est en cours d'envoi. Pour vous connecter, saisissez le code que nous vous avons envoyé`,
+  'Your code is on the way. To log in, enter the code we sent you.': `Votre code est en cours d'envoi. Pour vous connecter, saisissez le code que nous vous avons envoyé.`,
 
   // Additional translations provided by customers
   'Add your Profile': 'Ajoutez votre profil',
@@ -119,6 +120,7 @@ export const frDict: AuthenticatorDictionary = {
   SMS: 'SMS',
   'User already exists': "L'utilisateur existe déjà",
   'User does not exist.': "L'utilisateur n'existe pas",
+  'User does not exist': "L'utilisateur n'existe pas",
   'Username cannot be empty': "Le nom d'utilisateur doit être renseigné",
   'Username/client id combination not found.': "L'utilisateur n'existe pas",
   'We Emailed You': 'Nous vous avons envoyé un code',
@@ -126,6 +128,12 @@ export const frDict: AuthenticatorDictionary = {
     'Votre code est en route. Pour vous connecter entrez le code reçu sur cette adresse email',
   'Your code is on the way. To log in, enter the code we texted to':
     'Votre code est en route. Pour vous connecter entrez le code reçu sur ce numéro de téléphone',
+  'Your code is on the way. {arrivalMessage}':
+    "Votre code est en cours d'envoi. Pour vous connecter, saisissez le code que nous vous avons envoyé. {arrivalMessage}",
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Votre code est en route. Pour vous connecter entrez le code reçu sur cette adresse email {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Votre code est en route. Pour vous connecter entrez le code reçu sur ce numéro de téléphone {destination}. {arrivalMessage}',
   'Your passwords must match': 'Vos mots de passe doivent être identiques',
   'It may take a minute to arrive.': 'Cela peut prendre quelques minutes.',
   Website: 'Site web',

--- a/packages/ui/src/i18n/dictionaries/authenticator/hu.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/hu.ts
@@ -135,6 +135,7 @@ export const huDict: AuthenticatorDictionary = {
   'Text Message (SMS)': 'SMS üzenet',
   'User already exists': 'A felhasználó már létezik',
   'User does not exist': 'Felhasználó nem található',
+  'User does not exist.': 'Felhasználó nem található',
   'User is disabled.': 'A felhasználó le van tiltva.',
   Username: 'Felhasználónév',
   'Username cannot be empty': 'A felhasználónév mező nem lehet üres',
@@ -150,7 +151,15 @@ export const huDict: AuthenticatorDictionary = {
     'A bejelentkezéshez szükséges kód küldése folyamatban van, amelyet a következő e-mail címre küldtünk:',
   'Your code is on the way. To log in, enter the code we sent you':
     'A bejelentkezéshez szükséges kód küldése folyamatban van',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'A bejelentkezéshez szükséges kód küldése folyamatban van.',
   'Your code is on the way. To log in, enter the code we texted to':
     'A bejelentkezéshez szükséges kód küldése folyamatban van, amelyet SMS-ben küldtünk a következő számra:',
+  'Your code is on the way. {arrivalMessage}':
+    'A bejelentkezéshez szükséges kód küldése folyamatban van. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'A bejelentkezéshez szükséges kód küldése folyamatban van, amelyet a következő e-mail címre küldtünk: {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'A bejelentkezéshez szükséges kód küldése folyamatban van, amelyet SMS-ben küldtünk a következő számra: {destination}. {arrivalMessage}',
   'Your passwords must match': 'A jelszavaknak meg kell egyezniük',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/id.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/id.ts
@@ -65,6 +65,8 @@ export const idDict: AuthenticatorDictionary = {
   'We Texted You': 'Kami mengirim SMS kepada Anda',
   'Your code is on the way. To log in, enter the code we sent you':
     'Kode Anda segera hadir. Untuk masuk, masukkan kode yang kami kirimkan kepada Anda',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Kode Anda segera hadir. Untuk masuk, masukkan kode yang kami kirimkan kepada Anda.',
 
   // Additional translations provided by customers
   'An account with the given email already exists.':
@@ -81,6 +83,7 @@ export const idDict: AuthenticatorDictionary = {
   'Have an account? ': 'Sudah punya akun? ',
   Hello: 'Halo',
   'Incorrect username or password.': 'Nama akun atau kata sandi salah.',
+  'Incorrect username or password': 'Nama akun atau kata sandi salah.',
   'Invalid phone number format': 'Nomor telepon tidak sesuai dengan format.',
   'Invalid verification code provided, please try again.':
     'Kode verifikasi tidak sesuai, mohon coba lagi.',
@@ -102,6 +105,7 @@ export const idDict: AuthenticatorDictionary = {
   SMS: 'SMS',
   'User already exists': 'Akun sudah terdaftar',
   'User does not exist.': 'Akun tidak terdaftar.',
+  'User does not exist': 'Akun tidak terdaftar.',
   'User is disabled.': 'Akun dinonaktifkan.',
   'Username cannot be empty': 'Nama akun tidak boleh kosong',
   'Username/client id combination not found.':
@@ -111,5 +115,11 @@ export const idDict: AuthenticatorDictionary = {
     'Kode anda dalam pengiriman. Untuk masuk, masukkan kode yang kami emailkan ke',
   'Your code is on the way. To log in, enter the code we texted to':
     'Kode anda dalam pengiriman. Untuk masuk, masukkan kode yang kami tuliskan ke',
+  'Your code is on the way. {arrivalMessage}':
+    'Kode Anda segera hadir. Untuk masuk, masukkan kode yang kami kirimkan kepada Anda. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Kode anda dalam pengiriman. Untuk masuk, masukkan kode yang kami emailkan ke {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Kode anda dalam pengiriman. Untuk masuk, masukkan kode yang kami tuliskan ke {destination}. {arrivalMessage}',
   'Your passwords must match': 'Kata sandi harus sama',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/it.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/it.ts
@@ -30,6 +30,8 @@ export const itDict: AuthenticatorDictionary = {
   'Hide password': 'Nascondi password',
   'It may take a minute to arrive':
     "L'arrivo potrebbe richiedere qualche minuto",
+  'It may take a minute to arrive.':
+    "L'arrivo potrebbe richiedere qualche minuto.",
   Loading: 'Caricamento in corso',
   'Multi-Factor Authentication': 'Autenticazione a più fattori',
   'Multi-Factor Authentication Setup':
@@ -70,8 +72,16 @@ export const itDict: AuthenticatorDictionary = {
     "Il codice è in arrivo. Per effettuare l'accesso, immetti il codice che ti abbiamo inviato via e-mail",
   'Your code is on the way. To log in, enter the code we sent you':
     'Il codice è in arrivo. Per accedere, immetti il codice che ti abbiamo inviato',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Il codice è in arrivo. Per accedere, immetti il codice che ti abbiamo inviato.',
   'Your code is on the way. To log in, enter the code we texted to':
     'Il codice è in arrivo. Per accedere, immetti il codice che abbiamo inviato tramite SMS',
+  'Your code is on the way. {arrivalMessage}':
+    'Il codice è in arrivo. Per accedere, immetti il codice che ti abbiamo inviato. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    "Il codice è in arrivo. Per effettuare l'accesso, immetti il codice che ti abbiamo inviato via e-mail {destination}. {arrivalMessage}",
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Il codice è in arrivo. Per accedere, immetti il codice che abbiamo inviato tramite SMS {destination}. {arrivalMessage}',
 
   // Additional translations provided by customers
   'An account with the given email already exists.':
@@ -96,5 +106,6 @@ export const itDict: AuthenticatorDictionary = {
   'Sign Up': 'Registrati',
   'User already exists': 'Utente già esistente',
   'User does not exist': 'Utente inesistente',
+  'User does not exist.': 'Utente inesistente',
   'Username cannot be empty': 'Il nome utente non può essere vuoto',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/ja.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/ja.ts
@@ -66,6 +66,8 @@ export const jaDict: AuthenticatorDictionary = {
   'We Texted You': 'テキストが送信されました',
   'Your code is on the way. To log in, enter the code we sent you':
     'コードが途中です。ログインするには、送信したコードを入力してください',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'コードが途中です。ログインするには、送信したコードを入力してください。',
 
   // Additional translations provided by customers
   'An account with the given email already exists.':
@@ -95,10 +97,17 @@ export const jaDict: AuthenticatorDictionary = {
   'Sign Up': '登録 ',
   'User already exists': '既にユーザーが存在しています ',
   'User does not exist': 'ユーザーが存在しません ',
+  'User does not exist.': 'ユーザーが存在しません ',
   'Username cannot be empty': 'ユーザー名は入力必須です',
   'We Emailed You': 'コードを送信しました',
   'Your code is on the way. To log in, enter the code we emailed to':
     'ログインするには、メールに記載されたコードを入力してください。送信先:',
   'Your code is on the way. To log in, enter the code we texted to':
     'ログインするには、テキストメッセージに記載されたコードを入力してください。送信先:',
+  'Your code is on the way. {arrivalMessage}':
+    'コードが途中です。ログインするには、送信したコードを入力してください。{arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'ログインするには、メールに記載されたコードを入力してください。送信先: {destination}。{arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'ログインするには、テキストメッセージに記載されたコードを入力してください。送信先: {destination}。{arrivalMessage}',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/kr.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/kr.ts
@@ -37,6 +37,7 @@ export const krDict: AuthenticatorDictionary = {
   'Forgot password?': '비밀번호를 잊으셨나요?',
   'Hide password': '비밀번호 숨기기',
   'It may take a minute to arrive': '도착하는 데 1분 정도 걸릴 수 있습니다',
+  'It may take a minute to arrive.': '도착하는 데 1분 정도 걸릴 수 있습니다.',
   Loading: '로딩중',
   'Multi-Factor Authentication': '다중 인증',
   'Multi-Factor Authentication Setup': '다중 인증 설정',
@@ -77,8 +78,16 @@ export const krDict: AuthenticatorDictionary = {
     '코드가 전송 중입니다. 로그인하려면 이메일로 전송한 코드를 입력하세요',
   'Your code is on the way. To log in, enter the code we sent you':
     '코드가 전송 중입니다. 로그인하려면 전송한 코드를 입력하세요',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    '코드가 전송 중입니다. 로그인하려면 전송한 코드를 입력하세요.',
   'Your code is on the way. To log in, enter the code we texted to':
     '코드가 전송 중입니다. 로그인하려면 문자 메시지로 전송한 코드를 입력하세요',
+  'Your code is on the way. {arrivalMessage}':
+    '코드가 전송 중입니다. 로그인하려면 전송한 코드를 입력하세요. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    '코드가 전송 중입니다. 로그인하려면 이메일로 전송한 코드를 입력하세요 {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    '코드가 전송 중입니다. 로그인하려면 문자 메시지로 전송한 코드를 입력하세요 {destination}. {arrivalMessage}',
 
   // Additional translations provided by customers
   Birthdate: '생년월일',

--- a/packages/ui/src/i18n/dictionaries/authenticator/nb.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/nb.ts
@@ -41,6 +41,7 @@ export const nbDict: AuthenticatorDictionary = {
   'Forgot your password?': 'Glemt passordet ditt?',
   'Hide password': 'Skjul passordet',
   'It may take a minute to arrive': 'Det kan ta et minutt for å komme frem',
+  'It may take a minute to arrive.': 'Det kan ta et minutt for å komme frem.',
   Loading: 'Laster inn',
   'Multi-Factor Authentication': 'Flerfaktorautentisering',
   'Multi-Factor Authentication Setup': 'Oppsett av flerfaktorautentisering',
@@ -81,8 +82,16 @@ export const nbDict: AuthenticatorDictionary = {
     'Koden din er på vei. For å logge inn, skriv inn koden vi sendte e-post til',
   'Your code is on the way. To log in, enter the code we sent you':
     'Koden din er på vei. For å logge inn, skriv inn koden vi sendte deg',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Koden din er på vei. For å logge inn, skriv inn koden vi sendte deg.',
   'Your code is on the way. To log in, enter the code we texted to':
     'Koden din er på vei. For å logge inn, skriv inn koden vi sendte tekstmelding til',
+  'Your code is on the way. {arrivalMessage}':
+    'Koden din er på vei. For å logge inn, skriv inn koden vi sendte deg. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Koden din er på vei. For å logge inn, skriv inn koden vi sendte e-post til {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Koden din er på vei. For å logge inn, skriv inn koden vi sendte tekstmelding til {destination}. {arrivalMessage}',
 
   // Additional translations provided by customers
   'An account with the given email already exists.':
@@ -106,5 +115,6 @@ export const nbDict: AuthenticatorDictionary = {
   'Sign Up': 'Registrering',
   'User already exists': 'Brukeren finnes allerede',
   'User does not exist': 'Brukeren finnes ikke',
+  'User does not exist.': 'Brukeren finnes ikke',
   'Username cannot be empty': 'Brukernavnet kan ikke være tomt',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/nl.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/nl.ts
@@ -31,6 +31,7 @@ export const nlDict: AuthenticatorDictionary = {
   'Forgot your password?': 'Wachtwoord vergeten? ',
   'Hide password': 'Verberg wachtwoord',
   'It may take a minute to arrive': 'Het kan even duren voordat deze aankomt',
+  'It may take a minute to arrive.': 'Het kan even duren voordat deze aankomt.',
   Loading: 'Laden',
   'Multi-Factor Authentication': 'Multi-Factor Authentication',
   'Multi-Factor Authentication Setup': 'Multi-Factor Authentication instellen',
@@ -73,7 +74,15 @@ export const nlDict: AuthenticatorDictionary = {
     'Uw code is onderweg. Om in te loggen, voer de code in die we gemaild hebben naar',
   'Your code is on the way. To log in, enter the code we sent you':
     'Uw code is onderweg. Om in te loggen, voer de code in die we u hebben gestuurd',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Uw code is onderweg. Om in te loggen, voer de code in die we u hebben gestuurd.',
   'Your code is on the way. To log in, enter the code we texted to':
     'Uw code is onderweg. Om in te loggen, voer de code in die we hebben gestuurd naar',
+  'Your code is on the way. {arrivalMessage}':
+    'Uw code is onderweg. Om in te loggen, voer de code in die we u hebben gestuurd. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Uw code is onderweg. Om in te loggen, voer de code in die we gemaild hebben naar {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Uw code is onderweg. Om in te loggen, voer de code in die we hebben gestuurd naar {destination}. {arrivalMessage}',
   'Your passwords must match': 'Je wachtwoorden moeten overeenkomen',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/pl.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/pl.ts
@@ -29,6 +29,7 @@ export const plDict: AuthenticatorDictionary = {
   'Forgot your password?': 'Zapomniałeś hasła? ',
   'Hide password': 'Ukryj hasło',
   'It may take a minute to arrive': 'Może to chwilę potrwać',
+  'It may take a minute to arrive.': 'Może to chwilę potrwać.',
   Loading: 'Ładowanie',
   'Multi-Factor Authentication': 'Uwierzytelnianie wieloskładnikowe',
   'Multi-Factor Authentication Setup':
@@ -80,6 +81,14 @@ export const plDict: AuthenticatorDictionary = {
     'Twój kod został wysłany. Aby się zalogować, wprowadź kod wysłany na adres e-mail',
   'Your code is on the way. To log in, enter the code we sent you':
     'Twój kod został wysłany. Aby się zalogować, wprowadź wysłany do Ciebie kod',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Twój kod został wysłany. Aby się zalogować, wprowadź wysłany do Ciebie kod.',
   'Your code is on the way. To log in, enter the code we texted to':
     'Twój kod został wysłany. Aby się zalogować, wprowadź kod wysłany do Ciebie w wiadomości SMS pod numer',
+  'Your code is on the way. {arrivalMessage}':
+    'Twój kod został wysłany. Aby się zalogować, wprowadź wysłany do Ciebie kod. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Twój kod został wysłany. Aby się zalogować, wprowadź kod wysłany na adres e-mail {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Twój kod został wysłany. Aby się zalogować, wprowadź kod wysłany do Ciebie w wiadomości SMS pod numer {destination}. {arrivalMessage}',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/pt.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/pt.ts
@@ -42,6 +42,7 @@ export const ptDict: AuthenticatorDictionary = {
   'Forgot your password?': 'Esqueceu sua senha?',
   'Hide password': 'Esconder a senha',
   'It may take a minute to arrive': 'Pode levar um minuto para chegar',
+  'It may take a minute to arrive.': 'Pode levar um minuto para chegar.',
   Loading: 'Carregando',
   'Multi-Factor Authentication': 'Autenticação multifator',
   'Multi-Factor Authentication Setup':
@@ -83,8 +84,16 @@ export const ptDict: AuthenticatorDictionary = {
     'Seu código está a caminho. Para fazer login, insira o código para o qual enviamos um e-mail',
   'Your code is on the way. To log in, enter the code we sent you':
     'Seu código está a caminho. Para fazer login, insira o código que enviamos para você',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Seu código está a caminho. Para fazer login, insira o código que enviamos para você.',
   'Your code is on the way. To log in, enter the code we texted to':
     'Seu código está a caminho. Para fazer login, insira o código para o qual enviamos uma mensagem de texto',
+  'Your code is on the way. {arrivalMessage}':
+    'Seu código está a caminho. Para fazer login, insira o código que enviamos para você. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Seu código está a caminho. Para fazer login, insira o código para o qual enviamos um e-mail {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Seu código está a caminho. Para fazer login, insira o código para o qual enviamos uma mensagem de texto {destination}. {arrivalMessage}',
 
   // Additional translations provided by customers
   'An account with the given email already exists.':
@@ -93,6 +102,7 @@ export const ptDict: AuthenticatorDictionary = {
   'Confirm Sign In': 'Confirmar Início de Sessão',
   'Forgot Password': 'Esqueci Minha Senha',
   'Incorrect username or password.': 'Nome de usuário ou senha incorreta',
+  'Incorrect username or password': 'Nome de usuário ou senha incorreta',
   'Invalid password format': 'Formato de senha inválido',
   'Invalid phone number format': 'Formato de número de telefone inválido',
   'Loading...': 'Carregando...',
@@ -106,6 +116,7 @@ export const ptDict: AuthenticatorDictionary = {
   'Sign Up': 'Criar Conta',
   'User already exists': 'Usuário já existe',
   'User does not exist': 'Usuário não existe',
+  'User does not exist.': 'Usuário não existe',
   'Username cannot be empty': 'Nome de usuário não pode estar vazio',
   'Your passwords must match': 'Suas senhas devem ser iguais',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/ru.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/ru.ts
@@ -29,6 +29,7 @@ export const ruDict: AuthenticatorDictionary = {
   'Forgot your password?': 'Забыли ваш пароль?',
   'Hide password': 'Скрывать пароль',
   'It may take a minute to arrive': 'Доставка может занять некоторое время',
+  'It may take a minute to arrive.': 'Доставка может занять некоторое время.',
   Loading: 'Загрузка',
   'Multi-Factor Authentication': 'Многофакторная аутентификация',
   'Multi-Factor Authentication Setup':
@@ -69,6 +70,14 @@ export const ruDict: AuthenticatorDictionary = {
     'Ваш код отправлен. Чтобы войти в систему, введите код, который мы отправили по электронной почте',
   'Your code is on the way. To log in, enter the code we sent you':
     'Ваш код отправлен. Чтобы войти в систему, введите код, который мы послали вам',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Ваш код отправлен. Чтобы войти в систему, введите код, который мы послали вам.',
   'Your code is on the way. To log in, enter the code we texted to':
     'Ваш код отправлен. Чтобы войти в систему, введите код, который мы отправили текстовым сообщением',
+  'Your code is on the way. {arrivalMessage}':
+    'Ваш код отправлен. Чтобы войти в систему, введите код, который мы послали вам. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Ваш код отправлен. Чтобы войти в систему, введите код, который мы отправили по электронной почте {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Ваш код отправлен. Чтобы войти в систему, введите код, который мы отправили текстовым сообщением {destination}. {arrivalMessage}',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/sv.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/sv.ts
@@ -29,6 +29,7 @@ export const svDict: AuthenticatorDictionary = {
   'Forgot your password?': 'Glömt ditt lösenord? ',
   'Hide password': 'Dölj lösenord',
   'It may take a minute to arrive': 'Det kan ta en minut att komma fram',
+  'It may take a minute to arrive.': 'Det kan ta en minut att komma fram.',
   Loading: 'Laddar',
   'Multi-Factor Authentication': 'Multifaktorautentisering',
   'Multi-Factor Authentication Setup':
@@ -68,8 +69,16 @@ export const svDict: AuthenticatorDictionary = {
     'Din kod är på väg. För att logga in, ange koden vi mejlade till',
   'Your code is on the way. To log in, enter the code we sent you':
     'Din kod är på väg. För att logga in, ange koden vi skickade till dig',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Din kod är på väg. För att logga in, ange koden vi skickade till dig.',
   'Your code is on the way. To log in, enter the code we texted to':
     'Din kod är på väg. För att logga in, ange koden vi sms:ade till',
+  'Your code is on the way. {arrivalMessage}':
+    'Din kod är på väg. För att logga in, ange koden vi skickade till dig. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Din kod är på väg. För att logga in, ange koden vi mejlade till {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Din kod är på väg. För att logga in, ange koden vi sms:ade till {destination}. {arrivalMessage}',
 
   // Additional translations provided by customers
   'An account with the given email already exists.':
@@ -94,6 +103,7 @@ export const svDict: AuthenticatorDictionary = {
   'Sign Up': 'Registrering',
   'User already exists': 'Användaren finns redan',
   'User does not exist': 'Användaren finns inte',
+  'User does not exist.': 'Användaren finns inte',
   'Username cannot be empty': 'Användarnamnet kan inte vara tomt',
   'We Emailed You': 'Vi har skickat e-post till dig',
   'Please confirm your Password': 'Bekräfta ditt lösenord',

--- a/packages/ui/src/i18n/dictionaries/authenticator/th.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/th.ts
@@ -83,8 +83,16 @@ export const thDict: AuthenticatorDictionary = {
     'รหัสของคุณกำลังมา เพื่อเข้าสู่ระบบ กรุณากรอกรหัสที่เราส่งไปยังอีเมล',
   'Your code is on the way. To log in, enter the code we sent you':
     'รหัสของคุณกำลังมา เพื่อเข้าสู่ระบบ กรุณากรอกรหัสที่เราส่งให้คุณ',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'รหัสของคุณกำลังมา เพื่อเข้าสู่ระบบ กรุณากรอกรหัสที่เราส่งให้คุณ',
   'Your code is on the way. To log in, enter the code we texted to':
     'รหัสของคุณกำลังมา เพื่อเข้าสู่ระบบ กรุณากรอกรหัสที่เราส่งไปยัง SMS',
+  'Your code is on the way. {arrivalMessage}':
+    'รหัสของคุณกำลังมา เพื่อเข้าสู่ระบบ กรุณากรอกรหัสที่เราส่งให้คุณ {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'รหัสของคุณกำลังมา เพื่อเข้าสู่ระบบ กรุณากรอกรหัสที่เราส่งไปยังอีเมล {destination} {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'รหัสของคุณกำลังมา เพื่อเข้าสู่ระบบ กรุณากรอกรหัสที่เราส่งไปยัง SMS {destination} {arrivalMessage}',
 
   // Additional translations
   'An account with the given email already exists.':
@@ -112,5 +120,6 @@ export const thDict: AuthenticatorDictionary = {
   'Sign Up': 'ลงทะเบียน',
   'User already exists': 'ผู้ใช้นี้มีอยู่แล้ว',
   'User does not exist': 'ไม่มีผู้ใช้นี้',
+  'User does not exist.': 'ไม่มีผู้ใช้นี้',
   'Username cannot be empty': 'ต้องใส่ชื่อผู้ใช้งาน',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/tr.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/tr.ts
@@ -44,6 +44,7 @@ export const trDict: AuthenticatorDictionary = {
   'Forgot your password?': 'Şifrenizi mi unuttunuz?',
   'Hide password': 'Şifreyi gizle',
   'It may take a minute to arrive': 'Kodun gelmesi bir dakika sürebilir',
+  'It may take a minute to arrive.': 'Kodun gelmesi bir dakika sürebilir.',
   Loading: 'Yükleniyor',
   'Multi-Factor Authentication': 'Çok Faktörlü Kimlik Doğrulama',
   'Multi-Factor Authentication Setup': 'Çok Faktörlü Kimlik Doğrulama Kurulumu',
@@ -87,8 +88,16 @@ export const trDict: AuthenticatorDictionary = {
     'Kodunuz yolda. Oturum açmak için, gönderdiğimiz e-postadaki kodu girin',
   'Your code is on the way. To log in, enter the code we sent you':
     'Kodunuz yolda. Oturum açmak için, size gönderdiğimiz kodu girin',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Kodunuz yolda. Oturum açmak için, size gönderdiğimiz kodu girin.',
   'Your code is on the way. To log in, enter the code we texted to':
     'Kodunuz yolda. Oturum açmak için, gönderdiğimiz mesajdaki kodu girin',
+  'Your code is on the way. {arrivalMessage}':
+    'Kodunuz yolda. Oturum açmak için, size gönderdiğimiz kodu girin. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Kodunuz yolda. Oturum açmak için, gönderdiğimiz e-postadaki kodu girin {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Kodunuz yolda. Oturum açmak için, gönderdiğimiz mesajdaki kodu girin {destination}. {arrivalMessage}',
 
   // Additional translations provided by customers
   'An account with the given email already exists.':
@@ -106,5 +115,6 @@ export const trDict: AuthenticatorDictionary = {
   'Sign Up': 'Kayıt Ol',
   'User already exists': 'Bu kullanıcı zaten var',
   'User does not exist': 'Böyle bir kullanıcı mevcut değil',
+  'User does not exist.': 'Böyle bir kullanıcı mevcut değil',
   'Username cannot be empty': 'Kullanıcı adı boş olamaz',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/ua.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/ua.ts
@@ -30,6 +30,7 @@ export const uaDict: AuthenticatorDictionary = {
   'Forgot your password?': 'Забули ваш пароль?',
   'Hide password': 'Сховати пароль',
   'It may take a minute to arrive': 'Доставка може тривати хвилину',
+  'It may take a minute to arrive.': 'Доставка може тривати хвилину.',
   Loading: 'Загружаємо',
   'Multi-Factor Authentication': 'Багатофакторна автентифікація',
   'Multi-Factor Authentication Setup':
@@ -70,8 +71,16 @@ export const uaDict: AuthenticatorDictionary = {
     'Ваш код вже в дорозі. Щоб увійти, введіть код, що ми відправили вам на Email',
   'Your code is on the way. To log in, enter the code we sent you':
     'Ваш код вже в дорозі. Щоб увійти, введіть код, що ми вам відправили',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    'Ваш код вже в дорозі. Щоб увійти, введіть код, що ми вам відправили.',
   'Your code is on the way. To log in, enter the code we texted to':
     'Ваш код вже в дорозі. Щоб увійти, введіть код, що ми відправили вам текстовим повідомленням',
+  'Your code is on the way. {arrivalMessage}':
+    'Ваш код вже в дорозі. Щоб увійти, введіть код, що ми вам відправили. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    'Ваш код вже в дорозі. Щоб увійти, введіть код, що ми відправили вам на Email {destination}. {arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    'Ваш код вже в дорозі. Щоб увійти, введіть код, що ми відправили вам текстовим повідомленням {destination}. {arrivalMessage}',
 
   // Additional translations
   'An account with the given email already exists.':
@@ -80,6 +89,7 @@ export const uaDict: AuthenticatorDictionary = {
   'Confirm Sign In': 'Підтвердіть вхід',
   'Forgot Password': 'Забули пароль',
   'Incorrect username or password.': 'Невірне імʼя користувача або пароль',
+  'Incorrect username or password': 'Невірне імʼя користувача або пароль',
   'Invalid password format': 'Невірний формат паролю',
   'Invalid phone number format': 'Невірний формат номеру телефону',
   'Loading...': 'Загружаємо...',
@@ -94,6 +104,7 @@ export const uaDict: AuthenticatorDictionary = {
   'Sign Up': 'Зареєструватися',
   'User already exists': 'Користувач вже існує',
   'User does not exist': 'Такий користувач не існує',
+  'User does not exist.': 'Такий користувач не існує',
   'Username cannot be empty': 'Імʼя користувача не може бути пустим',
   'Your passwords must match': 'Паролі мають збігатися',
 };

--- a/packages/ui/src/i18n/dictionaries/authenticator/zh.ts
+++ b/packages/ui/src/i18n/dictionaries/authenticator/zh.ts
@@ -30,6 +30,7 @@ export const zhDict: AuthenticatorDictionary = {
   'Forgot your password?': '忘记密码了？',
   'Hide password': '隐藏密码',
   'It may take a minute to arrive': '可能需要一分钟才能到达',
+  'It may take a minute to arrive.': '可能需要一分钟才能到达。',
   Loading: '正在加载',
   'Multi-Factor Authentication': '多重身份验证',
   'Multi-Factor Authentication Setup': '多重身份验证设置',
@@ -70,8 +71,16 @@ export const zhDict: AuthenticatorDictionary = {
     '您的代码正在发送中。要登录，请输入我们通过电子邮件发送给以下人员的代码：',
   'Your code is on the way. To log in, enter the code we sent you':
     '您的代码正在发送中。要登录，请输入我们发送给您的代码',
+  'Your code is on the way. To log in, enter the code we sent you.':
+    '您的代码正在发送中。要登录，请输入我们发送给您的代码。',
   'Your code is on the way. To log in, enter the code we texted to':
     '您的代码正在发送中。要登录，请输入我们通过短信发送给以下人员的代码：',
+  'Your code is on the way. {arrivalMessage}':
+    '您的代码正在发送中。要登录，请输入我们发送给您的代码。{arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we emailed to {destination}. {arrivalMessage}':
+    '您的代码正在发送中。要登录，请输入我们通过电子邮件发送给以下人员的代码：{destination}。{arrivalMessage}',
+  'Your code is on the way. To log in, enter the code we texted to {destination}. {arrivalMessage}':
+    '您的代码正在发送中。要登录，请输入我们通过短信发送给以下人员的代码：{destination}。{arrivalMessage}',
 
   // Additional translations provided by customers
   'Confirm a Code': '确认码',
@@ -87,4 +96,5 @@ export const zhDict: AuthenticatorDictionary = {
   'Sign Up': '注册',
   'User already exists': '用户已经存在',
   'User does not exist': '用户不存在',
+  'User does not exist.': '用户不存在',
 };

--- a/packages/ui/src/i18n/translations.ts
+++ b/packages/ui/src/i18n/translations.ts
@@ -68,8 +68,17 @@ export type Dict = Record<string, string>;
  *
  * You can also use translate<string> to handle custom strings or dynamic content.
  */
-export function translate<T extends string>(phrase: T): string {
-  return I18n.get(phrase);
+export function translate<T extends string>(
+  phrase: T,
+  values?: Record<string, string>
+): string {
+  let result = I18n.get(phrase);
+  if (values) {
+    for (const [key, val] of Object.entries(values)) {
+      result = result.replaceAll(`{${key}}`, val);
+    }
+  }
+  return result;
 }
 
 /**

--- a/packages/ui/src/machines/authenticator/actions.ts
+++ b/packages/ui/src/machines/authenticator/actions.ts
@@ -157,7 +157,7 @@ const setFieldErrors = assign({
 const setRemoteError = assign({
   remoteError: (_, { data }: AuthEvent) => {
     if (data.name === 'NoUserPoolError') {
-      return `Configuration error (see console) – please contact the administrator`;
+      return translate(DefaultTexts.CONFIGURATION_ERROR);
     }
 
     const message = data?.message || '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10346,21 +10346,6 @@
   resolved "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz"
   integrity sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ==
 
-"@mapbox/node-pre-gyp@^1.0.0":
-  version "1.0.10"
-  resolved "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz"
-  integrity sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==
-  dependencies:
-    detect-libc "^2.0.0"
-    https-proxy-agent "^5.0.0"
-    make-dir "^3.1.0"
-    node-fetch "^2.6.7"
-    nopt "^5.0.0"
-    npmlog "^5.0.1"
-    rimraf "^3.0.2"
-    semver "^7.3.5"
-    tar "^6.1.11"
-
 "@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
   version "0.1.0"
   resolved "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz"
@@ -16857,7 +16842,7 @@ abab@^2.0.6:
   resolved "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
-abbrev@1, abbrev@^1.0.0:
+abbrev@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
@@ -17155,11 +17140,6 @@ appdirsjs@^1.2.4:
   resolved "https://registry.npmjs.org/appdirsjs/-/appdirsjs-1.2.7.tgz"
   integrity sha512-Quji6+8kLBC3NnBeo14nPDq0+2jUs5s3/xEye+udFHumHhRk4M7aAMXp/PBJqkKYGuuyR9M/6Dq7d2AViiGmhw==
 
-"aproba@^1.0.3 || ^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz"
-  integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
-
 arch@^2.1.1, arch@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz"
@@ -17190,14 +17170,6 @@ archiver@^7.0.1:
     readdir-glob "^1.1.2"
     tar-stream "^3.0.0"
     zip-stream "^6.0.1"
-
-are-we-there-yet@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz"
-  integrity sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^3.6.0"
 
 arg@2.0.0:
   version "2.0.0"
@@ -18887,11 +18859,6 @@ color-string@^1.6.0:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color-support@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz"
-  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
-
 color@^3.1.2:
   version "3.2.1"
   resolved "https://registry.npmjs.org/color/-/color-3.2.1.tgz"
@@ -19131,11 +19098,6 @@ connect@^3.6.5, connect@^3.7.0:
     finalhandler "1.1.2"
     parseurl "~1.3.3"
     utils-merge "1.0.1"
-
-console-control-strings@^1.0.0, console-control-strings@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-  integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
 console.table@^0.10.0:
   version "0.10.0"
@@ -19784,12 +19746,12 @@ decode-uri-component@^0.2.2:
   resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
-decompress-response@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz"
-  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
   dependencies:
-    mimic-response "^2.0.0"
+    mimic-response "^3.1.0"
 
 dedent-js@^1.0.1:
   version "1.0.1"
@@ -19964,11 +19926,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
-
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-  integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
 depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -21636,6 +21593,11 @@ exit@^0.1.2:
   resolved "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 expect-type@^1.2.1:
   version "1.2.2"
   resolved "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz"
@@ -22374,21 +22336,6 @@ fuzzy@^0.1.1:
   resolved "https://registry.npmjs.org/fuzzy/-/fuzzy-0.1.3.tgz"
   integrity sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==
 
-gauge@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz"
-  integrity sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==
-  dependencies:
-    aproba "^1.0.3 || ^2.0.0"
-    color-support "^1.1.2"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.1"
-    object-assign "^4.1.1"
-    signal-exit "^3.0.0"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
-    wide-align "^1.1.2"
-
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
@@ -22584,6 +22531,11 @@ getpass@^0.1.1:
   integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
   dependencies:
     assert-plus "^1.0.0"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
 github-slugger@^1.1.1:
   version "1.5.0"
@@ -22929,11 +22881,6 @@ has-tostringtag@^1.0.2:
   dependencies:
     has-symbols "^1.0.3"
 
-has-unicode@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
-  integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
-
 has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/has/-/has-1.0.3.tgz"
@@ -23273,7 +23220,7 @@ https-proxy-agent@7.0.6, https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.6:
     agent-base "^7.1.2"
     debug "4"
 
-https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
+https-proxy-agent@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
@@ -26796,10 +26743,10 @@ mimic-function@^5.0.0:
   resolved "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz"
   integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
-mimic-response@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz"
-  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
 min-indent@^1.0.0:
   version "1.0.1"
@@ -26861,7 +26808,7 @@ minimatch@^3.0.4, minimatch@^3.1.5:
   dependencies:
     brace-expansion "^5.0.2"
 
-minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -26928,6 +26875,11 @@ mitt@3.0.1, mitt@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+
+mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mkdirp@^0.5.1, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.6"
@@ -27122,7 +27074,7 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.14.0, nan@^2.17.0:
+nan@^2.14.0:
   version "2.17.0"
   resolved "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
@@ -27138,6 +27090,11 @@ nanospinner@^1.2.2:
   integrity sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==
   dependencies:
     picocolors "^1.1.1"
+
+napi-build-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz#13c22c0187fcfccce1461844136372a47ddc027e"
+  integrity sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==
 
 napi-postinstall@^0.3.0:
   version "0.3.4"
@@ -27276,6 +27233,13 @@ nocache@^3.0.1:
   resolved "https://registry.npmjs.org/nocache/-/nocache-3.0.4.tgz"
   integrity sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==
 
+node-abi@^3.3.0:
+  version "3.89.0"
+  resolved "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz#eea98bf89d4534743bbbf2defa9f4f9bd3bdccfd"
+  integrity sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==
+  dependencies:
+    semver "^7.3.5"
+
 node-addon-api@^6.1.0:
   version "6.1.0"
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz"
@@ -27298,7 +27262,7 @@ node-domexception@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
-node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.7, node-fetch@~2.6.1:
+node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@~2.6.1:
   version "2.6.9"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz"
   integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
@@ -27384,13 +27348,6 @@ node-version@^1.0.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/node-version/-/node-version-1.2.0.tgz"
   integrity sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==
-
-nopt@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz"
-  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
-  dependencies:
-    abbrev "1"
 
 nopt@^6.0.0:
   version "6.0.0"
@@ -27518,16 +27475,6 @@ npm-run-path@^6.0.0:
   dependencies:
     path-key "^4.0.0"
     unicorn-magic "^0.3.0"
-
-npmlog@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz"
-  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
-  dependencies:
-    are-we-there-yet "^2.0.0"
-    console-control-strings "^1.1.0"
-    gauge "^3.0.0"
-    set-blocking "^2.0.0"
 
 nth-check@^2.0.1, nth-check@^2.1.1:
   version "2.1.1"
@@ -28998,6 +28945,24 @@ preact@^10.25.1:
   resolved "https://registry.npmjs.org/preact/-/preact-10.26.4.tgz"
   integrity sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==
 
+prebuild-install@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz#d630abad2b147443f20a212917beae68b8092eec"
+  integrity sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^2.0.0"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
 precinct@^12.2.0:
   version "12.2.0"
   resolved "https://registry.npmjs.org/precinct/-/precinct-12.2.0.tgz"
@@ -29491,7 +29456,7 @@ rbush@^3.0.1:
   dependencies:
     quickselect "^2.0.0"
 
-rc@^1.0.1, rc@^1.1.6:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -29845,7 +29810,7 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
+readable-stream@^3.0.6, readable-stream@^3.4.0, readable-stream@^3.5.0:
   version "3.6.2"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -31213,12 +31178,12 @@ simple-concat@^1.0.0:
   resolved "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
 
-simple-get@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz"
-  integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
   dependencies:
-    decompress-response "^4.2.0"
+    decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 
@@ -31745,15 +31710,6 @@ string-natural-compare@^3.0.1:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
 string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
@@ -31761,6 +31717,15 @@ string-width@^2.0.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -32100,7 +32065,6 @@ stylus-lookup@^6.1.0:
 
 "stylus@github:stylus/stylus#0.59.0":
   version "0.59.0"
-  uid "8e29ff39fb563f91ef4eaff9b2c9f29e2a1910ec"
   resolved "https://codeload.github.com/stylus/stylus/tar.gz/8e29ff39fb563f91ef4eaff9b2c9f29e2a1910ec"
   dependencies:
     "@adobe/css-tools" "^4.0.1"
@@ -32317,7 +32281,7 @@ tapable@^2.2.1, tapable@^2.3.0:
   resolved "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz"
   integrity sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==
 
-tar-fs@3.0.5, tar-fs@^3.0.6, tar-fs@^3.0.8, tar-fs@^3.1.1:
+tar-fs@3.0.5, tar-fs@^2.0.0, tar-fs@^3.0.6, tar-fs@^3.0.8, tar-fs@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.2.tgz#114b012f54796f31e62f3e57792820a80b83ae6e"
   integrity sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==
@@ -34383,13 +34347,6 @@ why-is-node-running@^2.3.0:
   dependencies:
     siginfo "^2.0.0"
     stackback "0.0.2"
-
-wide-align@^1.1.2:
-  version "1.1.5"
-  resolved "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz"
-  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
-  dependencies:
-    string-width "^1.0.2 || 2 || 3 || 4"
 
 widest-line@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
#### Description of changes

This change introduces a more fine-grained control over translation texts in the Authenticator.

1.) **strings do accept placeholders and values now.**

translations with different positions of values is allowed. no more fragile construction in the source code.

```
// in english
an email has been sent to {emailAddress}.

// in german
Wir haben eine Email an {emailAddress} gesendet.
```

2.) **punctuation is part of translation**

Since the japanese language uses different period signs for delimiting sentences and in thai it is common to not use any at all. the translation controls punctuation.
This allows for a more natural way of communcation. 

3.) **backwards compatibility**
a small number of keys has been introduced to the translation files for backwards compatibility and to even out cognito inconsistencies.

#### Issue #, if available
https://github.com/aws-amplify/amplify-ui/issues/6966

#### Description of how you validated changes
- the textUtils class contains unit-tests. these still pass.
- the Authenticator still renders.

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
