### PR TITLE
fix(security): resolve js-yaml to 4.3.0 in build-system-tests/e2e lockfile

### DIFF
--- a/build-system-tests/e2e/yarn.lock
+++ b/build-system-tests/e2e/yarn.lock
@@ -2320,9 +2320,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Security fix — Dependabot alert #563 (high)

**Finding:** js-yaml — YAML merge-key chains can force quadratic CPU consumption (GHSA-52cp-r559-cp3m, CVE-2026-59869). Transitive dev-scoped dependency in `build-system-tests/e2e/yarn.lock`; vulnerable range `>= 4.0.0, < 4.3.0`; first patched version `4.3.0`.

**Alert:** https://github.com/aws-amplify/amplify-ui/security/dependabot/563

## Change

Lockfile-only re-resolution of the `js-yaml@^4.1.0` entry in `build-system-tests/e2e/yarn.lock` from 4.2.0 to 4.3.0. Both consumers (`cosmiconfig@^9.0.0` and `mocha`) declare `js-yaml "^4.1.0"`, which 4.3.0 satisfies — no `package.json` changes and no resolutions pin needed. Mirrors the approach used in #7062, which applied the identical fix to the root `yarn.lock` for sibling alert #566 (root lockfile intentionally untouched here).

## Verification

- `yarn install --frozen-lockfile` in `build-system-tests/e2e` exits clean with no lockfile drift
- Installed `js-yaml` resolves to 4.3.0; zero remaining js-yaml 4.0–4.2 references in the lockfile
- Functional smoke test (js-yaml load/parse) passed

Merging this PR will close Dependabot alert #563.