### PR TITLE
fix(security): re-resolve svgo@^2.7.0 to 2.8.3 (Dependabot alert #584)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25739,9 +25739,9 @@ svg-parser@^2.0.2:
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
 svgo@^2.7.0:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.2.tgz#8e99b7ba5ac9ed7e3a446063865f61e03223fe6b"
-  integrity sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.3.tgz#8de2fa579f3f7429dec3fb86471005cf46fb483a"
+  integrity sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==
   dependencies:
     commander "^7.2.0"
     css-select "^4.1.3"


### PR DESCRIPTION
## Security fix — Dependabot alert #584 (high)

**Finding:** svgo — "SVGO removeScripts plugin leaves some executable scripts intact" ([GHSA-2p49-hgcm-8545](https://github.com/advisories/GHSA-2p49-hgcm-8545), no CVE).
**Alert:** https://github.com/aws-amplify/amplify-ui/security/dependabot/584
**Type:** dependabot | **Severity:** high

### Description of the problem
The root `yarn.lock` entry `svgo@^2.7.0` resolved to **2.8.2**, which is in the vulnerable range (`>= 1.0.0, < 2.8.3`). It is a transitive development dependency via:

```
rollup-plugin-styles > cssnano > cssnano-preset-default > postcss-svgo@^5.1.0 > svgo ^2.7.0
```

### Description of changes
Lockfile-only re-resolution of the `svgo@^2.7.0` entry from 2.8.2 to **2.8.3** (the first patched version). 2.8.3 satisfies the existing `^2.7.0` range, so no `package.json` or `resolutions` changes are needed. svgo 2.8.3's dependency list is identical to 2.8.2, so no other lockfile entries were affected.

The separate `svgo@^4.0.1` lockfile entry is intentionally untouched — that is alert #576, addressed by #7067.

### Verification
- `yarn install --frozen-lockfile` passes (lockfile consistent)
- `yarn build` in `packages/react-storage` (a rollup-plugin-styles > cssnano > postcss-svgo consumer) passes
- `yarn why svgo` confirms only svgo@2.8.3 and svgo@4.0.1 remain

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.