### PR TITLE
fix(react-liveness): fire onError on server-initiated WebSocket close codes

### DIFF
--- a/.changeset/giant-geese-fetch.md
+++ b/.changeset/giant-geese-fetch.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react-liveness': patch
+---
+
+fix(react-liveness): fire onError on server-initiated WebSocket close codes

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/CustomWebSocketFetchHandler.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/CustomWebSocketFetchHandler.ts
@@ -219,12 +219,25 @@ export class CustomWebSocketFetchHandler {
       reject(error);
     };
 
-    socket.onclose = () => {
+    socket.onclose = (event: CloseEvent) => {
       this.removeNotUsableSockets(socket.url);
       if (socketErrorOccurred) return;
 
       if (streamError) {
         reject(streamError);
+      } else if (
+        event.code !== WS_CLOSURE_CODE.SUCCESS_CODE &&
+        event.code !== 1001
+      ) {
+        // Server closed the connection with an abnormal code (e.g. 4001
+        // StreamIdleTimeout, 4003 SessionExpired, 1006 abnormal closure).
+        reject(
+          new Error(
+            `Server ended the connection unexpectedly (code ${event.code}` +
+              (event.reason ? `: ${event.reason}` : '') +
+              ')'
+          )
+        );
       } else {
         resolve({
           done: true,

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/__tests__/CustomWebsocketFetchHandler.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/__tests__/CustomWebsocketFetchHandler.test.ts
@@ -120,6 +120,101 @@ describe(CustomWebSocketFetchHandler.name, () => {
       expect(handler.sockets[mockUrl].length).toBe(0);
     });
 
+    it('should reject output stream when server closes with abnormal code', async () => {
+      const handler = new CustomWebSocketFetchHandler();
+      const payload = new PassThrough();
+      const server = new WS(mockUrl);
+      const {
+        response: { body: responsePayload },
+      } = await handler.handle(
+        new HttpRequest({
+          body: payload,
+          hostname: mockHostname,
+          protocol: 'ws:',
+        })
+      );
+      await server.connected;
+
+      // Start iterating before closing so the iterator is waiting on next()
+      const iteratorPromise = (async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for await (const chunk of responsePayload) {
+          /** pass */
+        }
+      })();
+
+      // Give the iterator time to call next() and set up reject/resolve
+      await new Promise((r) => setTimeout(r, 0));
+
+      server.close({ code: 4001, reason: 'StreamIdleTimeout', wasClean: true });
+
+      await expect(iteratorPromise).rejects.toThrow(
+        'Server ended the connection unexpectedly (code 4001: StreamIdleTimeout)'
+      );
+    });
+
+    it('should reject output stream when connection drops without close frame (code 1006)', async () => {
+      const handler = new CustomWebSocketFetchHandler();
+      const payload = new PassThrough();
+      const server = new WS(mockUrl);
+      const {
+        response: { body: responsePayload },
+      } = await handler.handle(
+        new HttpRequest({
+          body: payload,
+          hostname: mockHostname,
+          protocol: 'ws:',
+        })
+      );
+      await server.connected;
+
+      const iteratorPromise = (async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for await (const chunk of responsePayload) {
+          /** pass */
+        }
+      })();
+
+      await new Promise((r) => setTimeout(r, 0));
+
+      server.close({ code: 1006, reason: '', wasClean: false });
+
+      await expect(iteratorPromise).rejects.toThrow(
+        'Server ended the connection unexpectedly (code 1006)'
+      );
+    });
+
+    it('should resolve normally when server closes with code 1000', async () => {
+      const handler = new CustomWebSocketFetchHandler();
+      const payload = new PassThrough();
+      const server = new WS(mockUrl);
+      const {
+        response: { body: responsePayload },
+      } = await handler.handle(
+        new HttpRequest({
+          body: payload,
+          hostname: mockHostname,
+          protocol: 'ws:',
+        })
+      );
+      await server.connected;
+
+      const iteratorPromise = (async () => {
+        const chunks: Uint8Array[] = [];
+        for await (const chunk of responsePayload) {
+          chunks.push(chunk);
+        }
+        return chunks;
+      })();
+
+      await new Promise((r) => setTimeout(r, 0));
+
+      server.close({ code: 1000, reason: '', wasClean: true });
+
+      const chunks = await iteratorPromise;
+      expect(chunks).toEqual([]);
+    });
+
     it('should return timeout error if cannot setup ws connection', async () => {
       const originalSetTimeout = globalThis.setTimeout;
 

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/__tests__/CustomWebsocketFetchHandler.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/__tests__/CustomWebsocketFetchHandler.test.ts
@@ -137,8 +137,7 @@ describe(CustomWebSocketFetchHandler.name, () => {
 
       // Start iterating before closing so the iterator is waiting on next()
       const iteratorPromise = (async () => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for await (const chunk of responsePayload) {
+        for await (const _ of responsePayload) {
           /** pass */
         }
       })();
@@ -169,8 +168,7 @@ describe(CustomWebSocketFetchHandler.name, () => {
       await server.connected;
 
       const iteratorPromise = (async () => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for await (const chunk of responsePayload) {
+        for await (const _ of responsePayload) {
           /** pass */
         }
       })();


### PR DESCRIPTION
#### Description of changes

The `CustomWebSocketFetchHandler`'s `socket.onclose` handler ignored the `CloseEvent` object entirely. When the Rekognition Streaming server closed the WebSocket with codes like 4001 (StreamIdleTimeout), 4003 (SessionExpired), or 1006 (abnormal closure/no close frame), the handler resolved the output stream as "done" i.e a normal completion. The state machine exited its `for await` loop cleanly, no `SERVER_ERROR` event was dispatched, and `onError` never fired. The component got stuck with no way to recover.

This change inspects `event.code` in `onclose`. If the code is not 1000 (normal) or 1001 (going away), the stream is rejected with an error, which propagates through the existing `responseStreamActor` → `SERVER_ERROR` → `onError` callback path.

#### Description of how you validated changes

- Added 3 new unit tests covering:
  - Server close with code 4001 → stream rejects with error
  - Connection drop with code 1006 → stream rejects with error
  - Server close with code 1000 → stream resolves normally (no regression)
- Full test suite passes (`yarn test` — 36 suites, 265 tests passed)

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
