### PR TITLE
fix(react-liveness): buffer WebSocket messages to prevent dropped server events

### DIFF
--- a/.changeset/fix-ws-message-queue.md
+++ b/.changeset/fix-ws-message-queue.md
@@ -1,0 +1,15 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+fix(react-liveness): buffer WebSocket messages to prevent dropped server events
+
+The `CustomWebSocketFetchHandler` async iterator used a single `resolve`
+function that was initialized as a no-op. If the server sent messages before
+the consumer called `.next()` on the iterator, those messages were silently
+dropped. This caused intermittent hangs where the `ServerSessionInformationEvent`
+was lost and the state machine polled `waitForSessionInfo` forever.
+
+This change replaces the single resolve/reject pattern with a proper message
+queue that buffers incoming WebSocket messages until the consumer is ready to
+receive them.

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/CustomWebSocketFetchHandler.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/CustomWebSocketFetchHandler.ts
@@ -202,56 +202,109 @@ export class CustomWebSocketFetchHandler {
     // To notify onclose event that error has occurred.
     let socketErrorOccurred = false;
 
-    // initialize as no-op.
-    let reject: (err?: unknown) => void = () => {};
-    let resolve: (result: IteratorResult<Uint8Array, void>) => void = () => {};
+    // Buffer for messages that arrive before the consumer calls .next().
+    // This prevents dropped messages when the server responds faster than
+    // the client sets up its async iterator (race condition).
+    const messageQueue: Uint8Array[] = [];
+    let waitingResolve:
+      | ((result: IteratorResult<Uint8Array, void>) => void)
+      | null = null;
+    let waitingReject: ((err?: unknown) => void) | null = null;
+    let done = false;
+    let endError: unknown = undefined;
 
     socket.onmessage = (event) => {
-      resolve({
-        done: false,
-        value: new Uint8Array(event.data),
-      });
+      const chunk = new Uint8Array(event.data);
+      if (waitingResolve) {
+        // Consumer is waiting for data — deliver immediately
+        const resolve = waitingResolve;
+        waitingResolve = null;
+        waitingReject = null;
+        resolve({ done: false, value: chunk });
+      } else {
+        // Consumer hasn't called .next() yet — buffer the message
+        messageQueue.push(chunk);
+      }
     };
 
     socket.onerror = (error) => {
       socketErrorOccurred = true;
       socket.close();
-      reject(error);
+      done = true;
+      endError = error;
+      if (waitingReject) {
+        const reject = waitingReject;
+        waitingResolve = null;
+        waitingReject = null;
+        reject(error);
+      }
     };
 
     socket.onclose = (event: CloseEvent) => {
       this.removeNotUsableSockets(socket.url);
       if (socketErrorOccurred) return;
 
+      done = true;
       if (streamError) {
-        reject(streamError);
+        endError = streamError;
       } else if (
         event.code !== WS_CLOSURE_CODE.SUCCESS_CODE &&
         event.code !== 1001
       ) {
         // Server closed the connection with an abnormal code (e.g. 4001
         // StreamIdleTimeout, 4003 SessionExpired, 1006 abnormal closure).
-        reject(
-          new Error(
-            `Server ended the connection unexpectedly (code ${event.code}` +
-              (event.reason ? `: ${event.reason}` : '') +
-              ')'
-          )
+        endError = new Error(
+          `Server ended the connection unexpectedly (code ${event.code}` +
+            (event.reason ? `: ${event.reason}` : '') +
+            ')'
         );
-      } else {
-        resolve({
-          done: true,
-          value: undefined,
-        });
+      }
+
+      if (waitingResolve) {
+        if (endError) {
+          const reject = waitingReject!;
+          waitingResolve = null;
+          waitingReject = null;
+          reject(endError);
+        } else {
+          const resolve = waitingResolve;
+          waitingResolve = null;
+          waitingReject = null;
+          resolve({ done: true, value: undefined });
+        }
       }
     };
 
     const outputStream: AsyncIterable<Uint8Array> = {
       [Symbol.asyncIterator]: () => ({
         next: () => {
+          // If there are buffered messages, deliver the next one immediately
+          if (messageQueue.length > 0) {
+            return Promise.resolve({
+              done: false,
+              value: messageQueue.shift()!,
+            } as IteratorResult<Uint8Array, void>);
+          }
+
+          // If the stream has ended, resolve/reject accordingly
+          if (done) {
+            if (endError) {
+              return Promise.reject(
+                endError instanceof Error
+                  ? endError
+                  : new Error('Stream ended with an error')
+              );
+            }
+            return Promise.resolve({
+              done: true,
+              value: undefined,
+            } as IteratorResult<Uint8Array, void>);
+          }
+
+          // Otherwise wait for the next message or close event
           return new Promise((_resolve, _reject) => {
-            resolve = _resolve;
-            reject = _reject;
+            waitingResolve = _resolve;
+            waitingReject = _reject;
           });
         },
       }),
@@ -274,8 +327,7 @@ export class CustomWebSocketFetchHandler {
       } catch (err) {
         // We don't throw the error here because the send()'s returned
         // would already be settled by the time sending chunk throws error.
-        // Instead, the notify the output stream to throw if there's
-        // exceptions
+        // Instead, notify the output stream to throw if there's exceptions
         if (err instanceof Error) {
           streamError = err;
         }

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/__tests__/CustomWebsocketFetchHandler.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/createStreamingClient/__tests__/CustomWebsocketFetchHandler.test.ts
@@ -213,6 +213,46 @@ describe(CustomWebSocketFetchHandler.name, () => {
       expect(chunks).toEqual([]);
     });
 
+    it('should buffer messages that arrive before consumer calls next()', async () => {
+      const handler = new CustomWebSocketFetchHandler();
+      const payload = new PassThrough();
+      const server = new WS(mockUrl);
+      const {
+        response: { body: responsePayload },
+      } = await handler.handle(
+        new HttpRequest({
+          body: payload,
+          hostname: mockHostname,
+          protocol: 'ws:',
+        })
+      );
+      await server.connected;
+
+      // Send messages BEFORE the consumer starts iterating
+      const message1 = new Uint8Array([1, 2, 3]);
+      const message2 = new Uint8Array([4, 5, 6]);
+      server.send(message1.buffer);
+      server.send(message2.buffer);
+
+      // Give messages time to be received by onmessage handler
+      await new Promise((r) => setTimeout(r, 0));
+
+      // NOW start consuming — messages should be buffered and delivered
+      const chunks: Uint8Array[] = [];
+      const iteratorPromise = (async () => {
+        for await (const chunk of responsePayload) {
+          chunks.push(chunk);
+          if (chunks.length === 2) break;
+        }
+      })();
+
+      await iteratorPromise;
+
+      expect(chunks.length).toBe(2);
+      expect(chunks[0]).toEqual(message1);
+      expect(chunks[1]).toEqual(message2);
+    });
+
     it('should return timeout error if cannot setup ws connection', async () => {
       const originalSetTimeout = globalThis.setTimeout;
 


### PR DESCRIPTION
## Description

Fixes the WebSocket message race condition where server messages are silently dropped if they arrive before the async iterator consumer starts iterating.

## Problem

The `connect()` method in `CustomWebSocketFetchHandler` uses an async iterator pattern where `socket.onmessage` calls a `resolve` function. This `resolve` is initialized as a no-op and only becomes a real function when the consumer calls `.next()` on the iterator.

If the server sends messages (e.g., `ServerSessionInformationEvent`) before `responseStreamActor`'s `for await` loop calls `.next()`, those messages hit the no-op resolve and are silently lost. The state machine then polls `waitForSessionInfo` forever because `hasParsedSessionInfo` never becomes true.

This is reproducible ~30% of the time on retry attempts, because the server responds faster on subsequent connections (warmed up).

Related Issue: #6999 

## Changes

Replaces the single `resolve`/`reject` variable pattern with a proper message queue:
- Incoming messages are buffered in an array when no consumer is waiting
- When the consumer calls `.next()`, buffered messages are delivered immediately (FIFO)
- If the stream has already ended when `.next()` is called, the appropriate resolve/reject is returned
- Error handling for `onerror`, `onclose`, and stream errors is preserved

## How it was tested

- All 12 existing WebSocket handler tests pass
- New test: `should buffer messages that arrive before consumer calls next()` — sends messages before iterating, verifies they are all received in order
- Full liveness test suite passes (36 suites, 267 tests)

## Related

Fixes #6999
