### PR TITLE
fix(deps): bump undici to 6.27.0 (CVE-2026-11525)

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "socks": "^2.7.3",
     "tar": "^7.5.10",
     "tar-fs": "^3.1.1",
-    "undici": "^6.23.0",
+    "undici": "^6.27.0",
     "webpack-dev-middleware": "^5.3.4",
     "webpack-dev-server": "^5.2.1",
     "yaml": "2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20770,7 +20770,7 @@ esbuild-wasm@>=0.23.0:
   resolved "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.27.0.tgz"
   integrity sha512-4XpLDOY4sOzqgiezPXDkHTn25cBA1MKN5OTotehoFR7/wTpSYCK76OA8rQfpiuz12G27JpGxxdh+/D9GcNl61w==
 
-esbuild@0.25.4, esbuild@>=0.23.0, esbuild@^0.24.0, esbuild@^0.25.0, esbuild@^0.27.0, esbuild@~0.23.0, esbuild@~0.25.0:
+esbuild@0.25.4, esbuild@>=0.23.0, esbuild@^0.24.0, esbuild@^0.25.0, "esbuild@^0.27.0 || ^0.28.0", esbuild@~0.23.0, esbuild@~0.25.0:
   version "0.25.1"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz"
   integrity sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==
@@ -33026,10 +33026,10 @@ undici-types@~6.21.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
-undici@^5.25.4, undici@^6.23.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.25.0.tgz#8c4efb8c998dc187fc1cfb5dde1ef19a211849fb"
-  integrity sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==
+undici@^5.25.4, undici@^6.27.0:
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
+  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Security Fix

Resolves Dependabot alert [#551](https://github.com/aws-amplify/amplify-ui/security/dependabot/551) (severity: **low**).

**Vulnerability:** undici vulnerable to Set-Cookie SameSite attribute downgrade via permissive substring matching (CVE-2026-11525, GHSA-g8m3-5g58-fq7m).

**Fix:** Bumped the `undici` resolution in `package.json` from `^6.23.0` to `^6.27.0` (first patched version: 6.27.0) and regenerated `yarn.lock`.

**CI Status:** Unit tests pass. E2E failures are unrelated (docs build + svelte auth creds infra issue).