### PR TITLE
fix(build-system-tests): pin ANDROID_AVD_HOME so emulator finds the created AVD

### DIFF
--- a/.github/workflows/reusable-build-system-test-react-native.yml
+++ b/.github/workflows/reusable-build-system-test-react-native.yml
@@ -88,6 +88,13 @@ jobs:
         if: ${{ matrix.platform == 'android' }}
         run: |
           echo "ANDROID_HOME=$ANDROID_HOME"
+          # The new avdmanager writes AVDs to $HOME/.config/.android/avd, but the
+          # emulator looks in $ANDROID_AVD_HOME (default $HOME/.android/avd). Pin both
+          # tools to the same directory so the created AVD is actually found, and
+          # persist it via $GITHUB_ENV so the "Start Android emulator" step agrees.
+          export ANDROID_AVD_HOME="$HOME/.android/avd"
+          echo "ANDROID_AVD_HOME=$ANDROID_AVD_HOME" >> "$GITHUB_ENV"
+          mkdir -p "$ANDROID_AVD_HOME"
           yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null || true
           $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "platform-tools" "emulator" "build-tools;33.0.2" "platforms;android-27" "system-images;android-27;default;x86_64"
           # `--tag` and `--abi` must be passed explicitly: without them avdmanager


### PR DESCRIPTION
#### Description of changes

Follow-up to #7042. A manual `workflow_dispatch` run ([28773192990](https://github.com/aws-amplify/amplify-ui/actions/runs/28773192990/job/85311200279)) confirmed the `--tag/--abi` fix works — the AVD now gets created — but the emulator still couldn't find it. The fail-fast check I added surfaced it in ~50s, and `avdmanager list avd` revealed the real problem, a path mismatch:

```
Available AVDs:            # emulator -list-avds → empty
##[error]AVD Pixel_5_API_27 was not created by avdmanager
  Path: /home/runner/.config/.android/avd/Pixel_5_API_27.avd   # avdmanager DID create it here
  Based on: Android 8.1 ("Oreo") Tag/ABI: default/x86_64
```

The modern `avdmanager` writes AVDs to `$HOME/.config/.android/avd`, but the emulator (and `emulator -list-avds`) looks in `$ANDROID_AVD_HOME`, defaulting to `$HOME/.android/avd`. The two tools disagree on the location, so the freshly-created AVD is invisible to the emulator.

Fix: pin `ANDROID_AVD_HOME` to a single directory (`$HOME/.android/avd`), `mkdir -p` it, and persist it via `$GITHUB_ENV` so the later "Start Android emulator" step uses the same location. Both tools now agree.

No third-party actions are used (respecting the repo's Actions allow-list).

#### Issue #, if available

Follow-up to #7039 / #7041 / #7042.

#### Description of how you validated changes

- Root cause taken directly from the dispatched run's logs (AVD created under `~/.config/.android/avd`, emulator searching `~/.android/avd`).
- Validated the workflow YAML parses.
- Can be validated end-to-end via the `workflow_dispatch` trigger (added in #7042) once merged, without waiting for the 2-hourly schedule.

#### Checklist

- [x] Have read the Pull Request Guidelines
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added — N/A, CI workflow-only change
- [x] PR title and commit messages follow conventional commit syntax
- [ ] _If this change should result in a version bump_, changeset added — N/A, CI-only change
