### PR TITLE
fix(security): re-resolve brace-expansion 1.x to 1.1.16 in root yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12434,9 +12434,9 @@ boxen@1.3.0:
     widest-line "^2.0.0"
 
 brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
## Description

Lockfile-only security fix for **Dependabot alert #564** (high severity): https://github.com/aws-amplify/amplify-ui/security/dependabot/564

**brace-expansion** — DoS via exponential-time expansion of consecutive non-expanding `{}` groups (GHSA-3jxr-9vmj-r5cp / CVE-2026-13149). Transitive runtime-scope dependency in the root `yarn.lock` (pulled in via minimatch 3.x). Vulnerable range: `< 1.1.16`; first patched version: `1.1.16`.

## Fix

Deleted the vulnerable `brace-expansion@^1.1.7` block (resolved to 1.1.15) from the root `yarn.lock` and re-ran `yarn install`, re-resolving it to **1.1.16** (patched, semver-compatible — no `package.json` or `resolutions` change needed).

Scope notes:
- The 2.x block (2.1.1, alert #565 / PR #7063) and 5.x block (5.0.6, alert #561 / PR #7056) are untouched.
- `build-system-tests/e2e/yarn.lock` (alerts #560/#562, PR #7057) is not modified.

## Verification

- `grep -A4 'brace-expansion@' yarn.lock` shows the 1.x block at **1.1.16** — no 1.x version in the vulnerable range remains
- `yarn why brace-expansion` finds brace-expansion@1.1.16 hoisted for all minimatch-3.x consumers (2.1.1 / 5.0.6 untouched for theirs)
- `yarn install` exits cleanly ("success Saved lockfile")
- Lockfile-only change (no source files touched); the repo's standard CI checks (prettier/eslint/unit tests) run on this PR

Diff is exactly 1 file (`yarn.lock`), 3 insertions / 3 deletions.
