### PR TITLE
fix(ui-angular): trigger change detection on auth machine transitions

### DIFF
--- a/.changeset/fix-angular-authenticator-change-detection.md
+++ b/.changeset/fix-angular-authenticator-change-detection.md
@@ -1,0 +1,12 @@
+---
+'@aws-amplify/ui-angular': patch
+---
+
+fix(ui-angular): render authenticator route changes on Angular v22+
+
+The Authenticator is driven by an xstate machine, and the component previously
+relied on zone.js to trigger change detection when the machine transitioned
+between routes. That implicit behavior is no longer guaranteed on Angular v22+,
+which left the Authenticator stuck on its initial route and rendered an empty
+component. Change detection now runs on every machine transition so the rendered
+route always reflects the current machine state.

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.spec.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.spec.ts
@@ -1,0 +1,113 @@
+import { Component, Input } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { AuthenticatorComponent } from './authenticator.component';
+import { AuthenticatorService } from '../../../../services/authenticator.service';
+import { AmplifySlotComponent } from '../../../../utilities/amplify-slot/amplify-slot.component';
+import { TabsComponent } from '../../../../primitives/tabs/tabs.component';
+import { TabItemComponent } from '../../../../primitives/tab-item/tab-item.component';
+import { SignInComponent } from '../sign-in/sign-in.component';
+import { SignUpComponent } from '../sign-up/sign-up.component';
+import { BaseFormFieldsComponent } from '../base-form-fields/base-form-fields.component';
+import { ButtonComponent } from '../../../../primitives/button/button.component';
+import { ErrorComponent } from '../../../../primitives/error/error.component';
+import { TextFieldComponent } from '../../../../primitives/text-field/text-field.component';
+import { PasswordFieldComponent } from '../../../../primitives/password-field/password-field.component';
+
+@Component({
+  selector: 'amplify-form-field',
+  template: '<div></div>',
+  standalone: false,
+})
+class MockFormFieldComponent {
+  @Input() name: string;
+  @Input() formField: any;
+}
+
+@Component({
+  selector: 'amplify-federated-sign-in',
+  template: '',
+  standalone: false,
+})
+class MockFederatedSignInComponent {}
+
+describe('AuthenticatorComponent', () => {
+  let fixture: ComponentFixture<AuthenticatorComponent>;
+  let mockAuthService: Record<string, unknown>;
+  let machineSubscriber: () => void;
+
+  beforeEach(async () => {
+    machineSubscriber = () => undefined;
+
+    mockAuthService = {
+      route: 'setup',
+      isPending: false,
+      error: undefined,
+      authState: {
+        context: { actorRef: { getSnapshot: () => ({ context: {} }) } },
+      },
+      authStatus: 'unauthenticated',
+      hubSubject: { subscribe: jest.fn() },
+      slotContext: {},
+      context: {},
+      initializeMachine: jest.fn(),
+      subscribe: jest.fn((callback: () => void) => {
+        machineSubscriber = callback;
+        return { unsubscribe: jest.fn() };
+      }),
+      updateForm: jest.fn(),
+      submitForm: jest.fn(),
+      toSignIn: jest.fn(),
+      toSignUp: jest.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      declarations: [
+        AuthenticatorComponent,
+        AmplifySlotComponent,
+        TabsComponent,
+        TabItemComponent,
+        SignInComponent,
+        SignUpComponent,
+        BaseFormFieldsComponent,
+        ButtonComponent,
+        ErrorComponent,
+        TextFieldComponent,
+        PasswordFieldComponent,
+        MockFormFieldComponent,
+        MockFederatedSignInComponent,
+      ],
+      providers: [{ provide: AuthenticatorService, useValue: mockAuthService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AuthenticatorComponent);
+  });
+
+  it('should mount successfully', () => {
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('initializes the machine once it reaches the setup route', () => {
+    fixture.detectChanges(); // triggers ngOnInit -> subscribe
+    expect(mockAuthService['subscribe']).toHaveBeenCalled();
+
+    // machine emits while in 'setup'
+    machineSubscriber();
+    expect(mockAuthService['initializeMachine']).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the sign-in route when the machine transitions to signIn', () => {
+    fixture.detectChanges();
+
+    // transition machine to signIn and notify subscribers
+    mockAuthService['route'] = 'signIn';
+    machineSubscriber();
+
+    const el: HTMLElement = fixture.nativeElement;
+    // The authenticator container and sign-in component should now be rendered.
+    // This regression-guards against the view staying empty when the machine
+    // transitions without a zone-triggered change detection (Angular v22+).
+    expect(el.querySelector('[data-amplify-authenticator]')).toBeTruthy();
+    expect(el.querySelector('amplify-sign-in')).toBeTruthy();
+  });
+});

--- a/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
+++ b/packages/angular/projects/ui-angular/src/lib/components/authenticator/components/authenticator/authenticator.component.ts
@@ -117,9 +117,19 @@ export class AuthenticatorComponent
     this.unsubscribeMachine = this.authenticator.subscribe(() => {
       const { route } = this.authenticator;
 
-      if (this.isHandlingHubEvent) {
-        this.changeDetector.detectChanges();
+      /*
+       * Run change detection on every state machine transition.
+       *
+       * The authenticator's state is driven by an xstate machine whose
+       * transitions are not reliably tracked by Angular's change detection.
+       * Previously we relied on zone.js noticing the async work behind these
+       * transitions, but that is no longer guaranteed (e.g. Angular v22+),
+       * which left the view stuck on the initial route. Detecting changes
+       * here ensures the rendered route always matches machine state.
+       */
+      this.changeDetector.detectChanges();
 
+      if (this.isHandlingHubEvent) {
         const initialStateWithDefault = initialState ?? 'signIn';
 
         // We can stop manual change detection if we're back to the initial state


### PR DESCRIPTION
#### Description of changes

The Angular `Authenticator` is driven by an xstate machine. The component previously
relied on zone.js to trigger Angular change detection when the machine transitioned
between routes (e.g. `setup` → `signIn`), only calling `detectChanges()` explicitly
for synchronous Hub events.

That implicit reliance on zone.js no longer holds on Angular v22+. As a result the
Authenticator stayed stuck on its initial route and rendered an empty
`<amplify-authenticator></amplify-authenticator>` element — no sign-in form, no tabs,
no inputs. The machine state was correct (`route === 'signIn'`), but the view was never
re-rendered to reflect it.

This change runs change detection on **every** machine subscription callback, so the
rendered route always reflects the current machine state regardless of how the host
application configures change detection.

Note: this completes the fix started in #7003. That PR added explicit
`changeDetection: ChangeDetectionStrategy.Default` annotations, but the real root cause
was that no change detection was being triggered at all on machine transitions — which
this PR addresses.

#### Issue #, if available

Build System Test Canary failing on `angular, latest` (Angular v22).

#### Description of how you validated changes

- Reproduced locally by scaffolding an Angular v22 app, installing the published
  `@aws-amplify/ui-angular@next` package, and rendering the Authenticator in a headless
  browser: confirmed the component rendered empty, and that forcing change detection
  (`ApplicationRef`/`applyChanges`) immediately populated the form — isolating this as a
  change-detection issue, not a state issue.
- Rebuilt the library from this branch, dropped it into the same Angular v22 app, and
  confirmed the sign-in form, tabs, and email/username input all render, and that
  switching to the "Create Account" tab renders the sign-up form.
- Added a regression unit test (`authenticator.component.spec.ts`) that transitions the
  machine to `signIn` and asserts the route renders. Verified it **fails** against the
  prior behavior and **passes** with this fix.
- `yarn test` for `@aws-amplify/ui-angular` passes (15 suites / 43 tests).

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
