### PR TITLE
fix(build-system-tests): create RN Android AVD reliably (pass --tag/--abi)

### DIFF
--- a/.github/workflows/build-system-test-react-native.yml
+++ b/.github/workflows/build-system-test-react-native.yml
@@ -8,6 +8,7 @@ permissions:
 on:
   schedule:
     - cron: '0 */2 * * *' # Run on the first minute of each even numbered hour
+  workflow_dispatch: # Allow manual runs (e.g. to validate emulator changes without waiting for the schedule)
 
 jobs:
   build:

--- a/.github/workflows/reusable-build-system-test-react-native.yml
+++ b/.github/workflows/reusable-build-system-test-react-native.yml
@@ -88,9 +88,19 @@ jobs:
         if: ${{ matrix.platform == 'android' }}
         run: |
           echo "ANDROID_HOME=$ANDROID_HOME"
-          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "platform-tools" "emulator" "build-tools;33.0.2" "system-images;android-27;default;x86_64"
-          echo "no" | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --force --name Pixel_5_API_27 --device "pixel_5" --package "system-images;android-27;default;x86_64"
+          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null || true
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "platform-tools" "emulator" "build-tools;33.0.2" "platforms;android-27" "system-images;android-27;default;x86_64"
+          # `--tag` and `--abi` must be passed explicitly: without them avdmanager
+          # prints "Auto-selecting single ABI" and exits 0 WITHOUT creating the AVD.
+          echo "no" | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager --verbose create avd --force --name Pixel_5_API_27 --package "system-images;android-27;default;x86_64" --tag "default" --abi "x86_64" --device "pixel_5"
+          # Fail fast (instead of waiting 420s for a boot that can't happen) if the AVD was not created.
+          echo "Available AVDs:"
+          $ANDROID_HOME/emulator/emulator -list-avds
+          if ! $ANDROID_HOME/emulator/emulator -list-avds | grep -qx "Pixel_5_API_27"; then
+            echo "::error::AVD Pixel_5_API_27 was not created by avdmanager"
+            $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager list avd || true
+            exit 1
+          fi
 
       - name: Start Android emulator
         if: ${{ matrix.platform == 'android' }}


### PR DESCRIPTION
#### Description of changes

Follow-up to #7041. The RN Android canary now compiles and runs on `ubuntu-latest`, but the "Start Android emulator" step still failed — see run [28769725263](https://github.com/aws-amplify/amplify-ui/actions/runs/28769725263):

```
ERROR | Unknown AVD name [Pixel_5_API_27], use -list-avds to see valid list.
ERROR | HOME is defined but there is no file Pixel_5_API_27.ini in $HOME/.android/avd
##[error]Android emulator did not reach sys.boot_completed within 420s
```

Root cause: the `avdmanager create avd` command never created the AVD. Without an explicit `--tag`/`--abi`, `avdmanager` printed `Auto-selecting single ABI x86_64` and then exited **0 without creating the AVD**, so the "Install Android emulator" step went green while producing nothing. The emulator then failed instantly on an unknown AVD, and `adb wait-for-device` blocked for the full 420s before the guard fired.

Fix:

- Pass `--tag "default" --abi "x86_64"` explicitly to `avdmanager` (with `--verbose`), and put `--package` before `--device`, matching the standard CI recipe. This is what actually makes the AVD get created.
- Install `platforms;android-27` alongside the system image.
- After creation, verify with `emulator -list-avds` and **fail fast with a clear error** if `Pixel_5_API_27` is missing — so a silent no-create surfaces immediately instead of wasting 420s on an impossible boot.

No third-party actions are used (respecting the repo's Actions allow-list).

#### Issue #, if available

Follow-up to #7039 / #7041.

#### Description of how you validated changes

- Traced the exact failure from run 28769725263 logs (AVD absent; `avdmanager` exited 0 after "Auto-selecting single ABI").
- Confirmed the canary genuinely needs a booted emulator: `build-android.sh` runs `react-native log-android` + `npm run android`, which install and launch the app on a device.
- Validated the workflow YAML parses.
- Full runtime validation requires a scheduled/dispatched run on GitHub Actions (Linux + KVM), which can't be exercised locally.

#### Checklist

- [x] Have read the Pull Request Guidelines
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added — N/A, CI workflow-only change
- [x] PR title and commit messages follow conventional commit syntax
- [ ] _If this change should result in a version bump_, changeset added — N/A, CI-only change
