### PR TITLE
fix(security): resolve js-yaml 4.x to 4.3.0 in root yarn.lock (Dependabot #566)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18776,9 +18776,9 @@ js-yaml@^3.13.1, js-yaml@^3.6.1:
     esprima "^4.0.0"
 
 js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Security fix — Dependabot alert #566 (high)

Resolves [Dependabot alert #566](https://github.com/aws-amplify/amplify-ui/security/dependabot/566): **js-yaml — YAML merge-key chains can force quadratic CPU consumption** ([GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m)), severity **high**.

### What
Lockfile-only re-resolution of the transitive `js-yaml` 4.x entry in the **root `yarn.lock`**: `4.2.0` → `4.3.0` (first patched version). No `package.json` changes and no `resolutions` pin — the existing `^4.1.x` semver ranges (consumers: `@changesets/parse@^0.4.3`, `cosmiconfig@^9.0.0`) already satisfy 4.3.0; the lockfile block was simply deleted and re-resolved via `yarn install`.

The `js-yaml` 3.x entry is untouched (already patched at 3.15.0 via #7052).

### Why Dependabot couldn't auto-fix
`js-yaml` 4.x is a transitive devDependency with no direct `package.json` entry, and Dependabot does not open fix PRs for transitive dependencies in yarn classic lockfiles.

### Verification
- `yarn install --frozen-lockfile` passes (no lockfile drift)
- `node_modules` js-yaml is 4.3.0 and loads/parses YAML correctly
- `yarn changeset status` (direct consumer of js-yaml 4.x via `@changesets/parse`) runs clean
- `turbo run build lint test --filter=@aws-amplify/ui` — all tasks successful

Diff is exactly 1 file (`yarn.lock`), 3 insertions / 3 deletions.
