### PR TITLE
chore(examples): fix flaky next-app-router controlled value e2e

### DIFF
--- a/examples/next-app-router/src/app/storage-browser/controlled-value/page.tsx
+++ b/examples/next-app-router/src/app/storage-browser/controlled-value/page.tsx
@@ -2,12 +2,11 @@
 import { StorageBrowser } from '../storage-browser'; // IGNORE
 
 import React from 'react';
-import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 import { StorageBrowserEventValue } from '@aws-amplify/ui-react-storage/browser';
 
 export default function Page() {
-  const router = useRouter();
   const pathname = usePathname();
   const params = useSearchParams();
 
@@ -18,9 +17,18 @@ export default function Page() {
       const nextParams = new URLSearchParams();
       nextParams.set('value', JSON.stringify(nextValue));
 
-      router.push(`${pathname}?${nextParams.toString()}`);
+      // `history.pushState` is used instead of `router.push` because the update
+      // is a search param change only. `router.push` triggers an RSC round trip
+      // that the App Router can silently discard while prefetch requests for the
+      // route are still in flight, leaving `value` on its previous state with no
+      // error and no retry.
+      window.history.pushState(
+        null,
+        '',
+        `${pathname}?${nextParams.toString()}`
+      );
     },
-    [pathname, router]
+    [pathname]
   );
 
   return (


### PR DESCRIPTION
## Description of changes

The `e2e (next-app-router)` job has been failing intermittently on
`storage/storage-browser/controlled-value.feature`, scenario "Handles controlled
value prop". 6 of the last 11 runs of that job failed, always on the same step
with the same assertion:

```
When  I click the "my-deeply-nested-prefix/" button
- click                                    <- succeeded
Then  I see the "No files." message
findByText  No files.                      0
AssertionError: Timed out retrying after 15000ms
```

The failure screenshot shows the click landing, then the browser sitting on
`my-nested-prefix` for the full 15s with the `my-deeply-nested-prefix/` row still
in the table. Environments across passing and failing runs are identical (same
Next, Cypress, Chrome and Node versions, same cache hits), and suite time is 18s
when it passes vs 33s when it fails, exactly the timeout and nothing else.

### Root cause

I reproduced this locally by throttling the CPU 20x via CDP
(`Emulation.setCPUThrottlingRate`) and delaying `_rsc` responses so that prefetch
traffic overlaps the navigation, the way it does on a slow CI runner. That gave
5 failures in 8 attempts with the identical signature.

Instrumenting the example page to log every render's `value` prop, every
`onValueChange`, and every RSC request showed the amplify-ui side of the chain
behaving correctly. Failing run:

```
app  render path=my-nested-prefix/
app  onValueChange path=my-nested-prefix/my-deeply-nested-prefix/
app  pushed
app  render path=my-nested-prefix/        <- reverted to the previous value
```

Passing run:

```
app  onValueChange path=my-nested-prefix/my-deeply-nested-prefix/
app  pushed
rsc  req  path=my-nested-prefix/my-deeply-nested-prefix/  purpose=navigate
rsc  resp path=my-nested-prefix/my-deeply-nested-prefix/
app  render path=my-nested-prefix/my-deeply-nested-prefix/
```

So `onValueChange` fires with the correct value and `router.push` is called with
the correct URL. Next then discards the navigation: no RSC request for the pushed
URL, no history entry, and the component re-renders with the previous search
params. The browser URL confirms it, on failing runs it is still the original
`<Link>` URL. The trigger is prefetch requests for the route still being in
flight when the push is issued.

Because `StorageBrowser` is fully controlled on this page, there is no internal
fallback state and no retry, so one dropped push freezes the UI permanently.
That is why the failure is a clean 15s timeout rather than a slow pass. The
sibling `default-value.feature` covers nearly the same navigation through
`defaultValue` (uncontrolled, no round trip) and has never flaked.

### The change

The update is a search param change only, so there is no reason to pay for an
RSC round trip. `history.pushState` is supported by the App Router for exactly
this case and `useSearchParams` reflects it, so the value lands synchronously
and back/forward continue to work.

This is a test-app-only change. No library code is touched and no changeset is
needed.

## Issue #, if available

n/a

## Description of how you validated changes

- Reproduced the failure locally: CPU throttled 20x plus 1200ms delay on `_rsc`
  responses gave **5 failures in 8 attempts** on the unmodified example.
- Same harness against this change: **12 of 12 passing**.
- `controlled-value.feature` as CI runs it: passing (908ms).
- Full `@next-app-router` suite: **all 97 specs, 312 tests passing** in 15s.
- `yarn next-app-router-example lint` and `build` clean.

Test time for the scenario also drops from 8-14s to 4-8s under load, since the
navigation no longer waits on the server.

## Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md#unit-tests)
- [ ] Relevant documentation is changed or added (and PR referenced)

## Note

Arguably this is also a Next.js bug, dropping a `router.push` with no error and
no retry is hard to defend. A minimal upstream repro may be worth filing
separately. This change makes the test app correct regardless.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
