### PR TITLE
fix(security): bump brace-expansion 2.x to 2.1.3 in root yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12442,9 +12442,9 @@ brace-expansion@^1.1.7:
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1, brace-expansion@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
-  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
+  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
   dependencies:
     balanced-match "^1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12442,9 +12442,9 @@ brace-expansion@^1.1.7:
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1, brace-expansion@^2.0.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
-  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.3.tgz#1bf69aacdf6a4380ca17c284d9f928d4aa6401bc"
+  integrity sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==
   dependencies:
     balanced-match "^1.0.0"
 


### PR DESCRIPTION
## Description

Lockfile-only security fix for **Dependabot alert [#565](https://github.com/aws-amplify/amplify-ui/security/dependabot/565)** (high severity).

**brace-expansion** — DoS via exponential-time expansion of consecutive non-expanding `{}` groups ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) / [CVE-2026-13149](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)).
Transitive dev-scope dependency in the root `yarn.lock`.
Vulnerable range: `>= 2.0.0, < 2.1.2`; patched version: **2.1.3**.

## Fix

Re-resolved the `brace-expansion@^2.0.1, brace-expansion@^2.0.2` block in the root `yarn.lock` to **2.1.3** (patched, semver-compatible — no `package.json` or `resolutions` change needed).

Scope notes:
- The 1.x block (1.1.15, alert #564) and 5.x block (5.0.6, alert #561 / PR #7056) are untouched.
- `build-system-tests/e2e/yarn.lock` (alerts #560/#562, PR #7057) is not modified.

## Verification
- `yarn why brace-expansion` shows only 1.1.15 / 2.1.3 / 5.0.6 — no version in the vulnerable range remains
- `yarn install` exits cleanly
- Diff is exactly 1 file (`yarn.lock`), 3 insertions / 3 deletions.