### PR TITLE
fix(security): re-resolve brace-expansion 1.x to 1.1.17 in root yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12244,9 +12244,9 @@ boxen@1.3.0:
     widest-line "^2.0.0"
 
 brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.17.tgz#a375e14e41d672617de69526be02d0d7751a6909"
+  integrity sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
## Security fix

Resolves **Dependabot alert #607** (high severity): https://github.com/aws-amplify/amplify-ui/security/dependabot/607

**Finding:** `brace-expansion` (npm, transitive dependency in the root `yarn.lock`) is vulnerable to a DoS via unbounded expansion length causing an out-of-memory process crash (CVE-2026-14257 / GHSA-mh99-v99m-4gvg). The `brace-expansion@^1.1.7` lockfile entry resolved to 1.1.16, which is inside the vulnerable range (< 1.1.17).

## Fix

Lockfile-only change: re-resolved the `brace-expansion@^1.1.7` entry in the root `yarn.lock` from 1.1.16 to 1.1.17 (first patched version) — updated version, resolved URL, and integrity to the npm-published 1.1.17 tarball. No `package.json` or `resolutions` changes.

- The 2.x entry (2.1.3) is untouched (not affected).
- The 5.x entry (5.0.7) is untouched — covered by #7076 for alert #604.
- `build-system-tests/` and `e2e/` lockfiles untouched.

## Verification

- `yarn install` completes cleanly with no further lockfile churn (diff stays 3 insertions / 3 deletions in `yarn.lock` only)
- Installed `brace-expansion` copies in `node_modules`: 4× 1.1.17, 13× 2.1.3, 9× 5.0.7 — zero vulnerable 1.x (< 1.1.17) copies remain
- `yarn build` (14/14 turbo tasks), `yarn lint` (14/14), and `yarn test` (13/13) all pass at the workspace root

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.