### PR TITLE
fix(react-liveness): clear model load timeout timer on rejection

### DIFF
--- a/.changeset/fix-model-load-timer-leak.md
+++ b/.changeset/fix-model-load-timer-leak.md
@@ -1,0 +1,11 @@
+---
+"@aws-amplify/ui-react-liveness": patch
+---
+
+fix(react-liveness): clear model load timeout timer on rejection
+
+The model loading timeout introduced previously only cleared the timer
+when `loadModels()` resolved (via `.then()`). If `loadModels()` rejected
+(e.g. a fast CDN failure or WASM compile error), the 10s timer was left
+running, leaking until it fired. Switched to `.finally()` so the timer is
+cleared on both resolve and reject paths.

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/types/faceDetection.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/types/faceDetection.ts
@@ -43,9 +43,10 @@ export abstract class FaceDetection {
     let timeoutId: ReturnType<typeof setTimeout>;
 
     this.modelLoadingPromise = Promise.race([
-      this.loadModels().then((result) => {
+      // `finally` ensures the timeout is cleared whether loadModels
+      // resolves or rejects, preventing a leaked timer on fast failures.
+      this.loadModels().finally(() => {
         clearTimeout(timeoutId);
-        return result;
       }),
       new Promise<void>((_, reject) => {
         timeoutId = setTimeout(

--- a/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/__tests__/blazefaceFaceDetection.test.ts
+++ b/packages/react-liveness/src/components/FaceLivenessDetector/service/utils/__tests__/blazefaceFaceDetection.test.ts
@@ -120,6 +120,9 @@ describe('blazefaceFaceDetection', () => {
       // Advance past the 10s timeout — should NOT reject since timer was cleared
       jest.advanceTimersByTime(10_000);
       await expect(model.modelLoadingPromise).resolves.toBeUndefined();
+
+      // No leaked timers should remain
+      expect(jest.getTimerCount()).toBe(0);
     });
 
     it('should reject with timeout error if model loading stalls', async () => {
@@ -136,14 +139,24 @@ describe('blazefaceFaceDetection', () => {
       );
     });
 
-    it('should reject with original error if model loading fails before timeout', async () => {
+    it('should reject with original error if model loading fails before timeout and clear the timer', async () => {
       const model = new BlazeFaceFaceDetection();
-      model.loadModels = () => Promise.reject(new Error('WASM backend failed'));
+      // Model rejects after a short delay, before the 10s timeout
+      model.loadModels = () =>
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('WASM backend failed')), 500)
+        );
       model.triggerModelLoading();
+
+      jest.advanceTimersByTime(500);
 
       await expect(model.modelLoadingPromise).rejects.toThrow(
         'WASM backend failed'
       );
+
+      // The timeout timer should have been cleared on rejection — no leaked
+      // timers should remain pending.
+      expect(jest.getTimerCount()).toBe(0);
     });
 
     it('should not re-trigger loading if already in progress', async () => {


### PR DESCRIPTION
## Description

Follow-up to #7005. Fixes a timer leak in the model loading timeout when `loadModels()` rejects.

## Problem

The model load timeout used `.then()` to clear the timer:

```typescript
this.loadModels().then((result) => {
  clearTimeout(timeoutId);
  return result;
})
```

`.then()`'s callback only runs on **resolve**. If `loadModels()` **rejects** (fast CDN failure, WASM compile error), the `Promise.race` rejects immediately with the original error — but the 10s `setTimeout` is never cleared. It stays scheduled and fires later, calling `reject()` on the already-settled race promise (a harmless no-op), but the timer reference leaks for the full 10s.

## Fix

Switch `.then()` to `.finally()` so the timer is cleared on both resolve and reject paths:

```typescript
this.loadModels().finally(() => {
  clearTimeout(timeoutId);
})
```

## How it was tested

- Updated the "fails before timeout" test to reject after a delay and assert `jest.getTimerCount() === 0` afterward
- Added the same timer-count assertion to the resolve test
- All 36 liveness test suites pass (271 tests)
