### PR TITLE
fix(storage): handle multi-file download errors (e.g. 403 Glacier)

### DIFF
--- a/.changeset/fix-zipdownload-glacier.md
+++ b/.changeset/fix-zipdownload-glacier.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/ui-react-storage': patch
+---
+
+fix(storage): surface non-OK responses (e.g. 403 Glacier) as errors during multi-file download instead of writing the error response body into the zip

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/zipdownload.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/zipdownload.spec.ts
@@ -137,6 +137,9 @@ describe('zipDownloadHandler', () => {
     mockGetUrl.mockResolvedValue({ expiresAt, url });
 
     globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
       headers: { get: (h: string) => (h === 'content-length' ? '100' : null) },
       body: new ReadableStream({
         start(ctrl) {
@@ -227,6 +230,55 @@ describe('zipDownloadHandler', () => {
       message: error.message,
       status: 'FAILED',
     });
+  });
+
+  it('marks a non-ok response (e.g. 403 Glacier) FAILED without blocking the rest of the batch', async () => {
+    // S3 returns 403 for a GLACIER/DEEP_ARCHIVE object that has not been
+    // restored. `fetch` resolves (does not reject) with a non-ok response, so
+    // without a `response.ok` guard the error body would be zipped as file
+    // content and the task would settle COMPLETE.
+    (globalThis.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: { get: () => null },
+        body: new ReadableStream({
+          start(ctrl) {
+            ctrl.close();
+          },
+        }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: {
+          get: (h: string) => (h === 'content-length' ? '100' : null),
+        },
+        body: new ReadableStream({
+          start(ctrl) {
+            ctrl.enqueue(new Uint8Array(100));
+            ctrl.close();
+          },
+        }),
+      });
+
+    const file1 = { id: 'g1', key: 'prefix/archived', fileKey: 'archived' };
+    const file2 = { id: 'g2', key: 'prefix/available', fileKey: 'available' };
+    const all = [file1, file2];
+    const base = createBaseInput();
+
+    const r1 = zipDownloadHandler({ ...base, data: file1, all });
+    expect(await r1.result).toEqual({
+      status: 'FAILED',
+      message: 'Failed to download prefix/archived: 403 Forbidden',
+      error: expect.any(Error),
+    });
+
+    // The failing file did not cancel the batch — file 2 downloads normally.
+    const r2 = zipDownloadHandler({ ...base, data: file2, all });
+    expect(await r2.result).toEqual({ status: 'COMPLETE' });
   });
 
   it('posts stream to service worker and triggers download', async () => {

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/zipdownload.spec.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/__tests__/zipdownload.spec.ts
@@ -276,9 +276,77 @@ describe('zipDownloadHandler', () => {
       error: expect.any(Error),
     });
 
-    // The failing file did not cancel the batch — file 2 downloads normally.
+    // The `!response.ok` throw fires before `zipWriter.add`, so the 403 body
+    // must never become a zip entry — assert that directly, not via the status.
+    expect(mockAddedFilenames).not.toContain('archived');
+
+    // The failure did not cancel the batch — file 2 downloads normally.
     const r2 = zipDownloadHandler({ ...base, data: file2, all });
     expect(await r2.result).toEqual({ status: 'COMPLETE' });
+
+    expect(mockAddedFilenames).toEqual(['available']);
+  });
+
+  it('does not abort the batch when a file fails in-flight (concurrent dispatch)', async () => {
+    // Production dispatches with `concurrency: 1` (the sequential test above).
+    // Here both files are in flight at once, so a regression that aborted the
+    // shared `batchAbort` on a per-file failure would cancel the sibling —
+    // surfacing CANCELED instead of COMPLETE, which the sequential test can't see.
+    (globalThis.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: { get: () => null },
+        body: new ReadableStream({
+          start(ctrl) {
+            ctrl.close();
+          },
+        }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: {
+          get: (h: string) => (h === 'content-length' ? '100' : null),
+        },
+        body: new ReadableStream({
+          start(ctrl) {
+            ctrl.enqueue(new Uint8Array(100));
+            ctrl.close();
+          },
+        }),
+      });
+
+    const file1 = { id: 'c1', key: 'prefix/archived', fileKey: 'archived' };
+    const file2 = { id: 'c2', key: 'prefix/available', fileKey: 'available' };
+    const all = [file1, file2];
+    const base = createBaseInput();
+
+    const r1 = zipDownloadHandler({ ...base, data: file1, all });
+    const onProgress = jest.fn();
+    const r2 = zipDownloadHandler({
+      ...base,
+      data: file2,
+      all,
+      options: { onProgress },
+    });
+    const [result1, result2] = await Promise.all([r1.result, r2.result]);
+
+    expect(result1).toEqual({
+      status: 'FAILED',
+      message: 'Failed to download prefix/archived: 403 Forbidden',
+      error: expect.any(Error),
+    });
+    expect(result2).toEqual({ status: 'COMPLETE' });
+
+    expect(mockAddedFilenames).not.toContain('archived');
+    expect(mockAddedFilenames).toEqual(['available']);
+    // The sibling's bytes actually flowed into its entry, not just a COMPLETE
+    // status: onProgress only reaches 'COMPLETE' after the response body is fully
+    // read and enqueued toward the zip writer.
+    expect(onProgress).toHaveBeenCalledWith(file2, 1, 'COMPLETE');
   });
 
   it('posts stream to service worker and triggers download', async () => {

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/zipdownload.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/zipdownload.ts
@@ -237,6 +237,8 @@ const download = async (
     signal: state.batchAbort.signal,
   });
   if (!response.ok) {
+    // Release the connection — the error body (S3 error XML) is never consumed.
+    response.body?.cancel().catch(() => {});
     throw new Error(
       `Failed to download ${key}: ${response.status} ${response.statusText}`
     );

--- a/packages/react-storage/src/components/StorageBrowser/actions/handlers/zipdownload.ts
+++ b/packages/react-storage/src/components/StorageBrowser/actions/handlers/zipdownload.ts
@@ -236,6 +236,11 @@ const download = async (
     mode: 'cors',
     signal: state.batchAbort.signal,
   });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ${key}: ${response.status} ${response.statusText}`
+    );
+  }
   if (!response.body) throw new Error(`Empty response body for ${key}`);
   const size = data.size ?? +(response.headers.get('content-length') ?? 0);
   let transferred = 0;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md
-->

#### Description of changes

Adds a response-status check to the multi-file (zip) download handler so that non-OK HTTP responses are surfaced as errors instead of being silently written into the downloaded archive.

Previously, download() in zipdownload.ts passed the fetch response body straight to the zip writer without checking `response.ok`. When S3 returned an error for an object — for example a 403 for an object in Glacier / Glacier Deep Archive storage that hasn't been restored — the error response body (XML error payload) was zipped into the archive as if it were the file's contents. The user got a "successful" download containing a corrupt/garbage file rather than a clear failure.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

1. In a Storage Browser multi-file download, include an object that returns a non-OK response (e.g. a 403 from an unrestored Glacier object).
2. Before: the archive downloads "successfully" but the affected file contains the S3 error XML.
3. After: the download for that key throws failed to download; the rest of the batch is unaffected.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Have read the [Pull Request Guidelines](https://github.com/aws-amplify/amplify-ui/blob/main/CONTRIBUTING.md)
- [x] PR description included
- [x] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax
- [x] _If this change should result in a version bump_, [changeset added](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (This can be done after creating the PR.) This does not apply to changes made to `docs`, `e2e`, `examples`, or other private packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
