### PR TITLE
fix(deps): resolve Dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "ws": "^8.17.1",
     "stylus": "github:stylus/stylus#0.59.0",
     "on-headers": "^1.1.0",
-    "tmp": "^0.2.4",
+    "tmp": "^0.2.6",
     "**/jest/**/js-yaml": "~3.14.2",
     "**/@badeball/cypress-cucumber-preprocessor/**/glob": "~10.5.0",
     "**/@badeball/cacache/**/glob": "~10.5.0",
@@ -202,7 +202,7 @@
   },
   "overrides": {
     "stylus": "github:stylus/stylus#0.59.0",
-    "tmp": "^0.2.4",
+    "tmp": "^0.2.6",
     "@tensorflow-models/face-detection": {
       "rimraf": "5.0.0"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -32435,10 +32435,10 @@ tldts@^6.1.32:
   dependencies:
     tldts-core "^6.1.77"
 
-tmp@0.2.3, tmp@^0.0.33, tmp@^0.2.1, tmp@^0.2.4, tmp@~0.2.3:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
-  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
+tmp@0.2.3, tmp@^0.0.33, tmp@^0.2.1, tmp@^0.2.4, tmp@^0.2.6, tmp@~0.2.3:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.6.tgz#0dfac10fd09a9319288eb0e8f0ed524604e183b4"
+  integrity sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Summary

Resolves all open Dependabot security alerts by bumping the `tmp` package resolution.

## Security Fixes

| Alert | Package | Vulnerability | Fix |
|-------|---------|---------------|-----|
| #502 | `tmp` | [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) - Path Traversal via unsanitized prefix/postfix that enables directory escape | `^0.2.4` → `^0.2.6` |
| #505 | `tmp` | [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) - Path Traversal via unsanitized prefix/postfix that enables directory escape | `^0.2.4` → `^0.2.6` |

## Changes

- Updated `tmp` in root `package.json` `resolutions` block from `^0.2.4` to `^0.2.6`
- Updated `tmp` in root `package.json` `overrides` block from `^0.2.4` to `^0.2.6`
- Regenerated `yarn.lock` (tmp now resolves to 0.2.6)

## Impact

The `tmp` package is a transitive dependency only (not a direct dep of any published package). It is pulled in by:
- `@cucumber/cucumber` (via `@aws-amplify/ui-e2e`)
- `external-editor` (via `@changesets/cli`)
- `karma` (via `@aws-amplify/ui-angular-example`)
- `patch-package` (via `@aws-amplify/ui-react-liveness`)
- `cypress` (via `@aws-amplify/ui-e2e`)

No changeset required since no published package's direct dependencies changed.

## Verification

- ✅ `yarn install` - lockfile updated successfully
- ✅ `yarn build` - all 14 packages build successfully
- ✅ `yarn why tmp` confirms resolution to 0.2.6