### PR TITLE
fix(security): retarget stale minimatch pins in e2e lockfile

### DIFF
--- a/build-system-tests/e2e/package.json
+++ b/build-system-tests/e2e/package.json
@@ -30,10 +30,9 @@
     "qs": "^6.15.2",
     "diff": "8.0.3",
     "serialize-javascript": "^7.0.5",
-    "**/find-cypress-specs/minimatch": "^10.2.4",
-    "**/mocha/minimatch": "5.1.8",
-    "**/@typescript-eslint/typescript-estree/minimatch": "9.0.7",
-    "**/glob/minimatch": "9.0.7",
+    "**/mocha/minimatch": "9.0.8",
+    "**/mocha/glob/minimatch": "9.0.8",
+    "**/rimraf/glob/minimatch": "9.0.8",
     "uuid": "^11.1.1",
     "tmp": "^0.2.6"
   }

--- a/build-system-tests/e2e/yarn.lock
+++ b/build-system-tests/e2e/yarn.lock
@@ -822,11 +822,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
   integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
-  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
 balanced-match@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
@@ -854,24 +849,10 @@ bluebird@^3.7.2:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-brace-expansion@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
-  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
-  dependencies:
-    balanced-match "^1.0.0"
-
-brace-expansion@^5.0.2:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
-  dependencies:
-    balanced-match "^4.0.2"
-
-brace-expansion@^5.0.5:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
-  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
+brace-expansion@^5.0.2, brace-expansion@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -2535,21 +2516,14 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@5.1.8, minimatch@^9.0.5:
-  version "5.1.8"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.8.tgz#32a16ebcccd6421c674430acb199b8806c68169b"
-  integrity sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@9.0.7, minimatch@^10.2.2, minimatch@^9.0.4:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.7.tgz#d76c4d0b3b527877016d6cc1b9922fc8e0ffe7b0"
-  integrity sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==
+minimatch@9.0.8, minimatch@^9.0.4, minimatch@^9.0.5:
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.8.tgz#bb3aa36d7b42ea77a93c44d5c1082b188112497c"
+  integrity sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==
   dependencies:
     brace-expansion "^5.0.2"
 
-minimatch@^10.2.4:
+minimatch@^10.2.2, minimatch@^10.2.4:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
   integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==


### PR DESCRIPTION
#### Description of changes

