### PR TITLE
fix(ai): stop rendering empty assistant bubble before streamed response

### DIFF
--- a/.changeset/fix-aiconversation-empty-bubble.md
+++ b/.changeset/fix-aiconversation-empty-bubble.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/ui-react-ai': patch
+---
+
+fix(ai): stop rendering an empty assistant bubble before the streamed response
+
+`handleSendMessage` optimistically appends an assistant placeholder with the synthetic id `temp-id-2`. In 1.5.1 the stream handler began matching the streamed message by its real id, which never equals `temp-id-2`, so the first stream event appended a second assistant message instead of replacing the placeholder — leaving an empty bubble beside the real reply. When no message matches the streamed id, the handler now replaces the optimistic placeholder in place, while preserving the by-id matching that handles out-of-order and duplicate stream events.

--- a/packages/react-ai/src/hooks/__tests__/useAIConversation.test.ts
+++ b/packages/react-ai/src/hooks/__tests__/useAIConversation.test.ts
@@ -272,4 +272,59 @@ describe('useAIConverstion', () => {
       expect(text).toBe('ABC');
     });
   });
+
+  // Regression test for https://github.com/aws-amplify/amplify-ui/issues/7105
+  // The streamed assistant events carry the real message id, which never
+  // matches the optimistic 'temp-id-2' placeholder added by sendMessage. In
+  // 1.5.1 that caused the placeholder to be left behind, rendering an empty
+  // assistant bubble alongside the real streamed one.
+  it('replaces the optimistic assistant placeholder instead of leaving an empty bubble', async () => {
+    const client = new mockClient();
+    const { useAIConversation } = createAIHooks(client);
+    const { result } = renderHook(() => useAIConversation('pirateChat'));
+
+    await waitFor(() => {
+      expect(result.current[0].data.conversation).toBeDefined();
+    });
+
+    act(() => {
+      result.current[1]({ content: [{ text: 'hello' }] });
+    });
+
+    // optimistic user + assistant placeholder
+    await waitFor(() => {
+      expect(result.current[0].data.messages).toHaveLength(2);
+    });
+
+    // real streaming events for the assistant turn (real id, not 'temp-id-2')
+    act(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      _next({
+        id: '123',
+        conversationId: id,
+        contentBlockIndex: 0,
+        contentBlockDeltaIndex: 0,
+        text: 'Hello ',
+      });
+    });
+    act(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      _next({
+        id: '123',
+        conversationId: id,
+        contentBlockIndex: 0,
+        contentBlockDeltaIndex: 1,
+        text: 'world',
+      });
+    });
+
+    await waitFor(() => {
+      const { messages } = result.current[0].data;
+      const assistantMessages = messages.filter((m) => m.role === 'assistant');
+      // exactly one assistant bubble, containing the streamed content
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0].id).toBe('123');
+      expect(assistantMessages[0].content[0].text).toBe('Hello world');
+    });
+  });
 });

--- a/packages/react-ai/src/hooks/useAIConversation.tsx
+++ b/packages/react-ai/src/hooks/useAIConversation.tsx
@@ -35,6 +35,14 @@ interface AIConversationState {
 // initialized: the hook has successfully gotten a conversation and is ready to rock
 const INITIALIZE_REF = ['initial', 'initialLoading', 'initialized'] as const;
 
+// Synthetic ids used for the messages optimistically added by
+// `handleSendMessage` before the backend assigns real ids. The streamed
+// assistant events carry the real message id, so the first event of a turn
+// won't match by id; we use this to swap the placeholder in place instead of
+// appending a second (empty) assistant bubble.
+const OPTIMISTIC_USER_MESSAGE_ID = 'temp-id';
+const OPTIMISTIC_ASSISTANT_MESSAGE_ID = 'temp-id-2';
+
 function hasStarted(state: (typeof INITIALIZE_REF)[number]) {
   return ['initialLoading', 'initialized'].includes(state);
 }
@@ -250,17 +258,27 @@ export function createUseAIConversation<
               isLoading: true,
             };
 
-            // Match by message ID instead of assuming last message
+            // Match by real message ID (handles out-of-order / duplicate
+            // events for a message we've already started rendering). On the
+            // first event of a turn there is no match yet, so fall back to the
+            // optimistic assistant placeholder added by handleSendMessage;
+            // replacing it in place avoids leaving an empty assistant bubble.
             const existingIndex = prev.data.messages.findIndex(
               (m) => m.id === id
             );
+            const targetIndex =
+              existingIndex >= 0
+                ? existingIndex
+                : prev.data.messages.findIndex(
+                    (m) => m.id === OPTIMISTIC_ASSISTANT_MESSAGE_ID
+                  );
 
             const updatedMessages =
