### PR TITLE
fix(security): force @hono/node-server >= 2.0.5 (dependabot #575)

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "**/@angular-devkit/build-angular/http-proxy-middleware": "3.0.7",
     "**/@angular-devkit/build-angular/piscina": "4.9.3",
     "**/@angular/build/piscina": "4.9.3",
-    "**/pacote/sigstore": "^4.1.1"
+    "**/pacote/sigstore": "^4.1.1",
+    "**/@modelcontextprotocol/sdk/@hono/node-server": "^2.0.5"
   },
   "devDependencies": {
     "@aws-amplify/backend": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5722,10 +5722,10 @@
   dependencies:
     "@hapi/hoek" "^11.0.2"
 
-"@hono/node-server@^1.19.9":
-  version "1.19.14"
-  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
-  integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
+"@hono/node-server@^1.19.9", "@hono/node-server@^2.0.5":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-2.0.11.tgz#0e947b19fe8602232cf6049feeda8f15dea47569"
+  integrity sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==
 
 "@humanfs/core@^0.19.2":
   version "0.19.2"


### PR DESCRIPTION
## Security fix — Dependabot alert #575 (medium)

**Finding:** `@hono/node-server` — Node.js Adapter for Hono: Path traversal in serve-static on Windows via encoded backslash (`%5C`) — [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9). Vulnerable range: `< 2.0.5`; first patched: `2.0.5`.
**Alert:** https://github.com/aws-amplify/amplify-ui/security/dependabot/575

## Why a resolution

Dependency chain: `@angular/cli ^20.3.26` (devDependency) → `@modelcontextprotocol/sdk 1.26.0` (exact pin) → `@hono/node-server ^1.19.9` (resolved 1.19.14). Even the latest `@modelcontextprotocol/sdk` still requires `^1.19.9`, so there is no upgrade path via parents, and Dependabot cannot auto-fix because 2.0.5 is a major bump outside the semver range.

## Change

Added a scoped yarn resolution to the root `package.json` (matching the repo's existing scoped-resolution style):

```json
"**/@modelcontextprotocol/sdk/@hono/node-server": "^2.0.5"
```

`yarn.lock` now resolves `@hono/node-server` to **2.0.11** everywhere (no entry < 2.0.5 remains). Peer dep `hono ^4` is satisfied by the lockfile's `hono 4.12.30`.

This is a dev-only chain (`@angular/cli` tooling); the MCP-server feature of `@angular/cli` is not used by amplify-ui builds, so major-bump compat risk is minimal.

## Verification

- `yarn install` clean
- `yarn ui build` OK
- `yarn angular build` OK (exercises `@angular/cli`, the chain's root)
- `yarn angular test` — 43/43 passed (15 suites)
- `yarn angular lint` (tsc + eslint) clean