### PR TITLE
fix(ui-angular): add explicit ChangeDetectionStrategy for Angular 22

### DIFF
--- a/.changeset/tiny-mice-glow.md
+++ b/.changeset/tiny-mice-glow.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-angular': patch
+---
+
+This change adds changeDetection: ChangeDetectionStrategy.Default to all components, preserving existing behavior across Angular 19-22+ without any API or behavioral changes for consumers.

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterContentInit,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
@@ -29,6 +30,7 @@ const { getSignInTabText, getSignUpTabText } = authenticatorTextUtil;
   templateUrl: './authenticator.component.html',
   providers: [CustomComponentsService], // make sure custom components are scoped to this authenticator only
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class AuthenticatorComponent
   implements OnInit, AfterContentInit, OnDestroy

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/base-form-fields/base-form-fields.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/base-form-fields/base-form-fields.component.ts
@@ -1,4 +1,10 @@
-import { Component, HostBinding, Input, OnInit } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  OnInit,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {
   FormFieldComponents,
   FormFieldsArray,
@@ -13,6 +19,7 @@ import { AuthenticatorService } from '../../../../services/authenticator.service
   selector: 'amplify-base-form-fields',
   standalone: false,
   templateUrl: './base-form-fields.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class BaseFormFieldsComponent implements OnInit {
   @Input() route: FormFieldComponents; // formFields to sort and render

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-reset-password/amplify-confirm-reset-password.component.ts
@@ -1,4 +1,9 @@
-import { Component, HostBinding, Input } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import {
   FormFieldsArray,
@@ -17,6 +22,7 @@ const {
   selector: 'amplify-confirm-reset-password',
   standalone: false,
   templateUrl: './amplify-confirm-reset-password.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ConfirmResetPasswordComponent {
   @HostBinding('attr.data-amplify-authenticator-confirmsignin') dataAttr = '';

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-in/confirm-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-in/confirm-sign-in.component.ts
@@ -1,4 +1,9 @@
-import { Component, HostBinding, OnInit } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  OnInit,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {
   FormFieldsArray,
   getActorContext,
@@ -15,6 +20,7 @@ const { getConfirmText, getBackToSignInText, getChallengeText } =
   selector: 'amplify-confirm-sign-in',
   standalone: false,
   templateUrl: './confirm-sign-in.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ConfirmSignInComponent implements OnInit {
   @HostBinding('attr.data-amplify-authenticator-confirmsignin') dataAttr = '';

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-up/confirm-sign-up.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-sign-up/confirm-sign-up.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding } from '@angular/core';
+import { Component, HostBinding, ChangeDetectionStrategy } from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import {
   FormFieldsArray,
@@ -16,6 +16,7 @@ const {
   selector: 'amplify-confirm-sign-up',
   standalone: false,
   templateUrl: './confirm-sign-up.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ConfirmSignUpComponent {
   @HostBinding('attr.data-amplify-authenticator-confirmsignup') dataAttr = '';

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/confirm-verify-user/amplify-confirm-verify-user.component.ts
@@ -1,4 +1,9 @@
-import { Component, HostBinding, Input } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {
   FormFieldsArray,
   getFormDataFromEvent,
@@ -12,6 +17,7 @@ const { getAccountRecoveryInfoText, getSkipText, getSubmitText } =
   selector: 'amplify-confirm-verify-user',
   standalone: false,
   templateUrl: './amplify-confirm-verify-user.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ConfirmVerifyUserComponent {
   @HostBinding('attr.data-amplify-authenticator-confirmverifyuser')

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/federated-sign-in-button/federated-sign-in-button.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/federated-sign-in-button/federated-sign-in-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 import { FederatedIdentityProviders } from '@aws-amplify/ui';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 
@@ -6,6 +6,7 @@ import { AuthenticatorService } from '../../../../services/authenticator.service
   selector: 'amplify-federated-sign-in-button',
   standalone: false,
   templateUrl: './federated-sign-in-button.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class FederatedSignInButtonComponent {
   @Input() provider: FederatedIdentityProviders;

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/federated-sign-in/federated-sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/federated-sign-in/federated-sign-in.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { FederatedIdentityProviders } from '@aws-amplify/ui';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import { authenticatorTextUtil } from '@aws-amplify/ui';
@@ -9,6 +9,7 @@ const { getSignInWithFederationText, getOrText } = authenticatorTextUtil;
   selector: 'amplify-federated-sign-in',
   standalone: false,
   templateUrl: './federated-sign-in.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class FederatedSignInComponent implements OnInit {
   public FederatedProviders = FederatedIdentityProviders;

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/force-new-password/force-new-password-form-fields/force-new-password-form-fields.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/force-new-password/force-new-password-form-fields/force-new-password-form-fields.component.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'amplify-force-new-password-form-fields',
   standalone: false,
   templateUrl: './force-new-password-form-fields.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ForceNewPasswordFormFieldsComponent {}

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/force-new-password/force-new-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/force-new-password/force-new-password.component.ts
@@ -1,4 +1,9 @@
-import { Component, HostBinding, Input } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import { getFormDataFromEvent, authenticatorTextUtil } from '@aws-amplify/ui';
 
@@ -8,6 +13,7 @@ const { getChangePasswordText, getBackToSignInText } = authenticatorTextUtil;
   selector: 'amplify-force-new-password',
   standalone: false,
   templateUrl: './force-new-password.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ForceNewPasswordComponent {
   @HostBinding('attr.data-amplify-authenticator-forcenewpassword')

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/forgot-password/forgot-password.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/forgot-password/forgot-password.component.ts
@@ -1,4 +1,9 @@
-import { Component, HostBinding, Input } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import {
   FormFieldsArray,
@@ -13,6 +18,7 @@ const { getResetYourPasswordText, getSendCodeText, getBackToSignInText } =
   selector: 'amplify-forgot-password',
   standalone: false,
   templateUrl: './forgot-password.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ForgotPasswordComponent {
   @HostBinding('attr.data-amplify-authenticator-forgotpassword') dataAttr = '';

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/form-field/form-field.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 import {
   translate,
   countryDialCodes,
@@ -12,6 +12,7 @@ import { AuthenticatorService } from '../../../../services/authenticator.service
   selector: 'amplify-form-field',
   standalone: false,
   templateUrl: './form-field.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class FormFieldComponent {
   @Input() name: string; // name of the input field

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/select-mfa-type/select-mfa-type.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/select-mfa-type/select-mfa-type.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import {
   getActorContext,
   getFormDataFromEvent,
@@ -21,6 +21,7 @@ const {
   selector: 'amplify-select-mfa-type',
   standalone: false,
   templateUrl: './select-mfa-type.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SelectMfaTypeComponent implements OnInit {
   public headerText: string;

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/setup-email/setup-email.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/setup-email/setup-email.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 import {
   authenticatorTextUtil,
   classNames,
@@ -15,6 +15,7 @@ const { getConfirmText, getBackToSignInText, getSetupEmailText } =
   selector: 'amplify-setup-email',
   standalone: false,
   templateUrl: './setup-email.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SetupEmailComponent {
   public headerText = getSetupEmailText();

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/setup-totp/setup-totp.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/setup-totp/setup-totp.component.ts
@@ -1,4 +1,9 @@
-import { Component, HostBinding, OnInit } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  OnInit,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import QRCode from 'qrcode';
 import { ConsoleLogger as Logger } from 'aws-amplify/utils';
 import {
@@ -25,6 +30,7 @@ const {
   selector: 'amplify-setup-totp',
   standalone: false,
   templateUrl: './setup-totp.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SetupTotpComponent implements OnInit {
   @HostBinding('attr.data-amplify-authenticator-setup-totp') dataAttr = '';

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-in/sign-in.component.ts
@@ -1,4 +1,9 @@
-import { Component, HostBinding, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  ViewEncapsulation,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import {
   authenticatorTextUtil,
@@ -13,6 +18,7 @@ const { getForgotPasswordText, getSignInText } = authenticatorTextUtil;
   standalone: false,
   templateUrl: './sign-in.component.html',
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SignInComponent {
   @HostBinding('attr.data-amplify-authenticator-signin') dataAttr = '';

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-up/sign-up-form-fields/sign-up-form-fields.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-up/sign-up-form-fields/sign-up-form-fields.component.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'amplify-sign-up-form-fields',
   standalone: false,
   templateUrl: './sign-up-form-fields.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SignUpFormFieldsComponent {}

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-up/sign-up.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/sign-up/sign-up.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding } from '@angular/core';
+import { Component, HostBinding, ChangeDetectionStrategy } from '@angular/core';
 import { AuthenticatorService } from '../../../../services/authenticator.service';
 import { getFormDataFromEvent, authenticatorTextUtil } from '@aws-amplify/ui';
 
@@ -8,6 +8,7 @@ const { getCreateAccountText } = authenticatorTextUtil;
   selector: 'amplify-sign-up',
   standalone: false,
   templateUrl: './sign-up.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SignUpComponent {
   @HostBinding('attr.data-amplify-authenticator-signup') dataAttr = '';

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/verify-user/verify-user.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/verify-user/verify-user.component.ts
@@ -4,6 +4,7 @@ import {
   Input,
   OnInit,
   ViewEncapsulation,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {
   getActorState,
@@ -26,6 +27,7 @@ const { getSkipText, getVerifyText, getAccountRecoveryInfoText } =
   standalone: false,
   templateUrl: './verify-user.component.html',
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class VerifyUserComponent implements OnInit {
   @HostBinding('attr.data-amplify-authenticator-verifyuser') dataAttr = '';

--- a/packages/angular/projects/ui-angular/src/lib/primitives/button/button.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/button/button.component.ts
@@ -1,9 +1,16 @@
-import { Component, HostBinding, Input, OnInit } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  OnInit,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 
 @Component({
   selector: 'button[amplify-button]',
   standalone: false,
   templateUrl: './button.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ButtonComponent implements OnInit {
   @Input() type: 'submit' | 'button' = 'button';

--- a/packages/angular/projects/ui-angular/src/lib/primitives/checkbox/checkbox.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/checkbox/checkbox.component.ts
@@ -1,9 +1,15 @@
-import { Component, Input, OnInit } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnInit,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 
 @Component({
   selector: 'amplify-checkbox',
   standalone: false,
   templateUrl: './checkbox.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class CheckboxComponent implements OnInit {
   @Input() defaultChecked = false;

--- a/packages/angular/projects/ui-angular/src/lib/primitives/error/error.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/error/error.component.ts
@@ -1,10 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { translate } from '@aws-amplify/ui';
 
 @Component({
   selector: 'amplify-error',
   standalone: false,
   templateUrl: './error.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ErrorComponent {
   public isVisible = true;

--- a/packages/angular/projects/ui-angular/src/lib/primitives/password-field/password-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/password-field/password-field.component.ts
@@ -1,4 +1,10 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { translate, ComponentClassName } from '@aws-amplify/ui';
 import { nanoid } from 'nanoid';
 import { classNames } from '@aws-amplify/ui';
@@ -7,6 +13,7 @@ import { classNames } from '@aws-amplify/ui';
   selector: 'amplify-password-field',
   standalone: false,
   templateUrl: './password-field.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class PasswordFieldComponent {
   @Input() autocomplete = 'new-password';

--- a/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/phone-number-field/phone-number-field.component.ts
@@ -1,4 +1,10 @@
-import { Component, HostBinding, Input, OnInit } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  OnInit,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { nanoid } from 'nanoid';
 import { countryDialCodes } from '@aws-amplify/ui';
 
@@ -6,6 +12,7 @@ import { countryDialCodes } from '@aws-amplify/ui';
   selector: 'amplify-phone-number-field',
   standalone: false,
   templateUrl: './phone-number-field.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class PhoneNumberFieldComponent implements OnInit {
   @Input() autocomplete = 'new-password';

--- a/packages/angular/projects/ui-angular/src/lib/primitives/select/select.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/select/select.component.ts
@@ -1,9 +1,10 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'amplify-form-select',
   standalone: false,
   templateUrl: './select.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SelectComponent {
   @Input() items: string[];

--- a/packages/angular/projects/ui-angular/src/lib/primitives/tab-item/tab-item.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/tab-item/tab-item.component.ts
@@ -1,9 +1,15 @@
-import { Component, HostBinding, Input } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 
 @Component({
   selector: 'amplify-tab-item',
   standalone: false,
   templateUrl: './tab-item.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class TabItemComponent {
   @Input() title: string;

--- a/packages/angular/projects/ui-angular/src/lib/primitives/tabs/tabs.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/tabs/tabs.component.ts
@@ -5,6 +5,7 @@ import {
   QueryList,
   Output,
   EventEmitter,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import { nanoid } from 'nanoid';
 import { TabItemComponent } from '../tab-item/tab-item.component';
@@ -13,6 +14,7 @@ import { TabItemComponent } from '../tab-item/tab-item.component';
   selector: 'amplify-tabs',
   standalone: false,
   templateUrl: './tabs.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class TabsComponent implements AfterContentInit {
   @ContentChildren(TabItemComponent) tabs: QueryList<TabItemComponent>;

--- a/packages/angular/projects/ui-angular/src/lib/primitives/text-field/text-field.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/primitives/text-field/text-field.component.ts
@@ -1,10 +1,16 @@
-import { Component, HostBinding, Input } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { nanoid } from 'nanoid';
 
 @Component({
   selector: 'amplify-text-field',
   standalone: false,
   templateUrl: './text-field.component.html',
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class TextFieldComponent {
   @Input() autocomplete = 'new-password';

--- a/packages/angular/projects/ui-angular/src/lib/utilities/amplify-slot/amplify-slot.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/utilities/amplify-slot/amplify-slot.component.ts
@@ -4,6 +4,7 @@ import {
   HostBinding,
   Input,
   TemplateRef,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import { CustomComponentsService } from '../../services/custom-components.service';
 
@@ -11,6 +12,7 @@ import { CustomComponentsService } from '../../services/custom-components.servic
   selector: 'amplify-slot',
   templateUrl: './amplify-slot.component.html',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class AmplifySlotComponent implements AfterContentInit {
   @Input() name: string;


### PR DESCRIPTION
Fix Angular 22 compatibility: explicitly set ChangeDetectionStrategy.Default on all components

Angular 22.0.0 (released June 3, 2026) changed the default change detection strategy from Default (Eager) to OnPush for components that don't explicitly specify one. Since none of the 29 components in @aws-amplify/ui-angular had an explicit changeDetection property, they silently became OnPush under Angular 22 — causing the authenticator to render as an empty element because XState state machine transitions no longer triggered view updates.

This change adds changeDetection: ChangeDetectionStrategy.Default to all components, preserving existing behavior across Angular 19-22+ without any API or behavioral changes for consumers.