### PR TITLE
fix(security): re-resolve brace-expansion to 5.0.7 (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12449,9 +12449,9 @@ brace-expansion@^2.0.1, brace-expansion@^2.0.2:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.5:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
+  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Security fix

Resolves **Dependabot alert #561** (severity: **high**): https://github.com/aws-amplify/amplify-ui/security/dependabot/561

**Finding:** `brace-expansion` — DoS via exponential-time expansion of consecutive non-expanding `{}` groups ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)). Transitive npm dependency in `yarn.lock` (runtime scope, via `minimatch`). Vulnerable range: `>= 3.0.0, < 5.0.7`; first patched version: `5.0.7`.

## Description of changes

Lockfile-only re-resolution: the single vulnerable `yarn.lock` block (`brace-expansion@^5.0.5`, previously resolved to `5.0.6`) is updated to `5.0.7` with the official npm tarball URL and integrity hash. The existing semver range already satisfies `5.0.7`, so no `package.json` edits and no `resolutions` entry are needed. The two non-vulnerable lockfile entries (`1.1.15` and `2.1.1`) are outside the vulnerable range and left untouched.

## Verification

- `yarn install --frozen-lockfile` succeeds (yarn 1.22.22)
- All installed `brace-expansion` copies in `node_modules` are `1.1.15` / `2.1.1` / `5.0.7` — none in the vulnerable range
- `yarn ui lint` (tsc + eslint) passes
- `yarn ui test` passes (44 suites / 501 tests, 0 failures)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.