### PR TITLE
fix(deps): force estimo's nanoid to >=5.1.11 (resolves integer-overflow alert #651)

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@babel/core": "^7.22.0",
     "@babel/preset-env": "^7.22.0",
     "cookie": "^0.7.0",
+    "**/estimo/nanoid": "^5.1.11",
     "decode-uri-component": "^0.5.0",
     "diff": "^8.0.3",
     "json5": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20945,10 +20945,10 @@ nanoid@3.3.18, nanoid@^3.3.16:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
   integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
-nanoid@5.1.5:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.5.tgz#f7597f9d9054eb4da9548cdd53ca70f1790e87de"
-  integrity sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==
+nanoid@5.1.5, nanoid@^5.1.11:
+  version "5.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.16.tgz#fe345c0a1f9007c32fbb5c139e1208bfd3f41ef7"
+  integrity sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==
 
 nanoid@^5.1.0:
   version "5.1.11"


### PR DESCRIPTION
#### Description of changes

Resolves Dependabot alert #651 (GHSA-xwg4-73v4-xw9w / CVE-2026-73086) — `nanoid` **integer overflow / wraparound**, vulnerable range `>= 4.0.0, < 5.1.11`.

The only in-range instance was `nanoid@5.1.5`, pinned exactly by `estimo@^3.0.3` (a build/perf dev tool). The repo's other nanoid trees are already safe: `nanoid@^5.1.0` resolves to `5.1.11`, and the `nanoid@^3.3.16` (3.x, CJS) tree is outside the vulnerable `>= 4.0.0` range.

A **scoped** resolution `"**/estimo/nanoid": "^5.1.11"` bumps only estimo's nanoid to `5.1.16` (latest 5.1.x). A global `nanoid` override was deliberately avoided — it would force the 3.x CJS tree onto ESM-only nanoid 5 and break it. `nanoid` 5.1.16 has no dependencies, so it's a clean drop-in.

#### Issue #, if available

Dependabot alert #651.

#### Description of how you validated changes

- Confirmed `5.1.11` is the first patched version; `5.1.16` (used here) satisfies it and is the current 5.1.x release.
- `yarn install --frozen-lockfile` passes, confirming the lockfile satisfies the new resolution and estimo's `nanoid` now resolves to `5.1.16`.
- Verified the 3.x (`3.3.18`) tree is untouched and the `^5.1.0` tree (`5.1.11`) remains safe.
- Diff limited to one `resolutions` line in `package.json` and the single `nanoid` block in `yarn.lock`.

#### Checklist

- [x] Have read the Pull Request Guidelines
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow conventional commit syntax
- [ ] _If this change should result in a version bump_, changeset added

> Note: dependency-only security fix via a scoped lockfile `resolutions` override on a dev-tool transitive dep. No changeset needed; no source or test changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
