### PR TITLE
fix(build-system-tests): remove undici pins to resolve 3 Dependabot alerts

### DIFF
--- a/build-system-tests/e2e/package.json
+++ b/build-system-tests/e2e/package.json
@@ -28,8 +28,6 @@
   "resolutions": {
     "esbuild": "^0.25.0",
     "qs": "^6.15.2",
-    "undici": "6.24.0",
-    "@actions/http-client/undici": "6.24.0",
     "diff": "8.0.3",
     "serialize-javascript": "^7.0.5",
     "**/find-cypress-specs/minimatch": "^10.2.4",

--- a/build-system-tests/e2e/yarn.lock
+++ b/build-system-tests/e2e/yarn.lock
@@ -3643,10 +3643,10 @@ typescript@^5.1.6, typescript@^5.9.3:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@6.24.0, undici@^6.23.0:
-  version "6.24.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.24.0.tgz#ad36b879b4882d14addc13dd641da7ed7ac7623a"
-  integrity sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==
+undici@^6.23.0:
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
+  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
 
 unicorn-magic@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Description

Removes the two exact-pin `undici` resolutions from `build-system-tests/e2e/package.json` and re-resolves the lockfile, bumping undici **6.24.0 → 6.27.0**.

The exact pins blocked Dependabot from fixing three open alerts on `build-system-tests/e2e/yarn.lock`:

| Alert | Severity | Advisory |
|-------|----------|----------|
| #546 | medium | [GHSA-p88m-4jfj-68fv](https://github.com/advisories/GHSA-p88m-4jfj-68fv) — HTTP header injection via Set-Cookie percent-decoding |
| #547 | low | [GHSA-g8m3-5g58-fq7m](https://github.com/advisories/GHSA-g8m3-5g58-fq7m) — Set-Cookie SameSite downgrade |
| #545 | low | [GHSA-35p6-xmwp-9g52](https://github.com/advisories/GHSA-35p6-xmwp-9g52) — HTTP response queue poisoning via keep-alive socket reuse |

All three are fixed in undici 6.27.0. With the pins gone, undici floats within `@actions/http-client`'s `^6.23.0` range, so future patches land via normal Dependabot updates.

## Impact

- Dev-only e2e/canary tooling workspace; no published packages affected.
- Diff is limited to the two removed resolution lines and the single undici lockfile entry — no other dependency moved.
- `yarn install` completes cleanly.

## Testing

- `yarn install` regenerates lockfile with undici@6.27.0 (verified entry + integrity hash).