### PR TITLE
fix(build-system-tests): pass --no-gitInit & --packageManager to nuxi init for CI

### DIFF
--- a/build-system-tests/scripts/mega-app-create-app.sh
+++ b/build-system-tests/scripts/mega-app-create-app.sh
@@ -91,11 +91,13 @@ if [[ "$FRAMEWORK" == 'vue' ]]; then
         echo "vue create --preset ../templates/components/vue/preset-${FRAMEWORK_VERSION}.json $MEGA_APP_NAME"
         echo 'Y' | vue create --preset ../templates/components/vue/preset-${FRAMEWORK_VERSION}.json $MEGA_APP_NAME
     elif [ "$BUILD_TOOL" == 'nuxt' ]; then
-        # nuxi >=3.36 requires an explicit --gitInit/--no-gitInit in non-interactive
-        # terminals (CI). The mega-app is throwaway and needs no git repo, so pass
-        # --no-gitInit to keep `nuxi init` from failing with exit code 2 in CI.
-        echo "npx nuxi@latest init $MEGA_APP_NAME -t v4 --no-gitInit"
-        npx nuxi@latest init $MEGA_APP_NAME -t v4 --no-gitInit
+        # nuxi >=3.36 no longer defaults the interactive prompts in a non-interactive
+        # terminal (CI); it requires them as explicit flags or fails with exit code 2.
+        # Two prompts apply here: --gitInit (the mega-app is throwaway, no git repo
+        # needed -> --no-gitInit) and --packageManager (the rest of build-system-tests
+        # is npm-based -> npm).
+        echo "npx nuxi@latest init $MEGA_APP_NAME -t v4 --no-gitInit --packageManager=npm"
+        npx nuxi@latest init $MEGA_APP_NAME -t v4 --no-gitInit --packageManager=npm
     fi
 fi
 

--- a/build-system-tests/scripts/mega-app-create-app.sh
+++ b/build-system-tests/scripts/mega-app-create-app.sh
@@ -91,8 +91,11 @@ if [[ "$FRAMEWORK" == 'vue' ]]; then
         echo "vue create --preset ../templates/components/vue/preset-${FRAMEWORK_VERSION}.json $MEGA_APP_NAME"
         echo 'Y' | vue create --preset ../templates/components/vue/preset-${FRAMEWORK_VERSION}.json $MEGA_APP_NAME
     elif [ "$BUILD_TOOL" == 'nuxt' ]; then
-        echo "npx nuxi@latest init $MEGA_APP_NAME -t v4"
-        npx nuxi@latest init $MEGA_APP_NAME -t v4
+        # nuxi >=3.36 requires an explicit --gitInit/--no-gitInit in non-interactive
+        # terminals (CI). The mega-app is throwaway and needs no git repo, so pass
+        # --no-gitInit to keep `nuxi init` from failing with exit code 2 in CI.
+        echo "npx nuxi@latest init $MEGA_APP_NAME -t v4 --no-gitInit"
+        npx nuxi@latest init $MEGA_APP_NAME -t v4 --no-gitInit
     fi
 fi
 


### PR DESCRIPTION
## Problem

The hourly **Build System Test Canary** (primary/web) workflow has been failing on every run, keeping the *Github Build System Test Failure* CloudWatch alarm in ALARM state (ticket [V2257625415](https://t.corp.amazon.com/V2257625415)).

The only failing job is `build (vue, latest, nuxt, latest, npm, 24)`. It dies at the **Setup Mega App** step:

```
npx nuxi@latest init <app> -t v4   # resolves to nuxi@3.36.0
...
■  Non-interactive terminal detected. Missing required argument: --gitInit
##[error]Process completed with exit code 2.
```

## Root cause

`nuxi` (>= 3.36) changed `nuxi init` so that in a **non-interactive terminal** (CI), the interactive prompts are no longer defaulted — they must be passed as explicit flags or the command fails with exit code 2. Two prompts apply here:
1. `--gitInit` — the mega-app is throwaway, so `--no-gitInit`.
2. `--packageManager` — surfaces *after* gitInit is satisfied; `build-system-tests` is npm-based throughout, so `npm`.

Because the canary pins `nuxi@latest`, the new CLI is pulled fresh every run. This is an upstream tooling change, not a regression in any released Amplify package, so there is **no customer impact**.

## Fix

```diff
- npx nuxi@latest init $MEGA_APP_NAME -t v4
+ npx nuxi@latest init $MEGA_APP_NAME -t v4 --no-gitInit --packageManager=npm
```

## Testing

Reproduced and verified locally against `nuxi@3.36.0` in a non-interactive shell (`</dev/null`):

| Command | Result |
|---|---|
| `nuxi init -t v4` (original) | ❌ exit 2 — `Missing required argument: --gitInit` |
| `nuxi init -t v4 --no-gitInit` | ❌ exit 2 — `Missing required argument: --packageManager` |
| `nuxi init -t v4 --no-gitInit --packageManager=npm` | ✅ exit 0 — "Nuxt project has been created with the v4 template" |

- `bash -n build-system-tests/scripts/mega-app-create-app.sh` passes.
- Full canary confirmation will come from the next scheduled run after merge (the workflow is `schedule`-only and runs against `main`).