### PR TITLE
fix(deps): bump vulnerable deps to patched versions (resolves all open Dependabot alerts)

### DIFF
--- a/build-system-tests/e2e/yarn.lock
+++ b/build-system-tests/e2e/yarn.lock
@@ -3618,9 +3618,9 @@ typescript@^5.1.6, typescript@^5.9.3:
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 undici@^6.23.0:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
-  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unicorn-magic@^0.4.0:
   version "0.4.0"

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -29,7 +29,7 @@
     "@angular/compiler-cli": "^20.3.26",
     "@angular/animations": "^20.3.26",
     "@angular/common": "^20.3.27",
-    "@angular/compiler": "^20.3.26",
+    "@angular/compiler": "^20.3.27",
     "@angular/core": "^20.3.27",
     "@angular/platform-browser": "^20.3.26",
     "@angular/platform-browser-dynamic": "^20.3.26",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -23,7 +23,7 @@
     "@angular/animations": "^20.3.26",
     "@angular/cli": "^20.3.26",
     "@angular/common": "^20.3.27",
-    "@angular/compiler": "^20.3.26",
+    "@angular/compiler": "^20.3.27",
     "@angular/compiler-cli": "^20.3.26",
     "@angular/core": "^20.3.27",
     "@angular/forms": "^20.3.26",

--- a/yarn.lock
+++ b/yarn.lock
@@ -569,10 +569,10 @@
     tslib "^2.3.0"
     yargs "^18.0.0"
 
-"@angular/compiler@20.3.26", "@angular/compiler@^20.3.26":
-  version "20.3.26"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-20.3.26.tgz#d4a7a87401ae1ef3a354c91a82b71156db121801"
-  integrity sha512-H4DVTBCiyM4dGytFi2C8sMGflxXzPnoQ6Ajfs4hJ/Dekg6ypfvW5Ze7BDh4TaMQvaX2joM5LhBYW5jTxBx66hA==
+"@angular/compiler@20.3.27", "@angular/compiler@^20.3.27":
+  version "20.3.27"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-20.3.27.tgz#052a968f3830b9279d299b7ee0d1f248bdf0dc23"
+  integrity sha512-in3THZ678GAYuOR9RZV18+zZz0KGhlGikyUEfLeALLjGf9ZaR3n+t19BmYx6G2VkF/Xqadne1omQ2vbl6PRASA==
   dependencies:
     tslib "^2.3.0"
 
@@ -12396,9 +12396,9 @@ boxen@1.3.0:
     widest-line "^2.0.0"
 
 brace-expansion@^1.1.7:
-  version "1.1.17"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.17.tgz#a375e14e41d672617de69526be02d0d7751a6909"
-  integrity sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -12411,9 +12411,9 @@ brace-expansion@^2.0.1, brace-expansion@^2.0.2:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
-  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -15938,9 +15938,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fast-url-parser@1.1.3:
   version "1.1.3"
@@ -17078,9 +17078,9 @@ hoist-non-react-statics@^3.3.0:
     react-is "^16.7.0"
 
 hono@^4.11.4:
-  version "4.12.30"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.30.tgz#4d57b051c66617b003b7ba318910cb5b79c4c7ac"
-  integrity sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.13.0.tgz#ac1ba1650b4fd9cbe53e17bea0525f53cb65813d"
+  integrity sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==
 
 hosted-git-info@^7.0.0:
   version "7.0.2"
@@ -24927,9 +24927,9 @@ socket.io-adapter@~2.5.2:
     ws "~8.21.0"
 
 socket.io-parser@~4.2.4:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.6.tgz#19156bf179af3931abd05260cfb1491822578a6f"
-  integrity sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==
+  version "4.2.7"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.7.tgz#679e51fe24d1c81df90fc5f7efe4a5f432fe99c0"
+  integrity sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==
   dependencies:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.4.1"
@@ -26625,9 +26625,9 @@ undici-types@~6.21.0:
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici@^6.23.0, undici@^6.25.0:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
-  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
#### Description of changes

Resolves **all open Dependabot alerts** on the repo in a single dependency-only change. Each package is bumped to its first patched version; every target already satisfies the existing semver range (or, for `@angular/compiler`, the sub-package manifest pin), so the changes are surgical lockfile/manifest edits with no unrelated tree churn.

| Alert(s) | Package | Bump | Advisory |
|---|---|---|---|
| #609 | `@angular/compiler` | `20.3.26 → 20.3.27` | i18n XSS via event-handler attributes |
| #617 | `brace-expansion` (1.x) | `1.1.17 → 1.1.18` | ReDoS / unbounded intermediate arrays |
| #619 | `brace-expansion` (5.x) | `5.0.8 → 5.0.9` | ReDoS / unbounded intermediate arrays |
| #621 | `fast-uri` | `3.1.4 → 3.1.5` | host confusion via backslash |
| #625 | `hono` | `4.12.30 → 4.13.0` | ReDoS in CORS middleware |
| #620 | `socket.io-parser` | `4.2.6 → 4.2.7` | zero-attachment memory exhaustion |
| #622, #623, #624 | `undici` (root lockfile) | `6.27.0 → 6.28.0` | CRLF injection, cookie injection, response desync |
| #614, #615, #616 | `undici` (`build-system-tests/e2e` lockfile) | `6.27.0 → 6.28.0` | same three advisories in the e2e lockfile |

`@angular/compiler` is bumped in the two Angular sub-package manifests (`packages/angular`, `examples/angular`) plus the lockfile, following the same pattern as the already-merged sibling PRs #7092 (`@angular/common`) and #7095 (`@angular/core`). All other packages are purely transitive and re-resolve within their existing ranges (lockfile-only).

> This consolidates the individual Dependabot PRs (#7094 compiler, #7097 hono, #7098 fast-uri, #7099 socket.io-parser, #7100 undici) into one reviewable change, and additionally covers the `undici` alerts in the e2e lockfile (#614–#616) that the Dependabot PRs did not touch, and the two `brace-expansion` alerts that had no open PR.

#### Issue #, if available

Dependabot alerts #609, #614, #615, #616, #617, #619, #620, #621, #622, #623, #624, #625.

#### Description of how you validated changes

- Confirmed each target version is the first patched version for its advisory and satisfies the existing range / manifest pin.
- Verified every pinned `version` / `resolved` tarball / `integrity` hash against the npm registry.
- Confirmed no dependency ranges changed across any bump (hono/fast-uri: no deps; socket.io-parser: same `debug ~4.4.1` + `@socket.io/component-emitter ~3.1.0`, both already present; compiler/brace-expansion: unchanged), so no new transitive entries are needed and the lockfile stays internally consistent.
- Diff is limited to 7 lockfile blocks in root `yarn.lock`, 1 block in the e2e `yarn.lock`, and the single `@angular/compiler` line in each of the two Angular manifests.

#### Checklist

- [x] Have read the Pull Request Guidelines
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow conventional commit syntax
- [ ] _If this change should result in a version bump_, changeset added

> Note: dependency-only security fix. The `@angular/compiler` bump is in the published `@aws-amplify/ui-angular` package's devDependencies; add a changeset if maintainers consider it release-affecting. No source or test changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