Fixes the root cause behind the repeated `dependency-review` failures on the
`brace-expansion` alerts for `build-system-tests/e2e` (for example [#7057's run](https://github.com/aws-amplify/amplify-ui/actions/runs/30162996119/job/89691257191)),
rather than bumping `brace-expansion` again inside a version line that has no patched release.

**Root cause:** four `resolutions` entries in `build-system-tests/e2e/package.json` had gone
stale. Their targets moved on to newer majors, so the pins turned into cross-major *downgrades*
that froze `minimatch` — and therefore `brace-expansion` — on abandoned lines:

| consumer | declares | was resolved to | `brace-expansion` |
| --- | --- | --- | --- |
| `mocha@11.7.6` | `minimatch@^9.0.5` | **5.1.8** (pinned) | `^2.0.1` → 2.1.1 |
| `glob@10.5.0` | `minimatch@^9.0.4` | 9.0.7 (pinned) | `^5.0.2` → 5.0.6 |
| `glob@13.0.6` | `minimatch@^10.2.2` | **9.0.7** (pinned) | `^5.0.2` → 5.0.6 |
| `@typescript-eslint/typescript-estree@8.61.1` | `minimatch@^10.2.2` | **9.0.7** (pinned) | `^5.0.2` → 5.0.6 |
| `find-cypress-specs@1.54.12` | `minimatch@^10.2.4` | 10.2.5 | `^5.0.5` → 5.0.7 |

`minimatch@5.x` depends on `brace-expansion@^2.0.1` for its entire life, and the newest 2.x
release (2.1.2) is still vulnerable to [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)
(`<= 5.0.7`, patched only in 5.0.8). So while `mocha` was held on `minimatch@5.1.8` this lockfile
could not reach a patched `brace-expansion` at all — every attempt to bump within 2.x was
guaranteed to stay flagged.

**Change:** retarget the pins at versions that are both inside each consumer's declared range
and on a `brace-expansion` line that receives patches, then let the `brace-expansion` entries
re-resolve.

- `**/mocha/minimatch`: `5.1.8` → `9.0.8` (satisfies `^9.0.5`, depends on `brace-expansion@^5.0.2`)
- `**/glob/minimatch: 9.0.7` replaced by `**/mocha/glob/minimatch` and `**/rimraf/glob/minimatch`
  at `9.0.8`, so `glob@13` is no longer downgraded off its declared `^10.2.2`
- `**/@typescript-eslint/typescript-estree/minimatch` and `**/find-cypress-specs/minimatch`
  removed — both declare `^10.2.x` and resolve to the patched 10.2.5 on their own

The pins have to stay in some form: `minimatch@9.0.9` reverted to `brace-expansion@^2.0.2`,
so letting `^9.0.4`/`^9.0.5` float would land back on the unpatchable 2.x line. `9.0.8` is the
highest 9.x that uses `brace-expansion@^5.0.2`, and it is above the `>= 9.0.7` fix line for all
three open `minimatch` ReDoS advisories.

Resulting lockfile state — one `brace-expansion`, no semver violations, everything patched:

```
brace-expansion@^5.0.2, brace-expansion@^5.0.5 -> 5.0.8
minimatch@9.0.8, minimatch@^9.0.4, minimatch@^9.0.5 -> 9.0.8   (mocha, glob@10)
minimatch@^10.2.2, minimatch@^10.2.4 -> 10.2.5                 (glob@13, typescript-estree, find-cypress-specs)
```

Dev-scope only: `build-system-tests/e2e` is the canary Cypress project, nothing here ships to customers.

#### Issue #, if available

Resolves Dependabot alerts #560 and #562 (both `brace-expansion` in
`build-system-tests/e2e/yarn.lock`) and pre-empts GHSA-mh99-v99m-4gvg for the same lockfile.

Supersedes #7057, which fixed the 2.x entry to 2.1.2 and was then blocked by the newer advisory.
Related: #7063 and #7076 cover the root `yarn.lock`.

#### Description of how you validated changes

- `yarn install` in `build-system-tests/e2e` succeeds, and a second run reports
  `success Already up-to-date` — the lockfile is stable, matching how CI installs this project
  (plain `yarn install` with `CYPRESS_INSTALL_BINARY=0`).
- Diff is confined to `minimatch`/`brace-expansion` plus the now-unreferenced
  `balanced-match@^1.0.0` entry that only `brace-expansion@2.x` needed.
- Installed on disk: a single `brace-expansion@5.0.8`, `minimatch@10.2.5` hoisted,
  `minimatch@9.0.8` under `mocha` and `glob`.
- Runtime check of every `minimatch` copy against `brace-expansion@5.0.8`: pattern matching,
  brace patterns (`features/**/*.{feature,ts}`), `braceExpand`, `glob.globSync` with a brace
  pattern, and `require` of `mocha` and `find-cypress-specs` all behave as expected. The
  advisory's proof-of-concept input now returns a bounded result in ~240ms instead of crashing
  the process.
- Checked each newly added version against the GitHub Advisory Database: `minimatch@9.0.8`,
  `brace-expansion@5.0.8` and `balanced-match@4.0.4` have no advisories affecting them.
- The Cypress canary suite that consumes this lockfile is not exercised by PR checks: Build
  System Test Canary runs on a schedule against `main`, so it will first execute after merge.
  That is why the `minimatch`/`brace-expansion` compatibility was verified directly with the
  runtime checks above.

#### Note for a follow-up

The root `yarn.lock` has the same failure mode, which is why #7063 cannot pass `dependency-review`
as written: `minimatch@^5.x` resolves to 5.1.9 and `minimatch@^9.0.x` to 9.0.9, and both of those
depend on `brace-expansion@2.x` (`^2.0.1`/`^2.0.2` → 2.1.1). Bumping that entry to 2.1.2 stays
inside the unpatchable line. Getting those consumers onto `minimatch@9.0.8`/`10.2.5` is the
equivalent fix there, and it is deliberately left out of this PR to keep the monorepo lockfile
churn separate.

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax

Not applicable: no changeset — `build-system-tests` is a private package and nothing published changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
