### PR TITLE
fix(security): bump transitive fast-uri to 3.1.5 (Dependabot alert 621)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15938,9 +15938,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fast-url-parser@1.1.3:
   version "1.1.3"


### PR DESCRIPTION
## Description of changes

Targeted, lockfile-only bump of the transitive dependency `fast-uri` from **3.1.4 → 3.1.5** in `yarn.lock`.

**Security finding:** Dependabot alert [#621](https://github.com/aws-amplify/amplify-ui/security/dependabot/621) — **high** severity.
`fast-uri` vulnerable to host confusion via backslash authority introducer (CVE-2026-18446 / GHSA-7p8r-x3mc-p8w7, CWE-436, CVSS 7.5). Pulled in transitively via `ajv@8` (`fast-uri: ^3.0.1`); 3.1.5 satisfies that existing range, so no `resolutions` entry or `package.json` change is needed.

**Why not Dependabot PR #7098:** its broad lockfile regeneration also downgraded `@angular/core` 20.3.27 → 20.3.26, reintroducing GHSA-jj27-h5hq-8x99 and failing the dependency-review CI gate. This PR hand-edits only the single `fast-uri@^3.0.1` lockfile block (resolved URL + integrity fetched from the npm registry); verified via `git diff` that no other entry moved and `@angular/core` remains at 20.3.27.

**Validation (local):**
- `yarn install --pure-lockfile` succeeds and installs fast-uri 3.1.5
- `turbo run build --filter=@aws-amplify/ui-react-storage...` — 4 tasks OK
- react-storage unit tests: 228 suites, 1509 passed / 5 todo
- `yarn size` (size-limit) checks pass in packages/react-storage

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
