### PR TITLE
fix(docs): upgrade docs release build to Node 24

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -6,8 +6,8 @@ applications:
         preBuild:
           commands:
             - rm -rf node_modules
-            - nvm install 20.19.5
-            - nvm use 20.19.5
+            - nvm install 24
+            - nvm use 24
             - node -v
             - export FLUTTER_HOME=${HOME}/sdks/flutter
             # pin to flutter v3.22.2
@@ -19,8 +19,8 @@ applications:
             - (cd .. && yarn install && yarn build)
         build:
           commands:
-            - nvm install 20.19.5
-            - nvm use 20.19.5
+            - nvm install 24
+            - nvm use 24
             - node -v
             - yarn flutter:build
             - yarn build


### PR DESCRIPTION
The docs release build (Amplify Hosting, `amplify.yml`) pinned Node 20.19.5 via nvm. `lint-staged@17.0.7` declares `engines.node: >=22.22.1`, so `yarn install` aborted with "Found incompatible module" and the docs deploy failed.

This bumps both the preBuild and build phases to Node 24 (satisfies the engine requirement).