### PR TITLE
chore(react-core): add npm package metadata

### DIFF
--- a/.changeset/react-core-metadata.md
+++ b/.changeset/react-core-metadata.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/ui-react-core": patch
+---
+
+Add npm package metadata links for the React core package.

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -20,6 +20,15 @@
   },
   "types": "dist/types/index.d.ts",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws-amplify/amplify-ui",
+    "directory": "packages/react-core"
+  },
+  "homepage": "https://github.com/aws-amplify/amplify-ui/tree/main/packages/react-core#readme",
+  "bugs": {
+    "url": "https://github.com/aws-amplify/amplify-ui/issues"
+  },
   "files": [
     "dist",
     "elements",


### PR DESCRIPTION
## Description

Adds package metadata for `@aws-amplify/ui-react-core` so npm and downstream tooling can link back to the source package, README, and issue tracker.

This mirrors the package-level `repository` metadata used by other Amplify UI packages and adds `homepage` and `bugs` fields for the React core package.

## Changes

- Add `repository` metadata with `directory: "packages/react-core"`
- Add package homepage pointing to the React core README
- Add bugs URL pointing to the Amplify UI issue tracker
- Add a patch changeset for `@aws-amplify/ui-react-core`

## Validation

- `npm view @aws-amplify/ui-react-core@3.6.4 name version repository homepage bugs license --json`
- `npm pack --dry-run --json ./packages/react-core`
- `git diff --check`
