### PR TITLE
fix(security): bump transitive immutable to 4.3.9 / 5.1.9 (Dependabot #577)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -17380,14 +17380,14 @@ immer@^9.0.12:
   integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
 immutable@^4.0.0, immutable@~3.7.6:
-  version "4.3.8"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.8.tgz#02d183c7727fb2bb1d5d0380da0d779dce9296a7"
-  integrity sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.9.tgz#c98349e05e9c6e2a4d8fe88ac0b363e0d536b544"
+  integrity sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==
 
 immutable@^5.0.2, immutable@^5.1.5:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.1.6.tgz#21639bc80f9a0713e141a5f5a154ef9fdabf36dd"
-  integrity sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.1.9.tgz#ac23c3a01992ab665e14ac9ffff298f28cd74a0c"
+  integrity sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==
 
 import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.1"


### PR DESCRIPTION
## Description

Fixes **Dependabot alert #577** (high severity): https://github.com/aws-amplify/amplify-ui/security/dependabot/577

`immutable` (transitive npm dependency, yarn.lock) is affected by **CVE-2026-59879 / GHSA-v56q-mh7h-f735** — Immutable.js `List` 32-bit trie overflow leading to unrecoverable DoS. Vulnerable ranges: `<4.3.9` and `>=5.0.0-beta.1 <5.1.8`.

## Fix

Lockfile-only bump of both transitive `immutable` entries (no `package.json` edits, no new resolutions, pinned Angular versions untouched):

| Lockfile entry | Before | After |
|---|---|---|
| `immutable@^5.0.2` (sass via @angular-devkit/build-angular, @angular/build, ng-packagr) | 5.1.6 (vulnerable) | **5.1.9** |
| `immutable@^4.0.0, immutable@~3.7.6` (sass, @ardatan/relay-compiler) | 4.3.8 (vulnerable range) | **4.3.9** |

Both patched versions satisfy the existing semver ranges; the two stale entry blocks were removed from `yarn.lock` and re-resolved via `yarn install`. No other `immutable` versions remain in the lockfile.

## Verification (local)

- `yarn install` ✅ (also with `--frozen-lockfile`)
- `yarn build` ✅ (14/14 turbo tasks incl. ui-angular)
- `yarn lint` ✅ (14/14)
- `yarn test` ✅ (13/13)
- size-limit gates: react, react-ai, react-geo, react-liveness, react-notifications ✅

> **Note:** the `unit (react-storage)` size-limit gate is over budget by 43 B (`StorageBrowser` 157.04 kB vs 157 kB budget) — this is **pre-existing on unmodified `main`** (verified via baseline run at 25e8d96a4, introduced by the folder-download merge #7046) and unrelated to this lockfile change. It will fail that CI job for any PR until the budget is bumped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
