### PR TITLE
ci(e2e): install Cypress binary on binary-cache miss

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -164,6 +164,10 @@ jobs:
         with:
           skip-cypress-binary: false
 
+      - name: Install Cypress binary on cache miss
+        if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
+        run: npx cypress install
+
       - name: Build @aws-amplify/ui package
         if: steps.restore-ui-cache.outputs.cache-hit != 'true'
         run: yarn ui build
@@ -702,6 +706,10 @@ jobs:
         uses: ./.github/actions/install-with-retries
         with:
           skip-cypress-binary: false
+
+      - name: Install Cypress binary on cache miss
+        if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
+        run: npx cypress install
 
       - name: Build ui package
         run: yarn ui build


### PR DESCRIPTION
## Problem

E2E jobs fail with:

> Your Cypress binary is missing.

Example failing runs: [29340165609](https://github.com/aws-amplify/amplify-ui/actions/runs/29340165609), [29411804130](https://github.com/aws-amplify/amplify-ui/actions/runs/29411804130).

## Root Cause

When a PR changes `yarn.lock`, the **node_modules** cache (keyed on `hashFiles('yarn.lock')`) **HITs** on the _previous_ lockfile while the **Cypress binary** cache (`~/.cache/Cypress`, same key pattern) **MISSes** on the new lockfile.

The install step runs, but `yarn install` sees the restored `node_modules`, prints "Already up-to-date.", and **skips postinstall scripts** — so the Cypress binary never downloads to `~/.cache/Cypress/<version>/`.

Any PR that changes `yarn.lock` hits this since #7028 regenerated the lockfile on 2026-07-09.

## Fix

Add a fallback step immediately after dependency installation that runs `npx cypress install` **only when the binary cache missed**:

```yaml
- name: Install Cypress binary on cache miss
  if: steps.restore-cypress-cache.outputs.cache-hit != 'true'
  run: npx cypress install
```

The `if` guard ensures this is a **no-op on cache hits**, adding zero overhead to the happy path. Applied to both the `e2e` and `docs` jobs which share the same pattern.

## Testing

- YAML validated with `python3 -c "import yaml,sys;yaml.safe_load(...)"`
- This PR does **not** change `yarn.lock`, so the Cypress binary cache will HIT and the new step will be skipped (verifiable in the Actions log). The real proof is the next `yarn.lock`-changing PR, which will exercise the fallback path.