### PR TITLE
fix(build-system-tests): correct find-cypress-specs minimatch resolution

### DIFF
--- a/build-system-tests/e2e/package.json
+++ b/build-system-tests/e2e/package.json
@@ -32,7 +32,7 @@
     "@actions/http-client/undici": "6.24.0",
     "diff": "8.0.3",
     "serialize-javascript": "^7.0.5",
-    "**/find-cypress-specs/minimatch": "3.1.4",
+    "**/find-cypress-specs/minimatch": "^10.2.4",
     "**/mocha/minimatch": "5.1.8",
     "**/@typescript-eslint/typescript-estree/minimatch": "9.0.7",
     "**/glob/minimatch": "9.0.7",

--- a/build-system-tests/e2e/yarn.lock
+++ b/build-system-tests/e2e/yarn.lock
@@ -854,14 +854,6 @@ bluebird@^3.7.2:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
 brace-expansion@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
@@ -873,6 +865,13 @@ brace-expansion@^5.0.2:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
   integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+  dependencies:
+    balanced-match "^4.0.2"
+
+brace-expansion@^5.0.5:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
+  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -1118,11 +1117,6 @@ common-tags@^1.8.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
   integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 console.table@^0.10.0:
   version "0.10.0"
@@ -2541,13 +2535,6 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@3.1.4, minimatch@^10.2.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.4.tgz#89d910ea3970a77ac8edfd30340ccd038b758079"
-  integrity sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimatch@5.1.8, minimatch@^9.0.5:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.8.tgz#32a16ebcccd6421c674430acb199b8806c68169b"
@@ -2561,6 +2548,13 @@ minimatch@9.0.7, minimatch@^10.2.2, minimatch@^9.0.4:
   integrity sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==
   dependencies:
     brace-expansion "^5.0.2"
+
+minimatch@^10.2.4:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+  dependencies:
+    brace-expansion "^5.0.5"
 
 minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"


### PR DESCRIPTION
## Summary

Fixes the **Build System Test Canary** which started failing on \`main\` immediately after #7028 merged, with:

\`\`\`
Your configFile threw an error from: build-system-tests/e2e/cypress.config.ts
The error was thrown while executing your e2e.setupNodeEvents() function:
TypeError: minimatch is not a function
\`\`\`

## Root cause

\`build-system-tests/e2e/package.json\` pins \`"**/find-cypress-specs/minimatch": "3.1.4"\`. That resolution was added when \`find-cypress-specs\` used minimatch v3.

The lockfile regeneration in #7028 bumped \`find-cypress-specs\` to **1.54.12**, which now requires \`minimatch@^10.2.4\` and imports it via the **named export**:

\`\`\`js
const { minimatch } = require('minimatch') // find-cypress-specs/src/index.js:10
\`\`\`

minimatch 3.x is a bare-function export with no \`.minimatch\` property, so \`{ minimatch }\` was \`undefined\` and calling it threw. The regen collapsed find-cypress-specs's \`^10.2.4\` request onto the \`3.1.4\` lockfile entry, forcing the incompatible version.

The repo-root workspace has no such forcing resolution (find-cypress-specs resolves minimatch 10.2.5 there), which is why the regular PR e2e suites passed — only \`build-system-tests/e2e\` was affected.

## Fix

Update the resolution `**/find-cypress-specs/minimatch` from `3.1.4` → `^10.2.4` so find-cypress-specs gets a compatible v10 (resolves to 10.2.5) that provides the named export.

## Verification

- \`find-cypress-specs\` now resolves \`minimatch@10.2.5\`; \`typeof m.minimatch === 'function'\`.
- \`require('find-cypress-specs')\` and \`getSpecs()\` (the code path that threw) load and run without error.
- The \`@badeball/cypress-cucumber-preprocessor\` chain loads cleanly.