### PR TITLE
fix(deps): resolve open Dependabot security alerts (nanoid, js-yaml)

### DIFF
--- a/build-system-tests/e2e/yarn.lock
+++ b/build-system-tests/e2e/yarn.lock
@@ -2301,9 +2301,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 
@@ -2608,15 +2608,10 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@^3.3.12:
-  version "3.3.12"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
-  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
-
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@^3.3.12, nanoid@^3.3.16:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 no-case@^3.0.4:
   version "3.0.4"

--- a/packages/angular/projects/ui-angular/package.json
+++ b/packages/angular/projects/ui-angular/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui": "6.15.5",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.18",
     "qrcode": "1.5.0",
     "tslib": "^2.5.2",
     "xstate": "^4.33.6"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui": "6.15.5",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.18",
     "qrcode": "1.5.0",
     "xstate": "^4.33.6"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -41,7 +41,7 @@
     "@aws-amplify/ui": "6.15.5",
     "@vueuse/core": "7.5.5",
     "@xstate/vue": "0.8.1",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.18",
     "qrcode": "1.5.0",
     "xstate": "^4.33.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18738,17 +18738,17 @@ js-tokens@^10.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1, js-yaml@^3.6.1:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
-  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 
@@ -20940,20 +20940,15 @@ nan@2.17.0, nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
 
-nanoid@3.3.8:
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
-  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
+nanoid@3.3.18, nanoid@^3.3.16:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 nanoid@5.1.5:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.5.tgz#f7597f9d9054eb4da9548cdd53ca70f1790e87de"
   integrity sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==
-
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
 
 nanoid@^5.1.0:
   version "5.1.11"


### PR DESCRIPTION
## Description

Resolves the open [Dependabot security alerts](https://github.com/aws-amplify/amplify-ui/security/dependabot) by bumping the affected dependencies to their first patched versions. Security-only change — no unrelated dependency bumps and no reformatting.

There were 13 open alerts covering 3 distinct packages (`nanoid`, `js-yaml`, `extract-zip`). 11 are fixed here; the 2 `extract-zip` alerts have no upstream fix available (see below).

### Alerts fixed

| Package | Advisory | CVE | Severity | From → To | Manifest(s) |
|---|---|---|---|---|---|
| `nanoid` | [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv) | CVE-2026-67214 | High | `3.3.8` → `3.3.18` | `packages/vue/package.json`, `packages/svelte/package.json`, `packages/angular/projects/ui-angular/package.json` |
| `nanoid` | [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv) | CVE-2026-67214 | High | `3.3.12` / `3.3.16` → `3.3.18` | `yarn.lock`, `build-system-tests/e2e/yarn.lock` |
| `nanoid` | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) | CVE-2026-67213 | High | `3.3.8` / `3.3.16` → `3.3.18` | `packages/vue/package.json`, `packages/svelte/package.json`, `packages/angular/projects/ui-angular/package.json`, `yarn.lock` |
| `js-yaml` | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | — | High | `4.3.0` → `4.3.1` | `yarn.lock`, `build-system-tests/e2e/yarn.lock` |
| `js-yaml` | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | — | High | `3.15.0` → `3.15.1` | `yarn.lock` |

- **`nanoid`** — `GHSA-28wg-ghj8-5hjv` (non-secure generators can loop indefinitely with negative size, patched in `3.3.16`) and `GHSA-2v37-7h3g-55p8` (custom generators can loop indefinitely when size is zero, patched in `3.3.18`). Both are satisfied by `3.3.18`. `nanoid` is an exact-pinned direct dependency of the Vue, Svelte and Angular packages, so the pins were bumped; the transitive `^3.3.12` / `^3.3.16` lockfile entries were bumped to match. The `nanoid` 5.x entries in the tree are outside both vulnerable ranges and were left untouched.
- **`js-yaml`** — `GHSA-5p4m-2wfm-xmqj` (quadratic CPU consumption in `!!omap` resolution) affects both the 3.x and 4.x lines. Dev-only transitive dependency, so it is bumped in place in the lockfiles to the patched patch releases on each line (`3.15.1`, `4.3.1`) — no major-version change.

### Not fixed — needs manual decision

| Package | Advisory | CVE | Severity | Reason |
|---|---|---|---|---|
| `extract-zip` | [GHSA-jmr9-qjv8-65gv](https://github.com/advisories/GHSA-jmr9-qjv8-65gv) | CVE-2026-56876 | High | **No patched version exists upstream.** The advisory covers `<= 2.0.1` and `2.0.1` is the latest published release, so there is no version to upgrade to. Dependabot reports no `first_patched_version`. Dev-only dependency (pulled in via Puppeteer-style tooling in `yarn.lock` and `build-system-tests/e2e/yarn.lock`). Requires either an upstream fix or replacing/removing the dependent tooling. |

## Minimal lockfile delta

Because this is a single-lockfile Yarn 1 monorepo, a full `yarn install` re-resolution can shift unrelated transitive dependencies and trip the `size-limit` checks. The change is therefore scoped to only the affected entries — 5 files, +20/−30 lines:

```
 build-system-tests/e2e/yarn.lock                  | 19 +++++++----------
 packages/angular/projects/ui-angular/package.json |  2 +-
 packages/svelte/package.json                      |  2 +-
 packages/vue/package.json                         |  2 +-
 yarn.lock                                         | 25 +++++++++--------------
 5 files changed, 20 insertions(+), 30 deletions(-)
```

The dependency sets are identical across all bumped versions (`nanoid` has none; `js-yaml` 3.x keeps `argparse ^1.0.7` + `esprima ^4.0.0`, 4.x keeps `argparse ^2.0.1`), so no new transitive resolution is introduced. Compatible descriptors were merged into single lockfile entries (`nanoid@3.3.18, nanoid@^3.3.16`).

## Verification

All run on Node 22.22.3 / Yarn 1.22.22.

- **`yarn install --frozen-lockfile` → exit 0**, and `yarn.lock` is **byte-identical** afterwards, proving the hand-edited lockfile is internally consistent and that no re-resolution drift was introduced.
- **Resolved versions on disk after install:** every `nanoid` 3.x copy is `3.3.18` and every `js-yaml` copy is `3.15.1` or `4.3.1` — a full tree scan found **no remaining copy inside any vulnerable range**.
- **Builds:** `yarn build:exclude-angular` → **13/13 turbo tasks successful**; `yarn angular build` → exit 0.
- **Lint:** `yarn vue lint`, `yarn svelte lint`, `yarn angular lint` → all exit 0.
- **Unit tests:** `yarn vue test` → 27/27 suites, 161 passed / 5 skipped; `yarn angular test` → 15/15 suites, 43 passed; `yarn svelte test` → exit 0.
- **`size-limit`:** could not be measured in this environment — `@size-limit/time` fails to launch headless Chrome (`Chromium revision is not found or downloaded`). This failure was confirmed to be **pre-existing and environmental**: stashing this change and re-running `yarn size` on a clean tree reproduces the identical error, so it is unrelated to this PR. No byte-size limit was exceeded; the failure occurs in the Chrome runtime-timing plugin before any size comparison. CI should report the real numbers — impact is expected to be negligible (a patch bump of `nanoid`, which is unchanged in API and size class, plus dev-only `js-yaml`).

## Issue

Addresses the open Dependabot security alerts on `main`.
