### PR TITLE
fix(build-system-tests): bound RN Android canary emulator boot to stop 6h hangs

### DIFF
--- a/.github/workflows/reusable-build-system-test-react-native.yml
+++ b/.github/workflows/reusable-build-system-test-react-native.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: macos-15-intel
+    # Bound the whole job so a wedged emulator boot can't run until GitHub's 6h hard limit.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -87,7 +89,7 @@ jobs:
             ~/Library/Android/sdk/build-tools
             ~/Library/Android/sdk/platform-tools
             ~/.android/avd
-          key: ${{ runner.os }}-android-sdk-27-x86_64-snapshot-v1
+          key: ${{ runner.os }}-android-sdk-27-x86_64-snapshot-v2
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
@@ -126,6 +128,8 @@ jobs:
         run: |
           echo -e "echo \$ANDROID_HOME"
           echo $ANDROID_HOME
+          # macOS runners have no GNU `timeout`; coreutils provides it for the emulator boot-wait guard below (mirrors reusable-e2e.yml).
+          brew install coreutils
           $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "build-tools;33.0.2" "platform-tools" "system-images;android-27;default;x86_64"
           $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --name Pixel_5_API_27 --force --device "pixel_5" --abi x86_64 --package "system-images;android-27;default;x86_64"
 
@@ -133,7 +137,11 @@ jobs:
         if: ${{ matrix.platform == 'android' && steps.android-cache.outputs.cache-hit != 'true' }}
         run: |
           $ANDROID_HOME/emulator/emulator -avd Pixel_5_API_27 -port ${{ env.EMULATOR_PORT }} -no-boot-anim -no-audio -no-snapshot-load -gpu host -accel on &
-          $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
+          if ! timeout 420 $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'; then
+            echo "::error::Android emulator did not reach sys.boot_completed within 420s; failing fast instead of hanging until the 6h limit"
+            $ANDROID_HOME/platform-tools/adb devices
+            exit 1
+          fi
           $ANDROID_HOME/platform-tools/adb devices
           # disable spell checker
           $ANDROID_HOME/platform-tools/adb shell settings put secure spell_checker_enabled 0
@@ -148,7 +156,11 @@ jobs:
         if: ${{ matrix.platform == 'android' && steps.android-cache.outputs.cache-hit == 'true' }}
         run: |
           $ANDROID_HOME/emulator/emulator -avd Pixel_5_API_27 -port ${{ env.EMULATOR_PORT }} -no-boot-anim -no-audio -snapshot default_boot -gpu host -accel on &
-          $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
+          if ! timeout 420 $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'; then
+            echo "::error::Android emulator did not reach sys.boot_completed within 420s; failing fast instead of hanging until the 6h limit"
+            $ANDROID_HOME/platform-tools/adb devices
+            exit 1
+          fi
           $ANDROID_HOME/platform-tools/adb devices
 
       - name: Create MegaApp ${{ env.MEGA_APP_NAME }} and run build on NodeJS ${{ matrix.node-version }}


### PR DESCRIPTION
## Problem

The `Build System Test Canary / React Native` workflow (`build-system-test-react-native.yml` → `reusable-build-system-test-react-native.yml`) has been **failing on every scheduled run for months**. Each failing run does not fail fast — it **hangs for ~6 hours** and is then cancelled by GitHub's hard job limit, burning macOS runner minutes every 2 hours.

- Last successful run: **#20779 on 2026-06-10**
- **221 consecutive failures** since then.

### Root cause

The Android emulator job launches the emulator with a hand-rolled `emulator … &` followed by an **unbounded** `adb wait-for-device` boot-wait loop, and the job has **no `timeout-minutes`**. On `macos-15-intel` (1 virtual core) a cold boot frequently wedges; the wait loop then spins forever until the 6h limit cancels the job.

This is made permanent by a stale snapshot cache: the cache key `…-snapshot-v1` always cache-hits, but the cached snapshot is **incompatible with the current runner emulator** (every run logs `Failed to load snapshot 'default_boot'`). Because the snapshot-resave step is gated on a cache *miss*, the broken snapshot is never refreshed — so it stays broken forever.

## Changes

This PR is intentionally a tight, low-risk mitigation to **stop the 6h hangs** and give the canary a chance to recover. One file changed (`reusable-build-system-test-react-native.yml`):

1. **`timeout-minutes: 45` on the emulator job** — a wedged boot can no longer run until GitHub's 6h limit.
2. **Bound the boot-wait with `timeout 420`** in *both* emulator-start steps (cold-boot and cached). On timeout it emits a `::error::` annotation, dumps `adb devices`, and fails the step fast instead of hanging.
   - macOS runners don't ship GNU `timeout`, so this adds `brew install coreutils` to the emulator-install step — mirroring the **already-working** pattern in `reusable-e2e.yml` (`brew install coreutils` + `timeout 5m` for the identical `adb wait-for-device` call).
3. **Bump the snapshot cache key `…-snapshot-v1` → `…-snapshot-v2`** so the next cold boot regenerates a snapshot compatible with the current emulator and re-saves it under the new key.

## Validation

- `python yaml.safe_load` parses the workflow cleanly.
- `bash -n` passes on each modified `run:` block (validates the `if/timeout/fi` wrapper and the preserved device-side loop quoting).
- `actionlint` reports **no new findings** vs. the original file (the only message — `macos-15-intel` "unknown label" — is pre-existing and is a benign gap in actionlint's bundled runner-label list).

The verbatim device-side boot-wait command is unchanged; it is only wrapped in `timeout` + failure handling.
