### PR TITLE
chore: bump piscina to 4.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,9 @@
     "@angular/platform-browser": "19.2.20",
     "@angular/platform-browser-dynamic": "19.2.20",
     "@angular/router": "19.2.20",
-    "**/serve/ajv": "^6.14.0"
+    "**/serve/ajv": "^6.14.0",
+    "**/@angular-devkit/build-angular/piscina": "4.9.3",
+    "**/@angular/build/piscina": "4.9.3"
   },
   "devDependencies": {
     "@aws-amplify/backend": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@angular/router": "19.2.20",
     "**/serve/ajv": "^6.14.0",
     "**/@angular-devkit/build-angular/piscina": "4.9.3",
-    "**/@angular/build/piscina": "4.9.3"
+    "**/@angular/build/piscina": "4.9.3",
     "**/pacote/sigstore": "^4.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21750,14 +21750,7 @@ pirates@^4.0.1, pirates@^4.0.4, pirates@^4.0.6:
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
 
-piscina@4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/piscina/-/piscina-4.8.0.tgz#5f5c5b1f4f3f50f8de894239c98b7b10d41ba4a6"
-  integrity sha512-EZJb+ZxDrQf3dihsUL7p42pjNyrNIFJCrRHPMgxu/svsj+P3xS3fuEWp7k2+rfsavfl1N0G29b1HGs7J0m8rZA==
-  optionalDependencies:
-    "@napi-rs/nice" "^1.0.1"
-
-piscina@^4.7.0:
+piscina@4.8.0, piscina@4.9.3, piscina@^4.7.0:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/piscina/-/piscina-4.9.3.tgz#a8df8f699f1f3721c01720d0e7dcc49e7de1fea8"
   integrity sha512-3e3ka9QCE8RJ5I9uszdAADZnkcYi21cqmF3gxox3u884N72qpFHCsIVhHt8cEQ9t3Auq/NqoiCEuhxlxxQuDWA==


### PR DESCRIPTION
## Description

Fixes Dependabot alert:
- **#543** (high) — `piscina` — [GHSA-x9g3-xrwr-cwfg](https://github.com/advisories/GHSA-x9g3-xrwr-cwfg), patched in 4.9.3

**Dependency chains:**
- `piscina@4.8.0` pinned exactly by `@angular-devkit/build-angular` and `@angular/build@19.2.27` (Angular example app tooling)
- `piscina@^4.7.0` via `ng-packagr` (already resolved to 4.9.3 in the lockfile)

**Fix approach:** added scoped yarn resolutions `"**/@angular-devkit/build-angular/piscina": "4.9.3"` and `"**/@angular/build/piscina": "4.9.3"` to the root `package.json` (4.8.0 is an exact pin, so an in-range bump was not possible).

**Verification (yarn.lock after `yarn install`):**
```
piscina@4.8.0, piscina@4.9.3, piscina@^4.7.0:
  version "4.9.3"
```
No vulnerable versions remain in the lockfile. Dev-only dependency; no runtime impact.