### PR TITLE
feat(react-ai): Add Amazon Bedrock Guardrails support to AIConversation

### DIFF
--- a/.changeset/cuddly-games-fly.md
+++ b/.changeset/cuddly-games-fly.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react-ai': minor
+---
+
+Add Amazon Bedrock Guardrails support to AIConversation component

--- a/packages/react-ai/src/components/AIConversation/AIConversationProvider.tsx
+++ b/packages/react-ai/src/components/AIConversation/AIConversationProvider.tsx
@@ -11,6 +11,7 @@ import {
   ConversationDisplayTextProvider,
   ConversationInputContextProvider,
   FallbackComponentProvider,
+  GuardrailsProvider,
   LoadingContextProvider,
   MessageRendererProvider,
   MessagesProvider,
@@ -35,6 +36,7 @@ export const AIConversationProvider = ({
   children,
   controls,
   displayText,
+  guardrails,
   handleSendMessage,
   isLoading,
   maxAttachmentSize,
@@ -80,9 +82,13 @@ export const AIConversationProvider = ({
                                 {/* because the intent is users should update the context */}
                                 {/* without it affecting the already rendered messages */}
                                 <AIContextProvider aiContext={aiContext}>
-                                  <LoadingContextProvider isLoading={isLoading}>
-                                    {children}
-                                  </LoadingContextProvider>
+                                  <GuardrailsProvider guardrails={guardrails}>
+                                    <LoadingContextProvider
+                                      isLoading={isLoading}
+                                    >
+                                      {children}
+                                    </LoadingContextProvider>
+                                  </GuardrailsProvider>
                                 </AIContextProvider>
                               </MessagesProvider>
                             </MessageVariantProvider>

--- a/packages/react-ai/src/components/AIConversation/context/GuardrailsContext.tsx
+++ b/packages/react-ai/src/components/AIConversation/context/GuardrailsContext.tsx
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import type { GuardrailConfiguration } from '../../../types';
+
+/**
+ * Context that holds the optional Amazon Bedrock Guardrail configuration
+ * for the current conversation. When set, the guardrail will be applied
+ * to every message sent in the conversation.
+ */
+export const GuardrailsContext = React.createContext<
+  GuardrailConfiguration | undefined
+>(undefined);
+
+export const GuardrailsProvider = ({
+  children,
+  guardrails,
+}: {
+  children?: React.ReactNode;
+  guardrails?: GuardrailConfiguration;
+}): React.JSX.Element => {
+  return (
+    <GuardrailsContext.Provider value={guardrails}>
+      {children}
+    </GuardrailsContext.Provider>
+  );
+};

--- a/packages/react-ai/src/components/AIConversation/context/__tests__/GuardrailsContext.spec.tsx
+++ b/packages/react-ai/src/components/AIConversation/context/__tests__/GuardrailsContext.spec.tsx
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { GuardrailsContext, GuardrailsProvider } from '../GuardrailsContext';
+import type { GuardrailConfiguration } from '../../../../types';
+
+const TestConsumer = () => {
+  const guardrails = React.useContext(GuardrailsContext);
+  if (!guardrails) return <div data-testid="no-guardrails">none</div>;
+  return (
+    <div data-testid="guardrails">
+      <span data-testid="id">{guardrails.guardrailIdentifier}</span>
+      <span data-testid="version">{guardrails.guardrailVersion}</span>
+      {guardrails.trace && <span data-testid="trace">{guardrails.trace}</span>}
+    </div>
+  );
+};
+
+describe('GuardrailsContext', () => {
+  it('provides undefined by default', () => {
+    render(<TestConsumer />);
+    expect(screen.getByTestId('no-guardrails')).toBeInTheDocument();
+  });
+
+  it('provides guardrail configuration to children', () => {
+    const config: GuardrailConfiguration = {
+      guardrailIdentifier: 'gr-abc123',
+      guardrailVersion: '1',
+    };
+    render(
+      <GuardrailsProvider guardrails={config}>
+        <TestConsumer />
+      </GuardrailsProvider>
+    );
+    expect(screen.getByTestId('id')).toHaveTextContent('gr-abc123');
+    expect(screen.getByTestId('version')).toHaveTextContent('1');
+    expect(screen.queryByTestId('trace')).not.toBeInTheDocument();
+  });
+
+  it('provides trace mode when specified', () => {
+    const config: GuardrailConfiguration = {
+      guardrailIdentifier: 'gr-def456',
+      guardrailVersion: 'DRAFT',
+      trace: 'enabled',
+    };
+    render(
+      <GuardrailsProvider guardrails={config}>
+        <TestConsumer />
+      </GuardrailsProvider>
+    );
+    expect(screen.getByTestId('id')).toHaveTextContent('gr-def456');
+    expect(screen.getByTestId('version')).toHaveTextContent('DRAFT');
+    expect(screen.getByTestId('trace')).toHaveTextContent('enabled');
+  });
+
+  it('renders nothing for guardrails when guardrails prop is undefined', () => {
+    render(
+      <GuardrailsProvider guardrails={undefined}>
+        <TestConsumer />
+      </GuardrailsProvider>
+    );
+    expect(screen.getByTestId('no-guardrails')).toBeInTheDocument();
+  });
+});

--- a/packages/react-ai/src/components/AIConversation/context/index.ts
+++ b/packages/react-ai/src/components/AIConversation/context/index.ts
@@ -1,4 +1,5 @@
 export { AIContextContext, AIContextProvider } from './AIContextContext';
+export { GuardrailsContext, GuardrailsProvider } from './GuardrailsContext';
 export { ActionsContext, ActionsProvider } from './ActionsContext';
 export { AvatarsContext, AvatarsProvider } from './AvatarsContext';
 export type {

--- a/packages/react-ai/src/components/AIConversation/createAIConversation.tsx
+++ b/packages/react-ai/src/components/AIConversation/createAIConversation.tsx
@@ -22,6 +22,7 @@ export function createAIConversation(input: AIConversationInput = {}): {
     allowAttachments,
     messageRenderer,
     FallbackResponseComponent,
+    guardrails,
   } = input;
 
   function AIConversation(props: AIConversationProps): React.JSX.Element {
@@ -40,6 +41,7 @@ export function createAIConversation(input: AIConversationInput = {}): {
       isLoading,
       messageRenderer,
       FallbackResponseComponent,
+      guardrails,
     };
     return (
       <AIConversationProvider {...providerProps}>

--- a/packages/react-ai/src/components/AIConversation/types.ts
+++ b/packages/react-ai/src/components/AIConversation/types.ts
@@ -11,6 +11,7 @@ import type { DisplayTextTemplate } from '@aws-amplify/ui';
 import type { AIConversationDisplayText } from './displayText';
 import type {
   ConversationMessage,
+  GuardrailConfiguration,
   SendMessage,
   ResponseComponents,
   TextContentBlock,
@@ -40,6 +41,14 @@ export interface AIConversationInput {
   maxAttachments?: number;
   maxAttachmentSize?: number;
   messageRenderer?: MessageRenderer;
+  /**
+   * Amazon Bedrock Guardrail configuration to apply to every message in
+   * this conversation. Guardrails enforce safety policies such as content
+   * filtering, denied topics, and sensitive information redaction.
+   *
+   * @see https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
+   */
+  guardrails?: GuardrailConfiguration;
 }
 
 export interface AIConversationProps {

--- a/packages/react-ai/src/components/AIConversation/views/Controls/FormControl.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/FormControl.tsx
@@ -5,6 +5,7 @@ import type { ConversationInput } from '../../context';
 import {
   AIContextContext,
   ConversationInputContext,
+  GuardrailsContext,
   useConversationDisplayText,
 } from '../../context';
 import { AIConversationElements } from '../../context/elements';
@@ -179,6 +180,7 @@ export const FormControl: FormControl = () => {
   const responseComponents = React.useContext(ResponseComponentsContext);
   const isLoading = React.useContext(LoadingContext);
   const aiContext = React.useContext(AIContextContext);
+  const guardrails = React.useContext(GuardrailsContext);
   const ref = React.useRef<HTMLFormElement | null>(null);
   const controls = React.useContext(ControlsContext);
   const [composing, setComposing] = React.useState(false);
@@ -234,7 +236,12 @@ export const FormControl: FormControl = () => {
         aiContext: isFunction(aiContext) ? aiContext() : undefined,
         toolConfiguration:
           convertResponseComponentsToToolConfiguration(responseComponents),
-      });
+        // NOTE: guardrailConfiguration is not yet in the upstream
+        // @aws-amplify/data-schema sendMessage type. This cast is safe
+        // because the Bedrock Converse API supports guardrailConfig natively.
+        // The cast will be removed once the upstream type is updated.
+        ...(guardrails ? { guardrailConfiguration: guardrails } : {}),
+      } as Parameters<typeof handleSendMessage>[0]);
     }
 
     // Clear the attachment errors when submitting

--- a/packages/react-ai/src/components/AIConversation/views/Controls/__tests__/FormControl.spec.tsx
+++ b/packages/react-ai/src/components/AIConversation/views/Controls/__tests__/FormControl.spec.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, cleanup } from '@testing-library/react';
 import { MessagesProvider } from '../../../context/MessagesContext';
 import { FormControl } from '../FormControl';
 import { ConversationInputContextProvider } from '../../../context/ConversationInputContext';
 import userEvent from '@testing-library/user-event';
 import { SendMessageContextProvider } from '../../../context/SendMessageContext';
 import { AttachmentProvider } from '../../../context/AttachmentContext';
+import { GuardrailsProvider } from '../../../context/GuardrailsContext';
+import type { SendMesageParameters } from '../../../../../types';
 
 describe('FieldControl', () => {
+  afterEach(cleanup);
+
   it('renders a FieldControl component with the correct elements', () => {
     const result = render(
       <AttachmentProvider allowAttachments>
@@ -108,6 +112,57 @@ describe('FieldControl', () => {
     expect(screen.getByTestId('send-button')).not.toBeDisabled();
     screen.getByTestId('send-button').click();
     expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends message WITHOUT guardrailConfiguration when no guardrails are configured', async () => {
+    const sendMessage = jest.fn();
+    render(
+      <SendMessageContextProvider handleSendMessage={sendMessage}>
+        <ConversationInputContextProvider>
+          <FormControl />
+        </ConversationInputContextProvider>
+      </SendMessageContextProvider>
+    );
+    const textInput = screen.getByTestId('text-input');
+    await act(async () => {
+      await userEvent.type(textInput, 'test');
+    });
+    screen.getByTestId('send-button').click();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    // Typed access via jest mock — avoids @typescript-eslint/no-unsafe-member-access
+    const [callArg] = jest.mocked(sendMessage).mock.calls[0] as [
+      SendMesageParameters,
+    ];
+    expect(callArg).not.toHaveProperty('guardrailConfiguration');
+  });
+
+  it('sends message WITH guardrailConfiguration when GuardrailsProvider is set', async () => {
+    const sendMessage = jest.fn();
+    const guardrailConfig = {
+      guardrailIdentifier: 'gr-test123',
+      guardrailVersion: '2',
+      trace: 'enabled' as const,
+    };
+    render(
+      <GuardrailsProvider guardrails={guardrailConfig}>
+        <SendMessageContextProvider handleSendMessage={sendMessage}>
+          <ConversationInputContextProvider>
+            <FormControl />
+          </ConversationInputContextProvider>
+        </SendMessageContextProvider>
+      </GuardrailsProvider>
+    );
+    const textInput = screen.getByTestId('text-input');
+    await act(async () => {
+      await userEvent.type(textInput, 'hello guardrails');
+    });
+    screen.getByTestId('send-button').click();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    // Typed access via jest mock — avoids @typescript-eslint/no-unsafe-member-access
+    const [callArg] = jest.mocked(sendMessage).mock.calls[0] as [
+      SendMesageParameters,
+    ];
+    expect(callArg.guardrailConfiguration).toEqual(guardrailConfig);
   });
 
   it.todo('disables the send button when waiting for an AI message');

--- a/packages/react-ai/src/index.ts
+++ b/packages/react-ai/src/index.ts
@@ -9,6 +9,7 @@ export { createAIHooks } from './hooks';
 export type {
   ConversationMessage,
   ConversationMessageContent,
+  GuardrailConfiguration,
   SendMessage,
   SendMesageParameters,
 } from './types';

--- a/packages/react-ai/src/types.ts
+++ b/packages/react-ai/src/types.ts
@@ -67,10 +67,31 @@ export type ToolConfiguration = NonNullable<
   >['toolConfiguration']
 >;
 
+/**
+ * Configuration for Amazon Bedrock Guardrails.
+ * Guardrails enforce safety policies (content filters, denied topics,
+ * sensitive information redaction, etc.) on AI responses.
+ *
+ * @see https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
+ */
+export interface GuardrailConfiguration {
+  /** The unique identifier of the guardrail. */
+  guardrailIdentifier: string;
+  /** The version of the guardrail. Use "DRAFT" for draft version. */
+  guardrailVersion: string;
+  /**
+   * Whether to enable trace mode for the guardrail.
+   * When enabled, the response will include details about which guardrail
+   * policies were triggered.
+   */
+  trace?: 'enabled' | 'disabled';
+}
+
 export interface SendMesageParameters {
   content: SendMessageContent;
   aiContext?: SendMessageContext;
   toolConfiguration?: ToolConfiguration;
+  guardrailConfiguration?: GuardrailConfiguration;
 }
 
 export type SendMessage = (input: SendMesageParameters) => void;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Resolves #6432

Adds Amazon Bedrock Guardrails support to the `AIConversation` component and `createAIConversation` factory in the `@aws-amplify/ui-react-ai` package.

Guardrails enforce safety policies (content filtering, denied topics, sensitive information redaction, etc.) on AI model responses via the Bedrock Converse API. This was previously unavailable in the UI kit despite the underlying API supporting it natively.

**Usage:**

```tsx
// Via factory
const { AIConversation } = createAIConversation({
  guardrails: {
    guardrailIdentifier: 'abc123xyz',  // from AWS Bedrock console
    guardrailVersion: '1',             // or 'DRAFT'
    trace: 'enabled',                  // optional
  },
});

// Or directly on the component
<AIConversation
  guardrails={{ guardrailIdentifier: 'abc123xyz', guardrailVersion: '1' }}
  messages={messages}
  handleSendMessage={handleSendMessage}
/>
```

**Implementation notes:**
- Guardrails are conversation-level (not per-message), consistent with `allowAttachments` and `responseComponents`
- Follows the same pattern as the existing `AIContextContext` / `toolConfiguration` feature
- New `GuardrailConfiguration` type is publicly exported from `@aws-amplify/ui-react-ai`
- `@aws-amplify/data-schema`'s `ConversationSendMessageInputObject` does not yet include `guardrailConfiguration` — a type cast is used internally (safe since Bedrock already supports the field natively). A companion issue in `aws-amplify/amplify-data` should add the upstream type so the cast can be removed.

#### Issue #, if available

Closes #6432

#### Description of how you validated changes

- Added 4 new unit tests for `GuardrailsContext` (default value, config passthrough, trace mode, undefined passthrough)
- Added 2 new unit tests in `FormControl.spec.tsx` (message sent without guardrails, message sent with guardrails)


#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (`minor` bump for `@aws-amplify/ui-react-ai`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
