### PR TITLE
chore: bump ajv (6.x) to 6.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "@angular/forms": "19.2.20",
     "@angular/platform-browser": "19.2.20",
     "@angular/platform-browser-dynamic": "19.2.20",
-    "@angular/router": "19.2.20"
+    "@angular/router": "19.2.20",
+    "**/serve/ajv": "^6.14.0"
   },
   "devDependencies": {
     "@aws-amplify/backend": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11271,10 +11271,10 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@6.12.6:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+ajv@6.12.6, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.14.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
+  integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -11290,16 +11290,6 @@ ajv@8.18.0:
     fast-uri "^3.0.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
-
-ajv@^6.12.4, ajv@^6.12.5, ajv@^6.14.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
-  integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
 
 ajv@^8.0.0, ajv@^8.0.1, ajv@^8.17.1, ajv@^8.6.3, ajv@^8.9.0:
   version "8.20.0"


### PR DESCRIPTION
## Description

Fixes Dependabot alert:
- **#342** (medium) — `ajv` — [GHSA-2g4f-4pwh-qvx6](https://github.com/advisories/GHSA-2g4f-4pwh-qvx6), patched in 6.14.0

**Dependency chain:** `ajv@6.12.6` pinned exactly by `serve` (ui-angular-example dev tooling); `ajv@^6.12.4` (eslint) already resolved to 6.15.0.

**Fix approach:** added scoped yarn resolution `"**/serve/ajv": "^6.14.0"` to the root `package.json`. Deliberately scoped (not a bare `ajv` resolution) so ajv 8.x consumers are unaffected.

**Verification (yarn.lock after `yarn install`):**
```
ajv@6.12.6, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.14.0:
  version "6.15.0"
ajv@8.18.0:
  version "8.18.0"
ajv@^8.0.0, ajv@^8.0.1, ajv@^8.17.1, ajv@^8.6.3, ajv@^8.9.0:
  version "8.20.0"
```
No vulnerable ajv 6.x versions remain; ajv 8.x entries unchanged. Dev-only dependency; no runtime impact.