### PR TITLE
fix(deps): bump undici to 6.28.0 to address CRLF/cookie-injection & response-desync advisories

### DIFF
--- a/build-system-tests/e2e/yarn.lock
+++ b/build-system-tests/e2e/yarn.lock
@@ -3618,9 +3618,9 @@ typescript@^5.1.6, typescript@^5.9.3:
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 undici@^6.23.0:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
-  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unicorn-magic@^0.4.0:
   version "0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -26625,9 +26625,9 @@ undici-types@~6.21.0:
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici@^6.23.0, undici@^6.25.0:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
-  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
#### Description of changes

Resolves six medium-severity Dependabot alerts for the transitive `undici` dependency (three in the root `yarn.lock`, three in `build-system-tests/e2e/yarn.lock`), all fixed in `undici@6.28.0`:

- **#622 / #614** — downstream response desynchronization
- **#623 / #615** — cookie attribute injection via unsanitized values
- **#624 / #616** — CRLF injection via blob-like body

`undici` was pinned to `6.27.0` in both lockfiles and is purely transitive. Both existing ranges (`^6.23.0`, `^6.25.0`) already allow `6.28.0`, so this is a lockfile-only re-resolution — surgically editing just the `undici` entry in each lockfile (version, `resolved`, `integrity`). `undici@6.28.0` has no runtime dependencies, so nothing else in the tree shifts.

#### Issue #, if available

Dependabot alerts #614, #615, #616, #622, #623, #624.

#### Description of how you validated changes

- Confirmed `6.28.0` is the first patched version for all three advisories and satisfies the existing `^6.x` ranges.
- Verified the pinned `version` / `resolved` tarball / `integrity` hash against the npm registry for `undici@6.28.0`.
- Diff is limited to the single `undici` block in each of the two lockfiles (no dependency lines, since `undici` has none).

#### Checklist

- [x] Have read the Pull Request Guidelines
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow conventional commit syntax
- [ ] _If this change should result in a version bump_, changeset added

> Note: dependency-only security fix in lockfiles (transitive, purely in private `e2e` and non-published trees). No changeset needed; no source or test changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
