### PR TITLE
fix(deps): force decode-uri-component to 0.5.0 (resolves DoS alert #650)

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@babel/core": "^7.22.0",
     "@babel/preset-env": "^7.22.0",
     "cookie": "^0.7.0",
+    "decode-uri-component": "^0.5.0",
     "diff": "^8.0.3",
     "json5": "^2.2.1",
     "prismjs": "^1.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14093,10 +14093,10 @@ decode-named-character-reference@^1.0.0:
   dependencies:
     character-entities "^2.0.0"
 
-decode-uri-component@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
-  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
+decode-uri-component@^0.2.2, decode-uri-component@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.5.0.tgz#4592fa1e1d640ec5e2760e2e168ad2ab5f2c9da1"
+  integrity sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==
 
 decompress-response@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
#### Description of changes

Resolves Dependabot alert #650 (GHSA-vcc3-ghjq-m6fr / CVE-2026-45822) — `decode-uri-component` **DoS via exponential decoding of malformed percent-encoded input**, fixed in `0.5.0`.

`decode-uri-component` was pinned at `0.2.2` in `yarn.lock`, pulled in transitively by `query-string@^7.1.0` (via `decode-uri-component@^0.2.2`). Since the vulnerable range is `<= 0.4.2` and the patched `0.5.0` is outside the `^0.2.2` caret, a plain re-resolution can't reach it — so this adds a root `resolutions` entry (`"decode-uri-component": "^0.5.0"`), consistent with how this repo already overrides transitive deps.

`0.5.0` has no dependencies (only `engines: node >=14.16`) and keeps the same single-function API `query-string` calls, so it's a drop-in.

#### Issue #, if available

Dependabot alert #650.

#### Description of how you validated changes

- Confirmed `0.5.0` is the first patched version and is the current latest release.
- `yarn install --frozen-lockfile` passes, confirming the lockfile satisfies the new resolution and `query-string`'s `^0.2.2` now resolves to `0.5.0`.
- Diff limited to one `resolutions` line in `package.json` and the single `decode-uri-component` block in `yarn.lock`.

#### Checklist

- [x] Have read the Pull Request Guidelines
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow conventional commit syntax
- [ ] _If this change should result in a version bump_, changeset added

> Note: dependency-only security fix via a lockfile `resolutions` override (transitive dep). No changeset needed; no source or test changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
