### PR TITLE
docs: fix typo in FaceLivenessDetector onError prop description

### DIFF
--- a/docs/src/pages/[platform]/connected-components/liveness/react-props.ts
+++ b/docs/src/pages/[platform]/connected-components/liveness/react-props.ts
@@ -24,7 +24,7 @@ export const FACE_LIVENESS_DETECTOR_PROPS = [
   },
   {
     name: `onError?`,
-    description: 'Callback called when there is error occured on any step.',
+    description: 'Callback called when an error occurred on any step.',
     type: `(error: LivenessError) => void`,
   },
   {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Docs prop description for `onError?` reads "when there is error occured on any step" -> "when an error occurred on any step". Comment/string-only change.

#### Issue #, if available

N/A.

#### Description of how you validated changes

Affects only the React props documentation string in `docs/src/pages/[platform]/connected-components/liveness/react-props.ts`. No runtime/behavior change.

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
