### PR TITLE
fix(security): re-resolve brace-expansion in e2e lockfile to patched versions

### DIFF
--- a/build-system-tests/e2e/yarn.lock
+++ b/build-system-tests/e2e/yarn.lock
@@ -855,20 +855,13 @@ bluebird@^3.7.2:
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 brace-expansion@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
-  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
+  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
   dependencies:
     balanced-match "^1.0.0"
 
-brace-expansion@^5.0.2:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
-  dependencies:
-    balanced-match "^4.0.2"
-
-brace-expansion@^5.0.5:
+brace-expansion@^5.0.2, brace-expansion@^5.0.5:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
   integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==


### PR DESCRIPTION
## Security fix — Dependabot alert #560 (high)

Resolves **Dependabot** alert [#560](https://github.com/aws-amplify/amplify-ui/security/dependabot/560): `brace-expansion` — DoS via exponential-time expansion of consecutive non-expanding `{}` groups (CVE-2026-13149 / [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)). Severity: **high**. Transitive dev-scope dependency (via `minimatch`) in `build-system-tests/e2e/yarn.lock`.

### Fix
Lockfile-only change — exactly one file: `build-system-tests/e2e/yarn.lock`. Deleted the vulnerable `brace-expansion` entries and regenerated them via `yarn install` (no resolutions added, no hand-edited versions; integrity hashes registry-generated):

- `brace-expansion@^2.0.1`: 2.1.1 → **2.1.2** (patched, advisory range `>=2.0.0 <2.1.2`)
- `brace-expansion@^5.0.2`: 5.0.6 → **5.0.7** (patched, advisory range `>=3.0.0 <5.0.7`), deduped with the existing `^5.0.5` entry already at 5.0.7

The lockfile now contains no `brace-expansion` version in a vulnerable range of GHSA-3jxr-9vmj-r5cp.

### Verification
- `yarn install` in `build-system-tests/e2e` succeeds ("success Saved lockfile", exit 0)
- No `package.json` or source changes; repo-root `yarn.lock` untouched (no conflict with #7056, which addresses alert #561)

**Related:** #7056 fixes the same GHSA in the root lockfile (alert #561).