### PR TITLE
feat(storage): service worker streaming zip download

### DIFF
--- a/.changeset/sw-streaming-download.md
+++ b/.changeset/sw-streaming-download.md
@@ -1,0 +1,12 @@
+---
+'@aws-amplify/ui-react-storage': minor
+---
+
+feat(storage): service worker streaming zip download
+
+Replace the in-memory blob-based zip download with a service worker streaming
+architecture for `StorageBrowser` multi-file downloads. Files are streamed
+sequentially into a zip archive delivered via a service worker, removing the
+memory ceiling of the previous blob approach. Falls back to blob collection
+when the service worker is unavailable (unsupported browser, missing file, or
+insecure context).

--- a/.changeset/sw-streaming-download.md
+++ b/.changeset/sw-streaming-download.md
@@ -10,3 +10,9 @@ sequentially into a zip archive delivered via a service worker, removing the
 memory ceiling of the previous blob approach. Falls back to blob collection
 when the service worker is unavailable (unsupported browser, missing file, or
 insecure context).
+
+Note: per-file progress is now reported download-only by design — it reflects
+bytes read from S3, not zip finalization. Because entries are stored without
+compression (`level: 0`), the write/finalization phase is near-instant, so
+progress transitions directly from downloading to complete without a separate
+"zipping"/finishing phase.

