### PR TITLE
chore: bump http-proxy-middleware to 3.0.7 and 2.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
     "@angular/platform-browser": "19.2.20",
     "@angular/platform-browser-dynamic": "19.2.20",
     "@angular/router": "19.2.20",
-    "**/serve/ajv": "^6.14.0"
+    "**/serve/ajv": "^6.14.0",
+    "**/@angular-devkit/build-angular/http-proxy-middleware": "3.0.7"
   },
   "devDependencies": {
     "@aws-amplify/backend": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@angular/platform-browser-dynamic": "19.2.20",
     "@angular/router": "19.2.20",
     "**/serve/ajv": "^6.14.0",
-    "**/@angular-devkit/build-angular/http-proxy-middleware": "3.0.7"
+    "**/@angular-devkit/build-angular/http-proxy-middleware": "3.0.7",
     "**/pacote/sigstore": "^4.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16900,10 +16900,10 @@ http-proxy-agent@^7.0.0, http-proxy-agent@^7.0.1:
     agent-base "^7.1.0"
     debug "^4.3.4"
 
-http-proxy-middleware@3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz#9dcde663edc44079bc5a9c63e03fe5e5d6037fab"
-  integrity sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==
+http-proxy-middleware@3.0.5, http-proxy-middleware@3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz#53d3a1fe175bcacc507711cc52a0b32baf2c3442"
+  integrity sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==
   dependencies:
     "@types/http-proxy" "^1.17.15"
     debug "^4.3.6"
@@ -16913,9 +16913,9 @@ http-proxy-middleware@3.0.5:
     micromatch "^4.0.8"
 
 http-proxy-middleware@^2.0.9:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz#e9e63d68afaa4eee3d147f39149ab84c0c2815ef"
-  integrity sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz#b2df7b705203d7a8c269ac8450cf96b00c532f94"
+  integrity sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==
   dependencies:
     "@types/http-proxy" "^1.17.8"
     http-proxy "^1.18.1"


### PR DESCRIPTION
## Description

Fixes Dependabot alerts:
- **#542** (high) — `http-proxy-middleware@3.0.5` — [GHSA-gcq2-9pq2-cxqm](https://github.com/advisories/GHSA-gcq2-9pq2-cxqm)
- **#552** (medium) — `http-proxy-middleware@3.0.5` — [GHSA-64mm-vxmg-q3vj](https://github.com/advisories/GHSA-64mm-vxmg-q3vj)
- **#555** (medium) — `http-proxy-middleware@2.0.9` (2.x line) — [GHSA-64mm-vxmg-q3vj](https://github.com/advisories/GHSA-64mm-vxmg-q3vj)

**Dependency chains:**
- 3.0.5 pinned exactly by `@angular-devkit/build-angular` (Angular example app tooling)
- 2.0.9 via `webpack-dev-server@^5.2.1`

**Fix approach:**
- Added scoped yarn resolution `"**/@angular-devkit/build-angular/http-proxy-middleware": "3.0.7"` (3.0.5 is an exact pin, so an in-range bump was not possible)
- In-range lockfile bump of the `^2.0.9` entry to 2.0.10

**Verification (yarn.lock after `yarn install`):**
```
http-proxy-middleware@3.0.5, http-proxy-middleware@3.0.7:
  version "3.0.7"
http-proxy-middleware@^2.0.9:
  version "2.0.10"
```
No vulnerable versions remain in the lockfile. Dev-only dependencies; no runtime impact.