### PR TITLE
fix(build-system-tests): launch RN Android emulator via SDK CLI

### DIFF
--- a/.github/workflows/reusable-build-system-test-react-native.yml
+++ b/.github/workflows/reusable-build-system-test-react-native.yml
@@ -12,7 +12,11 @@ jobs:
   build:
     # Android builds run on ubuntu-latest so the emulator can use hardware (KVM)
     # acceleration. The previous macos-15-intel runner regularly wedged/segfaulted
-    # the hand-rolled emulator boot (see #7031).
+    # the emulator boot under `-gpu host` (see #7031).
+    #
+    # NOTE: this repo restricts GitHub Actions to an allow-list (GitHub-authored,
+    # aws-actions/*, aws-amplify/* and changesets/action), so the emulator is
+    # launched with the Android SDK CLI directly rather than a third-party action.
     runs-on: ubuntu-latest
     # Bound the whole job so a wedged emulator boot can't run until GitHub's 6h hard limit.
     timeout-minutes: 45
@@ -37,6 +41,7 @@ jobs:
 
     env:
       MEGA_APP_NAME: rn${{ matrix.framework-version.formatted }}${{ matrix.build-tool }}${{ matrix.build-tool-version }}${{ matrix.platform }}ui${{ inputs.dist-tag }}
+      EMULATOR_PORT: 5554
       GRADLE_OPTS: '-Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000'
     steps:
       - name: Checkout Amplify UI
@@ -79,21 +84,39 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # reactivecircus/android-emulator-runner manages the SDK, AVD and emulator
-      # lifecycle and keeps the emulator alive for the duration of `script`, so the
-      # MegaApp build and log check run against a booted device. This replaces the
-      # hand-rolled emulator launch/snapshot logic that repeatedly failed on macOS.
-      - name: Build MegaApp ${{ env.MEGA_APP_NAME }} on Android emulator (NodeJS ${{ matrix.node-version }})
+      - name: Install Android emulator
         if: ${{ matrix.platform == 'android' }}
-        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
-        with:
-          api-level: 27
-          arch: x86_64
-          target: default
-          profile: pixel_5
-          emulator-boot-timeout: 420
-          disable-animations: true
-          script: |
-            cd build-system-tests
-            npm run setup:${{ matrix.framework }}:${{ matrix.build-tool }} -- --name ${{ env.MEGA_APP_NAME }} --platform ${{ matrix.platform }} --tag ${{ inputs.dist-tag }} --framework-version ${{ matrix.framework-version.value }} --build-tool-version ${{ matrix.build-tool-version }}
-            npm run checkReactNativeLogs -- --log-file-name ${{ matrix.logfile }} --mega-app-name ${{ env.MEGA_APP_NAME }} --platform ${{ matrix.platform }}
+        run: |
+          echo "ANDROID_HOME=$ANDROID_HOME"
+          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "platform-tools" "emulator" "build-tools;33.0.2" "system-images;android-27;default;x86_64"
+          echo "no" | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --force --name Pixel_5_API_27 --device "pixel_5" --package "system-images;android-27;default;x86_64"
+
+      - name: Start Android emulator
+        if: ${{ matrix.platform == 'android' }}
+        run: |
+          # Headless launch with software GPU (swiftshader) + KVM; this is the
+          # reliable CI combination on Linux runners.
+          $ANDROID_HOME/emulator/emulator -avd Pixel_5_API_27 -port ${{ env.EMULATOR_PORT }} -no-window -no-boot-anim -no-audio -no-snapshot -gpu swiftshader_indirect -accel on -camera-back none &
+          if ! timeout 420 $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'; then
+            echo "::error::Android emulator did not reach sys.boot_completed within 420s; failing fast instead of hanging until the 6h limit"
+            $ANDROID_HOME/platform-tools/adb devices
+            exit 1
+          fi
+          $ANDROID_HOME/platform-tools/adb devices
+          # disable spell checker
+          $ANDROID_HOME/platform-tools/adb shell settings put secure spell_checker_enabled 0
+          # disable animations
+          $ANDROID_HOME/platform-tools/adb shell settings put global window_animation_scale 0.0
+          $ANDROID_HOME/platform-tools/adb shell settings put global transition_animation_scale 0.0
+          $ANDROID_HOME/platform-tools/adb shell settings put global animator_duration_scale 0.0
+
+      - name: Create MegaApp ${{ env.MEGA_APP_NAME }} and run build on NodeJS ${{ matrix.node-version }}
+        run: npm run setup:${{matrix.framework}}:${{matrix.build-tool}} -- --name ${{ env.MEGA_APP_NAME }} --platform ${{matrix.platform}} --tag ${{inputs.dist-tag}} --framework-version ${{matrix.framework-version.value}} --build-tool-version ${{matrix.build-tool-version}}
+        shell: bash
+        working-directory: build-system-tests
+
+      - name: Detect Mega App Error in Log
+        run: npm run checkReactNativeLogs -- --log-file-name ${{ matrix.logfile }} --mega-app-name ${{ env.MEGA_APP_NAME }} --platform ${{ matrix.platform }}
+        shell: bash
+        working-directory: build-system-tests


### PR DESCRIPTION
#### Description of changes

GitHub validates the whole called-workflow graph at startup, so any workflow referencing this reusable workflow failed with `startup_failure` before any job ran. That broke not just the canary but **`publish-next`, `publish-latest`, and `publish-hotfix`** (all `uses:` this reusable workflow) — e.g. run [28768197406](https://github.com/aws-amplify/amplify-ui/actions/runs/28768197406) died at startup, so `unit`/`e2e`/`publish` never executed.

This PR keeps the actual reliability improvement from #7039 (move to `ubuntu-latest` + KVM, which avoids the macOS `-gpu host` segfault) but boots the emulator with the **Android SDK CLI directly** — no third-party action:

- `sdkmanager` installs `platform-tools`, `emulator`, `build-tools;33.0.2`, and `system-images;android-27;default;x86_64`; `avdmanager` creates the `Pixel_5_API_27` AVD.
- The emulator launches headless with `-gpu swiftshader_indirect -accel on` (the reliable Linux CI combo), behind the same 420s fail-fast boot guard and 45-min job timeout.
- Animations/spell-check disabled after boot, matching the previous behavior and `reusable-e2e.yml`.
- The stale Android SDK/snapshot cache (a source of the original breakage) is not reintroduced; the Gradle dependency cache is kept.

`build-test-react-native` runs `needs: publish`, so it never gated the actual npm publish — removing the disallowed action is what restores the publish pipelines.

#### Issue #, if available

Fixes the `startup_failure` regression from #7039.

#### Description of how you validated changes

- Confirmed root cause from the failing run's annotation (Actions allow-list rejection) and that `publish-next/latest/hotfix` all reference this reusable workflow.
- Validated the workflow YAML parses and no longer references any non-allow-listed action.
- Full runtime validation requires a scheduled/dispatched run on GitHub Actions (Linux + KVM), which can't be exercised locally.

#### Checklist

- [x] Have read the Pull Request Guidelines
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added — N/A, CI workflow-only change
- [x] PR title and commit messages follow conventional commit syntax
- [ ] _If this change should result in a version bump_, changeset added — N/A, CI-only change
