### PR TITLE
chore: bump js-yaml to 3.15.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18419,9 +18419,9 @@ js-tokens@^10.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1, js-yaml@^3.6.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
## Description

Fixes Dependabot alert:
- **#558** (medium, dev scope) — `js-yaml` — [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68), patched in 3.15.0

**Dependency chain:** `js-yaml@^3.13.1` / `js-yaml@^3.6.1` (via jest / @changesets/cli transitive tooling), previously lockfile-held at 3.14.2.

**Fix approach:** in-range lockfile bump — removed the stale 3.14.2 lockfile entry and re-resolved; 3.15.0 satisfies the existing ranges, so no `package.json` change was needed.

**Verification (yarn.lock after `yarn install`):**
```
js-yaml@^3.13.1, js-yaml@^3.6.1:
  version "3.15.0"
```
The js-yaml 4.x entry (4.2.0) is unaffected. Dev-only dependency; no runtime impact.