### PR TITLE
ci(build-system-tests): replace Angular 19 mega-app with Angular 20

### DIFF
--- a/.github/workflows/reusable-build-system-test.yml
+++ b/.github/workflows/reusable-build-system-test.yml
@@ -54,10 +54,12 @@ jobs:
             build-tool-version: latest
             pkg-manager: npm
             node-version: 24
+          # Angular 20 is the floor of the @aws-amplify/ui-angular peer range.
+          # Angular 19 reached end of life on 2026-05-19.
           - framework: angular
-            framework-version: 19
+            framework-version: 20
             build-tool: angular-cli
-            build-tool-version: 19
+            build-tool-version: 20
             pkg-manager: npm
             node-version: 24
 


### PR DESCRIPTION
#### Description of changes

The `publish-next` workflow has been failing on every push to `main` since the Angular 20 upgrade (#7047) landed. The `publish` job itself succeeds, but the post-publish canary job `build-test / build (angular, 19, angular-cli, 19, npm, 24)` fails during `npm install`:

```
npm error code ERESOLVE
npm error While resolving: angular-19-angular-cli-19-ui-next@0.0.0
npm error Found: @angular/common@19.2.25
npm error   @angular/common@"^19.2.0" from the root project
npm error Could not resolve dependency:
npm error peer @angular/common@">= 20.0.0" from @aws-amplify/ui-angular@0.0.0-next-...
```

#7047 raised the `@aws-amplify/ui-angular` peer range to `>= 20.0.0`, but the build-system-test matrix still scaffolds an Angular 19 mega-app, so the published `@next` package can no longer be installed there. `install-with-retries` burns all 4 attempts and the job fails.

This replaces the Angular 19 matrix entry with Angular 20. Angular 19 reached end of life on 2026-05-19, so there is no reason to keep it in the canary matrix. Pinning to 20 keeps coverage of the floor of the declared peer range, alongside the existing `latest` (v22) entry.

No script changes are needed: both `mega-app-copy-files.sh` and `mega-app-install.sh` branch on `>= 21` for the newer bootstrap config and the explicit `zone.js` dependency, so an Angular 20 app takes the same path Angular 19 did.

#### Issue #, if available

N/A

#### Description of how you validated changes

- Verified the failing job and root cause in run [29840776966](https://github.com/aws-amplify/amplify-ui/actions/runs/29840776966) and in the two prior `publish-next` failures, all failing on the same Angular 19 job. The last green `publish-next` run predates #7047.
- Confirmed `.github/workflows/reusable-build-system-test.yml` is the only place the Angular matrix is defined (`build-system-test.yml` delegates to it, and the react-native reusable workflow has no Angular entries).
- Parsed the workflow YAML to confirm the matrix resolves to Angular `latest` + `20` with no remaining `19` entries.
- `prettier --check` passes on the modified file.
- The canary build for the new `angular-20-angular-cli-20` mega-app runs on merge to `main`.

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, changeset added — not applicable, CI-only change with no package code affected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
