### PR TITLE
fix(deps): force toml 4.3.0 and stream-json 3.6.0 (resolves #659/#660/#661)

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "@babel/core": "^7.22.0",
     "@babel/preset-env": "^7.22.0",
     "cookie": "^0.7.0",
+    "toml": "^4.2.0",
+    "stream-json": "^3.5.0",
     "fast-uri": "^3.1.6",
     "browserslist": "^4.28.7",
     "**/estimo/nanoid": "^5.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25104,17 +25104,17 @@ stream-browserify@3.0.0:
     inherits "~2.0.4"
     readable-stream "^3.5.0"
 
-stream-chain@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.2.5.tgz#b30967e8f14ee033c5b9a19bbe8a2cba90ba0d09"
-  integrity sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==
+stream-chain@^4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-4.2.5.tgz#9061d29573ab79c49258b2cbe2f72bed7629c79f"
+  integrity sha512-Wtyq3bNE3ggLR0v2vftqvuhltym3WbZAkZpfIrkr5F/6vpeUmWmwTgXa16zD87gpahwJ/Qulq3zVfUlgIc0J2A==
 
-stream-json@^1.7.4, stream-json@^1.7.5:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.9.1.tgz#e3fec03e984a503718946c170db7d74556c2a187"
-  integrity sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==
+stream-json@^1.7.4, stream-json@^1.7.5, stream-json@^3.5.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-3.6.0.tgz#99fdad598dc2f887c561b4c0a5fb61c594777f62"
+  integrity sha512-NiJdqxKyau579z/E8vfqcjWfSDWxW/AT99javFXdPXF147Z5za85LRXSHEmSX9TKOakB7gaIccfD0fOIctb7KQ==
   dependencies:
-    stream-chain "^2.2.5"
+    stream-chain "^4.2.5"
 
 streamroller@^3.1.5:
   version "3.1.5"
@@ -25962,10 +25962,10 @@ toidentifier@1.0.1, toidentifier@~1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-toml@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
-  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
+toml@^3.0.0, toml@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-4.3.0.tgz#10e2ff83296ec17d8935bf02364e4969cfeaae67"
+  integrity sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==
 
 toposort@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
#### Description of changes

Resolves three UI Dependabot alerts by force-upgrading two dev-only transitive deps to patched versions via scoped `resolutions`:

- **toml** `3.0.0 → 4.3.0` — uncontrolled recursion (#660, patched `4.2.0`) and prototype pollution (#659, patched `4.1.2`). Pulled in by `remark-mdx-frontmatter` (`^3.0.0`, docs MDX build). toml's public API is `.parse()`, unchanged across majors, so 4.x is a drop-in.
- **stream-json** `1.9.1 → 3.6.0` — unsafe pick/ignore/filter/replace parsing (#661, patched `3.5.0`). Pulled in by `detox`/`bunyamin` (`^1.7.x`, RN e2e logging).

The patched versions exist only in newer majors than the consumers' declared ranges (`^3` / `^1.7`), so there is no in-range fix — hence the forced resolutions. Both are build/test-only, operate on trusted local input, and are not shipped in any published `@aws-amplify/ui-*` package.

> Note: `stream-json` is a major bump (1→3) forced onto `detox`, which declares `^1.7.5`. Install and `--frozen-lockfile` pass; the e2e/CI run will confirm detox's log parsing still works with stream-json 3.x. Flagging in case detox needs a follow-up.

#### Issue #, if available

Dependabot alerts #659, #660, #661.

#### Description of how you validated changes

- `toml` resolves to `4.3.0`, `stream-json` to `3.6.0`; no vulnerable `toml@3.x` or `stream-json@<=3.4.0` remains.
- `yarn install --frozen-lockfile` passes.
- Diff limited to two `resolutions` lines and the `toml`/`stream-json` blocks (+ transitive `stream-chain`) in `yarn.lock`. No unrelated churn.

#### Checklist

- [x] Have read the Pull Request Guidelines
- [x] PR description included
- [ ] `yarn test` passes and tests are updated/added
- [x] PR title and commit messages follow conventional commit syntax
- [ ] _If this change should result in a version bump_, changeset added

> Dependency-only security fix via lockfile `resolutions`; no changeset needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