--- a/.github/workflows/reusable-build-system-test-react-native.yml
+++ b/.github/workflows/reusable-build-system-test-react-native.yml
@@ -10,7 +10,16 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15-intel
+    # Android builds run on ubuntu-latest so the emulator can use hardware (KVM)
+    # acceleration. The previous macos-15-intel runner regularly wedged/segfaulted
+    # the emulator boot under `-gpu host` (see #7031).
+    #
+    # NOTE: this repo restricts GitHub Actions to an allow-list (GitHub-authored,
+    # aws-actions/*, aws-amplify/* and changesets/action), so the emulator is
+    # launched with the Android SDK CLI directly rather than a third-party action.
+    runs-on: ubuntu-latest
+    # Bound the whole job so a wedged emulator boot can't run until GitHub's 6h hard limit.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -47,49 +56,12 @@ jobs:
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
-      - name: Restore CocoaPods cache
-        if: ${{ matrix.platform == 'ios' }}
-        id: restore-cocoapods-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./examples/react-native/ios/Pods
-          key: ${{ runner.os }}-cocoapods
-          restore-keys: pods-${{ hashFiles('examples/react-native/ios/Podfile.lock') }}
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
-
-      - name: Restore node_modules cache
-        if: ${{ matrix.platform == 'ios' }}
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        id: restore-cache
-        with:
-          path: |
-            ./node_modules
-            **/node_modules
-          key: ${{ runner.os }}-node24-nodemodules
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
-
       - name: Install Java 17
         if: ${{ matrix.platform == 'android' }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'corretto' # Amazon Corretto Build of OpenJDK
           java-version: '17'
-
-      - name: Cache Android SDK and emulator
-        if: ${{ matrix.platform == 'android' }}
-        id: android-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/Library/Android/sdk/system-images
-            ~/Library/Android/sdk/build-tools
-            ~/Library/Android/sdk/platform-tools
-            ~/.android/avd
-          key: ${{ runner.os }}-android-sdk-27-x86_64-snapshot-v1
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
       - name: Cache Gradle dependencies
         if: ${{ matrix.platform == 'android' }}
@@ -104,36 +76,50 @@ jobs:
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
-      - name: Install iOS simulator
-        if: ${{ matrix.platform == 'ios' }}
+      # KVM enables hardware acceleration for the Android emulator on Linux runners.
+      - name: Enable KVM
+        if: ${{ matrix.platform == 'android' }}
         run: |
-          brew tap wix/brew
-          brew install applesimutils
-          brew install watchman
-          brew link --overwrite python@3.11
-          echo "ruby --version"
-          ruby --version
-        continue-on-error: true # brew overwrite step addresses a python install issue: https://github.com/actions/runner-images/issues/8500
-
-      - name: Update CocoaPods
-        if: ${{ matrix.platform == 'ios' }}
-        run: |
-          gem update cocoapods xcodeproj
-          yarn react-native-example ios:pod-install
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Install Android emulator
         if: ${{ matrix.platform == 'android' }}
         run: |
-          echo -e "echo \$ANDROID_HOME"
-          echo $ANDROID_HOME
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "build-tools;33.0.2" "platform-tools" "system-images;android-27;default;x86_64"
-          $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --name Pixel_5_API_27 --force --device "pixel_5" --abi x86_64 --package "system-images;android-27;default;x86_64"
+          echo "ANDROID_HOME=$ANDROID_HOME"
+          # The new avdmanager writes AVDs to $HOME/.config/.android/avd, but the
+          # emulator looks in $ANDROID_AVD_HOME (default $HOME/.android/avd). Pin both
+          # tools to the same directory so the created AVD is actually found, and
+          # persist it via $GITHUB_ENV so the "Start Android emulator" step agrees.
+          export ANDROID_AVD_HOME="$HOME/.android/avd"
+          echo "ANDROID_AVD_HOME=$ANDROID_AVD_HOME" >> "$GITHUB_ENV"
+          mkdir -p "$ANDROID_AVD_HOME"
+          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null || true
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "platform-tools" "emulator" "build-tools;33.0.2" "platforms;android-27" "system-images;android-27;default;x86_64"
+          # `--tag` and `--abi` must be passed explicitly: without them avdmanager
+          # prints "Auto-selecting single ABI" and exits 0 WITHOUT creating the AVD.
+          echo "no" | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager --verbose create avd --force --name Pixel_5_API_27 --package "system-images;android-27;default;x86_64" --tag "default" --abi "x86_64" --device "pixel_5"
+          # Fail fast (instead of waiting 420s for a boot that can't happen) if the AVD was not created.
+          echo "Available AVDs:"
+          $ANDROID_HOME/emulator/emulator -list-avds
+          if ! $ANDROID_HOME/emulator/emulator -list-avds | grep -qx "Pixel_5_API_27"; then
+            echo "::error::AVD Pixel_5_API_27 was not created by avdmanager"
+            $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager list avd || true
+            exit 1
+          fi
 
-      - name: Start Android emulator (cold boot - first run)
-        if: ${{ matrix.platform == 'android' && steps.android-cache.outputs.cache-hit != 'true' }}
+      - name: Start Android emulator
+        if: ${{ matrix.platform == 'android' }}
         run: |
-          $ANDROID_HOME/emulator/emulator -avd Pixel_5_API_27 -port ${{ env.EMULATOR_PORT }} -no-boot-anim -no-audio -no-snapshot-load -gpu host -accel on &
-          $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
+          # Headless launch with software GPU (swiftshader) + KVM; this is the
+          # reliable CI combination on Linux runners.
+          $ANDROID_HOME/emulator/emulator -avd Pixel_5_API_27 -port ${{ env.EMULATOR_PORT }} -no-window -no-boot-anim -no-audio -no-snapshot -gpu swiftshader_indirect -accel on -camera-back none &
+          if ! timeout 420 $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'; then
+            echo "::error::Android emulator did not reach sys.boot_completed within 420s; failing fast instead of hanging until the 6h limit"
+            $ANDROID_HOME/platform-tools/adb devices
+            exit 1
+          fi
           $ANDROID_HOME/platform-tools/adb devices
           # disable spell checker
           $ANDROID_HOME/platform-tools/adb shell settings put secure spell_checker_enabled 0
@@ -141,15 +127,6 @@ jobs:
           $ANDROID_HOME/platform-tools/adb shell settings put global window_animation_scale 0.0
           $ANDROID_HOME/platform-tools/adb shell settings put global transition_animation_scale 0.0
           $ANDROID_HOME/platform-tools/adb shell settings put global animator_duration_scale 0.0
-          # Save snapshot for future runs
-          $ANDROID_HOME/platform-tools/adb emu avd snapshot save default_boot
-
-      - name: Start Android emulator (from snapshot - cached)
-        if: ${{ matrix.platform == 'android' && steps.android-cache.outputs.cache-hit == 'true' }}
-        run: |
-          $ANDROID_HOME/emulator/emulator -avd Pixel_5_API_27 -port ${{ env.EMULATOR_PORT }} -no-boot-anim -no-audio -snapshot default_boot -gpu host -accel on &
-          $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
-          $ANDROID_HOME/platform-tools/adb devices
 
       - name: Create MegaApp ${{ env.MEGA_APP_NAME }} and run build on NodeJS ${{ matrix.node-version }}
         run: npm run setup:${{matrix.framework}}:${{matrix.build-tool}} -- --name ${{ env.MEGA_APP_NAME }} --platform ${{matrix.platform}} --tag ${{inputs.dist-tag}} --framework-version ${{matrix.framework-version.value}} --build-tool-version ${{matrix.build-tool-version}}

--- a/.github/workflows/reusable-build-system-test-react-native.yml
+++ b/.github/workflows/reusable-build-system-test-react-native.yml
@@ -10,16 +10,7 @@ on:
 
 jobs:
   build:
-    # Android builds run on ubuntu-latest so the emulator can use hardware (KVM)
-    # acceleration. The previous macos-15-intel runner regularly wedged/segfaulted
-    # the emulator boot under `-gpu host` (see #7031).
-    #
-    # NOTE: this repo restricts GitHub Actions to an allow-list (GitHub-authored,
-    # aws-actions/*, aws-amplify/* and changesets/action), so the emulator is
-    # launched with the Android SDK CLI directly rather than a third-party action.
-    runs-on: ubuntu-latest
-    # Bound the whole job so a wedged emulator boot can't run until GitHub's 6h hard limit.
-    timeout-minutes: 45
+    runs-on: macos-15-intel
     strategy:
       fail-fast: false
       matrix:
@@ -56,12 +47,49 @@ jobs:
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
+      - name: Restore CocoaPods cache
+        if: ${{ matrix.platform == 'ios' }}
+        id: restore-cocoapods-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ./examples/react-native/ios/Pods
+          key: ${{ runner.os }}-cocoapods
+          restore-keys: pods-${{ hashFiles('examples/react-native/ios/Podfile.lock') }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+
+      - name: Restore node_modules cache
+        if: ${{ matrix.platform == 'ios' }}
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: restore-cache
+        with:
+          path: |
+            ./node_modules
+            **/node_modules
+          key: ${{ runner.os }}-node24-nodemodules
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
       - name: Install Java 17
         if: ${{ matrix.platform == 'android' }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'corretto' # Amazon Corretto Build of OpenJDK
           java-version: '17'
+
+      - name: Cache Android SDK and emulator
+        if: ${{ matrix.platform == 'android' }}
+        id: android-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/Library/Android/sdk/system-images
+            ~/Library/Android/sdk/build-tools
+            ~/Library/Android/sdk/platform-tools
+            ~/.android/avd
+          key: ${{ runner.os }}-android-sdk-27-x86_64-snapshot-v1
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
       - name: Cache Gradle dependencies
         if: ${{ matrix.platform == 'android' }}
@@ -76,50 +104,36 @@ jobs:
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
 
-      # KVM enables hardware acceleration for the Android emulator on Linux runners.
-      - name: Enable KVM
-        if: ${{ matrix.platform == 'android' }}
+      - name: Install iOS simulator
+        if: ${{ matrix.platform == 'ios' }}
         run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+          brew tap wix/brew
+          brew install applesimutils
+          brew install watchman
+          brew link --overwrite python@3.11
+          echo "ruby --version"
+          ruby --version
+        continue-on-error: true # brew overwrite step addresses a python install issue: https://github.com/actions/runner-images/issues/8500
+
+      - name: Update CocoaPods
+        if: ${{ matrix.platform == 'ios' }}
+        run: |
+          gem update cocoapods xcodeproj
+          yarn react-native-example ios:pod-install
 
       - name: Install Android emulator
         if: ${{ matrix.platform == 'android' }}
         run: |
-          echo "ANDROID_HOME=$ANDROID_HOME"
-          # The new avdmanager writes AVDs to $HOME/.config/.android/avd, but the
-          # emulator looks in $ANDROID_AVD_HOME (default $HOME/.android/avd). Pin both
-          # tools to the same directory so the created AVD is actually found, and
-          # persist it via $GITHUB_ENV so the "Start Android emulator" step agrees.
-          export ANDROID_AVD_HOME="$HOME/.android/avd"
-          echo "ANDROID_AVD_HOME=$ANDROID_AVD_HOME" >> "$GITHUB_ENV"
-          mkdir -p "$ANDROID_AVD_HOME"
-          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null || true
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "platform-tools" "emulator" "build-tools;33.0.2" "platforms;android-27" "system-images;android-27;default;x86_64"
-          # `--tag` and `--abi` must be passed explicitly: without them avdmanager
-          # prints "Auto-selecting single ABI" and exits 0 WITHOUT creating the AVD.
-          echo "no" | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager --verbose create avd --force --name Pixel_5_API_27 --package "system-images;android-27;default;x86_64" --tag "default" --abi "x86_64" --device "pixel_5"
-          # Fail fast (instead of waiting 420s for a boot that can't happen) if the AVD was not created.
-          echo "Available AVDs:"
-          $ANDROID_HOME/emulator/emulator -list-avds
-          if ! $ANDROID_HOME/emulator/emulator -list-avds | grep -qx "Pixel_5_API_27"; then
-            echo "::error::AVD Pixel_5_API_27 was not created by avdmanager"
-            $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager list avd || true
-            exit 1
-          fi
+          echo -e "echo \$ANDROID_HOME"
+          echo $ANDROID_HOME
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "build-tools;33.0.2" "platform-tools" "system-images;android-27;default;x86_64"
+          $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --name Pixel_5_API_27 --force --device "pixel_5" --abi x86_64 --package "system-images;android-27;default;x86_64"
 
-      - name: Start Android emulator
-        if: ${{ matrix.platform == 'android' }}
+      - name: Start Android emulator (cold boot - first run)
+        if: ${{ matrix.platform == 'android' && steps.android-cache.outputs.cache-hit != 'true' }}
         run: |
-          # Headless launch with software GPU (swiftshader) + KVM; this is the
-          # reliable CI combination on Linux runners.
-          $ANDROID_HOME/emulator/emulator -avd Pixel_5_API_27 -port ${{ env.EMULATOR_PORT }} -no-window -no-boot-anim -no-audio -no-snapshot -gpu swiftshader_indirect -accel on -camera-back none &
-          if ! timeout 420 $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'; then
-            echo "::error::Android emulator did not reach sys.boot_completed within 420s; failing fast instead of hanging until the 6h limit"
-            $ANDROID_HOME/platform-tools/adb devices
-            exit 1
-          fi
+          $ANDROID_HOME/emulator/emulator -avd Pixel_5_API_27 -port ${{ env.EMULATOR_PORT }} -no-boot-anim -no-audio -no-snapshot-load -gpu host -accel on &
+          $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
           $ANDROID_HOME/platform-tools/adb devices
           # disable spell checker
           $ANDROID_HOME/platform-tools/adb shell settings put secure spell_checker_enabled 0
@@ -127,6 +141,15 @@ jobs:
           $ANDROID_HOME/platform-tools/adb shell settings put global window_animation_scale 0.0
           $ANDROID_HOME/platform-tools/adb shell settings put global transition_animation_scale 0.0
           $ANDROID_HOME/platform-tools/adb shell settings put global animator_duration_scale 0.0
+          # Save snapshot for future runs
+          $ANDROID_HOME/platform-tools/adb emu avd snapshot save default_boot
+
+      - name: Start Android emulator (from snapshot - cached)
+        if: ${{ matrix.platform == 'android' && steps.android-cache.outputs.cache-hit == 'true' }}
+        run: |
+          $ANDROID_HOME/emulator/emulator -avd Pixel_5_API_27 -port ${{ env.EMULATOR_PORT }} -no-boot-anim -no-audio -snapshot default_boot -gpu host -accel on &
+          $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
+          $ANDROID_HOME/platform-tools/adb devices
 
       - name: Create MegaApp ${{ env.MEGA_APP_NAME }} and run build on NodeJS ${{ matrix.node-version }}
         run: npm run setup:${{matrix.framework}}:${{matrix.build-tool}} -- --name ${{ env.MEGA_APP_NAME }} --platform ${{matrix.platform}} --tag ${{inputs.dist-tag}} --framework-version ${{matrix.framework-version.value}} --build-tool-version ${{matrix.build-tool-version}}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ coverage/
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+*.tgz

--- a/docs/src/pages/[platform]/connected-components/storage/storage-browser/react.mdx
+++ b/docs/src/pages/[platform]/connected-components/storage/storage-browser/react.mdx
@@ -283,6 +283,79 @@ interface Config {
 </ExampleCode>
 </Example>
 
+### Download Service Worker
+
+The `StorageBrowser` component uses a [Service Worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) to enable streaming zip downloads for multi-file selections. This allows downloading large batches of files without memory limitations, as the zip is streamed directly to disk rather than being assembled in memory.
+
+#### Setup
+
+The service worker file must be served from your application's public directory. The `@aws-amplify/ui-react-storage` package includes a CLI tool to copy it for you:
+
+<Example>
+<ExampleCode>
+```bash
+npx @aws-amplify/ui-react-storage copy-serviceworker public
+```
+</ExampleCode>
+</Example>
+
+This copies `download-sw.js` into `<target>/amplify-storage-download/download-sw.js`, making it available under the service worker's scope path.
+
+#### Framework setup
+
+**Next.js / Vite / Create React App:**
+
+Run the copy command once after installing the package. The file will be served automatically from the `public/` folder.
+
+**Amplify Hosting (amplify.yml):**
+
+Add the copy step to your build spec so the service worker is available on every deploy:
+
+<Example>
+<ExampleCode>
+```yaml
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npx @aws-amplify/ui-react-storage copy-serviceworker public
+    build:
+      commands:
+        - npm run build
+```
+</ExampleCode>
+</Example>
+
+**npm scripts (recommended):**
+
+Add it to your `postinstall` or `prebuild` script so it stays up to date automatically:
+
+<Example>
+<ExampleCode>
+```json
+{
+  "scripts": {
+    "prebuild": "npx @aws-amplify/ui-react-storage copy-serviceworker public"
+  }
+}
+```
+</ExampleCode>
+</Example>
+
+#### How it works
+
+When a user downloads multiple files, the `StorageBrowser` component:
+
+1. Registers the service worker at `/amplify-storage-download/download-sw.js` with scope `/amplify-storage-download/`
+2. Streams each file from S3 into a zip archive
+3. Delivers the zip via the service worker, enabling streaming to disk without size limits
+
+If the service worker is not available (e.g., unsupported browser, missing file, or insecure context), the component automatically falls back to an in-memory blob-based download.
+
+<Message colorTheme="info" variation="filled" heading="Service Worker scope">
+The service worker is registered with scope `/amplify-storage-download/`. It only intercepts requests within this scope and does not affect other parts of your application.
+</Message>
+
 ## Customization
 
 ### Pagination

--- a/packages/react-storage/bin/copy-serviceworker.js
+++ b/packages/react-storage/bin/copy-serviceworker.js
@@ -27,9 +27,9 @@ if (!fs.existsSync(SW_SOURCE)) {
 
 const resolvedTarget = path.resolve(targetDir, 'amplify-storage-download');
 
-if (!fs.existsSync(resolvedTarget)) {
-  fs.mkdirSync(resolvedTarget, { recursive: true });
-}
+// `recursive: true` is a no-op when the directory already exists, so no
+// existence check is needed (and skipping it avoids a TOCTOU window).
+fs.mkdirSync(resolvedTarget, { recursive: true });
 
 const dest = path.join(resolvedTarget, SW_FILENAME);
 fs.copyFileSync(SW_SOURCE, dest);

--- a/packages/react-storage/bin/copy-serviceworker.js
+++ b/packages/react-storage/bin/copy-serviceworker.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const SW_FILENAME = 'download-sw.js';
+const SW_SOURCE = path.resolve(__dirname, '..', 'dist', SW_FILENAME);
+
+const targetDir = process.argv[2];
+
+if (!targetDir) {
+  console.error(
+    'Usage: npx @aws-amplify/ui-react-storage copy-serviceworker <target-dir>\n' +
+      'Example: npx @aws-amplify/ui-react-storage copy-serviceworker public'
+  );
+  process.exit(1);
+}
+
+if (!fs.existsSync(SW_SOURCE)) {
+  console.error(
+    `Error: Service worker source not found at ${SW_SOURCE}\n` +
+      'Make sure the package is properly installed.'
+  );
+  process.exit(1);
+}
+
+const resolvedTarget = path.resolve(targetDir, 'amplify-storage-download');
+
+if (!fs.existsSync(resolvedTarget)) {
+  fs.mkdirSync(resolvedTarget, { recursive: true });
+}
+
+const dest = path.join(resolvedTarget, SW_FILENAME);
+fs.copyFileSync(SW_SOURCE, dest);
+console.log(`✅ Copied ${SW_FILENAME} → ${dest}`);

--- a/packages/react-storage/eslint.config.js
+++ b/packages/react-storage/eslint.config.js
@@ -32,6 +32,8 @@ module.exports = defineConfig([
     '**/coverage',
     '**/dist',
     '**/node_modules',
+    '**/service-worker',
+    '**/bin',
   ]),
   {
     extends: compat.extends('@aws-amplify/amplify-ui/jest'),

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -73,7 +73,7 @@
       "name": "createStorageBrowser",
       "path": "dist/esm/browser.mjs",
       "import": "{ createStorageBrowser }",
-      "limit": "130 kB",
+      "limit": "131 kB",
       "ignore": [
         "@aws-amplify/storage"
       ]

--- a/packages/react-storage/package.json
+++ b/packages/react-storage/package.json
@@ -20,6 +20,9 @@
     "./styles.css": "./dist/styles.css"
   },
   "types": "dist/types/index.d.ts",
+  "bin": {
+    "copy-serviceworker": "./bin/copy-serviceworker.js"
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -28,6 +31,7 @@
   },
   "files": [
     "dist",
+    "bin",
     "LICENSE",
     "browser"
   ],
@@ -43,7 +47,7 @@
     "size": "yarn size-limit",
     "test": "jest",
     "test:watch": "yarn test --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc --project tsconfig.sw.json --noEmit"
   },
   "dependencies": {
     "@aws-amplify/ui": "6.15.4",

--- a/packages/react-storage/rollup.config.mjs
+++ b/packages/react-storage/rollup.config.mjs
@@ -62,6 +62,21 @@ const config = defineConfig([
     },
     plugins: [styles({ mode: ['extract'] })],
   },
+  // Service Worker — standalone IIFE, no externals, self-contained
+  {
+    input: 'src/components/StorageBrowser/service-worker/download-sw.ts',
+    output: {
+      file: 'dist/download-sw.js',
+      format: 'iife',
+    },
+    plugins: [
+      typescript({
+        declaration: false,
+        sourceMap: false,
+        tsconfig: 'tsconfig.sw.json',
+      }),
+    ],
+  },
 ]);
 
 export default config;

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/zipdownload.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/zipdownload.spec.ts
@@ -328,6 +328,40 @@ describe('zipDownloadHandler', () => {
     expect((globalThis.fetch as jest.Mock).mock.calls.length).toBe(1);
   });
 
+  it('does not resurrect the download when cancelled via the UI cancel button', async () => {
+    // Regression for the cancel-resurrection bug: cancel() must NOT delete the
+    // batch entry synchronously, otherwise the next queued file (concurrency: 1)
+    // builds a fresh batch and downloads files 2..N into a new zip.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ZipWriter } = require('@zip.js/zip.js');
+    (ZipWriter as jest.Mock).mockClear();
+
+    const file1 = { id: 'c1', key: 'prefix/file-1', fileKey: 'file-1' };
+    const file2 = { id: 'c2', key: 'prefix/file-2', fileKey: 'file-2' };
+    const all = [file1, file2];
+    const base = createBaseInput();
+
+    // Start file 1, then immediately hit the UI cancel button
+    const r1 = zipDownloadHandler({ ...base, data: file1, all });
+    r1.cancel!();
+    expect(await r1.result).toEqual({
+      status: 'CANCELED',
+      message: 'Download cancelled',
+    });
+
+    // File 2 is re-dispatched with the same `all`; it must take the cancelled
+    // early-exit rather than building a new batch.
+    const r2 = zipDownloadHandler({ ...base, data: file2, all });
+    expect(await r2.result).toEqual({
+      status: 'CANCELED',
+      message: 'Download cancelled',
+    });
+
+    // Exactly ONE batch (one ZipWriter) was constructed across both files —
+    // proving file 2 did not resurrect the download.
+    expect((ZipWriter as jest.Mock).mock.calls.length).toBe(1);
+  });
+
   describe('getFolderName logic', () => {
     it('uses parent folder name for nested keys', async () => {
       const input = createBaseInput();

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/zipdownload.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/zipdownload.spec.ts
@@ -292,22 +292,40 @@ describe('zipDownloadHandler', () => {
     expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:revoke-test');
   });
 
-  it('returns cancel function in early-exit cancelled path', () => {
-    // Simulate a cancelled batch by first starting a download, then cancelling,
-    // then calling handler again with the same `all` array
-    const input = createBaseInput();
-    const first = zipDownloadHandler(input);
+  it('takes the early-exit cancelled path for remaining files after a cancel', async () => {
+    // A multi-file batch keeps its state in `batchMap` until the final file
+    // settles. If an earlier file is cancelled, subsequent files must hit the
+    // `existingBatch.cancelled` early-exit branch and return CANCELED with a
+    // (noop) cancel function rather than starting a fresh batch/download.
+    const abortErr = new Error('The user aborted a request.');
+    abortErr.name = 'AbortError';
+    (globalThis.fetch as jest.Mock).mockRejectedValueOnce(abortErr);
 
-    // Cancel the batch
-    first.cancel!();
+    const file1 = { id: 'id1', key: 'prefix/file-1', fileKey: 'file-1' };
+    const file2 = { id: 'id2', key: 'prefix/file-2', fileKey: 'file-2' };
+    const all = [file1, file2];
+    const base = createBaseInput();
 
-    // Now call handler again with same `all` — should hit cancelled path
-    // Since batch is reset on cancel, calling with same `all` starts fresh
-    // To properly test the early-exit, we need to have a batch that's cancelled but not reset
-    // This happens when the abort fires but the handler is called again for remaining files.
-    // With concurrency=1 this is edge-case but we validate the return shape.
-    expect(first.cancel).toBeDefined();
-    expect(typeof first.cancel).toBe('function');
+    // File 1 — fetch rejects with AbortError → batch flagged cancelled (not reset)
+    const r1 = zipDownloadHandler({ ...base, data: file1, all });
+    expect(await r1.result).toEqual({
+      status: 'CANCELED',
+      message: 'Download cancelled',
+    });
+
+    // File 2 — same `all`; batch is still present and cancelled → early-exit branch
+    const r2 = zipDownloadHandler({ ...base, data: file2, all });
+    expect(r2.cancel).toBeDefined();
+    expect(typeof r2.cancel).toBe('function');
+    // The noop cancel on the early-exit path must not throw
+    expect(() => r2.cancel!()).not.toThrow();
+    expect(await r2.result).toEqual({
+      status: 'CANCELED',
+      message: 'Download cancelled',
+    });
+
+    // File 2 was never fetched (only the file-1 rejection was consumed)
+    expect((globalThis.fetch as jest.Mock).mock.calls.length).toBe(1);
   });
 
   describe('getFolderName logic', () => {
@@ -345,6 +363,23 @@ describe('zipDownloadHandler', () => {
       await flushAsync();
 
       expect(mockAnchor.download).toBe('photos.zip');
+    });
+
+    it('preserves spaces and URL-unsafe characters in the folder name', async () => {
+      // Regression guard: folder names with spaces (common in S3 prefixes) must
+      // survive into the download name. The SW round-trips the id through
+      // encode/decode so the stream lookup still matches (see download-sw.spec).
+      const input = createBaseInput();
+      input.data.key = 'my photos/vacation 2026/beach.jpg';
+      input.all = [
+        { ...input.all[0], key: 'my photos/vacation 2026/beach.jpg' },
+      ];
+
+      const { result } = zipDownloadHandler(input);
+      await result;
+      await flushAsync();
+
+      expect(mockAnchor.download).toBe('vacation 2026.zip');
     });
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/zipdownload.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/zipdownload.spec.ts
@@ -1,32 +1,105 @@
-import { getUrl, GetUrlInput } from '../../../storage-internal';
+import { TextEncoder, TextDecoder } from 'util';
+import {
+  ReadableStream,
+  WritableStream,
+  TransformStream,
+} from 'node:stream/web';
 
+// jsdom doesn't provide these Web APIs
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+(globalThis as any).TextEncoder = TextEncoder;
+(globalThis as any).TextDecoder = TextDecoder;
+(globalThis as any).ReadableStream = ReadableStream;
+(globalThis as any).WritableStream = WritableStream;
+(globalThis as any).TransformStream = TransformStream;
+/* eslint-enable @typescript-eslint/no-unsafe-member-access */
+
+import { getUrl, GetUrlInput } from '../../../storage-internal';
 import { zipDownloadHandler } from '../zipdownload';
 import type { DownloadHandlerInput } from '../download';
 
 jest.mock('../../../storage-internal');
-jest.mock('@zip.js/zip.js', () => {
-  return {
-    configure: jest.fn(),
-    BlobReader: jest.fn(),
-    BlobWriter: jest.fn(),
-    ZipWriter: jest.fn().mockImplementation(() => ({
-      add: jest.fn(
-        (
-          _name: string,
-          _reader: unknown,
-          options?: { onprogress?: (progress: number, total: number) => void }
-        ) => {
-          options?.onprogress?.(50, 100);
-          options?.onprogress?.(100, 100);
-          return Promise.resolve();
-        }
-      ),
-      close: jest.fn(() => Promise.resolve(new Blob())),
-    })),
-  };
-});
 
-const baseInput: DownloadHandlerInput = {
+const mockPostMessage = jest.fn();
+
+// jsdom doesn't provide MessageChannel — mock it so SW init path works
+class MockMessageChannel {
+  port1: { onmessage: ((ev: MessageEvent) => void) | null; close: jest.Mock };
+  port2: {};
+  constructor() {
+    this.port1 = { onmessage: null, close: jest.fn() };
+    this.port2 = {};
+    // Simulate the SW responding on port1 after a microtask
+    const { port1 } = this;
+    queueMicrotask(() => {
+      if (port1.onmessage) {
+        port1.onmessage(new MessageEvent('message', { data: 'ready' }));
+      }
+    });
+  }
+}
+(
+  globalThis as unknown as { MessageChannel: typeof MockMessageChannel }
+).MessageChannel = MockMessageChannel;
+
+let mockZipWritable: WritableStream | null = null;
+
+jest.mock('@zip.js/zip.js', () => ({
+  ZipWriter: jest.fn().mockImplementation((writable: WritableStream) => {
+    mockZipWritable = writable;
+    return {
+      add: jest
+        .fn()
+        .mockImplementation((_filename: string, readable: ReadableStream) => {
+          // Consume the input readable stream to simulate zip.js reading file data
+          const reader = readable.getReader();
+          const drain = async () => {
+            for (;;) {
+              const { done } = await reader.read();
+              if (done) break;
+            }
+          };
+          return drain();
+        }),
+      close: jest.fn().mockImplementation(async () => {
+        // Write final bytes and close the writable so collectBlob finishes (blob fallback).
+        // In the SW path nothing consumes the readable so writes may hang — use try-catch.
+        try {
+          const writer = mockZipWritable!.getWriter();
+          await Promise.race([
+            (async () => {
+              await writer.write(new Uint8Array([0x50, 0x4b]));
+              await writer.close();
+            })(),
+            new Promise<void>((resolve) => setTimeout(resolve, 5)),
+          ]);
+        } catch {
+          // writable already closed/errored (e.g. SW path or cancel)
+        }
+      }),
+    };
+  }),
+}));
+
+/**
+ * Flushes pending microtasks and macrotasks.
+ * Drains the event loop by yielding execution multiple times,
+ * giving chained .then() and setTimeout(fn, 0) callbacks time to fire.
+ *
+ * This replaces brittle `for (i < 10) { await setTimeout(0) }` loops.
+ */
+const flushAsync = async (): Promise<void> => {
+  // Each setTimeout(0) yields to both the microtask queue and the macrotask queue.
+  // Multiple iterations ensure deeply-chained promises fully resolve.
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  // A slightly longer wait to catch any delayed setTimeout callbacks (e.g. the 5ms race in mock close)
+  await new Promise<void>((resolve) => setTimeout(resolve, 20));
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+};
+
+const createBaseInput = (): DownloadHandlerInput => ({
   config: {
     accountId: 'accountId',
     bucket: 'bucket',
@@ -46,93 +119,232 @@ const baseInput: DownloadHandlerInput = {
       fileKey: 'file-name',
     },
   ],
-};
+});
 
 describe('zipDownloadHandler', () => {
   const url = new URL('mock://fake.url');
   const mockGetUrl = jest.mocked(getUrl);
-  globalThis.fetch = jest.fn(() => {
-    return Promise.resolve({
-      headers: {
-        get: (header: string) => {
-          if (header === 'content-length') {
-            return 100;
-          }
-        },
-      },
-      body: {
-        getReader: () => ({
-          read: jest
-            .fn()
-            .mockResolvedValueOnce({
-              value: { length: 50 },
-              done: false,
-            })
-            .mockResolvedValue({
-              value: { length: 50 },
-              done: true,
-            }),
-        }),
-      },
-    }) as unknown as Promise<Response>;
-  });
+  let mockAnchor: { href: string; download: string; click: jest.Mock };
 
   beforeEach(() => {
     const expiresAt = new Date();
     expiresAt.setDate(expiresAt.getDate() + 1);
     mockGetUrl.mockResolvedValue({ expiresAt, url });
+
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      headers: { get: (h: string) => (h === 'content-length' ? '100' : null) },
+      body: new ReadableStream({
+        start(ctrl) {
+          ctrl.enqueue(new Uint8Array(50));
+          ctrl.enqueue(new Uint8Array(50));
+          ctrl.close();
+        },
+      }),
+    });
+
+    Object.defineProperty(globalThis, 'crypto', {
+      value: { randomUUID: () => 'test-uuid-1234' },
+      writable: true,
+      configurable: true,
+    });
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        controller: true,
+        getRegistration: jest.fn().mockResolvedValue({
+          active: { postMessage: mockPostMessage },
+        }),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    mockAnchor = { href: '', download: '', click: jest.fn() };
+    jest
+      .spyOn(document, 'createElement')
+      .mockReturnValue(mockAnchor as unknown as HTMLElement);
   });
 
-  afterEach(() => {
-    mockGetUrl.mockReset();
+  afterEach(async () => {
+    await flushAsync();
+    jest.restoreAllMocks();
+    mockPostMessage.mockReset();
   });
 
-  it('calls `getUrl` with the expected values', () => {
-    zipDownloadHandler(baseInput);
+  it('calls `getUrl` with the expected values', async () => {
+    const input = createBaseInput();
+    const { result } = zipDownloadHandler(input);
+    await result;
     const expected: GetUrlInput = {
-      path: baseInput.data.key,
+      path: input.data.key,
       options: {
         bucket: {
-          bucketName: baseInput.config.bucket,
-          region: baseInput.config.region,
+          bucketName: input.config.bucket,
+          region: input.config.region,
         },
-        customEndpoint: baseInput.config.customEndpoint,
-        locationCredentialsProvider: baseInput.config.credentials,
+        customEndpoint: input.config.customEndpoint,
+        locationCredentialsProvider: input.config.credentials,
         validateObjectExistence: true,
         contentDisposition: 'attachment',
-        expectedBucketOwner: baseInput.config.accountId,
+        expectedBucketOwner: input.config.accountId,
       },
     };
     expect(mockGetUrl).toHaveBeenCalledWith(expected);
   });
 
   it('returns a complete status', async () => {
-    const { result } = zipDownloadHandler(baseInput);
+    const input = createBaseInput();
+    const { result } = zipDownloadHandler(input);
     expect(await result).toEqual({ status: 'COMPLETE' });
   });
 
-  it('calls the progress with statuses', async () => {
+  it('calls progress callbacks correctly', async () => {
     const onProgress = jest.fn();
+    const input = createBaseInput();
     const { result } = zipDownloadHandler({
-      ...baseInput,
-      options: {
-        onProgress,
-      },
+      ...input,
+      options: { onProgress },
     });
     await result;
-    expect(onProgress).toHaveBeenCalledWith(baseInput.data, 0.5, 'PENDING');
-    expect(onProgress).toHaveBeenCalledWith(baseInput.data, 0.5, 'FINISHING');
-    expect(onProgress).toHaveBeenCalledWith(baseInput.data, 1, 'COMPLETE');
+    expect(onProgress).toHaveBeenCalledWith(input.data, 0.5, 'PENDING');
+    expect(onProgress).toHaveBeenCalledWith(input.data, 1, 'COMPLETE');
   });
 
-  it('returns failed status', async () => {
+  it('returns failed status on error', async () => {
     const error = new Error('No download');
     mockGetUrl.mockRejectedValue(error);
-    const { result } = zipDownloadHandler(baseInput);
+    const input = createBaseInput();
+    const { result } = zipDownloadHandler(input);
     expect(await result).toEqual({
       error,
       message: error.message,
       status: 'FAILED',
+    });
+  });
+
+  it('posts stream to service worker and triggers download', async () => {
+    const input = createBaseInput();
+    const { result } = zipDownloadHandler(input);
+    // result now awaits cleanup (including SW anchor click) before resolving
+    await result;
+    await flushAsync();
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ downloadId: expect.any(String) }),
+      expect.any(Array)
+    );
+    expect(mockAnchor.href).toMatch(/\/amplify-storage-download\//);
+    expect(mockAnchor.download).toBe('prefix.zip');
+    expect(mockAnchor.click).toHaveBeenCalled();
+  });
+
+  it('falls back to blob when SW unavailable', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        controller: null,
+        getRegistration: jest.fn().mockResolvedValue({ active: null }),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const mockCreateObjectURL = jest.fn(() => 'blob:mock-url');
+    const mockRevokeObjectURL = jest.fn();
+    globalThis.URL.createObjectURL = mockCreateObjectURL;
+    globalThis.URL.revokeObjectURL = mockRevokeObjectURL;
+
+    const input = createBaseInput();
+    const { result } = zipDownloadHandler(input);
+    // result now awaits cleanup completion (blob download) before resolving
+    await result;
+
+    expect(mockPostMessage).not.toHaveBeenCalled();
+    expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(mockAnchor.href).toBe('blob:mock-url');
+    expect(mockAnchor.download).toBe('prefix.zip');
+    expect(mockAnchor.click).toHaveBeenCalled();
+  });
+
+  it('revokes blob URL after fallback download', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        controller: null,
+        getRegistration: jest.fn().mockResolvedValue({ active: null }),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const mockRevokeObjectURL = jest.fn();
+    globalThis.URL.createObjectURL = jest.fn(() => 'blob:revoke-test');
+    globalThis.URL.revokeObjectURL = mockRevokeObjectURL;
+
+    const input = createBaseInput();
+    const { result } = zipDownloadHandler(input);
+    // result now awaits cleanup completion before resolving
+    await result;
+
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:revoke-test');
+  });
+
+  it('returns cancel function in early-exit cancelled path', () => {
+    // Simulate a cancelled batch by first starting a download, then cancelling,
+    // then calling handler again with the same `all` array
+    const input = createBaseInput();
+    const first = zipDownloadHandler(input);
+
+    // Cancel the batch
+    first.cancel!();
+
+    // Now call handler again with same `all` — should hit cancelled path
+    // Since batch is reset on cancel, calling with same `all` starts fresh
+    // To properly test the early-exit, we need to have a batch that's cancelled but not reset
+    // This happens when the abort fires but the handler is called again for remaining files.
+    // With concurrency=1 this is edge-case but we validate the return shape.
+    expect(first.cancel).toBeDefined();
+    expect(typeof first.cancel).toBe('function');
+  });
+
+  describe('getFolderName logic', () => {
+    it('uses parent folder name for nested keys', async () => {
+      const input = createBaseInput();
+      input.data.key = 'photos/vacation/beach.jpg';
+      input.all = [{ ...input.all[0], key: 'photos/vacation/beach.jpg' }];
+
+      const { result } = zipDownloadHandler(input);
+      await result;
+      await flushAsync();
+
+      expect(mockAnchor.download).toBe('vacation.zip');
+    });
+
+    it('uses "archive" for root-level files with no slash', async () => {
+      const input = createBaseInput();
+      input.data.key = 'file.txt';
+      input.all = [{ ...input.all[0], key: 'file.txt' }];
+
+      const { result } = zipDownloadHandler(input);
+      await result;
+      await flushAsync();
+
+      expect(mockAnchor.download).toBe('archive.zip');
+    });
+
+    it('uses first-level folder for single-level paths', async () => {
+      const input = createBaseInput();
+      input.data.key = 'photos/beach.jpg';
+      input.all = [{ ...input.all[0], key: 'photos/beach.jpg' }];
+
+      const { result } = zipDownloadHandler(input);
+      await result;
+      await flushAsync();
+
+      expect(mockAnchor.download).toBe('photos.zip');
     });
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/zipdownload.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/zipdownload.ts
@@ -132,6 +132,13 @@ const initServiceWorkerStream = (state: BatchState): void => {
   state.swReady = navigator.serviceWorker
     .getRegistration('/amplify-storage-download/')
     .then((reg) => {
+      // If the batch was cancelled while getRegistration() was pending, bail out
+      // before wiring up the MessageChannel or keepalive interval. Otherwise the
+      // interval would be created after reset() already cleared batchMap, leaking
+      // a timer with no reference to clear it.
+      if (state.cancelled) {
+        return;
+      }
       if (!reg?.active) {
         state.blobPromise = collectBlob(state.zipReadable!);
         return;
@@ -219,18 +226,14 @@ const download = async (
 
   // When the browser dismisses the download dialog, the SW response stream
   // closes → TransformStream writable errors → zipWriter.add() rejects.
-  // Distinguish stream-closure errors (cancel) from other zip.js errors (real failures).
+  // We flag cancellation from two robust signals: an explicit abort in flight
+  // (UI cancel aborts batchAbort) or a standard `AbortError` (the DOM error name
+  // zip.js surfaces when its output stream is terminated by a dialog cancel).
+  // We deliberately avoid substring-matching zip.js's internal error messages,
+  // which are not a public API contract. Any other rejection is a genuine error.
   addPromise.catch((error: unknown) => {
-    const err = error instanceof Error ? error : new Error(String(error));
-    // zip.js throws AbortError or errors the writable when the output stream
-    // is terminated. These are caused by the user dismissing the download dialog
-    // (SW path) or by our explicit abort(). Any other error is a genuine failure.
-    if (
-      err.name === 'AbortError' ||
-      err.message.includes('abort') ||
-      err.message.includes('close') ||
-      state.batchAbort.signal.aborted
-    ) {
+    const err = error instanceof Error ? error : undefined;
+    if (state.batchAbort.signal.aborted || err?.name === 'AbortError') {
       state.cancelled = true;
     }
     // Re-throw is not needed — the await below will surface the rejection.

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/zipdownload.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/zipdownload.ts
@@ -1,116 +1,188 @@
+/**
+ * Zip Download Handler
+ *
+ * Downloads multiple S3 files sequentially into a streaming zip archive,
+ * delivered via service worker (with blob fallback for browsers without SW support).
+ *
+ * State machine: IDLE → DOWNLOADING → COMPLETE | CANCELLED
+ *
+ * Batch state is scoped per download session using a WeakMap keyed by the `all`
+ * array identity (guaranteed stable per useProcessTasks invocation).
+ * This avoids module-level singleton issues if multiple StorageBrowser instances
+ * share the same module.
+ *
+ * Cancel paths:
+ * - UI cancel (onActionCancel button): cancelBatch() → aborts fetch + writable → reset
+ * - Browser-dialog cancel: SW stream closes → addPromise rejects → cancelled=true → drain remaining files
+ */
 import { getUrl } from '../../storage-internal';
-import type {
-  DownloadHandler,
-  DownloadHandlerData,
-  DownloadHandlerInput,
-} from './download';
-import type { TaskResult, TaskResultStatus } from './types';
+import type { DownloadHandler, DownloadHandlerInput } from './download';
+import type { TaskData, TaskResult, TaskResultStatus } from './types';
 import { isFunction } from '@aws-amplify/ui';
 import { getProgress } from './utils';
-import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js';
+import { ZipWriter } from '@zip.js/zip.js';
 
 type DownloadTaskResult = TaskResult<TaskResultStatus, { url: URL }>;
 
-interface MyZipper {
-  addFile: (
-    file: Blob,
-    name: string,
-    options?: {
-      data: DownloadHandlerData;
-      signal?: AbortSignal;
-      onProgress?: (
-        percent: number,
-        key: string,
-        data: DownloadHandlerData
-      ) => void;
-    }
-  ) => Promise<void>;
-  getBlobUrl: () => Promise<string>;
-  destroy: () => void;
+// ─── Batch State ───
+
+interface BatchState {
+  zipWriter: ZipWriter<unknown>;
+  zipWritable: WritableStream<Uint8Array>;
+  zipReadable: ReadableStream<Uint8Array> | null;
+  downloadId: string;
+  blobPromise: Promise<Blob> | null;
+  swReady: Promise<void>;
+  cancelled: boolean;
+  batchAbort: AbortController;
+  batchTotal: number;
+  batchDone: number;
+  keepaliveInterval: ReturnType<typeof setInterval> | null;
+  folder: string;
 }
 
-const zipper: MyZipper = (() => {
-  let blobWriter: BlobWriter | null = null;
-  let zipWriter: ZipWriter<Blob> | null = null;
+/**
+ * Batch state is keyed by a stable serialization of the file IDs in the batch.
+ * useProcessTasks recreates the `all` array on each handler call (spread + map),
+ * so we cannot rely on reference identity. Sorting IDs produces a deterministic
+ * key that remains identical across calls for the same set of files.
+ */
+const batchMap = new Map<string, BatchState>();
 
-  return {
-    addFile: async (file, name, options) => {
-      const { data, signal, onProgress } = options ?? {};
-      if (!blobWriter) {
-        blobWriter = new BlobWriter('application/zip');
-        zipWriter = new ZipWriter(blobWriter);
-      }
-      await zipWriter!.add(name, new BlobReader(file), {
-        level: 0,
-        signal,
-        onprogress: (progress: number, total: number) => {
-          if (isFunction(onProgress) && data) {
-            onProgress(progress / total, name, data);
-          }
-          return undefined;
-        },
-      });
-    },
-    getBlobUrl: async () => {
-      if (!zipWriter) {
-        throw new Error('no zip');
-      }
-      const blob = await zipWriter.close();
-      zipWriter = null;
-      blobWriter = null;
-      return URL.createObjectURL(blob);
-    },
-    destroy: () => {
-      zipWriter = null;
-      blobWriter = null;
-    },
-  };
-})();
+/** Derives a stable batch key from the task data array. */
+const getBatchKey = (all: readonly TaskData[]): string =>
+  all
+    .map((item) => item.id)
+    .sort()
+    .join('\0');
 
+/** Tears down all listeners and removes batch from map. */
+const reset = (batchKey: string, state: BatchState): void => {
+  if (state.keepaliveInterval) {
+    clearInterval(state.keepaliveInterval);
+  }
+  batchMap.delete(batchKey);
+};
+
+/** Aborts the entire batch and tears down state. Idempotent. */
+const cancelBatch = (batchKey: string): void => {
+  const state = batchMap.get(batchKey);
+  if (!state || state.cancelled) return;
+  state.cancelled = true;
+  state.batchAbort.abort();
+  // Terminate the SW response stream by aborting the writable side of the TransformStream.
+  // This errors the readable (transferred to SW), which errors the Response, failing the browser download.
+  state.zipWritable.abort('Download cancelled').catch(() => {});
+  reset(batchKey, state);
+};
+
+// ─── Utilities ───
+
+/** Extracts the S3 bucket descriptor from handler config. */
 const constructBucket = ({
   bucket: bucketName,
   region,
 }: DownloadHandlerInput['config']) => ({ bucketName, region });
 
-const readBody = async (
-  response: Response,
-  { data, options }: DownloadHandlerInput
-) => {
-  let loading = true;
-  const chunks = [];
-  const reader = response.body!.getReader();
-  const size = +(response.headers.get('content-length') ?? 0);
-  let received = 0;
-  while (loading) {
-    const { value, done } = await reader.read();
-
-    if (done) {
-      loading = false;
-    } else {
-      chunks.push(value);
-      received += value.length;
-      if (isFunction(options?.onProgress)) {
-        options?.onProgress(
-          data,
-          getProgress({
-            totalBytes: size,
-            transferredBytes: received,
-          }),
-          'PENDING'
-        );
-      }
-    }
-  }
-
-  return new Blob(chunks);
+/**
+ * Derives the zip filename from the first key's parent folder.
+ *
+ * Examples:
+ * - "photos/vacation/beach.jpg" → "vacation"
+ * - "photos/file.txt" → "photos"
+ * - "file.txt" (no slash) → "archive"
+ * - "/file.txt" (slash at index 0 only) → "archive"
+ *
+ * For root-level multi-file selections (no common parent folder), returns "archive".
+ */
+const getFolderName = (key: string): string => {
+  const lastSlash = key.lastIndexOf('/');
+  if (lastSlash <= 0) return 'archive';
+  const parentPath = key.substring(0, lastSlash);
+  return parentPath.split('/').pop() ?? 'archive';
 };
 
+/** Collects a ReadableStream into a single Blob (fallback when SW is unavailable). */
+const collectBlob = async (
+  readable: ReadableStream<Uint8Array>
+): Promise<Blob> => {
+  const reader = readable.getReader();
+  const chunks: Uint8Array[] = [];
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return new Blob(chunks, { type: 'application/zip' });
+};
+
+// ─── Service Worker Initialization ───
+
+/**
+ * Registers the SW stream transfer (MessageChannel handshake + keepalive)
+ * or falls back to in-memory blob collection when SW is unavailable.
+ * Mutates state.swReady and state.blobPromise.
+ */
+const initServiceWorkerStream = (state: BatchState): void => {
+  if (!navigator.serviceWorker) {
+    state.blobPromise = collectBlob(state.zipReadable!);
+    return;
+  }
+
+  state.swReady = navigator.serviceWorker
+    .getRegistration('/amplify-storage-download/')
+    .then((reg) => {
+      if (!reg?.active) {
+        state.blobPromise = collectBlob(state.zipReadable!);
+        return;
+      }
+
+      // Cancel detection works via addPromise.catch: when the user dismisses the
+      // download dialog, the SW response stream closes → TransformStream writable
+      // errors → zipWriter.add() rejects → cancelled flag is set.
+
+      const { port1, port2 } = new MessageChannel();
+      port1.onmessage = () => {
+        const a = document.createElement('a');
+        a.href = `/amplify-storage-download/${state.downloadId}`;
+        a.download = `${state.folder}.zip`;
+        a.click();
+        port1.close();
+      };
+      reg.active.postMessage(
+        { downloadId: state.downloadId, stream: state.zipReadable },
+        [state.zipReadable as unknown as Transferable, port2]
+      );
+      state.zipReadable = null;
+
+      // Keepalive pings run for the entire batch duration to prevent Firefox's
+      // 30s SW idle timeout from terminating the worker mid-stream.
+      state.keepaliveInterval = setInterval(() => {
+        reg.active?.postMessage({ type: 'keepalive' });
+      }, 10_000);
+    });
+};
+
+// ─── Per-file Download ───
+
+/**
+ * Downloads a single file, streams it into the zip writer entry.
+ * Receives the active batch state explicitly — throws if state is invalid.
+ */
 const download = async (
-  { config, data, all, options }: DownloadHandlerInput,
-  abortController: AbortController
+  state: BatchState,
+  { config, data, options }: DownloadHandlerInput
 ) => {
   const { customEndpoint, credentials, accountId } = config;
   const { key } = data;
+  const filename = key.split('/').pop()!;
+
+  await state.swReady;
+  if (state.cancelled) {
+    throw new Error('Download cancelled');
+  }
+
+  // Note: getUrl is a presigned URL generation call (local, fast) — not cancellable
   const { url } = await getUrl({
     path: key,
     options: {
@@ -125,82 +197,224 @@ const download = async (
 
   const response = await fetch(url, {
     mode: 'cors',
-    signal: abortController.signal,
+    signal: state.batchAbort.signal,
   });
-  const blob = await readBody(response, { config, data, all, options });
-  const [filename] = key.split('/').reverse();
-  await zipper.addFile(blob, filename, {
-    data,
-    signal: abortController.signal,
-    onProgress: (progress, _name, _data) => {
-      if (isFunction(options?.onProgress)) {
-        options?.onProgress(
-          _data,
-          progress,
-          progress === 1 ? 'COMPLETE' : 'FINISHING'
-        );
-      }
+  if (!response.body) throw new Error(`Empty response body for ${key}`);
+  const size = data.size ?? +(response.headers.get('content-length') ?? 0);
+  let transferred = 0;
+
+  // Intermediate stream decouples fetch errors from zip.js internals.
+  // Closing this stream cleanly lets zip.js finalize the entry without
+  // uncaught AbortError rejections from its codec-worker.
+  let streamController!: ReadableStreamDefaultController<Uint8Array>;
+  const fileStream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      streamController = controller;
     },
   });
+
+  // Start the zip add — returns a promise that resolves when the
+  // ReadableStream we gave it closes.
+  const addPromise = state.zipWriter.add(filename, fileStream, { level: 0 });
+
+  // When the browser dismisses the download dialog, the SW response stream
+  // closes → TransformStream writable errors → zipWriter.add() rejects.
+  // Distinguish stream-closure errors (cancel) from other zip.js errors (real failures).
+  addPromise.catch((error: unknown) => {
+    const err = error instanceof Error ? error : new Error(String(error));
+    // zip.js throws AbortError or errors the writable when the output stream
+    // is terminated. These are caused by the user dismissing the download dialog
+    // (SW path) or by our explicit abort(). Any other error is a genuine failure.
+    if (
+      err.name === 'AbortError' ||
+      err.message.includes('abort') ||
+      err.message.includes('close') ||
+      state.batchAbort.signal.aborted
+    ) {
+      state.cancelled = true;
+    }
+    // Re-throw is not needed — the await below will surface the rejection.
+  });
+
+  try {
+    const reader = response.body.getReader();
+    for (;;) {
+      if (state.cancelled) {
+        streamController.close();
+        throw new Error('Download cancelled');
+      }
+      const { value, done } = await reader.read();
+      if (done) break;
+      transferred += value.length;
+      streamController.enqueue(value);
+
+      if (size > 0 && isFunction(options?.onProgress)) {
+        options!.onProgress(
+          data,
+          getProgress({ totalBytes: size, transferredBytes: transferred }),
+          'PENDING'
+        );
+      }
+    }
+
+    // All chunks read — close the stream so zip.js finalizes the entry
+    streamController.close();
+    await addPromise;
+
+    if (isFunction(options?.onProgress)) {
+      options!.onProgress(data, 1, 'COMPLETE');
+    }
+  } catch (e) {
+    const err = e as Error;
+    try {
+      streamController.close();
+    } catch {
+      /* already closed */
+    }
+    try {
+      await Promise.race([
+        addPromise,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('addPromise timeout')), 1000)
+        ),
+      ]);
+    } catch {
+      /* swallow — zip entry incomplete */
+    }
+    throw state.cancelled || err.name === 'AbortError'
+      ? new Error('Download cancelled')
+      : err;
+  }
+
   return filename;
 };
 
-const downloadHandler = (() => {
-  const fileDownloadQueue = new Map<string, boolean>();
+// ─── Post-file Settlement ───
 
-  const handler: DownloadHandler = ({ config, data, all, options }) => {
-    const { key } = data;
-    const [, folder] = key.split('/').reverse();
-    fileDownloadQueue.set(key, false);
-    const abortController = new AbortController();
+/**
+ * Called after each file completes (success or failure).
+ * Increments progress and triggers batch cleanup when all files are settled.
+ *
+ * IMPORTANT: For the final file, this function awaits cleanup completion
+ * (zipWriter.close + blob download) before returning. This ensures the
+ * user receives the download before useProcessTasks marks the task "done"
+ * and the component can unmount.
+ */
+const onFileSettled = async (
+  batchKey: string,
+  state: BatchState,
+  taskResult: DownloadTaskResult
+): Promise<DownloadTaskResult> => {
+  state.batchDone++;
+
+  if (state.batchDone < state.batchTotal) {
+    return taskResult;
+  }
+
+  // Final file — run cleanup synchronously in this promise chain so that
+  // the task result is not returned until the download is triggered.
+  try {
+    if (!state.cancelled && state.zipWriter) {
+      await state.zipWriter.close();
+      if (state.blobPromise) {
+        const blob = await state.blobPromise;
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = `${state.folder}.zip`;
+        a.click();
+        URL.revokeObjectURL(a.href);
+      }
+    }
+  } catch {
+    // zip close failed — batch was likely cancelled
+  } finally {
+    reset(batchKey, state);
+  }
+
+  return taskResult;
+};
+
+// ─── Handler ───
+
+/** Main entry point — called once per file in a multi-select download batch. */
+export const zipDownloadHandler: DownloadHandler = ({
+  config,
+  data,
+  all,
+  options,
+}) => {
+  const { key } = data;
+  const firstKey = all[0]?.key ?? key;
+  const folder = getFolderName(firstKey);
+  const batchKey = getBatchKey(all);
+
+  const existingBatch = batchMap.get(batchKey);
+
+  // ─── STEP 1: Handle cancelled state ───
+  if (existingBatch?.cancelled) {
+    existingBatch.batchDone++;
+    const result = Promise.resolve<DownloadTaskResult>({
+      status: 'CANCELED',
+      message: 'Download cancelled',
+    });
+    if (existingBatch.batchDone >= existingBatch.batchTotal) {
+      result.finally(() => reset(batchKey, existingBatch));
+    }
     return {
+      result,
       cancel: () => {
-        abortController.abort();
-        fileDownloadQueue.set(key, true);
+        /* already cancelled — noop */
       },
-      result: download({ config, data, all, options }, abortController)
-        .then((): DownloadTaskResult => {
-          fileDownloadQueue.set(key, true);
-          return {
-            status: 'COMPLETE' as const,
-          };
-        })
-        .catch((e): DownloadTaskResult => {
-          const error = e as Error;
-          fileDownloadQueue.set(key, true);
-          return {
-            status: 'FAILED',
-            message: error.message,
-            error,
-          };
-        })
-        .finally(() => {
-          const done = all.every(({ key }) => {
-            return fileDownloadQueue.get(key);
-          });
-          if (done) {
-            zipper
-              .getBlobUrl()
-              .then((blobURL) => {
-                if (blobURL) {
-                  zipper.destroy();
-                  const anchor = document.createElement('a');
-                  const clickEvent = new MouseEvent('click');
-                  anchor.href = blobURL;
-                  anchor.download = `${folder || 'archive'}.zip`;
-                  anchor.dispatchEvent(clickEvent);
-                }
-              })
-              .catch(() => {
-                // this catch happens, when no zip was created.
-                // it is handled by the UI showing "FAILED" for all files
-              });
-          }
-        }),
     };
+  }
+
+  // ─── STEP 2: Initialize zip writer on first file ───
+  let currentBatch: BatchState;
+  if (!existingBatch) {
+    const { readable, writable } = new TransformStream<
+      Uint8Array,
+      Uint8Array
+    >();
+    currentBatch = {
+      zipWriter: new ZipWriter(writable),
+      zipWritable: writable,
+      zipReadable: readable,
+      downloadId: `${folder}-${Date.now()}.zip`,
+      blobPromise: null,
+      swReady: Promise.resolve(),
+      cancelled: false,
+      batchAbort: new AbortController(),
+      batchTotal: all.length,
+      batchDone: 0,
+      keepaliveInterval: null,
+      folder,
+    };
+
+    batchMap.set(batchKey, currentBatch);
+    initServiceWorkerStream(currentBatch);
+  } else {
+    currentBatch = existingBatch;
+  }
+
+  // ─── STEP 3: Normal download ───
+  return {
+    cancel: () => {
+      cancelBatch(batchKey);
+    },
+    result: download(currentBatch, { config, data, all, options })
+      .then((): DownloadTaskResult => ({ status: 'COMPLETE' }))
+      .catch((e): DownloadTaskResult => {
+        const err = e as Error;
+        if (
+          err.message === 'Download cancelled' ||
+          err.name === 'AbortError' ||
+          currentBatch.cancelled
+        ) {
+          currentBatch.cancelled = true;
+          return { status: 'CANCELED', message: 'Download cancelled' };
+        }
+        return { status: 'FAILED', message: err.message, error: err };
+      })
+      .then((taskResult) => onFileSettled(batchKey, currentBatch, taskResult)),
   };
-
-  return handler;
-})();
-
-export { downloadHandler as zipDownloadHandler };
+};

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/zipdownload.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/zipdownload.ts
@@ -64,7 +64,19 @@ const reset = (batchKey: string, state: BatchState): void => {
   batchMap.delete(batchKey);
 };
 
-/** Aborts the entire batch and tears down state. Idempotent. */
+/**
+ * Marks the batch cancelled and tears down the active stream, but deliberately
+ * KEEPS the batchMap entry alive. Idempotent.
+ *
+ * The `cancelled` sentinel and the map entry share one key, so deleting the
+ * entry here would erase the very flag the drain path relies on: with
+ * `concurrency: 1`, useProcessTasks re-dispatches each remaining QUEUED file to
+ * the handler on settle. If the entry were gone, those files would miss the
+ * `existingBatch.cancelled` early-exit and build a brand-new batch — resurrecting
+ * the download. Instead we leave a tombstoned entry; the remaining files hit the
+ * early-exit branch and `reset()` runs only once `batchDone === batchTotal`
+ * (in the STEP 1 early-exit or onFileSettled), for both cancel and completion.
+ */
 const cancelBatch = (batchKey: string): void => {
   const state = batchMap.get(batchKey);
   if (!state || state.cancelled) return;
@@ -73,7 +85,13 @@ const cancelBatch = (batchKey: string): void => {
   // Terminate the SW response stream by aborting the writable side of the TransformStream.
   // This errors the readable (transferred to SW), which errors the Response, failing the browser download.
   state.zipWritable.abort('Download cancelled').catch(() => {});
-  reset(batchKey, state);
+  // Stop keepalive pings immediately, but do NOT delete the map entry — the
+  // remaining queued files must still find this (cancelled) batch. The entry is
+  // removed by reset() at the final drain.
+  if (state.keepaliveInterval) {
+    clearInterval(state.keepaliveInterval);
+    state.keepaliveInterval = null;
+  }
 };
 
 // ─── Utilities ───
@@ -156,8 +174,17 @@ const initServiceWorkerStream = (state: BatchState): void => {
         a.click();
         port1.close();
       };
+      // Send the user-facing filename explicitly. `downloadId` embeds Date.now()
+      // to keep the SW's stream-map key unique across batches — that timestamp
+      // must NOT leak into the saved filename. The SW uses `filename` for the
+      // Content-Disposition header so the SW path and the blob-fallback path both
+      // save `${folder}.zip`.
       reg.active.postMessage(
-        { downloadId: state.downloadId, stream: state.zipReadable },
+        {
+          downloadId: state.downloadId,
+          filename: `${state.folder}.zip`,
+          stream: state.zipReadable,
+        },
         [state.zipReadable as unknown as Transferable, port2]
       );
       state.zipReadable = null;

--- a/packages/react-storage/src/components/StorageBrowser/createStorageBrowser/StorageBrowserDefault.tsx
+++ b/packages/react-storage/src/components/StorageBrowser/createStorageBrowser/StorageBrowserDefault.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useServiceWorkerRegistration } from '../service-worker/useServiceWorkerRegistration';
 import { useViews } from '../views';
 import { useStore } from '../store';
 
@@ -10,6 +11,7 @@ import { useStore } from '../store';
  * - render `ActionView` on action selection
  */
 export default function StorageBrowserDefault(): React.JSX.Element {
+  useServiceWorkerRegistration();
   const { primary } = useViews();
   const { LocationActionView, LocationDetailView, LocationsView } = primary;
 

--- a/packages/react-storage/src/components/StorageBrowser/service-worker/__tests__/download-sw.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/service-worker/__tests__/download-sw.spec.ts
@@ -78,33 +78,64 @@ describe('download-sw', () => {
 
     const response: Response = respondWith.mock.calls[0][0];
     expect(response.headers.get('Content-Disposition')).toBe(
-      'attachment; filename="my-file.zip"'
+      "attachment; filename*=UTF-8''my-file.zip"
     );
     expect(response.headers.get('Content-Type')).toBe(
       'application/octet-stream'
     );
   });
 
-  it('decodes URI components in filename', () => {
+  it('stores the stream under the unencoded id and matches the encoded request URL', () => {
+    // The page stores the stream keyed by the raw (unencoded) download id.
+    // The browser percent-encodes the id when the <a download> navigation fires.
+    // The SW must decode the request pathname before looking the stream up.
     const stream = new ReadableStream();
-    const encodedId = 'path/to/my%20file.zip';
+    const unencodedId = 'path/to/my file.zip';
     messageHandler()({
       origin: ORIGIN,
-      data: { downloadId: encodedId, stream },
+      data: { downloadId: unencodedId, stream },
       ports: [{ postMessage: jest.fn() }],
     });
 
     const respondWith = jest.fn();
     fetchHandler()({
       request: {
-        url: `https://localhost/amplify-storage-download/${encodedId}`,
+        // Browser-encoded form of the same id (space -> %20)
+        url: 'https://localhost/amplify-storage-download/path/to/my%20file.zip',
+      },
+      respondWith,
+    });
+
+    // Lookup succeeds despite the encoding mismatch
+    expect(respondWith).toHaveBeenCalledWith(expect.any(Response));
+    const response: Response = respondWith.mock.calls[0][0];
+    expect(response.headers.get('Content-Disposition')).toBe(
+      "attachment; filename*=UTF-8''my%20file.zip"
+    );
+  });
+
+  it('decodes URI components in filename', () => {
+    // Stream stored under the unencoded id; request arrives percent-encoded.
+    const stream = new ReadableStream();
+    const unencodedId = 'path/to/my file.zip';
+    messageHandler()({
+      origin: ORIGIN,
+      data: { downloadId: unencodedId, stream },
+      ports: [{ postMessage: jest.fn() }],
+    });
+
+    const respondWith = jest.fn();
+    fetchHandler()({
+      request: {
+        url: 'https://localhost/amplify-storage-download/path/to/my%20file.zip',
       },
       respondWith,
     });
 
     const response: Response = respondWith.mock.calls[0][0];
+    // RFC 5987 extended notation re-encodes the filename
     expect(response.headers.get('Content-Disposition')).toBe(
-      'attachment; filename="my file.zip"'
+      "attachment; filename*=UTF-8''my%20file.zip"
     );
   });
 

--- a/packages/react-storage/src/components/StorageBrowser/service-worker/__tests__/download-sw.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/service-worker/__tests__/download-sw.spec.ts
@@ -29,10 +29,14 @@ describe('download-sw', () => {
   const messageHandler = () => listeners['message'] as (e: any) => void;
   const fetchHandler = () => listeners['fetch'] as (e: any) => void;
 
+  // Service worker messages must originate from a same-origin client.
+  const ORIGIN = self.location.origin;
+
   it('intercepts fetch matching /amplify-storage-download/ pattern', () => {
     const stream = new ReadableStream();
     const mockPort = { postMessage: jest.fn() };
     messageHandler()({
+      origin: ORIGIN,
       data: { downloadId: 'test-id', stream },
       ports: [mockPort],
     });
@@ -59,6 +63,7 @@ describe('download-sw', () => {
   it('returns response with correct headers', () => {
     const stream = new ReadableStream();
     messageHandler()({
+      origin: ORIGIN,
       data: { downloadId: 'my-file.zip', stream },
       ports: [{ postMessage: jest.fn() }],
     });
@@ -84,6 +89,7 @@ describe('download-sw', () => {
     const stream = new ReadableStream();
     const encodedId = 'path/to/my%20file.zip';
     messageHandler()({
+      origin: ORIGIN,
       data: { downloadId: encodedId, stream },
       ports: [{ postMessage: jest.fn() }],
     });
@@ -117,6 +123,7 @@ describe('download-sw', () => {
   it('cleans up stored stream after responding', () => {
     const stream = new ReadableStream();
     messageHandler()({
+      origin: ORIGIN,
       data: { downloadId: 'cleanup-test', stream },
       ports: [{ postMessage: jest.fn() }],
     });
@@ -139,5 +146,29 @@ describe('download-sw', () => {
       respondWith: respondWith2,
     });
     expect(respondWith2).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages from a foreign origin', () => {
+    const stream = new ReadableStream();
+    const mockPort = { postMessage: jest.fn() };
+    // Message from a different origin must be rejected — the stream is not stored
+    // and no acknowledgement is sent.
+    messageHandler()({
+      origin: 'https://evil.example.com',
+      data: { downloadId: 'foreign-id', stream },
+      ports: [mockPort],
+    });
+
+    expect(mockPort.postMessage).not.toHaveBeenCalled();
+
+    // A subsequent fetch for that ID falls through (stream was never stored)
+    const respondWith = jest.fn();
+    fetchHandler()({
+      request: {
+        url: 'https://localhost/amplify-storage-download/foreign-id',
+      },
+      respondWith,
+    });
+    expect(respondWith).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-storage/src/components/StorageBrowser/service-worker/__tests__/download-sw.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/service-worker/__tests__/download-sw.spec.ts
@@ -139,6 +139,32 @@ describe('download-sw', () => {
     );
   });
 
+  it('uses the explicit filename for Content-Disposition, not the timestamped id', () => {
+    // The page keeps a timestamped id unique for the stream map, but sends the
+    // clean user-facing filename separately. The SW must use the filename so the
+    // saved file is e.g. "photos.zip", not "photos-1720080000000.zip".
+    const stream = new ReadableStream();
+    const downloadId = 'photos-1720080000000.zip';
+    messageHandler()({
+      origin: ORIGIN,
+      data: { downloadId, filename: 'photos.zip', stream },
+      ports: [{ postMessage: jest.fn() }],
+    });
+
+    const respondWith = jest.fn();
+    fetchHandler()({
+      request: {
+        url: `https://localhost/amplify-storage-download/${downloadId}`,
+      },
+      respondWith,
+    });
+
+    const response: Response = respondWith.mock.calls[0][0];
+    expect(response.headers.get('Content-Disposition')).toBe(
+      "attachment; filename*=UTF-8''photos.zip"
+    );
+  });
+
   it('does not call respondWith when no stream stored', () => {
     const respondWith = jest.fn();
     fetchHandler()({

--- a/packages/react-storage/src/components/StorageBrowser/service-worker/__tests__/download-sw.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/service-worker/__tests__/download-sw.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TextEncoder, TextDecoder } from 'util';
+import { ReadableStream } from 'node:stream/web';
+
+// jsdom doesn't provide these Web APIs. Polyfill from Node builtins.
+(globalThis as any).TextEncoder = TextEncoder;
+(globalThis as any).TextDecoder = TextDecoder;
+(globalThis as any).ReadableStream = ReadableStream;
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { Response: UndiciResponse } = require('undici');
+(globalThis as any).Response = UndiciResponse;
+
+// Capture event listeners the SW registers on `self`
+const listeners: Record<string, Function> = {};
+jest.spyOn(self, 'addEventListener').mockImplementation(((
+  type: string,
+  handler: Function
+) => {
+  listeners[type] = handler;
+}) as any);
+
+// Import triggers side-effect listener registration
+import '../download-sw';
+
+describe('download-sw', () => {
+  const messageHandler = () => listeners['message'] as (e: any) => void;
+  const fetchHandler = () => listeners['fetch'] as (e: any) => void;
+
+  it('intercepts fetch matching /amplify-storage-download/ pattern', () => {
+    const stream = new ReadableStream();
+    const mockPort = { postMessage: jest.fn() };
+    messageHandler()({
+      data: { downloadId: 'test-id', stream },
+      ports: [mockPort],
+    });
+
+    const respondWith = jest.fn();
+    fetchHandler()({
+      request: { url: 'https://localhost/amplify-storage-download/test-id' },
+      respondWith,
+    });
+
+    expect(respondWith).toHaveBeenCalledWith(expect.any(Response));
+  });
+
+  it('ignores URLs not matching the pattern', () => {
+    const respondWith = jest.fn();
+    fetchHandler()({
+      request: { url: 'https://localhost/other-path/file.zip' },
+      respondWith,
+    });
+
+    expect(respondWith).not.toHaveBeenCalled();
+  });
+
+  it('returns response with correct headers', () => {
+    const stream = new ReadableStream();
+    messageHandler()({
+      data: { downloadId: 'my-file.zip', stream },
+      ports: [{ postMessage: jest.fn() }],
+    });
+
+    const respondWith = jest.fn();
+    fetchHandler()({
+      request: {
+        url: 'https://localhost/amplify-storage-download/my-file.zip',
+      },
+      respondWith,
+    });
+
+    const response: Response = respondWith.mock.calls[0][0];
+    expect(response.headers.get('Content-Disposition')).toBe(
+      'attachment; filename="my-file.zip"'
+    );
+    expect(response.headers.get('Content-Type')).toBe(
+      'application/octet-stream'
+    );
+  });
+
+  it('decodes URI components in filename', () => {
+    const stream = new ReadableStream();
+    const encodedId = 'path/to/my%20file.zip';
+    messageHandler()({
+      data: { downloadId: encodedId, stream },
+      ports: [{ postMessage: jest.fn() }],
+    });
+
+    const respondWith = jest.fn();
+    fetchHandler()({
+      request: {
+        url: `https://localhost/amplify-storage-download/${encodedId}`,
+      },
+      respondWith,
+    });
+
+    const response: Response = respondWith.mock.calls[0][0];
+    expect(response.headers.get('Content-Disposition')).toBe(
+      'attachment; filename="my file.zip"'
+    );
+  });
+
+  it('does not call respondWith when no stream stored', () => {
+    const respondWith = jest.fn();
+    fetchHandler()({
+      request: {
+        url: 'https://localhost/amplify-storage-download/unknown-id',
+      },
+      respondWith,
+    });
+
+    expect(respondWith).not.toHaveBeenCalled();
+  });
+
+  it('cleans up stored stream after responding', () => {
+    const stream = new ReadableStream();
+    messageHandler()({
+      data: { downloadId: 'cleanup-test', stream },
+      ports: [{ postMessage: jest.fn() }],
+    });
+
+    const respondWith = jest.fn();
+    fetchHandler()({
+      request: {
+        url: 'https://localhost/amplify-storage-download/cleanup-test',
+      },
+      respondWith,
+    });
+    expect(respondWith).toHaveBeenCalled();
+
+    // Second fetch for same ID should fall through
+    const respondWith2 = jest.fn();
+    fetchHandler()({
+      request: {
+        url: 'https://localhost/amplify-storage-download/cleanup-test',
+      },
+      respondWith: respondWith2,
+    });
+    expect(respondWith2).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-storage/src/components/StorageBrowser/service-worker/download-sw.ts
+++ b/packages/react-storage/src/components/StorageBrowser/service-worker/download-sw.ts
@@ -5,8 +5,15 @@
 declare const self: ServiceWorkerGlobalScope;
 export type {}; // make this a module to avoid global scope pollution
 
-// Stores ReadableStreams posted from the main thread, keyed by download ID
-const pendingStreams = new Map<string, ReadableStream>();
+// Stores the ReadableStream (and its user-facing filename) posted from the main
+// thread, keyed by download ID. The download ID embeds a timestamp to stay
+// unique; the filename is carried separately so the timestamp never reaches the
+// saved file name.
+interface PendingDownload {
+  stream: ReadableStream;
+  filename: string;
+}
+const pendingStreams = new Map<string, PendingDownload>();
 
 // Skip waiting to activate immediately on first install (no navigation required)
 self.addEventListener('install', () => {
@@ -31,6 +38,7 @@ self.addEventListener('message', (event) => {
   const data = event.data as {
     type?: string;
     downloadId?: string;
+    filename?: string;
     stream?: ReadableStream;
   };
 
@@ -42,12 +50,17 @@ self.addEventListener('message', (event) => {
     return;
   }
 
-  const { downloadId, stream } = data as {
+  const { downloadId, filename, stream } = data as {
     downloadId: string;
+    filename?: string;
     stream: ReadableStream;
   };
   if (downloadId && stream) {
-    pendingStreams.set(downloadId, stream);
+    // Fall back to the id's last path segment only if no explicit filename was
+    // provided (older callers); the page normally sends `${folder}.zip`.
+    const resolvedFilename =
+      filename ?? downloadId.split('/').pop() ?? 'download.zip';
+    pendingStreams.set(downloadId, { stream, filename: resolvedFilename });
     // Acknowledge receipt so the main thread knows it's safe to trigger the download
     if (event.ports[0]) {
       event.ports[0].postMessage({ ready: true });
@@ -65,19 +78,20 @@ self.addEventListener('fetch', (event) => {
   // decode it before looking up the stream stored under the unencoded key.
   const rawId = url.pathname.split('/amplify-storage-download/')[1];
   const downloadId = decodeURIComponent(rawId);
-  const stream = pendingStreams.get(downloadId);
+  const pending = pendingStreams.get(downloadId);
 
-  if (!stream) return;
+  if (!pending) return;
 
   pendingStreams.delete(downloadId);
 
-  // downloadId is already decoded above.
-  const filename = downloadId.split('/').pop()!;
+  const { stream, filename } = pending;
   event.respondWith(
     new Response(stream, {
       headers: {
         // RFC 5987 extended notation encodes arbitrary UTF-8 (including quotes
         // and backslashes that S3 keys may legally contain) without escaping.
+        // `filename` is the user-facing name sent by the page (e.g. folder.zip),
+        // NOT the timestamped internal downloadId.
         'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(
           filename
         )}`,

--- a/packages/react-storage/src/components/StorageBrowser/service-worker/download-sw.ts
+++ b/packages/react-storage/src/components/StorageBrowser/service-worker/download-sw.ts
@@ -60,18 +60,27 @@ self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
   if (!url.pathname.startsWith('/amplify-storage-download/')) return;
 
-  const downloadId = url.pathname.split('/amplify-storage-download/')[1];
+  // The download id is percent-encoded by the browser when the <a> navigation
+  // fires (folder names may contain spaces or other URL-unsafe characters), so
+  // decode it before looking up the stream stored under the unencoded key.
+  const rawId = url.pathname.split('/amplify-storage-download/')[1];
+  const downloadId = decodeURIComponent(rawId);
   const stream = pendingStreams.get(downloadId);
 
   if (!stream) return;
 
   pendingStreams.delete(downloadId);
 
-  const filename = decodeURIComponent(downloadId.split('/').pop()!);
+  // downloadId is already decoded above.
+  const filename = downloadId.split('/').pop()!;
   event.respondWith(
     new Response(stream, {
       headers: {
-        'Content-Disposition': `attachment; filename="${filename}"`,
+        // RFC 5987 extended notation encodes arbitrary UTF-8 (including quotes
+        // and backslashes that S3 keys may legally contain) without escaping.
+        'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(
+          filename
+        )}`,
         'Content-Type': 'application/octet-stream',
       },
     })

--- a/packages/react-storage/src/components/StorageBrowser/service-worker/download-sw.ts
+++ b/packages/react-storage/src/components/StorageBrowser/service-worker/download-sw.ts
@@ -20,6 +20,14 @@ self.addEventListener('activate', (event) => {
 
 // Receive stream from main thread via MessageChannel
 self.addEventListener('message', (event) => {
+  // Security: only accept messages from same-origin clients. A service worker
+  // exclusively communicates with pages it controls, which are same-origin by
+  // definition. Rejecting mismatched origins guards against cross-origin
+  // senders attempting to inject or hijack download streams.
+  if (event.origin !== self.location.origin) {
+    return;
+  }
+
   const data = event.data as {
     type?: string;
     downloadId?: string;

--- a/packages/react-storage/src/components/StorageBrowser/service-worker/download-sw.ts
+++ b/packages/react-storage/src/components/StorageBrowser/service-worker/download-sw.ts
@@ -1,0 +1,71 @@
+/// <reference lib="webworker" />
+
+// Service Worker for streaming zip downloads in StorageBrowser
+
+declare const self: ServiceWorkerGlobalScope;
+export type {}; // make this a module to avoid global scope pollution
+
+// Stores ReadableStreams posted from the main thread, keyed by download ID
+const pendingStreams = new Map<string, ReadableStream>();
+
+// Skip waiting to activate immediately on first install (no navigation required)
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+// Claim clients immediately so navigator.serviceWorker.controller is available
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+// Receive stream from main thread via MessageChannel
+self.addEventListener('message', (event) => {
+  const data = event.data as {
+    type?: string;
+    downloadId?: string;
+    stream?: ReadableStream;
+  };
+
+  if (data.type === 'keepalive') {
+    // Extend SW lifetime to prevent Firefox's 30s idle timeout from terminating
+    // the worker while streaming. Each keepalive holds the SW alive for 15s,
+    // overlapping with the 10s ping interval from the page.
+    event.waitUntil(new Promise((resolve) => setTimeout(resolve, 15_000)));
+    return;
+  }
+
+  const { downloadId, stream } = data as {
+    downloadId: string;
+    stream: ReadableStream;
+  };
+  if (downloadId && stream) {
+    pendingStreams.set(downloadId, stream);
+    // Acknowledge receipt so the main thread knows it's safe to trigger the download
+    if (event.ports[0]) {
+      event.ports[0].postMessage({ ready: true });
+    }
+  }
+});
+
+// Intercept fetch requests matching the download URL pattern
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  if (!url.pathname.startsWith('/amplify-storage-download/')) return;
+
+  const downloadId = url.pathname.split('/amplify-storage-download/')[1];
+  const stream = pendingStreams.get(downloadId);
+
+  if (!stream) return;
+
+  pendingStreams.delete(downloadId);
+
+  const filename = decodeURIComponent(downloadId.split('/').pop()!);
+  event.respondWith(
+    new Response(stream, {
+      headers: {
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Content-Type': 'application/octet-stream',
+      },
+    })
+  );
+});

--- a/packages/react-storage/src/components/StorageBrowser/service-worker/useServiceWorkerRegistration.ts
+++ b/packages/react-storage/src/components/StorageBrowser/service-worker/useServiceWorkerRegistration.ts
@@ -10,19 +10,18 @@ export function useServiceWorkerRegistration(): void {
       navigator.serviceWorker
         .register(SW_URL, { scope: SW_DOWNLOAD_SCOPE })
         .catch((err) => {
-          // Registration failure is non-critical; blob fallback handles downloads.
-          // Surface it in development to help diagnose the most common setup
-          // mistake — forgetting to run `copy-serviceworker` so the SW file is
+          // Registration failure is non-critical; the blob fallback handles
+          // downloads. We still surface it: a failed registration is a real
+          // (silent otherwise) degradation, and the most common cause is
+          // forgetting the copy-serviceworker setup step so the SW file isn't
           // served from the app's public directory.
-          if (process.env.NODE_ENV !== 'production') {
-            // eslint-disable-next-line no-console
-            console.warn(
-              '[StorageBrowser] Download service worker registration failed; ' +
-                'falling back to in-memory blob downloads. Ensure the service ' +
-                'worker file is served (see the copy-serviceworker setup step):',
-              err
-            );
-          }
+          // eslint-disable-next-line no-console
+          console.warn(
+            '[StorageBrowser] Download service worker registration failed; ' +
+              'falling back to in-memory blob downloads. Ensure the service ' +
+              'worker file is served (see the copy-serviceworker setup step):',
+            err
+          );
         });
     }
   }, []);

--- a/packages/react-storage/src/components/StorageBrowser/service-worker/useServiceWorkerRegistration.ts
+++ b/packages/react-storage/src/components/StorageBrowser/service-worker/useServiceWorkerRegistration.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+export const SW_DOWNLOAD_SCOPE = '/amplify-storage-download/';
+
+const SW_URL = '/amplify-storage-download/download-sw.js';
+
+export function useServiceWorkerRegistration(): void {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register(SW_URL, { scope: SW_DOWNLOAD_SCOPE })
+        .catch(() => {
+          // Registration failure is non-critical; blob fallback handles downloads
+        });
+    }
+  }, []);
+}

--- a/packages/react-storage/src/components/StorageBrowser/service-worker/useServiceWorkerRegistration.ts
+++ b/packages/react-storage/src/components/StorageBrowser/service-worker/useServiceWorkerRegistration.ts
@@ -9,8 +9,20 @@ export function useServiceWorkerRegistration(): void {
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker
         .register(SW_URL, { scope: SW_DOWNLOAD_SCOPE })
-        .catch(() => {
-          // Registration failure is non-critical; blob fallback handles downloads
+        .catch((err) => {
+          // Registration failure is non-critical; blob fallback handles downloads.
+          // Surface it in development to help diagnose the most common setup
+          // mistake — forgetting to run `copy-serviceworker` so the SW file is
+          // served from the app's public directory.
+          if (process.env.NODE_ENV !== 'production') {
+            // eslint-disable-next-line no-console
+            console.warn(
+              '[StorageBrowser] Download service worker registration failed; ' +
+                'falling back to in-memory blob downloads. Ensure the service ' +
+                'worker file is served (see the copy-serviceworker setup step):',
+              err
+            );
+          }
         });
     }
   }, []);

--- a/packages/react-storage/src/components/StorageBrowser/useAction/types.ts
+++ b/packages/react-storage/src/components/StorageBrowser/useAction/types.ts
@@ -68,7 +68,9 @@ export interface UseHandlerOptions<TTask extends Task>
   extends Pick<
     ProcessTasksOptions<TTask>,
     'onTaskError' | 'onTaskProgress' | 'onTaskSuccess'
-  > {}
+  > {
+  concurrency?: number;
+}
 
 export interface UseHandlerOptionsWithItems<TTask extends Task>
   extends UseHandlerOptions<TTask> {

--- a/packages/react-storage/src/components/StorageBrowser/useAction/useHandler.ts
+++ b/packages/react-storage/src/components/StorageBrowser/useAction/useHandler.ts
@@ -64,10 +64,14 @@ export function useHandler<
         ...(hasData
           ? { data: input.data, all: [input.data] }
           : // if no `data` provided, provide `concurrency` to `options`
-            { options: { concurrency: DEFAULT_ACTION_CONCURRENCY } }),
+            {
+              options: {
+                concurrency: options?.concurrency ?? DEFAULT_ACTION_CONCURRENCY,
+              },
+            }),
       });
     },
-    [getConfig, handleProcessing, reset]
+    [getConfig, handleProcessing, reset, options?.concurrency]
   );
 
   if (isOptionsWithItems(options)) {

--- a/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DownloadView/useDownloadView.ts
+++ b/packages/react-storage/src/components/StorageBrowser/views/LocationActionView/DownloadView/useDownloadView.ts
@@ -24,6 +24,7 @@ export const useDownloadView = (
 
   const [processState, handleProcess] = useAction('download', {
     items,
+    concurrency: 1,
   });
 
   const { isProcessing, isProcessingComplete, statusCounts, tasks } =

--- a/packages/react-storage/tsconfig.json
+++ b/packages/react-storage/tsconfig.json
@@ -4,5 +4,5 @@
     "skipLibCheck": true
   },
   "include": ["*.mjs", "*.ts", "src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/**/service-worker/**"]
 }

--- a/packages/react-storage/tsconfig.sw.json
+++ b/packages/react-storage/tsconfig.sw.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "lib": ["ES2020", "WebWorker"],
+    "strict": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/components/StorageBrowser/service-worker/*.ts"]
+}


### PR DESCRIPTION
Replace the in-memory blob-based zip download with a service worker streaming architecture for StorageBrowser multi-file downloads. Falls back to blob collection when the SW is unavailable.

Key changes:
- Add download-sw.ts service worker with skipWaiting + clients.claim
- Add zipdownload handler with WeakMap-scoped batch state (no singleton)
- Stream files sequentially into zip via zip.js (concurrency=1)
- MessageChannel handshake for SW stream transfer + keepalive pings
- Blob fallback with inline cleanup (no fire-and-forget race)
- composedDownloadHandler routes single-file vs multi-file downloads
- useServiceWorkerRegistration hook for automatic SW registration
- copy-serviceworker bin script for npm consumers
- Documentation for SW setup across frameworks
- Comprehensive test suite with deterministic async flushing

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [ ] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [ ] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [ ] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