-              existingIndex >= 0
+              targetIndex >= 0
                 ? [
-                    ...prev.data.messages.slice(0, existingIndex),
+                    ...prev.data.messages.slice(0, targetIndex),
                     message,
-                    ...prev.data.messages.slice(existingIndex + 1),
+                    ...prev.data.messages.slice(targetIndex + 1),
                   ]
                 : [...prev.data.messages, message];
 
@@ -311,14 +329,14 @@ export function createUseAIConversation<
                   content,
                   role: 'user',
                   createdAt: new Date().toISOString(),
-                  id: 'temp-id',
+                  id: OPTIMISTIC_USER_MESSAGE_ID,
                   conversationId: conversation.id ?? '',
                 },
                 {
                   content: [{ text: ' ' }],
                   role: 'assistant',
                   createdAt: new Date().toISOString(),
-                  id: 'temp-id-2',
+                  id: OPTIMISTIC_ASSISTANT_MESSAGE_ID,
                   conversationId: conversation.id ?? '',
                   isLoading: true,
                 },


### PR DESCRIPTION
#### Description of changes

`AIConversation` renders an empty assistant message bubble before/beside the streamed reply (regression in `@aws-amplify/ui-react-ai` 1.5.1; worked in 1.5.0).

**Root cause.** When a message is sent, `handleSendMessage` in `useAIConversation` optimistically appends an assistant placeholder with the synthetic id `temp-id-2` and content `{ text: ' ' }` (a truthy single space, so it passes `MessageList`'s renderable-content filter and shows up as a bubble). In 1.5.1 the `onStreamEvent` handler was changed to locate the streamed message by its **real** id:

```ts
const existingIndex = prev.data.messages.findIndex((m) => m.id === id);
```

The real streamed id (e.g. `…#stream`) never equals `temp-id-2`, so on the first event of a turn `existingIndex < 0` and the handler **appends a new** assistant message instead of replacing the placeholder — leaving the empty `temp-id-2` bubble behind. In 1.5.0 the handler replaced the *last* message unconditionally, so the placeholder was always overwritten.

**Fix.** When no message matches the real streamed id, fall back to replacing the optimistic assistant placeholder in place; only append when neither is found. This keeps the 1.5.1 by-id matching that handles out-of-order and duplicate stream events. The two synthetic ids are extracted into named constants so the placeholder id used on send and the fallback used on stream can't drift apart.

#### Issue #, if available

Fixes #7105

#### Description of how you validated changes

**1. Unit / regression test** — added `replaces the optimistic assistant placeholder instead of leaving an empty bubble` to `useAIConversation.test.ts`. It sends a message (creating the `temp-id-2` placeholder), streams events carrying a real id, and asserts exactly one assistant message remains with the streamed content. The full hook suite passes (7/7), including the existing duplicate- and out-of-order-event tests, confirming the fix doesn't regress the 1.5.1 behavior:

```
✓ handles duplicate stream events without content corruption
✓ handles out-of-order stream events correctly
✓ replaces the optimistic assistant placeholder instead of leaving an empty bubble
```

**2. End-to-end validation in the browser against a real backend.** I deployed two identical apps to AWS Amplify Hosting — same Amplify Gen2 backend shape (Cognito + AppSync + a Bedrock-backed `a.conversation` route, `Claude Haiku 4.5`) and the same UI — differing **only** in the `@aws-amplify/ui-react-ai` version. Each app shows a live "assistant bubbles in state" counter and a debug panel dumping the raw `messages` array.

| Build | Link |
|---|---|
| **BUG** — published `@aws-amplify/ui-react-ai@1.5.1` | https://main.drlq31ask9pgc.amplifyapp.com |
| **FIX** — `1.5.1` + this patch | https://main.d3dm9gvskmju2i.amplifyapp.com |

Sign-in for both (demo user): `demo7105@example.com` / `Demo7105!pass`. Send any prompt and watch the assistant area while it streams.

Observed (same prompt sent to both):

- **BUG** — during *and* after streaming, **2** assistant bubbles. The raw array contains a lingering placeholder:
  ```
  [ { id: "temp-id",    role: "user",      text: "…" },
    { id: "temp-id-2",  role: "assistant", isLoading: true, text: " " },   ← empty bubble
    { id: "…#stream",   role: "assistant", isLoading: true, text: "# The Robot Painter…" } ]
  ```
- **FIX** — **1** assistant bubble throughout. No `temp-id-2`:
  ```
  [ { id: "temp-id",  role: "user",      text: "…" },
    { id: "…#stream", role: "assistant", isLoading: false, text: "# A Robot's Canvas…" } ]
  ```

> Note: the two hosted apps are temporary demo resources for this PR and will be torn down after review.

#### Checklist

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
