### PR TITLE
ci(build-system-tests): run RN Android canary via android-emulator-runner on ubuntu

### DIFF
--- a/.github/workflows/reusable-build-system-test-react-native.yml
+++ b/.github/workflows/reusable-build-system-test-react-native.yml
@@ -10,7 +10,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15-intel
+    # Android builds run on ubuntu-latest so the emulator can use hardware (KVM)
+    # acceleration. The previous macos-15-intel runner regularly wedged/segfaulted
+    # the hand-rolled emulator boot (see #7031).
+    runs-on: ubuntu-latest
     # Bound the whole job so a wedged emulator boot can't run until GitHub's 6h hard limit.
     timeout-minutes: 45
     strategy:
@@ -34,7 +37,6 @@ jobs:
 
     env:
       MEGA_APP_NAME: rn${{ matrix.framework-version.formatted }}${{ matrix.build-tool }}${{ matrix.build-tool-version }}${{ matrix.platform }}ui${{ inputs.dist-tag }}
-      EMULATOR_PORT: 5554
       GRADLE_OPTS: '-Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000'
     steps:
       - name: Checkout Amplify UI
@@ -49,49 +51,12 @@ jobs:
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
-      - name: Restore CocoaPods cache
-        if: ${{ matrix.platform == 'ios' }}
-        id: restore-cocoapods-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./examples/react-native/ios/Pods
-          key: ${{ runner.os }}-cocoapods
-          restore-keys: pods-${{ hashFiles('examples/react-native/ios/Podfile.lock') }}
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
-
-      - name: Restore node_modules cache
-        if: ${{ matrix.platform == 'ios' }}
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        id: restore-cache
-        with:
-          path: |
-            ./node_modules
-            **/node_modules
-          key: ${{ runner.os }}-node24-nodemodules
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
-
       - name: Install Java 17
         if: ${{ matrix.platform == 'android' }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'corretto' # Amazon Corretto Build of OpenJDK
           java-version: '17'
-
-      - name: Cache Android SDK and emulator
-        if: ${{ matrix.platform == 'android' }}
-        id: android-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/Library/Android/sdk/system-images
-            ~/Library/Android/sdk/build-tools
-            ~/Library/Android/sdk/platform-tools
-            ~/.android/avd
-          key: ${{ runner.os }}-android-sdk-27-x86_64-snapshot-v2
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
       - name: Cache Gradle dependencies
         if: ${{ matrix.platform == 'android' }}
@@ -106,69 +71,29 @@ jobs:
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
-      - name: Install iOS simulator
-        if: ${{ matrix.platform == 'ios' }}
-        run: |
-          brew tap wix/brew
-          brew install applesimutils
-          brew install watchman
-          brew link --overwrite python@3.11
-          echo "ruby --version"
-          ruby --version
-        continue-on-error: true # brew overwrite step addresses a python install issue: https://github.com/actions/runner-images/issues/8500
-
-      - name: Update CocoaPods
-        if: ${{ matrix.platform == 'ios' }}
-        run: |
-          gem update cocoapods xcodeproj
-          yarn react-native-example ios:pod-install
-
-      - name: Install Android emulator
+      # KVM enables hardware acceleration for the Android emulator on Linux runners.
+      - name: Enable KVM
         if: ${{ matrix.platform == 'android' }}
         run: |
-          echo -e "echo \$ANDROID_HOME"
-          echo $ANDROID_HOME
-          # macOS runners have no GNU `timeout`; coreutils provides it for the emulator boot-wait guard below (mirrors reusable-e2e.yml).
-          brew install coreutils
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "build-tools;33.0.2" "platform-tools" "system-images;android-27;default;x86_64"
-          $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --name Pixel_5_API_27 --force --device "pixel_5" --abi x86_64 --package "system-images;android-27;default;x86_64"
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
-      - name: Start Android emulator (cold boot - first run)
-        if: ${{ matrix.platform == 'android' && steps.android-cache.outputs.cache-hit != 'true' }}
-        run: |
-          $ANDROID_HOME/emulator/emulator -avd Pixel_5_API_27 -port ${{ env.EMULATOR_PORT }} -no-boot-anim -no-audio -no-snapshot-load -gpu host -accel on &
-          if ! timeout 420 $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'; then
-            echo "::error::Android emulator did not reach sys.boot_completed within 420s; failing fast instead of hanging until the 6h limit"
-            $ANDROID_HOME/platform-tools/adb devices
-            exit 1
-          fi
-          $ANDROID_HOME/platform-tools/adb devices
-          # disable spell checker
-          $ANDROID_HOME/platform-tools/adb shell settings put secure spell_checker_enabled 0
-          # disable animations
-          $ANDROID_HOME/platform-tools/adb shell settings put global window_animation_scale 0.0
-          $ANDROID_HOME/platform-tools/adb shell settings put global transition_animation_scale 0.0
-          $ANDROID_HOME/platform-tools/adb shell settings put global animator_duration_scale 0.0
-          # Save snapshot for future runs
-          $ANDROID_HOME/platform-tools/adb emu avd snapshot save default_boot
-
-      - name: Start Android emulator (from snapshot - cached)
-        if: ${{ matrix.platform == 'android' && steps.android-cache.outputs.cache-hit == 'true' }}
-        run: |
-          $ANDROID_HOME/emulator/emulator -avd Pixel_5_API_27 -port ${{ env.EMULATOR_PORT }} -no-boot-anim -no-audio -snapshot default_boot -gpu host -accel on &
-          if ! timeout 420 $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'; then
-            echo "::error::Android emulator did not reach sys.boot_completed within 420s; failing fast instead of hanging until the 6h limit"
-            $ANDROID_HOME/platform-tools/adb devices
-            exit 1
-          fi
-          $ANDROID_HOME/platform-tools/adb devices
-
-      - name: Create MegaApp ${{ env.MEGA_APP_NAME }} and run build on NodeJS ${{ matrix.node-version }}
-        run: npm run setup:${{matrix.framework}}:${{matrix.build-tool}} -- --name ${{ env.MEGA_APP_NAME }} --platform ${{matrix.platform}} --tag ${{inputs.dist-tag}} --framework-version ${{matrix.framework-version.value}} --build-tool-version ${{matrix.build-tool-version}}
-        shell: bash
-        working-directory: build-system-tests
-
-      - name: Detect Mega App Error in Log
-        run: npm run checkReactNativeLogs -- --log-file-name ${{ matrix.logfile }} --mega-app-name ${{ env.MEGA_APP_NAME }} --platform ${{ matrix.platform }}
-        shell: bash
-        working-directory: build-system-tests
+      # reactivecircus/android-emulator-runner manages the SDK, AVD and emulator
+      # lifecycle and keeps the emulator alive for the duration of `script`, so the
+      # MegaApp build and log check run against a booted device. This replaces the
+      # hand-rolled emulator launch/snapshot logic that repeatedly failed on macOS.
+      - name: Build MegaApp ${{ env.MEGA_APP_NAME }} on Android emulator (NodeJS ${{ matrix.node-version }})
+        if: ${{ matrix.platform == 'android' }}
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
+        with:
+          api-level: 27
+          arch: x86_64
+          target: default
+          profile: pixel_5
+          emulator-boot-timeout: 420
+          disable-animations: true
+          script: |
+            cd build-system-tests
+            npm run setup:${{ matrix.framework }}:${{ matrix.build-tool }} -- --name ${{ env.MEGA_APP_NAME }} --platform ${{ matrix.platform }} --tag ${{ inputs.dist-tag }} --framework-version ${{ matrix.framework-version.value }} --build-tool-version ${{ matrix.build-tool-version }}
+            npm run checkReactNativeLogs -- --log-file-name ${{ matrix.logfile }} --mega-app-name ${{ env.MEGA_APP_NAME }} --platform ${{ matrix.platform }}


### PR DESCRIPTION
#### Description of changes

The scheduled **Build System Test Canary / React Native** workflow (`build-system-test-react-native.yml`) has been permanently failing on every run. All matrix jobs fail at the "Start Android emulator" step with:

```
WARNING | Device 'cache' does not have the requested snapshot 'default_boot'
WARNING | Failed to load snapshot 'default_boot'
Segmentation fault: 11  emulator ... -snapshot default_boot -gpu host -accel on
##[error]Android emulator did not reach sys.boot_completed within 420s
```

Two compounding, infrastructure-level problems on the `macos-15-intel` runner:

1. The `actions/cache` key hits but the cached AVD has no valid `default_boot` snapshot, so the "cached boot" path can never fast-boot. The snapshot re-save step is gated on a cache miss, so the broken cache stays sticky.
2. The emulator itself segfaults under `-gpu host -accel on` (Apple Software Renderer), so it never reaches `sys.boot_completed`.

The prior change (#7031) added a `timeout-minutes` + 420s boot guard so the job fails fast instead of hanging until GitHub's 6h limit. That commit explicitly called out the real fix as a follow-up:

> replace the hand-rolled emulator launch with `reactivecircus/android-emulator-runner` and move the Android matrix to `ubuntu-latest` (KVM) for reliability and speed.

This PR implements that follow-up:

- Move the job to **`ubuntu-latest`** and enable **KVM** so the emulator gets hardware acceleration.
- Replace the manual SDK install / cold-boot / snapshot plumbing with **`reactivecircus/android-emulator-runner`** (pinned to v2.37.0 SHA), which manages the SDK, AVD, and emulator lifecycle and keeps the device alive while the MegaApp build and log check run inside its `script`. Emulator config is preserved: API 27, `x86_64`, `default` target, `pixel_5` profile, 420s boot timeout, animations disabled.
- Remove the now-unused iOS-only steps (CocoaPods/node_modules cache, iOS simulator install, CocoaPods update) and the Android SDK/snapshot cache, since the matrix is Android-only and the runner is now Linux. The Gradle dependency cache is kept.

#### Issue #, if available

N/A — follow-up to #7031.

#### Description of how you validated changes

- Confirmed the failure signature and root cause from the latest scheduled runs' logs (snapshot load failure + emulator segfault).
- Validated the workflow YAML parses successfully.
- Full validation requires the scheduled/dispatched run of this reusable workflow on GitHub Actions (Linux + KVM), which cannot be exercised locally.

#### Checklist

- [x] Have read the Pull Request Guidelines
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added — N/A, CI workflow-only change
- [x] PR title and commit messages follow conventional commit syntax
- [ ] _If this change should result in a version bump_, changeset added — N/A, CI-only change (no package version bump)
